### PR TITLE
fix(committees): flag stale weekly-brief narrative on in-window activity

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -82,13 +82,23 @@
             <span class="font-semibold">AI Assistant</span>
             <span class="text-xs text-gray-500">{{ weekLabel() }}</span>
           </div>
-          @if (b.state === 'generated') {
-            <span class="rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-700" data-testid="weekly-brief-card-state-badge">Generated</span>
-          } @else if (b.state === 'edited') {
-            <span class="rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-700" data-testid="weekly-brief-card-state-badge">Edited</span>
-          } @else if (b.state === 'approved') {
-            <span class="rounded bg-emerald-100 px-2 py-0.5 text-xs text-emerald-700" data-testid="weekly-brief-card-state-badge">Approved</span>
-          }
+          <div class="flex items-center gap-2">
+            @if (staleness()?.stale) {
+              <lfx-tag
+                value="May be out of date"
+                severity="warn"
+                icon="fa-light fa-clock-rotate-left"
+                [tooltip]="stalenessTooltip()"
+                data-testid="weekly-brief-card-staleness-tag" />
+            }
+            @if (b.state === 'generated') {
+              <span class="rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-700" data-testid="weekly-brief-card-state-badge">Generated</span>
+            } @else if (b.state === 'edited') {
+              <span class="rounded bg-amber-100 px-2 py-0.5 text-xs text-amber-700" data-testid="weekly-brief-card-state-badge">Edited</span>
+            } @else if (b.state === 'approved') {
+              <span class="rounded bg-emerald-100 px-2 py-0.5 text-xs text-emerald-700" data-testid="weekly-brief-card-state-badge">Approved</span>
+            }
+          </div>
         </div>
 
         @if (b.private_source_present) {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -76,7 +76,7 @@
     <lfx-card>
       <div class="flex flex-col gap-4">
         <!-- Header -->
-        <div class="flex items-center justify-between">
+        <div class="flex flex-wrap items-center justify-between gap-2">
           <div class="flex items-center gap-2">
             <i class="fa-light fa-sparkles text-blue-500"></i>
             <span class="font-semibold">AI Assistant</span>

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -441,3 +441,108 @@ describe('WeeklyBriefCardComponent — Sources disclosure (LFXV2-3335)', () => {
     expect(component.expandedSourceGroups().size).toBe(0);
   });
 });
+
+describe('WeeklyBriefCardComponent — staleness indicator (GH-1966)', () => {
+  let fixture: ComponentFixture<WeeklyBriefCardComponent>;
+
+  const COMMITTEE: Committee = { uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1' } as Committee;
+
+  function briefResponse(overrides: Partial<WeeklyBriefCurrentResponse> = {}): WeeklyBriefCurrentResponse {
+    return {
+      brief: {
+        uid: 'brief-1',
+        committee_uid: 'committee-1',
+        window_start: '2026-08-23T00:00:00Z',
+        window_end: '2026-08-29T23:59:59Z',
+        state: 'generated',
+        brief_text: 'Weekly summary.',
+        source_refs: [],
+        prompt_version: 'v1',
+        model: 'test-model',
+        regeneration_count: 0,
+        private_source_present: false,
+        created_at: '2026-08-24T00:00:00Z',
+        updated_at: '2026-08-24T00:00:00Z',
+        revision: 1,
+      },
+      throttle: { generates_used: 0, generates_limit: 2, regenerations_used: 0, regenerations_limit: 3, window_resets_at: '2026-08-30T00:00:00Z' },
+      caller_rating: null,
+      ...overrides,
+    };
+  }
+
+  async function setup(response: WeeklyBriefCurrentResponse): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [WeeklyBriefCardComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: WeeklyBriefService,
+          useValue: { getWeeklyBrief: vi.fn(() => of(response)), listWeeklyBriefs: vi.fn(() => of({ data: [] })) },
+        },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        ConfirmationService,
+        { provide: UserService, useValue: { impersonating: signal(false) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
+    fixture.componentRef.setInput('committee', COMMITTEE);
+    fixture.componentRef.setInput('canEdit', true);
+    await fixture.whenStable();
+  }
+
+  function stalenessTag(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-staleness-tag"]');
+  }
+
+  function regenerateButton(): HTMLButtonElement {
+    const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-regenerate-button"] button');
+    if (!el) throw new Error('no native button rendered inside weekly-brief-card-regenerate-button');
+    return el as HTMLButtonElement;
+  }
+
+  it('renders the staleness tag when stale', async () => {
+    await setup(briefResponse({ staleness: { stale: true, event_count: 3, event_count_is_floor: false } }));
+
+    expect(stalenessTag()).not.toBeNull();
+  });
+
+  it('does not render the staleness tag when not stale', async () => {
+    await setup(briefResponse({ staleness: { stale: false, event_count: 0, event_count_is_floor: false } }));
+
+    expect(stalenessTag()).toBeNull();
+  });
+
+  it('does not render the staleness tag when staleness is null (uncomputable)', async () => {
+    await setup(briefResponse({ staleness: null }));
+
+    expect(stalenessTag()).toBeNull();
+  });
+
+  it('leaves the Regenerate button enabled when stale, even with a fresh quota', async () => {
+    await setup(
+      briefResponse({
+        staleness: { stale: true, event_count: 1, event_count_is_floor: false },
+        throttle: { generates_used: 0, generates_limit: 2, regenerations_used: 0, regenerations_limit: 3, window_resets_at: '2026-08-30T00:00:00Z' },
+      })
+    );
+
+    expect(stalenessTag()).not.toBeNull();
+    expect(regenerateButton().disabled).toBeFalsy();
+  });
+
+  it('leaves the Regenerate button disabled on exhausted quota even when not stale — staleness never overrides the throttle gate', async () => {
+    await setup(
+      briefResponse({
+        staleness: { stale: false, event_count: 0, event_count_is_floor: false },
+        throttle: { generates_used: 2, generates_limit: 2, regenerations_used: 3, regenerations_limit: 3, window_resets_at: '2026-08-30T00:00:00Z' },
+      })
+    );
+
+    expect(stalenessTag()).toBeNull();
+    expect(regenerateButton().disabled).toBeTruthy();
+  });
+});

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -471,7 +471,7 @@ describe('WeeklyBriefCardComponent — staleness indicator (GH-1966)', () => {
     };
   }
 
-  async function setup(response: WeeklyBriefCurrentResponse): Promise<void> {
+  async function setup(response: WeeklyBriefCurrentResponse): Promise<WeeklyBriefCardComponent> {
     await TestBed.configureTestingModule({
       imports: [WeeklyBriefCardComponent],
       providers: [
@@ -492,6 +492,7 @@ describe('WeeklyBriefCardComponent — staleness indicator (GH-1966)', () => {
     fixture.componentRef.setInput('committee', COMMITTEE);
     fixture.componentRef.setInput('canEdit', true);
     await fixture.whenStable();
+    return fixture.componentInstance;
   }
 
   function stalenessTag(): HTMLElement | null {
@@ -520,6 +521,24 @@ describe('WeeklyBriefCardComponent — staleness indicator (GH-1966)', () => {
     await setup(briefResponse({ staleness: null }));
 
     expect(stalenessTag()).toBeNull();
+  });
+
+  it('tooltip says "last updated", not "generated" — updated_at is the last edit time for an edited brief, not its original generation time', async () => {
+    const component = await setup(briefResponse({ staleness: { stale: true, event_count: 3, event_count_is_floor: false } }));
+
+    expect(component.stalenessTooltip()).toBe('3 new events since this brief was last updated');
+  });
+
+  it('pluralizes "event" for a floor count of exactly 1 (a "1+" count is never exactly one)', async () => {
+    const component = await setup(briefResponse({ staleness: { stale: true, event_count: 1, event_count_is_floor: true } }));
+
+    expect(component.stalenessTooltip()).toBe('1+ new events since this brief was last updated');
+  });
+
+  it('keeps the singular for a non-floor count of exactly 1', async () => {
+    const component = await setup(briefResponse({ staleness: { stale: true, event_count: 1, event_count_is_floor: false } }));
+
+    expect(component.stalenessTooltip()).toBe('1 new event since this brief was last updated');
   });
 
   it('leaves the Regenerate button enabled when stale, even with a fresh quota', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -247,8 +247,10 @@ export class WeeklyBriefCardComponent {
 
   // BFF enrichment on the response envelope (GH-1966), not on `WeeklyBrief` itself — read from
   // `briefResponse`, same pattern as `callerRating`. `null` whenever staleness couldn't be
-  // computed (non-shareable state, mock mode, or a soft-failed upstream fetch); purely
-  // informational — never gates canGenerate/canRegenerate.
+  // computed (non-shareable state, mock mode, an unparseable timestamp, or an inconclusive or
+  // soft-failed upstream fetch); a brief generated after its own window closed instead
+  // confidently reports `stale: false`. Purely informational — never gates
+  // canGenerate/canRegenerate.
   public readonly staleness: Signal<WeeklyBriefStaleness | null> = computed(() => this.briefResponse()?.staleness ?? null);
 
   // Precomputed here rather than resolved inline in the template (repo rule:

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -257,8 +257,11 @@ export class WeeklyBriefCardComponent {
     const s = this.staleness();
     if (!s) return '';
     const suffix = s.event_count_is_floor ? '+' : '';
-    const noun = s.event_count === 1 ? 'event' : 'events';
-    return `${s.event_count}${suffix} new ${noun} since this brief was generated`;
+    // `updated_at` (what staleness compares against) is the last edit time for an `edited`
+    // brief, not its original generation time — "last updated" covers both without
+    // misattributing an edit to a regenerate that never happened.
+    const noun = s.event_count === 1 && !s.event_count_is_floor ? 'event' : 'events';
+    return `${s.event_count}${suffix} new ${noun} since this brief was last updated`;
   });
 
   public readonly canGenerate: Signal<boolean> = computed(() => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -35,6 +35,7 @@ import {
   WeeklyBriefSourceChip,
   WeeklyBriefSourceChipAction,
   WeeklyBriefSourceChipSection,
+  WeeklyBriefStaleness,
   WeeklyBriefThrottle,
 } from '@lfx-one/shared/interfaces';
 import { formatUtcDateRangeLabel, mapWeeklyBriefSourceRefsToChips } from '@lfx-one/shared/utils';
@@ -242,6 +243,22 @@ export class WeeklyBriefCardComponent {
     const override = this.optimisticRating();
     if (b && override && override.briefUid === b.uid && override.revision === b.revision) return override.value;
     return this.briefResponse()?.caller_rating ?? null;
+  });
+
+  // BFF enrichment on the response envelope (GH-1966), not on `WeeklyBrief` itself — read from
+  // `briefResponse`, same pattern as `callerRating`. `null` whenever staleness couldn't be
+  // computed (non-shareable state, mock mode, or a soft-failed upstream fetch); purely
+  // informational — never gates canGenerate/canRegenerate.
+  public readonly staleness: Signal<WeeklyBriefStaleness | null> = computed(() => this.briefResponse()?.staleness ?? null);
+
+  // Precomputed here rather than resolved inline in the template (repo rule:
+  // docs/reviews/frontend-checklist.md §4) — also avoids a nested ternary in markup.
+  public readonly stalenessTooltip: Signal<string> = computed(() => {
+    const s = this.staleness();
+    if (!s) return '';
+    const suffix = s.event_count_is_floor ? '+' : '';
+    const noun = s.event_count === 1 ? 'event' : 'events';
+    return `${s.event_count}${suffix} new ${noun} since this brief was generated`;
   });
 
   public readonly canGenerate: Signal<boolean> = computed(() => {

--- a/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
+++ b/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
@@ -14,9 +14,11 @@ export const WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID = 'wb-mock-quiet-week';
 
 /**
  * Deadline for `WeeklyBriefService#withStaleness`'s committee-activity fetch (GH-1966).
- * `MicroserviceProxyService` sets no request timeout of its own, and a purely informational
- * badge must never be able to stall the brief's own primary content (the card's initial load
- * has no client-side timeout either) — this guard degrades to `staleness: null` on expiry
- * instead of hanging `getCurrentBrief` indefinitely (general review finding, full-branch sweep).
+ * `MicroserviceProxyService` itself sets no timeout, but every proxied call still inherits
+ * `ApiClientService`'s per-request `AbortSignal.timeout` (30s by default) — so the pre-existing
+ * ceiling was ~30s, not unbounded. Still far too long for a purely informational badge to
+ * potentially delay the brief's own primary content (the card's initial load has no
+ * client-side timeout of its own), so this tightens it to 3s and degrades to `staleness: null`
+ * on expiry rather than waiting out the full request budget (general review finding, full-branch sweep).
  */
 export const WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS = 3_000;

--- a/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
+++ b/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
@@ -11,3 +11,12 @@
  * even relevant. Exercised directly by `weekly-brief.service.spec.ts`, not via the running app.
  */
 export const WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID = 'wb-mock-quiet-week';
+
+/**
+ * Deadline for `WeeklyBriefService#withStaleness`'s committee-activity fetch (GH-1966).
+ * `MicroserviceProxyService` sets no request timeout of its own, and a purely informational
+ * badge must never be able to stall the brief's own primary content (the card's initial load
+ * has no client-side timeout either) — this guard degrades to `staleness: null` on expiry
+ * instead of hanging `getCurrentBrief` indefinitely (general review finding, full-branch sweep).
+ */
+export const WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS = 3_000;

--- a/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
+++ b/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
@@ -17,8 +17,18 @@ export const WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID = 'wb-mock-quiet-week';
  * `MicroserviceProxyService` itself sets no timeout, but every proxied call still inherits
  * `ApiClientService`'s per-request `AbortSignal.timeout` (30s by default) — so the pre-existing
  * ceiling was ~30s, not unbounded. Still far too long for a purely informational badge to
- * potentially delay the brief's own primary content (the card's initial load has no
- * client-side timeout of its own), so this tightens it to 3s and degrades to `staleness: null`
- * on expiry rather than waiting out the full request budget (general review finding, full-branch sweep).
+ * potentially delay the brief's own primary content, so this tightens it and degrades to
+ * `staleness: null` on expiry rather than waiting out the full request budget (general review
+ * finding, full-branch sweep).
+ *
+ * Deliberately well under `WEEKLY_BRIEF_POLL_INTERVAL_MS` (4000ms, `@lfx-one/shared/constants`)
+ * — that's the client's own per-tick timeout on `GET /current` while `pollUntilTerminal` polls a
+ * generate/regenerate to completion. This fetch runs on every such tick once the brief reaches a
+ * shareable state, in parallel with (not in addition to) `withCallerRating`; a value close to or
+ * over 4s here could itself push a tick over the client's timeout and burn poll attempts on a
+ * brief that generated fine (full-branch sweep handoff, not independently loaded as a KB
+ * pattern). Not derived from that constant via a shared import — this file is deliberately
+ * import-free (see the sibling `weekly-brief.service.spec.ts` comment on why) — so keep the two
+ * in sync by hand if either changes.
  */
-export const WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS = 3_000;
+export const WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS = 1_500;

--- a/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
+++ b/apps/lfx-one/src/server/constants/weekly-brief.constants.ts
@@ -18,17 +18,15 @@ export const WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID = 'wb-mock-quiet-week';
  * `ApiClientService`'s per-request `AbortSignal.timeout` (30s by default) — so the pre-existing
  * ceiling was ~30s, not unbounded. Still far too long for a purely informational badge to
  * potentially delay the brief's own primary content, so this tightens it and degrades to
- * `staleness: null` on expiry rather than waiting out the full request budget (general review
- * finding, full-branch sweep).
+ * `staleness: null` on expiry rather than waiting out the full request budget.
  *
  * Deliberately well under `WEEKLY_BRIEF_POLL_INTERVAL_MS` (4000ms, `@lfx-one/shared/constants`)
  * — that's the client's own per-tick timeout on `GET /current` while `pollUntilTerminal` polls a
  * generate/regenerate to completion. This fetch runs on every such tick once the brief reaches a
  * shareable state, in parallel with (not in addition to) `withCallerRating`; a value close to or
  * over 4s here could itself push a tick over the client's timeout and burn poll attempts on a
- * brief that generated fine (full-branch sweep handoff, not independently loaded as a KB
- * pattern). Not derived from that constant via a shared import — this file is deliberately
- * import-free (see the sibling `weekly-brief.service.spec.ts` comment on why) — so keep the two
- * in sync by hand if either changes.
+ * brief that generated fine. Not derived from that constant via a shared import — this file is
+ * deliberately import-free (see the sibling `weekly-brief.service.spec.ts` comment on why) — so
+ * keep the two in sync by hand if either changes.
  */
 export const WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS = 1_500;

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -66,7 +66,7 @@ function buildRatingReq(body: unknown = {}): any {
 }
 
 function buildRes(): any {
-  return { status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn() };
+  return { status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn(), setHeader: vi.fn() };
 }
 
 describe('WeeklyBriefController', () => {
@@ -282,6 +282,15 @@ describe('WeeklyBriefController', () => {
 
       expect(weeklyBriefSvc.getCurrentBrief).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledWith(forbidden);
+    });
+
+    it('sets Cache-Control: no-store — the response carries per-user caller_rating and staleness (GH-1966), both derived from FGA-filtered data', async () => {
+      weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
+      const res = buildRes();
+
+      await controller.getCurrentBrief(buildReq(), res, vi.fn());
+
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     });
   });
 

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -186,6 +186,10 @@ export class WeeklyBriefController {
         revision: result.brief?.revision,
       });
 
+      // caller_rating and staleness (GH-1966) are both per-user/per-request BFF enrichments
+      // derived from FGA-filtered activity — must not sit in a shared or intermediary cache,
+      // same rationale as CommitteeActivityController.
+      res.setHeader('Cache-Control', 'no-store');
       res.json(result);
     } catch (error) {
       next(error);

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -178,7 +178,7 @@ describe('CommitteeActivityService', () => {
 
   it('returns an empty feed when every source is empty', async () => {
     const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-    expect(result).toEqual({ data: [], page_token: undefined, any_leg_failed: false });
+    expect(result).toEqual({ data: [], page_token: undefined, any_leg_saturated: false, any_leg_failed: false });
   });
 
   it('merges all four sources and sorts the result by occurred_at descending', async () => {
@@ -275,13 +275,13 @@ describe('CommitteeActivityService', () => {
   });
 
   describe('since/cursor/limit handling', () => {
-    it('sends since as date_from and cursor.before as date_to to every source, as best-effort narrowing', async () => {
-      // Every leg's occurred_at is derived from a field-fallback a single upstream date_field can't
-      // fully represent (see the comments in fetchPastMeetingEvents/fetchVoteEvents/etc.) — the
-      // upstream date params are best-effort narrowing to keep the fetched volume small, not a
-      // correctness guarantee. The in-memory since/cursor filter in getCommitteeActivity is what
-      // actually enforces the window; dropping the upstream narrowing entirely (an earlier version
-      // of this fix) traded that rare miss for hard truncation at fetchSize on every page instead.
+    it('sends since as date_from and cursor.before as date_to to meetings, as best-effort narrowing', async () => {
+      // Meetings' occurred_at is derived from a field-fallback a single upstream date_field can't
+      // fully represent (see fetchPastMeetingEvents' own comment) — the upstream date params are
+      // best-effort narrowing to keep the fetched volume small, not a correctness guarantee. The
+      // in-memory since/cursor filter in getCommitteeActivity is what actually enforces the window;
+      // dropping the upstream narrowing entirely (an earlier version of this fix) traded that rare
+      // miss for hard truncation at fetchSize on every page instead.
       await service.getCommitteeActivity(req, COMMITTEE_UID, {
         since: '2026-01-01T00:00:00Z',
         cursor: { before: '2026-02-01T00:00:00Z', key: 'vote:unrelated' },
@@ -292,8 +292,8 @@ describe('CommitteeActivityService', () => {
       // ceiling test below) — an already-whole-second cursor still round-trips through
       // Date.toISOString(), which always emits milliseconds, hence the trailing `.000Z`. `since`
       // round-trips through the same normalizeTimestamp/Date.toISOString() call on the way in, so
-      // it picks up the identical `.000Z` — these three assertions cover that round-trip shape for
-      // an already-well-formed `since`; the dedicated "normalizes a zone-less since" test below
+      // it picks up the identical `.000Z` — this assertion covers that round-trip shape for an
+      // already-well-formed `since`; the dedicated "normalizes a zone-less since" test below
       // covers the actual reformatting case (a value Date.parse accepts but isn't RFC3339 yet).
       expect(getMeetings).toHaveBeenCalledWith(
         req,
@@ -301,10 +301,34 @@ describe('CommitteeActivityService', () => {
         'v1_past_meeting',
         false
       );
-      expect(getVotes).toHaveBeenCalledWith(
-        req,
-        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' })
-      );
+    });
+
+    it('sends cursor.before as date_to to votes, but never since as date_from (GH-1967 review)', async () => {
+      // A deadline-driven vote_closed (isVoteDeadlinePast in mapVoteToEvent) can occur with no
+      // write to last_modified_time at all, so a date_from on it was systematically excluding
+      // exactly the votes `since` is meant to include, not a rare best-effort miss — the same
+      // failure class surveys already opted out of date_from for. date_to has no equivalent
+      // failure (over-inclusion is safe, trimmed by the in-memory pass) and is still sent, to keep
+      // Recent Activity's own cursor pagination able to reach older votes.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        since: '2026-01-01T00:00:00Z',
+        cursor: { before: '2026-02-01T00:00:00Z', key: 'vote:unrelated' },
+        limit: 8,
+      });
+
+      expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_field: 'last_modified_time', date_to: '2026-02-01T00:00:00.000Z' }));
+      expect(getVotes).toHaveBeenCalledWith(req, expect.not.objectContaining({ date_from: expect.anything() }));
+    });
+
+    it('sends no date_field/date_from/date_to to votes when only since is set, no cursor', async () => {
+      // Complements the paired test above — without a cursor, votes now sends none of the three
+      // date params at all (the same shape surveys already has), unlike meetings/files which still
+      // send date_from as best-effort narrowing.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', limit: 8 });
+
+      expect(getVotes).toHaveBeenCalledWith(req, expect.not.objectContaining({ date_field: expect.anything() }));
+      expect(getVotes).toHaveBeenCalledWith(req, expect.not.objectContaining({ date_from: expect.anything() }));
+      expect(getVotes).toHaveBeenCalledWith(req, expect.not.objectContaining({ date_to: expect.anything() }));
     });
 
     it('sends no date_field/date_from/date_to to the survey leg, even with since and cursor set', async () => {
@@ -389,7 +413,7 @@ describe('CommitteeActivityService', () => {
       vi.stubEnv('TZ', 'UTC');
       await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-05T00:00:00', limit: 8 });
 
-      expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_from: '2026-01-05T00:00:00.000Z' }));
+      expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ date_from: '2026-01-05T00:00:00.000Z' }), 'v1_past_meeting', false);
     });
 
     it.each([
@@ -443,6 +467,21 @@ describe('CommitteeActivityService', () => {
 
       expect(result.data).toHaveLength(1);
       expect(result.page_token).toBeUndefined();
+    });
+
+    it('keeps any_leg_saturated true even when page_token is dropped because every fetched row was filtered out of the merged pool (GH-1967 review)', async () => {
+      // The gap Copilot flagged: hasMore/page_token need a real lastPageItem to anchor a cursor on,
+      // so if the in-memory since filter drops every row from every leg (here: a saturated votes
+      // leg whose only fetched row is before `since`), page_token comes back undefined even though
+      // the votes leg's own upstream page was genuinely saturated — any_leg_saturated is read
+      // directly off each leg's own saturation and isn't affected by what survived filtering.
+      getVotes.mockResolvedValue({ data: [vote({ creation_time: '2020-01-01T00:00:00Z' })], page_token: 'more-votes-upstream' });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', limit: 8 });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.page_token).toBeUndefined();
+      expect(result.any_leg_saturated).toBe(true);
     });
 
     it('requests page_size = max(limit + 1, 25) from every source', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -178,7 +178,7 @@ describe('CommitteeActivityService', () => {
 
   it('returns an empty feed when every source is empty', async () => {
     const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-    expect(result).toEqual({ data: [], page_token: undefined });
+    expect(result).toEqual({ data: [], page_token: undefined, any_leg_failed: false });
   });
 
   it('merges all four sources and sorts the result by occurred_at descending', async () => {
@@ -745,6 +745,10 @@ describe('CommitteeActivityService', () => {
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data.map((e) => e.type)).toEqual(['vote_opened']);
       expect(warning).toHaveBeenCalled();
+      // GH-1967 review: a leg failure must be surfaced on the response, not just swallowed into an
+      // indistinguishable-from-empty `{events: [], saturated: false}` — see any_leg_failed's own
+      // interface doc comment (activity-event.internal.interface.ts) for why.
+      expect(result.any_leg_failed).toBe(true);
     });
 
     it('renders the other three sources when votes fail', async () => {
@@ -753,6 +757,7 @@ describe('CommitteeActivityService', () => {
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+      expect(result.any_leg_failed).toBe(true);
     });
 
     it('renders the other three sources when surveys fail', async () => {
@@ -795,6 +800,21 @@ describe('CommitteeActivityService', () => {
       // as the real, current message; the pre-existing folders-failure test above never exercised
       // this leg's own message, so this substring was previously pinned nowhere in the suite.
       expect(warning).toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('committee files'), expect.anything());
+    });
+
+    it('does not set any_leg_failed for a folders/links/files sub-fetch failure inside the document leg', async () => {
+      // fetchDocumentEvents catches folders/links/files individually and never rejects the whole
+      // document leg for one of them failing — any_leg_failed only tracks the outer per-leg catch
+      // in getCommitteeActivity (see its own doc comment), a deliberately narrower scope than every
+      // failure this endpoint can encounter.
+      getMeetings.mockResolvedValue({ data: [pastMeeting()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.any_leg_failed).toBe(false);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1290,13 +1290,15 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0].type).toBe('vote_closed');
     });
 
-    it("carries the vote's creation_time as payload.opened_at even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
+    it("carries the vote's creation_time as payload.opened_at and its end_time even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
       getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ENDED, creation_time: '2026-01-02T10:00:00Z', end_time: '2026-01-10T00:00:00Z' })] });
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      // end_time rides along for the weekly-brief staleness gate — upstream's VoteSource windows
+      // on it alone (GH-1967 Copilot review).
       expect(result.data[0]).toMatchObject({
         type: 'vote_closed',
         occurred_at: '2026-01-10T00:00:00Z',
-        payload: expect.objectContaining({ opened_at: '2026-01-02T10:00:00Z' }),
+        payload: expect.objectContaining({ opened_at: '2026-01-02T10:00:00Z', end_time: '2026-01-10T00:00:00Z' }),
       });
     });
 
@@ -1461,7 +1463,7 @@ describe('CommitteeActivityService', () => {
       expect(byType['survey_published']).toMatchObject({ payload: { survey_uid: 'survey-open' } });
     });
 
-    it("carries the survey's created_at as payload.opened_at even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
+    it("carries the survey's created_at as payload.opened_at and its cutoff_date even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'survey') {
           return Promise.resolve({
@@ -1474,6 +1476,7 @@ describe('CommitteeActivityService', () => {
                   survey_status: SurveyStatus.CLOSED,
                   created_at: '2026-01-01T00:00:00Z',
                   last_modified_at: '2026-01-05T00:00:00Z',
+                  survey_cutoff_date: '2026-01-06T00:00:00Z',
                 }),
               },
             ],
@@ -1483,10 +1486,13 @@ describe('CommitteeActivityService', () => {
       });
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      // Explicit CLOSED status (not a cutoff-driven closure), so occurred_at stays last_modified_at
+      // — and cutoff_date still rides along for the weekly-brief staleness gate, upstream's
+      // SurveySource window field (GH-1967 Copilot review).
       expect(result.data[0]).toMatchObject({
         type: 'survey_closed',
         occurred_at: '2026-01-05T00:00:00Z',
-        payload: expect.objectContaining({ opened_at: '2026-01-01T00:00:00Z' }),
+        payload: expect.objectContaining({ opened_at: '2026-01-01T00:00:00Z', cutoff_date: '2026-01-06T00:00:00Z' }),
       });
     });
   });

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1463,7 +1463,7 @@ describe('CommitteeActivityService', () => {
       expect(byType['survey_published']).toMatchObject({ payload: { survey_uid: 'survey-open' } });
     });
 
-    it("carries the survey's created_at as payload.opened_at and its cutoff_date even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
+    it('falls back to created_at for payload.opened_at when a survey has no send date, and still carries its cutoff_date (GH-1967 review)', async () => {
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'survey') {
           return Promise.resolve({
@@ -1487,12 +1487,44 @@ describe('CommitteeActivityService', () => {
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       // Explicit CLOSED status (not a cutoff-driven closure), so occurred_at stays last_modified_at
-      // — and cutoff_date still rides along for the weekly-brief staleness gate, upstream's
-      // SurveySource window field (GH-1967 Copilot review).
+      // — and with no survey_send_date on the row, opened_at falls back to created_at while
+      // cutoff_date still rides along for the weekly-brief staleness gate (GH-1967 Copilot review).
       expect(result.data[0]).toMatchObject({
         type: 'survey_closed',
         occurred_at: '2026-01-05T00:00:00Z',
         payload: expect.objectContaining({ opened_at: '2026-01-01T00:00:00Z', cutoff_date: '2026-01-06T00:00:00Z' }),
+      });
+    });
+
+    it('prefers survey_send_date over created_at for payload.opened_at — a scheduled survey opens when it sends, not when it is created (GH-1967 Copilot review)', async () => {
+      // ITX's survey API is a schedule API (POST /v2/surveys/schedule requires a future
+      // survey_send_date), so created_at is the record-creation moment, not the publish moment.
+      // SENT with a far-future cutoff keeps the survey published (not cutoff-closed) for this test.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'survey',
+                id: 'survey-scheduled',
+                data: survey({
+                  uid: 'survey-scheduled',
+                  survey_status: SurveyStatus.SENT,
+                  survey_cutoff_date: '2099-01-01T00:00:00Z',
+                  created_at: '2026-01-01T00:00:00Z',
+                  survey_send_date: '2026-01-05T09:00:00Z',
+                }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0]).toMatchObject({
+        type: 'survey_published',
+        payload: expect.objectContaining({ opened_at: '2026-01-05T09:00:00Z' }),
       });
     });
   });

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1290,6 +1290,16 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0].type).toBe('vote_closed');
     });
 
+    it("carries the vote's creation_time as payload.opened_at even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ENDED, creation_time: '2026-01-02T10:00:00Z', end_time: '2026-01-10T00:00:00Z' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0]).toMatchObject({
+        type: 'vote_closed',
+        occurred_at: '2026-01-10T00:00:00Z',
+        payload: expect.objectContaining({ opened_at: '2026-01-02T10:00:00Z' }),
+      });
+    });
+
     it('maps an active vote to vote_opened only', async () => {
       getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE })] });
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
@@ -1449,6 +1459,35 @@ describe('CommitteeActivityService', () => {
       const byType = Object.fromEntries(result.data.map((e) => [e.type, e]));
       expect(byType['survey_closed']).toMatchObject({ payload: { survey_uid: 'survey-closed' } });
       expect(byType['survey_published']).toMatchObject({ payload: { survey_uid: 'survey-open' } });
+    });
+
+    it("carries the survey's created_at as payload.opened_at even once closed, independent of the collapsed occurred_at (GH-1967 review)", async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'survey',
+                id: 'survey-closed',
+                data: survey({
+                  uid: 'survey-closed',
+                  survey_status: SurveyStatus.CLOSED,
+                  created_at: '2026-01-01T00:00:00Z',
+                  last_modified_at: '2026-01-05T00:00:00Z',
+                }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0]).toMatchObject({
+        type: 'survey_closed',
+        occurred_at: '2026-01-05T00:00:00Z',
+        payload: expect.objectContaining({ opened_at: '2026-01-01T00:00:00Z' }),
+      });
     });
   });
 });

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -248,15 +248,19 @@ export class CommitteeActivityService {
     // (filter-dimension) caveats discussed next, just in the sort dimension
     // instead.
     //
-    // Filter dimension: votes/files each filter on a single upstream `date_field` that only
-    // approximates their own multi-field occurred_at derivation (see each leg's own comment for
-    // which field and why) — sending that imperfect narrowing upstream still beats sending none at
-    // all, which was tried and reverted earlier in this file's history: it traded the rare
-    // filter-mismatch miss for hard truncation at `fetchSize` on every page instead, a strictly worse
-    // failure mode. The in-memory since/cursor pass in getCommitteeActivity is the correctness
-    // backstop against over-inclusion for both legs, not under-inclusion — an imperfectly-narrowed
-    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys
-    // send no `date_field` at all for a `date_from` reason: unlike votes/files, a survey's
+    // Filter dimension: files filters on a single upstream `date_field` that only approximates its
+    // own multi-field occurred_at derivation (see fetchDocumentEvents's own comment for which field
+    // and why) — sending that imperfect narrowing upstream still beats sending none at all, which
+    // was tried and reverted earlier in this file's history: it traded the rare filter-mismatch
+    // miss for hard truncation at `fetchSize` on every page instead, a strictly worse failure mode.
+    // The in-memory since/cursor pass in getCommitteeActivity is the correctness backstop against
+    // over-inclusion for files, not under-inclusion — an imperfectly-narrowed leg can still exclude
+    // a real in-window row upstream before that pass ever sees it. Votes (GH-1967 review) moved out
+    // of this bucket into the notes/surveys one below: a deadline-driven `vote_closed` can occur
+    // with no write to `last_modified_time` at all, so a `date_from` there wasn't a rare
+    // filter-mismatch miss the way files' is — it was systematic, the same failure class surveys
+    // documents next, so votes now only sends `date_to` (see fetchVoteEvents's own comment).
+    // Surveys send no `date_field` at all for a `date_from` reason: unlike files, a survey's
     // cutoff-driven occurred_at isn't bounded below by any field the row gets written to, so
     // date_field narrowing there would systematically (not rarely) exclude exactly the rows `since`
     // is meant to include — see fetchSurveyEvents. That reasoning only covers `date_from`, though;
@@ -462,15 +466,19 @@ export class CommitteeActivityService {
     // is still present. `anyLegSaturated` (above) already correctly reflects this via each leg's
     // real `page_token` (not row count) — but if EVERY leg's single page happens to filter down to
     // zero visible rows, `windowed`/`page` end up empty too, `lastPageItem` is undefined, and
-    // `hasMore` forces `false` regardless of `anyLegSaturated`: this response looks terminal even
-    // though a later upstream page (of any saturated leg) could contain rows this caller is
-    // authorized to see. Closing this for real means looping a leg's own upstream call until a
-    // visible candidate or exhaustion — ruled out for v1 by the ticket's "bounded calls, no
-    // per-event follow-ups" requirement (same constraint documented at the top of this method).
-    // Accepted as a known residual (per-request, not per-response — a follow-up request with the
-    // same `since`/no cursor would simply re-run this same fetch and could still surface nothing
-    // new if the access-filtering pattern hasn't changed), not solved by a second round-trip within
-    // this call.
+    // `hasMore`/`pageToken` force to a terminal-looking `false`/`undefined` regardless of
+    // `anyLegSaturated`, even though a later upstream page (of any saturated leg) could contain rows
+    // this caller is authorized to see. A second round-trip within this call would close it for
+    // real (looping a leg's own upstream call until a visible candidate or exhaustion) — ruled out
+    // for v1 by the ticket's "bounded calls, no per-event follow-ups" requirement (same constraint
+    // documented at the top of this method) — so instead `any_leg_saturated` (GH-1967 review) is
+    // returned on the response directly, independent of whether `pageToken` survived the
+    // `lastPageItem` computation, letting a completeness-sensitive caller (e.g.
+    // `WeeklyBriefService#withStaleness`) distrust an empty-looking result without needing a second
+    // request. Same fix closes an unrelated but structurally identical gap: `fetchSurveyEvents`'
+    // page, sorted by `updated_desc` rather than `occurred_at`, can be entirely filtered out of
+    // `windowed` by a cutoff-driven closure whose `occurred_at` doesn't match its sort position,
+    // even though the survey leg's own upstream page was genuinely saturated.
     const lastPageItem = page.at(-1);
     const hasMore = (windowed.length > limit || anyLegSaturated) && !!lastPageItem;
     const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
@@ -493,7 +501,7 @@ export class CommitteeActivityService {
       fetch_size: fetchSize,
     });
 
-    return { data, page_token: pageToken, any_leg_failed: anyLegFailed };
+    return { data, page_token: pageToken, any_leg_saturated: anyLegSaturated, any_leg_failed: anyLegFailed };
   }
 
   // ─── Committee (for enable_voting) ─────────────────────────────────────────
@@ -651,19 +659,21 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number
   ): Promise<{ events: (VoteOpenedActivityEvent | VoteClosedActivityEvent)[]; saturated: boolean }> {
-    // date_field: 'last_modified_time' is best-effort narrowing (see the filter-dimension paragraph
-    // in getCommitteeActivity's fetchSize comment for why narrowing imperfectly still beats not
-    // narrowing at all) — a vote's occurred_at is actually
-    // end_time/early_end_time/last_modified_time/creation_time depending on status, not always
-    // last_modified_time.
-    const hasWindow = !!since || !!before;
+    // date_to only, never date_from (GH-1967 review) — same asymmetry as fetchNotesAddedEvents,
+    // same reason as fetchSurveyEvents' own no-narrowing-at-all: a vote's occurred_at is actually
+    // end_time/early_end_time/last_modified_time/creation_time depending on status, and a
+    // deadline-driven vote_closed (isVoteDeadlinePast in mapVoteToEvent, below) can fire with no
+    // corresponding write to last_modified_time at all — a date_from on last_modified_time would
+    // then systematically exclude exactly the votes `since` is meant to include, not just
+    // best-effort-miss them (Copilot caught this once the staleness signal started depending on
+    // this leg's completeness). date_to has no equivalent failure — over-inclusion on the upper
+    // bound is always safe, trimmed by the in-memory since/cursor pass in getCommitteeActivity —
+    // and is still needed for Recent Activity's own cursor pagination to reach older votes.
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
-      ...(hasWindow && { date_field: 'last_modified_time' }),
-      ...(since && { date_from: since }),
-      ...(before && { date_to: before }),
+      ...(before && { date_field: 'last_modified_time', date_to: before }),
     };
 
     // page_token — see the saturation comment in getCommitteeActivity for why this is preferred
@@ -716,16 +726,17 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number
   ): Promise<{ events: (SurveyPublishedActivityEvent | SurveyClosedActivityEvent)[]; saturated: boolean }> {
-    // No date_field/date_from/date_to on this leg — unlike votes/files, surveys have a mode of
+    // No date_field/date_from/date_to on this leg — unlike files, surveys have a mode of
     // occurred_at (a cutoff-driven closure, see isCutoffDrivenClosure/mapSurveyToEvent below) that
     // is NOT bounded below by last_modified_at: a SENT survey can sit with an old last_modified_at
     // while its real occurred_at (survey_cutoff_date) is still in the future relative to that
     // write, with no upstream write ever marking the transition. Narrowing on
     // date_field: 'last_modified_at' (the previous approach) would upstream-exclude exactly that
     // row whenever `since` falls between its last_modified_at and its cutoff-driven occurred_at —
-    // not a rare-edge best-effort miss like the votes/files legs' narrowing, but a systematic one
-    // for every cutoff-driven closure `since` is meant to include (Copilot caught this on this
-    // leg's initial cutoff fix). Dropping upstream date narrowing here entirely closes that: this
+    // not a rare-edge best-effort miss like the files leg's narrowing, but a systematic one for
+    // every cutoff-driven closure `since` is meant to include (Copilot caught this on this leg's
+    // initial cutoff fix; votes had the same systematic gap for deadline-driven closures, fixed the
+    // same way — see fetchVoteEvents). Dropping upstream date narrowing here entirely closes that: this
     // leg falls back to the same "Known v1 limitation" already documented at the top of
     // getCommitteeActivity for every page_size-bounded leg (a survey outside the top-fetchSize
     // slice by `sort: updated_desc` can still be missed), which is an honest, pre-existing

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -713,7 +713,11 @@ export class CommitteeActivityService {
       type: isClosed ? 'vote_closed' : 'vote_opened',
       occurred_at: occurredAt,
       committee_uid: committeeUid,
-      payload: { vote_uid: vote.uid, name: vote.name, status: vote.status },
+      // opened_at (GH-1967 review) — always the vote's own creation_time, independent of isClosed,
+      // so a closed vote's collapsed occurred_at (its close moment) doesn't hide the fact that it
+      // opened at a different, potentially independently-relevant time. See
+      // VoteActivityEventPayload's own doc comment for why.
+      payload: { vote_uid: vote.uid, name: vote.name, status: vote.status, opened_at: firstValidTimestamp(vote.creation_time) || undefined },
     };
   }
 
@@ -782,7 +786,11 @@ export class CommitteeActivityService {
       type: displayStatus === SurveyStatus.CLOSED ? 'survey_closed' : 'survey_published',
       occurred_at: occurredAt,
       committee_uid: committeeUid,
-      payload: { survey_uid: survey.uid, title: survey.survey_title, status: displayStatus },
+      // opened_at (GH-1967 review) — always the survey's own created_at (its publish moment),
+      // independent of displayStatus, so a closed survey's collapsed occurred_at (its cutoff-driven
+      // closure) doesn't hide the fact that it published at a different, potentially
+      // independently-relevant time. See SurveyActivityEventPayload's own doc comment for why.
+      payload: { survey_uid: survey.uid, title: survey.survey_title, status: displayStatus, opened_at: firstValidTimestamp(survey.created_at) || undefined },
     };
   }
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -14,9 +14,9 @@ import type {
   CommitteeActivityLink,
   CommitteeActivityNoteAttachment,
   CommitteeActivityQuery,
+  CommitteeActivityResponse,
   DocumentUploadedActivityEvent,
   NotesAddedActivityEvent,
-  PaginatedResponse,
   PastMeeting,
   QueryServiceResponse,
   Survey,
@@ -188,7 +188,7 @@ export class CommitteeActivityService {
     this.voteService = new VoteService();
   }
 
-  public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<PaginatedResponse<ActivityEvent>> {
+  public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<CommitteeActivityResponse> {
     const { since: rawSince, cursor, limit } = options;
     // Same reject-not-degrade policy as the cursor/since checks below, for the same reason:
     // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
@@ -349,29 +349,52 @@ export class CommitteeActivityService {
     // "complex multi-step orchestration" case logging-patterns.md reserves INFO for.
     logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
 
+    // Tracked via closure side-effect (not folded into each leg's own resolved shape) so a failed
+    // leg's `{events: [], saturated: false}` return keeps the exact type each fetch* method already
+    // declares — adding a `failed` field there would turn every leg's resolved type into a
+    // success/failure union and force a runtime type-guard at every one of their many read sites
+    // below, for a value only this one aggregate ever needs.
+    let pastMeetingFailed = false;
+    let voteFailed = false;
+    let surveyFailed = false;
+    let documentFailed = false;
+    let notesFailed = false;
+
     const [committee, pastMeetingResult, voteResult, surveyResult, documentResult, notesResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
       this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
+        pastMeetingFailed = true;
         return { events: [], saturated: false };
       }),
       this.fetchVoteEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch vote activity, continuing without it', { committee_uid: committeeUid, err });
+        voteFailed = true;
         return { events: [], saturated: false };
       }),
       this.fetchSurveyEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch survey activity, continuing without it', { committee_uid: committeeUid, err });
+        surveyFailed = true;
         return { events: [], saturated: false };
       }),
       this.fetchDocumentEvents(req, committeeUid, since, before, fetchSize, cursor).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch document activity, continuing without it', { committee_uid: committeeUid, err });
+        documentFailed = true;
         return { events: [], saturated: false };
       }),
       this.fetchNotesAddedEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch notes activity, continuing without it', { committee_uid: committeeUid, err });
+        notesFailed = true;
         return { events: [], saturated: false };
       }),
     ]);
+
+    // Only meetings/votes/surveys count toward staleness (WEEKLY_BRIEF_STALENESS_EVENT_TYPES,
+    // GH-1966/#1967) — documents/notes are included too rather than narrowed to just those three,
+    // since this flag is generic to the endpoint (also read by the Recent Activity feed, which has
+    // no such narrowing) and a caller-specific leg subset would need to be threaded through
+    // CommitteeActivityQuery to compute correctly here.
+    const anyLegFailed = pastMeetingFailed || voteFailed || surveyFailed || documentFailed || notesFailed;
 
     // A committee-lookup failure already rejected the whole Promise.all above (see fetchCommittee's
     // doc comment) — by this line `committee` is always a resolved Committee.
@@ -466,10 +489,11 @@ export class CommitteeActivityService {
       // log alone — has_more can now be true without windowed.length exceeding limit, and a leg
       // count only signals saturation when compared against fetch_size (also not logged elsewhere).
       any_leg_saturated: anyLegSaturated,
+      any_leg_failed: anyLegFailed,
       fetch_size: fetchSize,
     });
 
-    return { data, page_token: pageToken };
+    return { data, page_token: pageToken, any_leg_failed: anyLegFailed };
   }
 
   // ─── Committee (for enable_voting) ─────────────────────────────────────────

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -795,10 +795,15 @@ export class CommitteeActivityService {
       type: displayStatus === SurveyStatus.CLOSED ? 'survey_closed' : 'survey_published',
       occurred_at: occurredAt,
       committee_uid: committeeUid,
-      // opened_at (GH-1967 review) — always the survey's own created_at (its publish moment),
-      // independent of displayStatus, so a closed survey's collapsed occurred_at (its cutoff-driven
-      // closure) doesn't hide the fact that it published at a different, potentially
-      // independently-relevant time. See SurveyActivityEventPayload's own doc comment for why.
+      // opened_at (GH-1967 review) — the survey's PUBLISH moment, independent of displayStatus, so
+      // a closed survey's collapsed occurred_at (its cutoff-driven closure) doesn't hide the fact
+      // that it opened at a different, potentially independently-relevant time. The publish moment
+      // is survey_send_date, NOT created_at: ITX's survey API is a schedule API (POST
+      // /v2/surveys/schedule requires survey_send_date in the future), so a scheduled survey is
+      // created well before it actually goes out — keying on created_at would misdate it (GH-1967
+      // Copilot review: a survey created before a weekly brief but sent after it would be missed by
+      // withStaleness's opened_at fallback). created_at stays as the fallback for rows with no send
+      // date. See SurveyActivityEventPayload's own doc comment for why opened_at exists at all.
       // cutoff_date (GH-1967 Copilot review) — upstream's weekly-brief SurveySource windows on
       // survey_cutoff_date and requires it to have already passed, so publication alone is never
       // brief-relevant; carried so the staleness signal can apply the same rule.
@@ -806,7 +811,7 @@ export class CommitteeActivityService {
         survey_uid: survey.uid,
         title: survey.survey_title,
         status: displayStatus,
-        opened_at: firstValidTimestamp(survey.created_at) || undefined,
+        opened_at: firstValidTimestamp(survey.survey_send_date ?? undefined, survey.created_at) || undefined,
         cutoff_date: firstValidTimestamp(survey.survey_cutoff_date ?? undefined) || undefined,
       },
     };

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -716,8 +716,17 @@ export class CommitteeActivityService {
       // opened_at (GH-1967 review) — always the vote's own creation_time, independent of isClosed,
       // so a closed vote's collapsed occurred_at (its close moment) doesn't hide the fact that it
       // opened at a different, potentially independently-relevant time. See
-      // VoteActivityEventPayload's own doc comment for why.
-      payload: { vote_uid: vote.uid, name: vote.name, status: vote.status, opened_at: firstValidTimestamp(vote.creation_time) || undefined },
+      // VoteActivityEventPayload's own doc comment for why. end_time (GH-1967 Copilot review) is
+      // carried for the same caller: upstream's weekly-brief VoteSource windows on end_time alone
+      // (NOT early_end_time — vote_source.go's date_field=end_time), so an in-window early close of
+      // a vote whose scheduled end_time falls outside the window is still not brief-relevant.
+      payload: {
+        vote_uid: vote.uid,
+        name: vote.name,
+        status: vote.status,
+        opened_at: firstValidTimestamp(vote.creation_time) || undefined,
+        end_time: firstValidTimestamp(vote.end_time) || undefined,
+      },
     };
   }
 
@@ -790,7 +799,16 @@ export class CommitteeActivityService {
       // independent of displayStatus, so a closed survey's collapsed occurred_at (its cutoff-driven
       // closure) doesn't hide the fact that it published at a different, potentially
       // independently-relevant time. See SurveyActivityEventPayload's own doc comment for why.
-      payload: { survey_uid: survey.uid, title: survey.survey_title, status: displayStatus, opened_at: firstValidTimestamp(survey.created_at) || undefined },
+      // cutoff_date (GH-1967 Copilot review) — upstream's weekly-brief SurveySource windows on
+      // survey_cutoff_date and requires it to have already passed, so publication alone is never
+      // brief-relevant; carried so the staleness signal can apply the same rule.
+      payload: {
+        survey_uid: survey.uid,
+        title: survey.survey_title,
+        status: displayStatus,
+        opened_at: firstValidTimestamp(survey.created_at) || undefined,
+        cutoff_date: firstValidTimestamp(survey.survey_cutoff_date ?? undefined) || undefined,
+      },
     };
   }
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -97,7 +97,7 @@ vi.mock('@lfx-one/shared/constants', () => ({
   AI_MODEL: 'mock-ai-model',
   VALKEY_CACHE: { WEEKLY_BRIEF_RATING_TTL_SECONDS: 7_776_000, WEEKLY_BRIEF_ACTION_ITEMS_TTL_SECONDS: 604800 },
   ACTIVITY_FEED_MAX_PAGE_SIZE: 50,
-  WEEKLY_BRIEF_STALENESS_EVENT_TYPES: ['meeting_held', 'vote_opened', 'vote_closed', 'document_uploaded'],
+  WEEKLY_BRIEF_STALENESS_EVENT_TYPES: ['meeting_held', 'vote_opened', 'vote_closed', 'survey_published', 'survey_closed'],
 }));
 // '../constants' (this app's server-only constants, not the `@lfx-one/shared` package) is
 // plain string/number literals with no transitive Angular imports — safe to leave unmocked,
@@ -726,13 +726,10 @@ describe('WeeklyBriefService', () => {
       });
     });
 
-    it('excludes a survey/notes event from the count — those feed event types are not brief sources, so regenerating could never reflect them', async () => {
+    it('excludes a notes event from the count — notes_added is not a brief source, so regenerating could never reflect it', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [
-          { type: 'survey_published', occurred_at: '2026-01-17T10:00:00.000Z' },
-          { type: 'notes_added', occurred_at: '2026-01-17T11:00:00.000Z' },
-        ],
+        data: [{ type: 'notes_added', occurred_at: '2026-01-17T11:00:00.000Z' }],
       });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -740,10 +737,14 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
     });
 
-    it('counts a document_uploaded event, and still counts a meeting/vote event alongside an excluded survey event', async () => {
+    it('counts survey_published/survey_closed events, and still excludes a document_uploaded event alongside a counted meeting/vote event — GH-1967 review: survey feeds the generator, document does not', async () => {
+      // Verified against lfx-v2-committee-service's buildClaimsAndRefs (group_weekly_brief_generator.go):
+      // it emits Kind: "survey" (fed into ClaimEvidence, the generator's actual LLM input) but never
+      // a "document"/"doc" kind — the original event-type list had this backwards.
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
+          { type: 'survey_published', occurred_at: '2026-01-17T08:30:00.000Z' },
           { type: 'survey_closed', occurred_at: '2026-01-17T09:00:00.000Z' },
           { type: 'document_uploaded', occurred_at: '2026-01-17T10:00:00.000Z' },
           { type: 'vote_opened', occurred_at: '2026-01-17T11:00:00.000Z' },
@@ -752,7 +753,7 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toEqual({ stale: true, event_count: 2, event_count_is_floor: false });
+      expect(result.staleness).toEqual({ stale: true, event_count: 3, event_count_is_floor: false });
     });
 
     it('carries both caller_rating and staleness together in the merged response (general review finding — the parallel-await merge is otherwise untested with both enrichments actually populated)', async () => {
@@ -829,6 +830,34 @@ describe('WeeklyBriefService', () => {
 
       expect(result.staleness).toBeNull();
       expect(logger.warning).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports unknown (null), not a false negative, when a committee-activity leg failed and nothing relevant turned up (GH-1967 review)', async () => {
+      // any_leg_failed means at least one of getCommitteeActivity's 5 legs was caught-and-degraded
+      // to {events: [], saturated: false} on a fetch failure — indistinguishable from that leg
+      // genuinely having nothing, so a confident "not stale" here would risk a false negative the
+      // same way an unfetched saturated page does.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({ data: [], any_leg_failed: true });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
+    });
+
+    it('still reports stale (not a degrade) when a committee-activity leg failed but other legs already found real qualifying activity', async () => {
+      // A leg failure can only hide a real positive, never manufacture a false one — once relevant
+      // activity has already been found, any_leg_failed on a different leg doesn't undermine it.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'meeting_held', occurred_at: '2026-01-17T10:00:00.000Z' }],
+        any_leg_failed: true,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: true, event_count: 1, event_count_is_floor: false });
     });
 
     it('marks event_count as a floor when the activity fetch itself paginated', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -654,11 +654,22 @@ describe('WeeklyBriefService', () => {
   });
 
   describe('getCurrentBrief — staleness enrichment (GH-1966)', () => {
+    // window_end deliberately far in the future (year 2030) rather than relative to "today" —
+    // this is the ONLY case briefWindow() can produce a still-open window (same-day Saturday),
+    // and pinning it far ahead keeps the fixture valid regardless of the real date this suite
+    // runs on, with no fake-timer dependency. updated_at doesn't need to be "real" — the code
+    // never compares it to "now", only to activity-event timestamps the test controls directly.
     const liveBrief = {
       uid: 'b1',
       state: 'generated',
-      updated_at: '2026-08-24T00:00:00.000Z',
-      window_end: '2026-08-30T23:59:59.999Z',
+      updated_at: '2030-01-03T00:00:00.000Z',
+      window_end: '2030-01-10T23:59:59.999Z', // window still open relative to any real test-run time
+    };
+    // Same brief, but for a window that already closed — the common case (6 of 7 days) per
+    // briefWindow(), and the one staleness must now stay silent on (general review finding).
+    const closedWindowBrief = {
+      ...liveBrief,
+      window_end: '2020-01-04T23:59:59.999Z', // safely in the past
     };
 
     beforeEach(() => {
@@ -690,12 +701,12 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: liveBrief.updated_at, limit: 50 });
     });
 
-    it('reports stale with the in-window event count', async () => {
+    it('reports stale with the event count, while the window is still open', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
-          { type: 'meeting_held', occurred_at: '2026-08-27T18:00:00.000Z' },
-          { type: 'vote_closed', occurred_at: '2026-08-26T09:00:00.000Z' },
+          { type: 'meeting_held', occurred_at: '2025-06-15T18:00:00.000Z' },
+          { type: 'vote_closed', occurred_at: '2025-06-14T09:00:00.000Z' },
         ],
       });
 
@@ -714,7 +725,7 @@ describe('WeeklyBriefService', () => {
       const key = buildWeeklyBriefRatingCacheKeyMock('committee-1', brief.uid, brief.revision, 'alice')!;
       valkeyStore.set(key, { rating: 'up' });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2026-08-27T18:00:00.000Z' }],
+        data: [{ type: 'meeting_held', occurred_at: '2025-06-15T18:00:00.000Z' }],
       });
 
       const result = await service.getCurrentBrief(userReq, 'committee-1');
@@ -725,21 +736,47 @@ describe('WeeklyBriefService', () => {
       });
     });
 
-    it('counts activity after brief.window_end as stale too — not scoped to the nominal week (GH-1966 fix: window_end almost always precedes updated_at by design, see briefWindow())', async () => {
+    it("skips the fetch entirely and reports null when the brief's own window has already closed — the common case (general review finding: a closed-week brief can't be updated by regenerating against a later week's activity)", async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: closedWindowBrief, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
+    it('excludes a future-dated event from the count (general review finding: the feed can return a vote already ENDED but stamped with a still-future end_time)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2026-09-02T10:00:00.000Z' }], // after liveBrief.window_end
+        data: [{ type: 'vote_closed', occurred_at: '2030-01-05T00:00:00.000Z' }], // after "now", still before window_end
       });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toEqual({ stale: true, event_count: 1, event_count_is_floor: false });
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
+    it('reports unknown (null), not a false negative, when the fetch saturated and nothing relevant turned up on this page', async () => {
+      // getCommitteeActivity sorts descending by occurred_at, so future-dated events (excluded
+      // by the "now" ceiling) sort ahead of genuinely relevant ones. If the fetch itself
+      // saturated (page_token set) and every returned event is future-dated, real relevant
+      // activity could still be sitting on a page never fetched — a confident `stale: false`
+      // there would be a false negative, not a floor-qualified true.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'vote_closed', occurred_at: '2030-01-05T00:00:00.000Z' }],
+        page_token: 'next-page',
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
     });
 
     it('marks event_count as a floor when the activity fetch itself paginated', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2026-08-27T18:00:00.000Z' }],
+        data: [{ type: 'meeting_held', occurred_at: '2025-06-15T18:00:00.000Z' }],
         page_token: 'next-page',
       });
 
@@ -756,7 +793,12 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(logger.warning).toHaveBeenCalledTimes(1);
-      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ updated_at: null }));
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'weekly_brief_staleness',
+        expect.any(String),
+        expect.objectContaining({ updated_at: null, window_end: liveBrief.window_end })
+      );
     });
 
     it('degrades to null and logs the offending raw value when the brief has an unparseable updated_at', async () => {
@@ -768,6 +810,17 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(logger.warning).toHaveBeenCalledTimes(1);
       expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ updated_at: 'not-a-date' }));
+    });
+
+    it('degrades to null and logs the offending raw value when the brief has an unparseable window_end', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, window_end: 'not-a-date' }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
+      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ window_end: 'not-a-date' }));
     });
 
     it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -30,6 +30,7 @@ const {
   createNewsletterMock,
   sendNewsletterMock,
   deleteNewsletterMock,
+  getCommitteeActivityMock,
 } = vi.hoisted(() => {
   const valkeyStore = new Map<string, unknown>();
   const valkeyServiceMock = {
@@ -81,6 +82,8 @@ const {
     createNewsletterMock: vi.fn(),
     sendNewsletterMock: vi.fn(),
     deleteNewsletterMock: vi.fn(),
+    // withStaleness' (GH-1966) collaborator — controlled per-test in its own describe block below.
+    getCommitteeActivityMock: vi.fn(),
   };
 });
 
@@ -93,6 +96,7 @@ vi.mock('@lfx-one/shared/constants', () => ({
   NEWSLETTER_BODY_MAX_LENGTH: 100_000,
   AI_MODEL: 'mock-ai-model',
   VALKEY_CACHE: { WEEKLY_BRIEF_RATING_TTL_SECONDS: 7_776_000, WEEKLY_BRIEF_ACTION_ITEMS_TTL_SECONDS: 604800 },
+  ACTIVITY_FEED_MAX_PAGE_SIZE: 50,
 }));
 // '../constants' (this app's server-only constants, not the `@lfx-one/shared` package) is
 // plain string/number literals with no transitive Angular imports — safe to leave unmocked,
@@ -139,6 +143,15 @@ vi.mock('./access-check.service', () => ({
 vi.mock('./ai.service', () => ({
   AiService: class {
     public extractBriefActionItems = extractBriefActionItems;
+  },
+}));
+// withStaleness' (GH-1966) collaborator — real committee-activity.service.ts transitively
+// imports meeting/project services that need @lfx-one/shared/interfaces at runtime (an enum
+// value, not just types), which this file mocks to `{}` above — leaving this unmocked would
+// crash the module graph, same reasoning as every other sibling-service mock in this file.
+vi.mock('./committee-activity.service', () => ({
+  CommitteeActivityService: class {
+    public getCommitteeActivity = getCommitteeActivityMock;
   },
 }));
 // Single mock for both weekly-brief.service.ts collaborators that live in valkey.service —
@@ -622,6 +635,120 @@ describe('WeeklyBriefService', () => {
       proxyRequest.mockResolvedValueOnce({ brief: null, throttle: null });
       await service.getCurrentBrief(req, 'a/b c');
       expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', '/committees/a%2Fb%20c/weekly-briefs/current', 'GET');
+    });
+  });
+
+  describe('getCurrentBrief — staleness enrichment (GH-1966)', () => {
+    const liveBrief = {
+      uid: 'b1',
+      state: 'generated',
+      updated_at: '2026-08-24T00:00:00.000Z',
+      window_end: '2026-08-30T23:59:59.999Z',
+    };
+
+    beforeEach(() => {
+      process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
+    });
+
+    it('reports not stale when no qualifying activity is found', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({ data: [] });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false, most_recent_event_at: undefined });
+      expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: liveBrief.updated_at, limit: 50 });
+    });
+
+    it('reports stale with the in-window event count and most-recent timestamp', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          { type: 'meeting_held', occurred_at: '2026-08-27T18:00:00.000Z' },
+          { type: 'vote_closed', occurred_at: '2026-08-26T09:00:00.000Z' },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({
+        stale: true,
+        event_count: 2,
+        event_count_is_floor: false,
+        most_recent_event_at: '2026-08-27T18:00:00.000Z',
+      });
+    });
+
+    it('excludes events after the brief window_end (a later, unrelated week)', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'meeting_held', occurred_at: '2026-09-02T10:00:00.000Z' }],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false, most_recent_event_at: undefined });
+    });
+
+    it('marks event_count as a floor when the activity fetch itself paginated', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'meeting_held', occurred_at: '2026-08-27T18:00:00.000Z' }],
+        page_token: 'next-page',
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness?.event_count_is_floor).toBe(true);
+    });
+
+    it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockRejectedValueOnce(new Error('upstream unavailable'));
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.brief).toBe(liveBrief);
+      expect(result.staleness).toBeNull();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('skips the activity fetch entirely for a brief in a non-shareable state', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, state: 'generating' }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeUndefined();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
+    it('skips the activity fetch entirely when there is no brief', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: null, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeUndefined();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
+    it("generateBrief's response carries no staleness field — only getCurrentBrief computes it", async () => {
+      const data = { brief: { uid: 'b1', state: 'generating' }, throttle: {} };
+      proxyRequestWithResponse.mockResolvedValueOnce({ status: 202, data, statusText: 'Accepted', headers: {} });
+
+      const result = await service.generateBrief(req, 'committee-1', { force: true });
+
+      expect(result.data).not.toHaveProperty('staleness');
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
+    it('mock mode never invokes the activity fetch — staleness is always null (documented gap: CommitteeActivityService has no mock branch)', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -671,12 +671,13 @@ describe('WeeklyBriefService', () => {
       getCommitteeActivityMock.mockResolvedValueOnce({ data: [] });
 
       void service.getCurrentBrief(userReq, 'committee-1'); // not awaited — the rating lookup above never resolves
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // If withStaleness were still chained after withCallerRating, this could never fire while
-      // the rating lookup is stuck — it firing anyway proves the two now run concurrently.
-      expect(getCommitteeActivityMock).toHaveBeenCalled();
+      // vi.waitFor, not a fixed number of chained microtask flushes — a correct microtask count
+      // is an implementation detail of fetchCurrentBrief's own await depth, and would make this
+      // test fail with a misleading "still serial" result if that depth ever changes for an
+      // unrelated reason (general review finding). If withStaleness were still chained after
+      // withCallerRating, this could never resolve while the rating lookup is stuck — it
+      // resolving anyway proves the two now run concurrently.
+      await vi.waitFor(() => expect(getCommitteeActivityMock).toHaveBeenCalled());
     });
 
     it('reports not stale when no qualifying activity is found', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -667,6 +667,7 @@ describe('WeeklyBriefService', () => {
       uid: 'b1',
       state: 'generated',
       updated_at: '2026-01-17T08:00:00.000Z', // generated the same Saturday its window closes
+      window_start: '2026-01-11T00:00:00.000Z', // the Sunday opening that window
       window_end: '2026-01-17T23:59:59.999Z',
     };
     // Same brief shape, but generated AFTER its own window had already closed — the common case
@@ -676,6 +677,7 @@ describe('WeeklyBriefService', () => {
       uid: 'b1',
       state: 'generated',
       updated_at: '2026-01-15T09:00:00.000Z', // Thursday, after the window below already closed
+      window_start: '2026-01-04T00:00:00.000Z',
       window_end: '2026-01-10T23:59:59.999Z', // the previous Saturday
     };
 
@@ -713,7 +715,13 @@ describe('WeeklyBriefService', () => {
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
           { type: 'meeting_held', occurred_at: '2026-01-17T18:00:00.000Z' },
-          { type: 'vote_closed', occurred_at: '2026-01-17T10:00:00.000Z' },
+          // vote_closed's payload.end_time is what upstream's VoteSource windows on — in-window
+          // here, so the vote is regeneration-consumable and the event counts (GH-1967 Copilot).
+          {
+            type: 'vote_closed',
+            occurred_at: '2026-01-17T10:00:00.000Z',
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', end_time: '2026-01-17T10:00:00.000Z' },
+          },
         ],
       });
 
@@ -755,13 +763,27 @@ describe('WeeklyBriefService', () => {
       // Verified against lfx-v2-committee-service's buildClaimsAndRefs (group_weekly_brief_generator.go):
       // it emits Kind: "survey" (fed into ClaimEvidence, the generator's actual LLM input) but never
       // a "document"/"doc" kind — the original event-type list had this backwards.
+      // Vote/survey events carry the payload field upstream windows on (end_time / cutoff_date —
+      // GH-1967 Copilot review); each one here is in-window and (for surveys) already passed.
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
-          { type: 'survey_published', occurred_at: '2026-01-17T08:30:00.000Z' },
-          { type: 'survey_closed', occurred_at: '2026-01-17T09:00:00.000Z' },
+          {
+            type: 'survey_published',
+            occurred_at: '2026-01-17T08:30:00.000Z',
+            payload: { survey_uid: 's1', title: 'Q1 Survey', status: 'Sent', cutoff_date: '2026-01-17T12:00:00.000Z' },
+          },
+          {
+            type: 'survey_closed',
+            occurred_at: '2026-01-17T09:00:00.000Z',
+            payload: { survey_uid: 's2', title: 'Q2 Survey', status: 'Closed', cutoff_date: '2026-01-17T09:00:00.000Z' },
+          },
           { type: 'document_uploaded', occurred_at: '2026-01-17T10:00:00.000Z' },
-          { type: 'vote_opened', occurred_at: '2026-01-17T11:00:00.000Z' },
+          {
+            type: 'vote_opened',
+            occurred_at: '2026-01-17T11:00:00.000Z',
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Active', end_time: '2026-01-17T18:00:00.000Z' },
+          },
         ],
       });
 
@@ -770,17 +792,19 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toEqual({ stale: true, event_count: 3, event_count_is_floor: false });
     });
 
-    it('counts a vote_closed event whose collapsed occurred_at is out-of-window when its payload.opened_at falls in the window (GH-1967 review)', async () => {
+    it('still counts a vote_closed event whose collapsed occurred_at is out-of-range when its end_time is in-window and its payload.opened_at is new — the fallback surviving source-window alignment (GH-1967 review)', async () => {
       // getCommitteeActivity collapses each vote to one event reflecting only its current state —
-      // a vote opened in-window that has since closed shows up only as vote_closed at its (now
-      // out-of-window) close moment. payload.opened_at is the fallback signal that catches this.
+      // a vote whose EARLY close landed after window_end while its scheduled end_time was in-window
+      // shows up only as vote_closed at that (out-of-range) close moment. Upstream's VoteSource
+      // windows on end_time alone, so a regeneration WOULD include this vote — payload.opened_at
+      // (in-window, after updated_at) is the fallback newness signal that catches it.
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
           {
             type: 'vote_closed',
-            occurred_at: '2026-01-18T10:00:00.000Z', // after window_end
-            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-17T12:00:00.000Z' }, // inside window
+            occurred_at: '2026-01-18T10:00:00.000Z', // after window_end (early_end_time)
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-17T12:00:00.000Z', end_time: '2026-01-17T22:00:00.000Z' }, // opened in-window after generation; end_time in-window
           },
         ],
       });
@@ -790,16 +814,101 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toEqual({ stale: true, event_count: 1, event_count_is_floor: false });
     });
 
-    it('does not count a vote_closed event when neither its occurred_at nor its payload.opened_at falls in the window', async () => {
-      // Negative control for the fallback above — a vote that both opened and closed outside the
-      // relevant window must not count, even though it has a payload.opened_at present.
+    it("does not count a vote_closed event whose opened_at falls in the window when its end_time does not — the opened_at fallback can no longer override upstream's source window (GH-1967 Copilot review)", async () => {
+      // The pre-alignment false positive Copilot flagged: a vote opened after generation but ending
+      // OUTSIDE the brief window — upstream's VoteSource (date_field=end_time) could never include
+      // it in a regeneration, so it must not flag the brief stale on its open moment alone.
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
           {
             type: 'vote_closed',
             occurred_at: '2026-01-18T10:00:00.000Z', // after window_end
-            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-16T00:00:00.000Z' }, // before updated_at
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-17T12:00:00.000Z', end_time: '2026-01-18T10:00:00.000Z' }, // opened in-window, but end_time outside it
+          },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
+    it('does not count a vote_closed event when neither its occurred_at nor its payload.opened_at falls in the window', async () => {
+      // Negative control for the fallback above — an upstream-selectable vote (end_time in-window)
+      // with NO new moment since generation (opened before updated_at, closed after window_end)
+      // must not count: staleness requires source-window qualification AND newness together.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          {
+            type: 'vote_closed',
+            occurred_at: '2026-01-18T10:00:00.000Z', // after window_end
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-16T00:00:00.000Z', end_time: '2026-01-17T22:00:00.000Z' }, // opened before updated_at; end_time in-window
+          },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
+    it('does not count a vote_opened event whose end_time falls outside the window — an open moment alone never qualifies a vote upstream (GH-1967 Copilot review)', async () => {
+      // Upstream's VoteSource selects votes solely by end_time ∈ [window_start, window_end]
+      // (vote_source.go: date_field=end_time), so a vote opened after generation but ending next
+      // week is invisible to a regeneration — flagging it stale would burn a weekly regeneration
+      // for no new content.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          {
+            type: 'vote_opened',
+            occurred_at: '2026-01-17T11:00:00.000Z', // in-window, after updated_at
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Active', end_time: '2026-01-24T10:00:00.000Z' }, // next week — outside the window
+          },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
+    it('does not count a survey_published event whose cutoff has not passed yet — upstream excludes surveys still collecting responses (GH-1967 Copilot review)', async () => {
+      // SurveySource drops cutoffs in the future even inside the window (survey_source.go:
+      // cutoff.After(time.Now()) — "excluding surveys still collecting responses"), so a publish
+      // moment alone must not qualify.
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-01-17T12:00:00.000Z')); // same Saturday as liveBrief
+        proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+        getCommitteeActivityMock.mockResolvedValueOnce({
+          data: [
+            {
+              type: 'survey_published',
+              occurred_at: '2026-01-17T11:00:00.000Z', // in-window, after updated_at, before pinned now
+              payload: { survey_uid: 's1', title: 'Q1 Survey', status: 'Sent', cutoff_date: '2026-01-17T20:00:00.000Z' }, // in-window but after pinned now
+            },
+          ],
+        });
+
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not count a survey_published event whose cutoff falls outside the window (GH-1967 Copilot review)', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          {
+            type: 'survey_published',
+            occurred_at: '2026-01-17T11:00:00.000Z', // in-window, after updated_at
+            payload: { survey_uid: 's1', title: 'Q1 Survey', status: 'Sent', cutoff_date: '2026-01-24T12:00:00.000Z' }, // next week — outside the window
           },
         ],
       });
@@ -868,7 +977,15 @@ describe('WeeklyBriefService', () => {
         vi.setSystemTime(new Date('2026-01-17T12:00:00.000Z')); // same Saturday as liveBrief, before its window_end
         proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
         getCommitteeActivityMock.mockResolvedValueOnce({
-          data: [{ type: 'vote_closed', occurred_at: '2026-01-17T18:00:00.000Z' }], // after pinned "now", still before window_end
+          // end_time in-window (upstream-selectable) so the ONLY thing excluding this event is the
+          // ceiling — occurred_at is after the pinned "now", still before window_end.
+          data: [
+            {
+              type: 'vote_closed',
+              occurred_at: '2026-01-17T18:00:00.000Z',
+              payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', end_time: '2026-01-17T18:00:00.000Z' },
+            },
+          ],
         });
 
         const result = await service.getCurrentBrief(req, 'committee-1');
@@ -987,6 +1104,17 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(logger.warning).toHaveBeenCalledTimes(1);
       expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ window_end: 'not-a-date' }));
+    });
+
+    it('degrades to null and logs the offending raw value when the brief has an unparseable window_start — the per-source window alignment has no lower bound without it (GH-1967 Copilot review)', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, window_start: 'not-a-date' }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
+      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ window_start: 'not-a-date' }));
     });
 
     it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -770,6 +770,57 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toEqual({ stale: true, event_count: 3, event_count_is_floor: false });
     });
 
+    it('counts a vote_closed event whose collapsed occurred_at is out-of-window when its payload.opened_at falls in the window (GH-1967 review)', async () => {
+      // getCommitteeActivity collapses each vote to one event reflecting only its current state —
+      // a vote opened in-window that has since closed shows up only as vote_closed at its (now
+      // out-of-window) close moment. payload.opened_at is the fallback signal that catches this.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          {
+            type: 'vote_closed',
+            occurred_at: '2026-01-18T10:00:00.000Z', // after window_end
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-17T12:00:00.000Z' }, // inside window
+          },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: true, event_count: 1, event_count_is_floor: false });
+    });
+
+    it('does not count a vote_closed event when neither its occurred_at nor its payload.opened_at falls in the window', async () => {
+      // Negative control for the fallback above — a vote that both opened and closed outside the
+      // relevant window must not count, even though it has a payload.opened_at present.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          {
+            type: 'vote_closed',
+            occurred_at: '2026-01-18T10:00:00.000Z', // after window_end
+            payload: { vote_uid: 'v1', name: 'Q1 Budget', status: 'Ended', opened_at: '2026-01-16T00:00:00.000Z' }, // before updated_at
+          },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
+    it('confidently reports not stale — and skips the fetch entirely — when updated_at exactly equals window_end (GH-1967 review)', async () => {
+      // The qualifying interval (updated_at, window_end] is provably empty here (nothing can be
+      // strictly greater than and at-most-equal-to the same instant) — the >= short-circuit (not
+      // just >) is what catches this without paying the fetch fan-out.
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, updated_at: liveBrief.window_end }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
     it('carries both caller_rating and staleness together in the merged response (general review finding — the parallel-await merge is otherwise untested with both enrichments actually populated)', async () => {
       const brief = { ...liveBrief, revision: 1 };
       proxyRequest.mockResolvedValueOnce({ brief, throttle: null });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -97,6 +97,7 @@ vi.mock('@lfx-one/shared/constants', () => ({
   AI_MODEL: 'mock-ai-model',
   VALKEY_CACHE: { WEEKLY_BRIEF_RATING_TTL_SECONDS: 7_776_000, WEEKLY_BRIEF_ACTION_ITEMS_TTL_SECONDS: 604800 },
   ACTIVITY_FEED_MAX_PAGE_SIZE: 50,
+  WEEKLY_BRIEF_STALENESS_EVENT_TYPES: ['meeting_held', 'vote_opened', 'vote_closed', 'document_uploaded'],
 }));
 // '../constants' (this app's server-only constants, not the `@lfx-one/shared` package) is
 // plain string/number literals with no transitive Angular imports — safe to leave unmocked,
@@ -723,6 +724,35 @@ describe('WeeklyBriefService', () => {
         event_count: 2,
         event_count_is_floor: false,
       });
+    });
+
+    it('excludes a survey/notes event from the count — those feed event types are not brief sources, so regenerating could never reflect them', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          { type: 'survey_published', occurred_at: '2026-01-17T10:00:00.000Z' },
+          { type: 'notes_added', occurred_at: '2026-01-17T11:00:00.000Z' },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
+    it('counts a document_uploaded event, and still counts a meeting/vote event alongside an excluded survey event', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          { type: 'survey_closed', occurred_at: '2026-01-17T09:00:00.000Z' },
+          { type: 'document_uploaded', occurred_at: '2026-01-17T10:00:00.000Z' },
+          { type: 'vote_opened', occurred_at: '2026-01-17T11:00:00.000Z' },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: true, event_count: 2, event_count_is_floor: false });
     });
 
     it('carries both caller_rating and staleness together in the merged response (general review finding — the parallel-await merge is otherwise untested with both enrichments actually populated)', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -750,6 +750,7 @@ describe('WeeklyBriefService', () => {
 
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
       expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ window_end: 'not-a-date' }));
     });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -686,11 +686,11 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false, most_recent_event_at: undefined });
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
       expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: liveBrief.updated_at, limit: 50 });
     });
 
-    it('reports stale with the in-window event count and most-recent timestamp', async () => {
+    it('reports stale with the in-window event count', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
@@ -705,7 +705,23 @@ describe('WeeklyBriefService', () => {
         stale: true,
         event_count: 2,
         event_count_is_floor: false,
-        most_recent_event_at: '2026-08-27T18:00:00.000Z',
+      });
+    });
+
+    it('carries both caller_rating and staleness together in the merged response (general review finding — the parallel-await merge is otherwise untested with both enrichments actually populated)', async () => {
+      const brief = { ...liveBrief, revision: 1 };
+      proxyRequest.mockResolvedValueOnce({ brief, throttle: null });
+      const key = buildWeeklyBriefRatingCacheKeyMock('committee-1', brief.uid, brief.revision, 'alice')!;
+      valkeyStore.set(key, { rating: 'up' });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'meeting_held', occurred_at: '2026-08-27T18:00:00.000Z' }],
+      });
+
+      const result = await service.getCurrentBrief(userReq, 'committee-1');
+
+      expect(result).toMatchObject({
+        caller_rating: 'up',
+        staleness: { stale: true, event_count: 1, event_count_is_floor: false },
       });
     });
 
@@ -717,7 +733,7 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false, most_recent_event_at: undefined });
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
     });
 
     it('marks event_count as a floor when the activity fetch itself paginated', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -743,14 +743,14 @@ describe('WeeklyBriefService', () => {
       expect(logger.warning).toHaveBeenCalledTimes(1);
     });
 
-    it('degrades to null and logs a warning instead of a silent "stale: false" when the brief has an unparseable window_end', async () => {
+    it('degrades to null and logs the offending raw value instead of a silent "stale: false" when the brief has an unparseable window_end', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, window_end: 'not-a-date' }, throttle: null });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
-      expect(logger.warning).toHaveBeenCalledTimes(1);
+      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ window_end: 'not-a-date' }));
     });
 
     it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -846,6 +846,20 @@ describe('WeeklyBriefService', () => {
       expect(logger.warning).toHaveBeenCalledTimes(1);
     });
 
+    it('reports unknown (null), not a false negative, when any_leg_saturated is true with no page_token and nothing relevant turned up (GH-1967 review)', async () => {
+      // Distinct from the page_token-set case above: this covers getCommitteeActivity's own
+      // documented gap where page_token comes back unset (no real lastPageItem to anchor a cursor
+      // on) even though a leg's own upstream page was genuinely saturated — any_leg_saturated is
+      // read directly off each leg's own saturation and isn't affected by that.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({ data: [], any_leg_saturated: true });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
+    });
+
     it('still reports stale (not a degrade) when a committee-activity leg failed but other legs already found real qualifying activity', async () => {
       // A leg failure can only hide a real positive, never manufacture a false one — once relevant
       // activity has already been found, any_leg_failed on a different leg doesn't undermine it.

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -433,6 +433,21 @@ describe('WeeklyBriefService', () => {
       expect(buildCacheKey).not.toHaveBeenCalled();
     });
 
+    it('never triggers the committee-activity staleness fan-out even for a shareable live-mode brief (GH-1966 perf regression guard)', async () => {
+      process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
+      proxyRequest.mockResolvedValueOnce({
+        brief: { uid: 'b1', state: 'generated', revision: 1, brief_text: 'Hello committee' },
+        throttle: null,
+      });
+      extractBriefActionItems.mockResolvedValueOnce({ items: [] });
+
+      await service.getActionItems(req, 'committee-1');
+
+      // getActionItems only needs `brief` — it must fetch via fetchCurrentBrief, not the
+      // enriched getCurrentBrief, so withStaleness' committee-activity fan-out never fires here.
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
     it('skips extraction and returns {items: []} when the cache key is null (fail-closed on an unsafe brief uid), logging a warning', async () => {
       buildCacheKey.mockReturnValueOnce(null);
 
@@ -700,6 +715,40 @@ describe('WeeklyBriefService', () => {
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.staleness?.event_count_is_floor).toBe(true);
+    });
+
+    it('reports unknown (null), not a false negative, when the fetch saturated and nothing turned up in-window on this page', async () => {
+      // getCommitteeActivity sorts descending by occurred_at, so if the fetch paginated
+      // (page_token set) and every returned event is newer than window_end, real in-window
+      // activity could still be sitting on a page never fetched — a confident `stale: false`
+      // here would be a false negative, not a floor-qualified true.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'meeting_held', occurred_at: '2026-09-02T10:00:00.000Z' }],
+        page_token: 'next-page',
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+    });
+
+    it('degrades to null instead of a silent false-negative "stale: true" when the brief has no updated_at (no lower bound to send upstream)', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, updated_at: undefined }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
+    it('degrades to null instead of a silent "stale: false" when the brief has an unparseable window_end', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, window_end: 'not-a-date' }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toBeNull();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
     it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {
@@ -1005,6 +1054,18 @@ describe('WeeklyBriefService', () => {
 
       expect(result.caller_rating).toBeNull();
     });
+
+    it('rateBrief resolves caller_rating via resolveRatableBrief without triggering the staleness fan-out, in live mode (GH-1966 perf regression guard)', async () => {
+      process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
+      const liveBrief = { uid: 'b1', state: 'generated', revision: 1, brief_text: 'Hello committee' };
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null }); // resolveRatableBrief's fetchCurrentBrief
+
+      await service.rateBrief(userReq, 'committee-1', 'b1', 'up', 1);
+
+      // resolveRatableBrief genuinely needs caller_rating (for the log line's previous_rating),
+      // so it still calls withCallerRating explicitly — but never withStaleness.
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('shareToSlack (LFXV2-3080)', () => {
@@ -1106,6 +1167,10 @@ describe('WeeklyBriefService', () => {
       expect(proxyRequest).toHaveBeenNthCalledWith(3, req, 'LFX_V2_SERVICE', '/committees/committee-1/weekly-briefs/share-to-chat', 'POST', undefined, {
         revision: 1,
       });
+      // GH-1966 perf regression guard: this method only needs `brief`, so it must fetch via
+      // fetchCurrentBrief, not the enriched getCurrentBrief — the committee-activity fan-out
+      // withStaleness would trigger for this shareable ('generated') brief must never fire here.
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
     it('logs the sending user (as their opaque sub, not the human-readable username) on a successful send — the committee-service call carries no caller identity of its own beyond the bearer token, so this is the only record of who shared it', async () => {
@@ -1253,6 +1318,8 @@ describe('WeeklyBriefService', () => {
         expect.objectContaining({ ed_reply_email: 'writer@example.com', committee_uids: ['committee-1'] })
       );
       expect(nonImpersonatingReq.bearerToken).toBe('writer-token');
+      // GH-1966 perf regression guard — same rationale as shareToSlack's equivalent assertion.
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
     it("impersonating: authorizes and sends under the REAL staff member's token/email, not the impersonated target's, and restores the impersonation token afterward", async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -685,7 +685,7 @@ describe('WeeklyBriefService', () => {
 
     it('starts the staleness fetch without waiting for the caller-rating lookup to resolve first (parallel, not serial — perf fix)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
-      valkeyServiceMock.getJson.mockReturnValueOnce(new Promise(() => {})); // caller-rating lookup hangs forever
+      valkeyServiceMock.getJson.mockReturnValueOnce(new Promise<never>(() => undefined)); // caller-rating lookup hangs forever
       getCommitteeActivityMock.mockResolvedValueOnce({ data: [] });
 
       void service.getCurrentBrief(userReq, 'committee-1'); // not awaited — the rating lookup above never resolves
@@ -926,7 +926,7 @@ describe('WeeklyBriefService', () => {
       vi.useFakeTimers();
       try {
         proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
-        getCommitteeActivityMock.mockReturnValueOnce(new Promise(() => {})); // never settles
+        getCommitteeActivityMock.mockReturnValueOnce(new Promise<never>(() => undefined)); // never settles
 
         const resultPromise = service.getCurrentBrief(req, 'committee-1');
         await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -733,22 +733,24 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toBeNull();
     });
 
-    it('degrades to null instead of a silent false-negative "stale: true" when the brief has no updated_at (no lower bound to send upstream)', async () => {
+    it('degrades to null and logs a warning instead of a silent false-negative "stale: true" when the brief has no updated_at (no lower bound to send upstream)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, updated_at: undefined }, throttle: null });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
     });
 
-    it('degrades to null instead of a silent "stale: false" when the brief has an unparseable window_end', async () => {
+    it('degrades to null and logs a warning instead of a silent "stale: false" when the brief has an unparseable window_end', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, window_end: 'not-a-date' }, throttle: null });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
     });
 
     it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -707,7 +707,7 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: liveBrief.updated_at, limit: 50 });
     });
 
-    it('reports stale for activity inside the window after the brief was generated, even though the window has long since closed by the time this is checked (the actual GH-1966 scenario)', async () => {
+    it('reports stale for activity inside the window after the brief was generated, even though the window has long since closed by the time this is checked (the class of scenario GH-1966 describes)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
@@ -751,7 +751,10 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
-    it('excludes an event after the window closed from the count — that activity belongs to a later week this brief can never cover', async () => {
+    it('confidently reports not stale (not a degrade) when the fetch returned data but none of it was in range, and nothing was truncated', async () => {
+      // No page_token back means the fetch was NOT truncated (committee-activity's hasMore only
+      // ever sets one alongside a real lastPageItem) — everything that exists was returned, so an
+      // all-irrelevant result here is a genuine, confident "not stale", not an unknown.
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [{ type: 'meeting_held', occurred_at: '2026-01-18T10:00:00.000Z' }], // after window_end
@@ -759,8 +762,25 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toBeNull(); // fetch returned data, none of it relevant — unknown, not a confident false
-      expect(logger.warning).toHaveBeenCalledTimes(1);
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+      expect(logger.warning).not.toHaveBeenCalled();
+    });
+
+    it('excludes an event after "now" from the count, even though it is still before window_end — an event cannot count as "already happened" before it has', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-01-17T12:00:00.000Z')); // same Saturday as liveBrief, before its window_end
+        proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+        getCommitteeActivityMock.mockResolvedValueOnce({
+          data: [{ type: 'vote_closed', occurred_at: '2026-01-17T18:00:00.000Z' }], // after pinned "now", still before window_end
+        });
+
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('reports unknown (null), not a false negative, when the fetch saturated and nothing relevant turned up on this page', async () => {
@@ -778,6 +798,7 @@ describe('WeeklyBriefService', () => {
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.staleness).toBeNull();
+      expect(logger.warning).toHaveBeenCalledTimes(1);
     });
 
     it('marks event_count as a floor when the activity fetch itself paginated', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -918,6 +918,35 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
     });
 
+    it('counts a scheduled survey created before the brief but SENT after it, when its collapsed survey_closed occurred_at is out of range — opened_at is the send moment, not creation (GH-1967 Copilot review)', async () => {
+      // Scheduled survey: created before the brief was generated, scheduled-sent after it, then
+      // explicitly closed with a last_modified after window_end — the collapsed survey_closed
+      // event's occurred_at is out of range, so only payload.opened_at carries the in-window open
+      // moment. CommitteeActivityService keys opened_at on survey_send_date (not created_at)
+      // precisely so this survey isn't missed; with created_at it would fall before updated_at and
+      // the survey would be invisible here.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [
+          {
+            type: 'survey_closed',
+            occurred_at: '2026-01-18T09:00:00.000Z', // after window_end (explicit close edit)
+            payload: {
+              survey_uid: 's1',
+              title: 'Q1 Survey',
+              status: 'Closed',
+              opened_at: '2026-01-17T11:00:00.000Z', // survey_send_date — in-window, after updated_at
+              cutoff_date: '2026-01-17T20:00:00.000Z', // in-window and (by real now) passed
+            },
+          },
+        ],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: true, event_count: 1, event_count_is_floor: false });
+    });
+
     it('confidently reports not stale — and skips the fetch entirely — when updated_at exactly equals window_end (GH-1967 review)', async () => {
       // The qualifying interval (updated_at, window_end] is provably empty here (nothing can be
       // strictly greater than and at-most-equal-to the same instant) — the >= short-circuit (not

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -654,22 +654,28 @@ describe('WeeklyBriefService', () => {
   });
 
   describe('getCurrentBrief — staleness enrichment (GH-1966)', () => {
-    // window_end deliberately far in the future (year 2030) rather than relative to "today" —
-    // this is the ONLY case briefWindow() can produce a still-open window (same-day Saturday),
-    // and pinning it far ahead keeps the fixture valid regardless of the real date this suite
-    // runs on, with no fake-timer dependency. updated_at doesn't need to be "real" — the code
-    // never compares it to "now", only to activity-event timestamps the test controls directly.
+    // Both dates safely in the past relative to any real test-run time (this repo's earliest
+    // plausible run date is long after Jan 2026) — deterministic without any fake-timer
+    // dependency. `updated_at` before `window_end` models a brief generated on window_end's own
+    // anchor Saturday (the only day briefWindow() can produce a still-current window) — that
+    // relationship, not "is window_end in the future right now", is what makes staleness
+    // computable: the brief stays checkable for the rest of that week, not just the day it was
+    // generated (general review finding, full-branch sweep — the previous version of this check
+    // gated on the wrong condition and suppressed exactly this case).
     const liveBrief = {
       uid: 'b1',
       state: 'generated',
-      updated_at: '2030-01-03T00:00:00.000Z',
-      window_end: '2030-01-10T23:59:59.999Z', // window still open relative to any real test-run time
+      updated_at: '2026-01-17T08:00:00.000Z', // generated the same Saturday its window closes
+      window_end: '2026-01-17T23:59:59.999Z',
     };
-    // Same brief, but for a window that already closed — the common case (6 of 7 days) per
-    // briefWindow(), and the one staleness must now stay silent on (general review finding).
+    // Same brief shape, but generated AFTER its own window had already closed — the common case
+    // (6 of 7 days) per briefWindow(). Provably not stale: the generator already had the
+    // complete, closed window available at that moment.
     const closedWindowBrief = {
-      ...liveBrief,
-      window_end: '2020-01-04T23:59:59.999Z', // safely in the past
+      uid: 'b1',
+      state: 'generated',
+      updated_at: '2026-01-15T09:00:00.000Z', // Thursday, after the window below already closed
+      window_end: '2026-01-10T23:59:59.999Z', // the previous Saturday
     };
 
     beforeEach(() => {
@@ -701,12 +707,12 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: liveBrief.updated_at, limit: 50 });
     });
 
-    it('reports stale with the event count, while the window is still open', async () => {
+    it('reports stale for activity inside the window after the brief was generated, even though the window has long since closed by the time this is checked (the actual GH-1966 scenario)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
         data: [
-          { type: 'meeting_held', occurred_at: '2025-06-15T18:00:00.000Z' },
-          { type: 'vote_closed', occurred_at: '2025-06-14T09:00:00.000Z' },
+          { type: 'meeting_held', occurred_at: '2026-01-17T18:00:00.000Z' },
+          { type: 'vote_closed', occurred_at: '2026-01-17T10:00:00.000Z' },
         ],
       });
 
@@ -725,7 +731,7 @@ describe('WeeklyBriefService', () => {
       const key = buildWeeklyBriefRatingCacheKeyMock('committee-1', brief.uid, brief.revision, 'alice')!;
       valkeyStore.set(key, { rating: 'up' });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2025-06-15T18:00:00.000Z' }],
+        data: [{ type: 'meeting_held', occurred_at: '2026-01-17T10:00:00.000Z' }],
       });
 
       const result = await service.getCurrentBrief(userReq, 'committee-1');
@@ -736,35 +742,36 @@ describe('WeeklyBriefService', () => {
       });
     });
 
-    it("skips the fetch entirely and reports null when the brief's own window has already closed — the common case (general review finding: a closed-week brief can't be updated by regenerating against a later week's activity)", async () => {
+    it('confidently reports not stale — and skips the fetch entirely — when the brief was (re)generated after its own window had already closed (the common case: the generator already had the complete, closed window)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: closedWindowBrief, throttle: null });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toBeNull();
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
-    it('excludes a future-dated event from the count (general review finding: the feed can return a vote already ENDED but stamped with a still-future end_time)', async () => {
+    it('excludes an event after the window closed from the count — that activity belongs to a later week this brief can never cover', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'vote_closed', occurred_at: '2030-01-05T00:00:00.000Z' }], // after "now", still before window_end
+        data: [{ type: 'meeting_held', occurred_at: '2026-01-18T10:00:00.000Z' }], // after window_end
       });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+      expect(result.staleness).toBeNull(); // fetch returned data, none of it relevant — unknown, not a confident false
+      expect(logger.warning).toHaveBeenCalledTimes(1);
     });
 
     it('reports unknown (null), not a false negative, when the fetch saturated and nothing relevant turned up on this page', async () => {
-      // getCommitteeActivity sorts descending by occurred_at, so future-dated events (excluded
-      // by the "now" ceiling) sort ahead of genuinely relevant ones. If the fetch itself
-      // saturated (page_token set) and every returned event is future-dated, real relevant
-      // activity could still be sitting on a page never fetched — a confident `stale: false`
-      // there would be a false negative, not a floor-qualified true.
+      // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
+      // ahead of genuinely relevant ones. If the fetch itself saturated (page_token set) and
+      // every returned event is out of range, real relevant activity could still be sitting on a
+      // page never fetched — a confident `stale: false` there would be a false negative, not a
+      // floor-qualified true.
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'vote_closed', occurred_at: '2030-01-05T00:00:00.000Z' }],
+        data: [{ type: 'meeting_held', occurred_at: '2026-01-18T10:00:00.000Z' }],
         page_token: 'next-page',
       });
 
@@ -776,7 +783,7 @@ describe('WeeklyBriefService', () => {
     it('marks event_count as a floor when the activity fetch itself paginated', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2025-06-15T18:00:00.000Z' }],
+        data: [{ type: 'meeting_held', occurred_at: '2026-01-17T10:00:00.000Z' }],
         page_token: 'next-page',
       });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -165,7 +165,7 @@ vi.mock('./valkey.service', () => ({
 
 import type { Request } from 'express';
 
-import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
+import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID, WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS } from '../constants';
 import { MicroserviceError } from '../errors';
 import { ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 
@@ -665,6 +665,20 @@ describe('WeeklyBriefService', () => {
       process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
     });
 
+    it('starts the staleness fetch without waiting for the caller-rating lookup to resolve first (parallel, not serial — perf fix)', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      valkeyServiceMock.getJson.mockReturnValueOnce(new Promise(() => {})); // caller-rating lookup hangs forever
+      getCommitteeActivityMock.mockResolvedValueOnce({ data: [] });
+
+      void service.getCurrentBrief(userReq, 'committee-1'); // not awaited — the rating lookup above never resolves
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // If withStaleness were still chained after withCallerRating, this could never fire while
+      // the rating lookup is stuck — it firing anyway proves the two now run concurrently.
+      expect(getCommitteeActivityMock).toHaveBeenCalled();
+    });
+
     it('reports not stale when no qualifying activity is found', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({ data: [] });
@@ -764,6 +778,24 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toBeNull();
       expect(logger.warning).toHaveBeenCalledTimes(1);
       expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('degrades to null after WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS instead of blocking getCurrentBrief indefinitely when the activity fetch hangs', async () => {
+      vi.useFakeTimers();
+      try {
+        proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+        getCommitteeActivityMock.mockReturnValueOnce(new Promise(() => {})); // never settles
+
+        const resultPromise = service.getCurrentBrief(req, 'committee-1');
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS);
+        const result = await resultPromise;
+
+        expect(result.brief).toBe(liveBrief);
+        expect(result.staleness).toBeNull();
+        expect(logger.warning).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('skips the activity fetch entirely for a brief in a non-shareable state', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -726,6 +726,20 @@ describe('WeeklyBriefService', () => {
       });
     });
 
+    it('excludes an event stamped at the exact same instant as brief.updated_at — the lower bound is strictly after, not at-or-after (GH-1967 review)', async () => {
+      // getCommitteeActivity's own since filter (isAtOrAfterSince) is inclusive (occurred_at >=
+      // since), so without withStaleness re-asserting a strict lower bound, an event stamped at
+      // exactly brief.updated_at would count as "new" activity that happened after generation.
+      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
+      getCommitteeActivityMock.mockResolvedValueOnce({
+        data: [{ type: 'meeting_held', occurred_at: liveBrief.updated_at }],
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+    });
+
     it('excludes a notes event from the count — notes_added is not a brief source, so regenerating could never reflect it', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -725,15 +725,15 @@ describe('WeeklyBriefService', () => {
       });
     });
 
-    it('excludes events after the brief window_end (a later, unrelated week)', async () => {
+    it('counts activity after brief.window_end as stale too — not scoped to the nominal week (GH-1966 fix: window_end almost always precedes updated_at by design, see briefWindow())', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
       getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2026-09-02T10:00:00.000Z' }],
+        data: [{ type: 'meeting_held', occurred_at: '2026-09-02T10:00:00.000Z' }], // after liveBrief.window_end
       });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.staleness).toEqual({ stale: false, event_count: 0, event_count_is_floor: false });
+      expect(result.staleness).toEqual({ stale: true, event_count: 1, event_count_is_floor: false });
     });
 
     it('marks event_count as a floor when the activity fetch itself paginated', async () => {
@@ -748,22 +748,6 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness?.event_count_is_floor).toBe(true);
     });
 
-    it('reports unknown (null), not a false negative, when the fetch saturated and nothing turned up in-window on this page', async () => {
-      // getCommitteeActivity sorts descending by occurred_at, so if the fetch paginated
-      // (page_token set) and every returned event is newer than window_end, real in-window
-      // activity could still be sitting on a page never fetched — a confident `stale: false`
-      // here would be a false negative, not a floor-qualified true.
-      proxyRequest.mockResolvedValueOnce({ brief: liveBrief, throttle: null });
-      getCommitteeActivityMock.mockResolvedValueOnce({
-        data: [{ type: 'meeting_held', occurred_at: '2026-09-02T10:00:00.000Z' }],
-        page_token: 'next-page',
-      });
-
-      const result = await service.getCurrentBrief(req, 'committee-1');
-
-      expect(result.staleness).toBeNull();
-    });
-
     it('degrades to null and logs a warning instead of a silent false-negative "stale: true" when the brief has no updated_at (no lower bound to send upstream)', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, updated_at: undefined }, throttle: null });
 
@@ -772,17 +756,18 @@ describe('WeeklyBriefService', () => {
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(logger.warning).toHaveBeenCalledTimes(1);
+      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ updated_at: null }));
     });
 
-    it('degrades to null and logs the offending raw value instead of a silent "stale: false" when the brief has an unparseable window_end', async () => {
-      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, window_end: 'not-a-date' }, throttle: null });
+    it('degrades to null and logs the offending raw value when the brief has an unparseable updated_at', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { ...liveBrief, updated_at: 'not-a-date' }, throttle: null });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.staleness).toBeNull();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(logger.warning).toHaveBeenCalledTimes(1);
-      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ window_end: 'not-a-date' }));
+      expect(logger.warning).toHaveBeenCalledWith(req, 'weekly_brief_staleness', expect.any(String), expect.objectContaining({ updated_at: 'not-a-date' }));
     });
 
     it('degrades to null and logs a warning (not an error) when the activity fetch throws, without failing getCurrentBrief', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1193,7 +1193,7 @@ export class WeeklyBriefService {
     // ENDED but stamped with a still-future `end_time`), so this also guards against those.
     const ceilingMs = Math.min(Date.now(), windowEndMs);
     try {
-      const { data, page_token } = await this.withStalenessFetchTimeout(
+      const { data, page_token, any_leg_failed } = await this.withStalenessFetchTimeout(
         this.committeeActivityService.getCommitteeActivity(req, committeeId, {
           since: brief.updated_at,
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
@@ -1224,13 +1224,21 @@ export class WeeklyBriefService {
       // `false` whenever every leg's page happens to filter down to zero FGA-visible rows
       // (committee-activity.service.ts's own comment on this). That case is indistinguishable
       // here from "genuinely no activity at all" and reports a confident `stale: false`; fixing
-      // it would mean surfacing `getCommitteeActivity`'s own per-leg saturation flag as a new
-      // field on its response, which is a shared-service change out of scope for this fix.
-      if (page_token && relevant.length === 0) {
-        logger.warning(req, 'weekly_brief_staleness', 'Activity fetch saturated with no in-range events, degrading staleness to null', {
+      // it would mean surfacing a per-request FGA-visibility retry loop, out of scope for this fix.
+      //
+      // `any_leg_failed` (GH-1967 review) covers a different gap: each of `getCommitteeActivity`'s
+      // 5 legs independently degrades a fetch failure into `{events: [], saturated: false}`
+      // (committee-activity.service.ts), indistinguishable from a leg that genuinely fetched
+      // nothing. A leg failure can only hide a real positive (relevant activity this fetch missed),
+      // never manufacture a false one — so it's only a reason to distrust a `relevant.length === 0`
+      // result, same as the saturated-with-nothing-relevant case above.
+      if (relevant.length === 0 && (page_token || any_leg_failed)) {
+        logger.warning(req, 'weekly_brief_staleness', 'Activity fetch was truncated or partially failed with no in-range events, degrading staleness to null', {
           committee_id: committeeId,
           brief_uid: brief.uid,
           fetched: data.length,
+          saturated: !!page_token,
+          any_leg_failed,
         });
         return { ...response, staleness: null };
       }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1207,7 +1207,11 @@ export class WeeklyBriefService {
       const relevant = data.filter((event) => {
         if (!(WEEKLY_BRIEF_STALENESS_EVENT_TYPES as readonly string[]).includes(event.type)) return false;
         const ms = Date.parse(event.occurred_at);
-        return !Number.isNaN(ms) && ms <= ceilingMs;
+        // `getCommitteeActivity`'s own `since` filter (isAtOrAfterSince) is inclusive (`ms >=
+        // since`), so without this, an event stamped at the exact same instant as brief.updated_at
+        // would count as "new" activity — the strict lower bound here is what actually enforces
+        // "happened after the brief was generated" (GH-1967 review).
+        return !Number.isNaN(ms) && ms > sinceMs && ms <= ceilingMs;
       });
       // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
       // ahead of relevant ones. If `page_token`/`any_leg_saturated`/`any_leg_failed` are all unset,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1128,13 +1128,14 @@ export class WeeklyBriefService {
 
   /**
    * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
-   * committee activity has occurred for this committee, since the brief's text was last
-   * generated/edited, while the brief's own window is still open. No brief, a non-shareable
-   * state, or an already-closed window leave `staleness` absent/`null` (see the inline comment
-   * below for why a closed window is never actionable). Mock mode, an unparseable `updated_at`,
-   * or a fetch fault also resolve to `staleness: null` rather than throwing. This is an honest
-   * best-effort indicator, never a precondition for anything, and must never consume
-   * generate/regenerate quota.
+   * committee activity has occurred, inside this brief's own window and after its text was last
+   * generated/edited, up to the earlier of "now" or the window's own close. No brief or a
+   * non-shareable state leave `staleness` absent entirely. Mock mode, an unparseable
+   * `updated_at`/`window_end`, an inconclusive fetch (see below), or a fetch fault all resolve
+   * to `staleness: null` rather than throwing. A brief (re)generated after its own window had
+   * already closed confidently reports `stale: false` — see the inline comment below for why
+   * that's provable, not a guess. This is an honest best-effort indicator, never a precondition
+   * for anything, and must never consume generate/regenerate quota.
    *
    * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
    * query-service) — it has no mock-data branch of its own. Comparing that live activity
@@ -1163,20 +1164,28 @@ export class WeeklyBriefService {
       });
       return { ...response, staleness: null };
     }
-    const nowMs = Date.now();
-    // `briefWindow()`'s own doc comment (and upstream's identical `WeeklyWindow` selection,
-    // confirmed against committee-service's Go source) means `window_end` names the PREVIOUS,
-    // already-closed week on 6 of 7 days. A closed-week brief is a retrospective summary;
-    // regenerating it re-summarizes that same closed period and cannot incorporate activity
-    // from whatever week is current now — so activity after `window_end` has no bearing on
-    // whether THIS brief's text is accurate, and confidently flagging it as "stale" would send
-    // the user to spend limited regeneration quota on a click that changes nothing. Only while
-    // the window is still open (`window_end >= now`, which `briefWindow()` only ever produces
-    // same-day on Saturday) can new activity actually invalidate this brief's own narrative —
-    // that narrow case is also the one the original GH-1966 report describes (general review
-    // finding, full-branch sweep: the first version of this check dropped `window_end`
-    // entirely, which fixed the no-op but reintroduced exactly this cross-week false-positive).
-    if (windowEndMs < nowMs) return { ...response, staleness: null };
+    // `briefWindow()`'s own selection (and upstream's identical `WeeklyWindow`, confirmed
+    // against committee-service's Go source) keeps ONE window "current" — retrievable via
+    // GET /current — from the Saturday it opens through the following Friday, rolling over only
+    // on the next Saturday. A brief first generated any day other than that anchor Saturday is
+    // therefore always generated AFTER its own window already closed (`updated_at > window_end`)
+    // — and since the generator had the complete, already-closed window available at that exact
+    // moment, nothing can have been missed: `stale: false` here is provable, not a guess, and
+    // skipping the fetch entirely avoids paying committee-activity's fan-out for a brief that
+    // can never be stale. This is also the case the *previous* version of this check got wrong
+    // in the other direction — gating on "is the window closed right now" instead of "was the
+    // window already closed when this brief was written" silently suppressed the one case that
+    // (general review finding, full-branch sweep, ×2): a brief generated on the anchor Saturday
+    // itself remains checkable for the rest of that week, since `updated_at` stays before
+    // `window_end` regardless of how much later "now" is.
+    if (sinceMs > windowEndMs) {
+      return { ...response, staleness: { stale: false, event_count: 0, event_count_is_floor: false } };
+    }
+    // The upper bound is whichever is earlier: the window's own close (activity after it belongs
+    // to a later week this brief can never cover) or "now" (an event can't have "already
+    // happened" before it has) — the feed can return future-dated events (e.g. a vote already
+    // ENDED but stamped with a still-future `end_time`), so this also guards against those.
+    const ceilingMs = Math.min(Date.now(), windowEndMs);
     try {
       const { data, page_token } = await this.withStalenessFetchTimeout(
         this.committeeActivityService.getCommitteeActivity(req, committeeId, {
@@ -1184,16 +1193,24 @@ export class WeeklyBriefService {
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
         })
       );
-      // The feed can return future-dated events (e.g. a vote already ENDED but stamped with a
-      // still-future `end_time`) — clamp to `now` so a not-yet-real event can't count as
-      // "activity that already happened" (general review finding).
-      const relevant = data.filter((event) => Date.parse(event.occurred_at) <= nowMs);
-      // getCommitteeActivity sorts descending by occurred_at, so future-dated events (excluded
-      // above) sort ahead of the real ones. If the fetch itself saturated (page_token set) and
-      // nothing relevant turned up on this page, genuinely relevant activity could still be
-      // sitting on a page never fetched — reporting a confident `false` there would be a false
-      // negative, not a floor-qualified true. Degrade to "unknown" instead.
-      if (page_token && relevant.length === 0) return { ...response, staleness: null };
+      const relevant = data.filter((event) => {
+        const ms = Date.parse(event.occurred_at);
+        return !Number.isNaN(ms) && ms <= ceilingMs;
+      });
+      // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
+      // ahead of relevant ones. If the fetch returned data at all but every event fell outside
+      // it, genuinely relevant activity could still be sitting on a page never fetched (whether
+      // or not this particular page saturated) — reporting a confident `false` there would be a
+      // false negative, not a floor-qualified true. Degrade to "unknown" instead (general review
+      // finding: originally gated on `page_token` alone, which missed the unpaginated case).
+      if (data.length > 0 && relevant.length === 0) {
+        logger.warning(req, 'weekly_brief_staleness', 'Activity fetch returned only out-of-range events, degrading staleness to null', {
+          committee_id: committeeId,
+          brief_uid: brief.uid,
+          fetched: data.length,
+        });
+        return { ...response, staleness: null };
+      }
       const staleness: WeeklyBriefStaleness = {
         stale: relevant.length > 0,
         event_count: relevant.length,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -10,6 +10,7 @@ import {
   WEEKLY_BRIEF_DEFAULT_THROTTLE,
   WEEKLY_BRIEF_ERROR_REASON,
   WEEKLY_BRIEF_SHAREABLE_STATES,
+  WEEKLY_BRIEF_STALENESS_EVENT_TYPES,
 } from '@lfx-one/shared/constants';
 import {
   Committee,
@@ -1170,9 +1171,10 @@ export class WeeklyBriefService {
       return { ...response, staleness: null };
     }
     // `briefWindow()`'s own selection (and upstream's identical `WeeklyWindow`, confirmed
-    // against committee-service's Go source) keeps ONE window "current" — retrievable via
-    // GET /current — from the Saturday it opens through the following Friday, rolling over only
-    // on the next Saturday. A brief first generated any day other than that anchor Saturday is
+    // against committee-service's Go source) is a Sun 00:00 → Sat 23:59:59.999 window, but keeps
+    // ONE window "current" — retrievable via GET /current — from the Saturday it CLOSES (the day
+    // it first becomes selectable) through the following Friday, rolling over only on the next
+    // Saturday. A brief first generated any day other than that anchor Saturday is
     // therefore always generated AFTER its own window already closed (`updated_at > window_end`)
     // — and since the generator had the complete, already-closed window available at that exact
     // moment, nothing can have been missed: `stale: false` here is provable — modulo the
@@ -1197,7 +1199,13 @@ export class WeeklyBriefService {
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
         })
       );
+      // WEEKLY_BRIEF_STALENESS_EVENT_TYPES narrows the feed's full event vocabulary down to the
+      // types that actually map onto a brief source kind — the feed also emits survey and
+      // meeting-notes events, which aren't brief sources and would flag activity regenerating
+      // could never reflect (see that constant's own doc comment for the full reasoning,
+      // including the mailing-list/membership blind spot it does NOT solve).
       const relevant = data.filter((event) => {
+        if (!(WEEKLY_BRIEF_STALENESS_EVENT_TYPES as readonly string[]).includes(event.type)) return false;
         const ms = Date.parse(event.occurred_at);
         return !Number.isNaN(ms) && ms <= ceilingMs;
       });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1128,13 +1128,13 @@ export class WeeklyBriefService {
 
   /**
    * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
-   * committee activity has occurred for this committee since the brief's text was last
-   * generated/edited — NOT scoped to `brief.window_end` (see the inline comment below for why
-   * that bound made the check a near-total no-op). No brief or a non-shareable state leave
-   * `staleness` absent entirely — a stricter gate than `withCallerRating`'s (which has no state
-   * check of its own). Mock mode, an unparseable `updated_at`, or a fetch fault all resolve to
-   * `staleness: null` rather than throwing. This is an honest best-effort indicator, never a
-   * precondition for anything, and must never consume generate/regenerate quota.
+   * committee activity has occurred for this committee, since the brief's text was last
+   * generated/edited, while the brief's own window is still open. No brief, a non-shareable
+   * state, or an already-closed window leave `staleness` absent/`null` (see the inline comment
+   * below for why a closed window is never actionable). Mock mode, an unparseable `updated_at`,
+   * or a fetch fault also resolve to `staleness: null` rather than throwing. This is an honest
+   * best-effort indicator, never a precondition for anything, and must never consume
+   * generate/regenerate quota.
    *
    * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
    * query-service) — it has no mock-data branch of its own. Comparing that live activity
@@ -1146,32 +1146,37 @@ export class WeeklyBriefService {
     const brief = response.brief;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) return response;
     if (!live) return { ...response, staleness: null };
-    // Deliberately NOT bounded by `brief.window_end`. `briefWindow()`'s own doc comment (and
-    // upstream's identical `WeeklyWindow` selection, confirmed against committee-service's Go
-    // source) means `window_end` is the PREVIOUS, already-closed week on 6 of 7 days — a brief
-    // generated today for that closed window already has `updated_at` after `window_end` by
-    // design, every time. Filtering activity to `<= window_end` therefore intersected an
-    // always-empty range on every day but the one (Saturday) a brief happens to be generated for
-    // the still-open current week — making the very first version of this check a near-total
-    // no-op (general review finding, full-branch sweep). What the tooltip already promises, and
-    // what actually reproduces the reported bug, is simpler: any real committee activity for
-    // this committee since the brief's text was last written, full stop — not scoped to which
-    // nominal "week" that activity falls in.
-    //
-    // Upstream marks `updated_at` NOT Required (confirmed against committee-service's Goa design
-    // — no `dsl.Required` entry), even though `WeeklyBrief` declares it non-optional `string`
-    // here — this guard is deliberately stricter than the declared type, not redundant with it.
-    // Without it, an absent `updated_at` would reach `getCommitteeActivity` as `since: undefined`,
-    // silently dropping the lower bound and returning the most recent activity of ANY age as if
-    // it were "since generated" (general review finding).
-    if (Number.isNaN(Date.parse(brief.updated_at ?? ''))) {
-      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at, degrading staleness to null', {
+    // Upstream marks NEITHER field Required (confirmed against committee-service's Goa design —
+    // neither carries a `dsl.Required` entry), even though `WeeklyBrief` declares both as
+    // non-optional `string` here — this guard is deliberately stricter than the declared type,
+    // not redundant with it. An absent `updated_at` would otherwise reach `getCommitteeActivity`
+    // as `since: undefined`, silently dropping the lower bound and returning the most recent
+    // activity of ANY age as if it were "since generated" (general review finding).
+    const sinceMs = Date.parse(brief.updated_at ?? '');
+    const windowEndMs = Date.parse(brief.window_end ?? '');
+    if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) {
+      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at/window_end, degrading staleness to null', {
         committee_id: committeeId,
         brief_uid: brief.uid,
         updated_at: brief.updated_at ?? null,
+        window_end: brief.window_end ?? null,
       });
       return { ...response, staleness: null };
     }
+    const nowMs = Date.now();
+    // `briefWindow()`'s own doc comment (and upstream's identical `WeeklyWindow` selection,
+    // confirmed against committee-service's Go source) means `window_end` names the PREVIOUS,
+    // already-closed week on 6 of 7 days. A closed-week brief is a retrospective summary;
+    // regenerating it re-summarizes that same closed period and cannot incorporate activity
+    // from whatever week is current now — so activity after `window_end` has no bearing on
+    // whether THIS brief's text is accurate, and confidently flagging it as "stale" would send
+    // the user to spend limited regeneration quota on a click that changes nothing. Only while
+    // the window is still open (`window_end >= now`, which `briefWindow()` only ever produces
+    // same-day on Saturday) can new activity actually invalidate this brief's own narrative —
+    // that narrow case is also the one the original GH-1966 report describes (general review
+    // finding, full-branch sweep: the first version of this check dropped `window_end`
+    // entirely, which fixed the no-op but reintroduced exactly this cross-week false-positive).
+    if (windowEndMs < nowMs) return { ...response, staleness: null };
     try {
       const { data, page_token } = await this.withStalenessFetchTimeout(
         this.committeeActivityService.getCommitteeActivity(req, committeeId, {
@@ -1179,9 +1184,19 @@ export class WeeklyBriefService {
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
         })
       );
+      // The feed can return future-dated events (e.g. a vote already ENDED but stamped with a
+      // still-future `end_time`) — clamp to `now` so a not-yet-real event can't count as
+      // "activity that already happened" (general review finding).
+      const relevant = data.filter((event) => Date.parse(event.occurred_at) <= nowMs);
+      // getCommitteeActivity sorts descending by occurred_at, so future-dated events (excluded
+      // above) sort ahead of the real ones. If the fetch itself saturated (page_token set) and
+      // nothing relevant turned up on this page, genuinely relevant activity could still be
+      // sitting on a page never fetched — reporting a confident `false` there would be a false
+      // negative, not a floor-qualified true. Degrade to "unknown" instead.
+      if (page_token && relevant.length === 0) return { ...response, staleness: null };
       const staleness: WeeklyBriefStaleness = {
-        stale: data.length > 0,
-        event_count: data.length,
+        stale: relevant.length > 0,
+        event_count: relevant.length,
         event_count_is_floor: !!page_token,
       };
       return { ...response, staleness };

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1193,7 +1193,7 @@ export class WeeklyBriefService {
     // ENDED but stamped with a still-future `end_time`), so this also guards against those.
     const ceilingMs = Math.min(Date.now(), windowEndMs);
     try {
-      const { data, page_token, any_leg_failed } = await this.withStalenessFetchTimeout(
+      const { data, page_token, any_leg_saturated, any_leg_failed } = await this.withStalenessFetchTimeout(
         this.committeeActivityService.getCommitteeActivity(req, committeeId, {
           since: brief.updated_at,
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
@@ -1210,34 +1210,35 @@ export class WeeklyBriefService {
         return !Number.isNaN(ms) && ms <= ceilingMs;
       });
       // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
-      // ahead of relevant ones. `page_token` is only ever set when a real `lastPageItem` exists
-      // (committee-activity.service.ts's `hasMore` computation) — so its absence, whenever
-      // `data.length > 0`, is a reliable signal the fetch was NOT truncated: everything that
-      // exists was returned, and if none of it is relevant, that's a confident `false`, not a
-      // degrade. Only when `page_token` IS set and nothing relevant turned up on this page could
-      // real relevant activity still be sitting on a page never fetched — that's the genuine
-      // false-negative risk this guards against.
+      // ahead of relevant ones. If `page_token`/`any_leg_saturated`/`any_leg_failed` are all unset,
+      // everything that exists was returned and known-complete, so an all-irrelevant result here is
+      // a confident `false`, not a degrade — see below for why none of the three, alone, is a
+      // reliable "nothing was truncated" signal on its own (`page_token` in particular needs a real
+      // `lastPageItem` to anchor a cursor on, so it can be absent even when a leg's own upstream
+      // page was genuinely saturated).
       //
-      // Known residual, not covered by this guard: `getCommitteeActivity` can also return
-      // `data: []` with no `page_token` even though a later upstream page (of a saturated leg)
-      // holds rows this caller is authorized to see — its own `hasMore` computation forces
-      // `false` whenever every leg's page happens to filter down to zero FGA-visible rows
-      // (committee-activity.service.ts's own comment on this). That case is indistinguishable
-      // here from "genuinely no activity at all" and reports a confident `stale: false`; fixing
-      // it would mean surfacing a per-request FGA-visibility retry loop, out of scope for this fix.
+      // `page_token` alone under-detects truncation for this purpose: it requires a real
+      // `lastPageItem` to anchor a cursor on, so if the in-memory since/cursor/timestamp pass
+      // filters every fetched row out of the merged pool (a FGA-filtered-empty upstream page, or a
+      // leg like surveys whose upstream sort doesn't match its own occurred_at — see
+      // committee-activity.service.ts's own comment on this), `page_token` comes back unset even
+      // though a leg's own upstream page was genuinely saturated. `any_leg_saturated` (GH-1967
+      // review) is read directly off each leg's own saturation, independent of whether anything
+      // from that leg survived into `data` — closing that gap for this caller.
       //
       // `any_leg_failed` (GH-1967 review) covers a different gap: each of `getCommitteeActivity`'s
       // 5 legs independently degrades a fetch failure into `{events: [], saturated: false}`
       // (committee-activity.service.ts), indistinguishable from a leg that genuinely fetched
       // nothing. A leg failure can only hide a real positive (relevant activity this fetch missed),
       // never manufacture a false one — so it's only a reason to distrust a `relevant.length === 0`
-      // result, same as the saturated-with-nothing-relevant case above.
-      if (relevant.length === 0 && (page_token || any_leg_failed)) {
+      // result, same as the truncation signals above.
+      if (relevant.length === 0 && (page_token || any_leg_saturated || any_leg_failed)) {
         logger.warning(req, 'weekly_brief_staleness', 'Activity fetch was truncated or partially failed with no in-range events, degrading staleness to null', {
           committee_id: committeeId,
           brief_uid: brief.uid,
           fetched: data.length,
           saturated: !!page_token,
+          any_leg_saturated,
           any_leg_failed,
         });
         return { ...response, staleness: null };

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -227,30 +227,16 @@ export class WeeklyBriefService {
    * exists yet for the window — a 404 here means "committee not found", a
    * real error the caller needs to see, not an empty-brief state to paper
    * over.
+   *
+   * This is the controller's read path — it carries both `caller_rating` and `staleness`
+   * (GH-1966). Internal callers that only need `brief`/`throttle` (`getActionItems`,
+   * `shareBrief`, `shareToSlack`) call `fetchCurrentBrief` directly instead: `withStaleness`'s
+   * committee-activity fan-out is real upstream cost that only the card's own read needs, and
+   * paying it on every action-item extraction, share, and rating write for a value those paths
+   * immediately discard would multiply that cost for nothing (general review finding).
    */
   public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
-    const live = this.isLive(req);
-    let response: WeeklyBriefCurrentResponse;
-    if (!live) {
-      const brief = currentMockBrief(committeeId);
-      response = {
-        brief,
-        throttle: {
-          ...WEEKLY_BRIEF_DEFAULT_THROTTLE,
-          generates_used: 1,
-          regenerations_used: brief.regeneration_count,
-          window_resets_at: nextSundayIso(),
-        },
-      };
-    } else {
-      logger.debug(req, 'get_weekly_brief_current', 'Proxying to committee-service', { committee_id: committeeId });
-      response = await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
-        req,
-        'LFX_V2_SERVICE',
-        `/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`,
-        'GET'
-      );
-    }
+    const { response, live } = await this.fetchCurrentBrief(req, committeeId);
     const withRating = await this.withCallerRating(req, committeeId, response);
     return this.withStaleness(req, committeeId, withRating, live);
   }
@@ -435,7 +421,7 @@ export class WeeklyBriefService {
    * (a miss, same as an actual cache miss) — that narrower case isn't covered here.
    */
   public async getActionItems(req: Request, committeeId: string): Promise<GetWeeklyBriefActionItemsResponse> {
-    const { brief } = await this.getCurrentBrief(req, committeeId);
+    const { brief } = (await this.fetchCurrentBrief(req, committeeId)).response;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state) || !brief.brief_text?.trim()) {
       return { items: [] };
     }
@@ -670,7 +656,7 @@ export class WeeklyBriefService {
    * this service — impersonation still shows staff what the target sees.
    */
   public async shareBrief(req: Request, committeeId: string, expectedRevision: number): Promise<ShareWeeklyBriefResult> {
-    const { brief } = await this.getCurrentBrief(req, committeeId);
+    const { brief } = (await this.fetchCurrentBrief(req, committeeId)).response;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
       throw new ResourceNotFoundError('Weekly brief', committeeId, {
         operation: 'share_weekly_brief',
@@ -908,7 +894,7 @@ export class WeeklyBriefService {
       });
     }
 
-    const { brief } = await this.getCurrentBrief(req, committeeId);
+    const { brief } = (await this.fetchCurrentBrief(req, committeeId)).response;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
       throw new ResourceNotFoundError('Weekly brief', committeeId, {
         operation: 'share_weekly_brief_slack',
@@ -1047,6 +1033,33 @@ export class WeeklyBriefService {
     return {};
   }
 
+  /** Fetches the current brief/throttle with no BFF-side enrichment — the shared collaborator for `getCurrentBrief` and the internal callers that don't need `caller_rating`/`staleness`. */
+  private async fetchCurrentBrief(req: Request, committeeId: string): Promise<{ response: WeeklyBriefCurrentResponse; live: boolean }> {
+    const live = this.isLive(req);
+    let response: WeeklyBriefCurrentResponse;
+    if (!live) {
+      const brief = currentMockBrief(committeeId);
+      response = {
+        brief,
+        throttle: {
+          ...WEEKLY_BRIEF_DEFAULT_THROTTLE,
+          generates_used: 1,
+          regenerations_used: brief.regeneration_count,
+          window_resets_at: nextSundayIso(),
+        },
+      };
+    } else {
+      logger.debug(req, 'get_weekly_brief_current', 'Proxying to committee-service', { committee_id: committeeId });
+      response = await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`,
+        'GET'
+      );
+    }
+    return { response, live };
+  }
+
   /**
    * Refuses mock mode outright in production instead of silently serving
    * fabricated brief content. `assertCommitteeRead`/`assertCommitteeWrite` gate
@@ -1096,7 +1109,9 @@ export class WeeklyBriefService {
   /**
    * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
    * committee activity has occurred inside the brief's own window since it was last
-   * generated/edited. Fails soft on every edge — no brief, non-shareable state, mock mode, or
+   * generated/edited. Fails soft on every edge: no brief or a non-shareable state leave
+   * `staleness` absent entirely (same convention as `caller_rating` on those same edges);
+   * mock mode, an unparseable `updated_at`/`window_end`, an inconclusive fetch (see below), or
    * a fetch fault all resolve to `staleness: null` rather than throwing. This is an honest
    * best-effort indicator, never a precondition for anything, and must never consume
    * generate/regenerate quota.
@@ -1111,13 +1126,28 @@ export class WeeklyBriefService {
     const brief = response.brief;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) return response;
     if (!live) return { ...response, staleness: null };
+    // Upstream marks both fields Required, but this BFF proxies the object straight through
+    // with no runtime validation of its own — an absent `updated_at` would otherwise reach
+    // `getCommitteeActivity` as `since: undefined`, silently dropping the lower bound and
+    // returning the most recent activity of ANY age as if it were "since generated" (general
+    // review finding); an absent/unparseable `window_end` would make every event fail the
+    // `<= windowEndMs` filter, silently reporting "not stale" instead of "unknown".
+    const sinceMs = Date.parse(brief.updated_at ?? '');
+    const windowEndMs = Date.parse(brief.window_end ?? '');
+    if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) return { ...response, staleness: null };
     try {
       const { data, page_token } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
         since: brief.updated_at,
         limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
       });
-      const windowEndMs = new Date(brief.window_end).getTime();
       const inWindow = data.filter((event) => new Date(event.occurred_at).getTime() <= windowEndMs);
+      // getCommitteeActivity sorts descending by occurred_at, so events newer than window_end
+      // (irrelevant to this brief) sort ahead of genuine in-window ones. If the fetch itself
+      // saturated (page_token set) and nothing in-window turned up on this page, real in-window
+      // activity could still be sitting on a page never fetched — reporting a confident `false`
+      // there would be a false negative, not a floor-qualified true. Degrade to "unknown"
+      // instead (general review finding).
+      if (page_token && inWindow.length === 0) return { ...response, staleness: null };
       const staleness: WeeklyBriefStaleness = {
         stale: inWindow.length > 0,
         event_count: inWindow.length,
@@ -1168,7 +1198,8 @@ export class WeeklyBriefService {
     expectedRevision: number,
     operation: string
   ): Promise<{ brief: WeeklyBrief; callerRating: WeeklyBriefRating | null }> {
-    const response = await this.getCurrentBrief(req, committeeId);
+    const { response: fetched } = await this.fetchCurrentBrief(req, committeeId);
+    const response = await this.withCallerRating(req, committeeId, fetched);
     const { brief } = response;
     if (!brief || brief.uid !== briefUid || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
       throw new ResourceNotFoundError('Weekly brief', briefUid, { operation, service: 'weekly_brief_service' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -249,8 +249,15 @@ export class WeeklyBriefService {
       this.withCallerRating(req, committeeId, response),
       this.withStaleness(req, committeeId, response, live),
     ]);
+    // Composed explicitly over `response` (not `{ ...withRating, ...withStale }`) so neither
+    // enrichment's key can be silently dropped if the other one's return shape ever changes —
+    // each helper's own object is only a source of its own field (general review finding).
     if (withRating === response && withStale === response) return response;
-    return { ...withRating, ...withStale };
+    return {
+      ...response,
+      ...(withRating !== response && { caller_rating: withRating.caller_rating }),
+      ...(withStale !== response && { staleness: withStale.staleness }),
+    };
   }
 
   /**
@@ -1121,13 +1128,13 @@ export class WeeklyBriefService {
 
   /**
    * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
-   * committee activity has occurred inside the brief's own window since it was last
-   * generated/edited. No brief or a non-shareable state leave `staleness` absent entirely — a
-   * stricter gate than `withCallerRating`'s (which has no state check of its own). Mock mode,
-   * an unparseable `updated_at`/`window_end`, an inconclusive fetch (see below), or a fetch
-   * fault all resolve to `staleness: null` rather than throwing. This is an honest best-effort
-   * indicator, never a precondition for anything, and must never consume generate/regenerate
-   * quota.
+   * committee activity has occurred for this committee since the brief's text was last
+   * generated/edited — NOT scoped to `brief.window_end` (see the inline comment below for why
+   * that bound made the check a near-total no-op). No brief or a non-shareable state leave
+   * `staleness` absent entirely — a stricter gate than `withCallerRating`'s (which has no state
+   * check of its own). Mock mode, an unparseable `updated_at`, or a fetch fault all resolve to
+   * `staleness: null` rather than throwing. This is an honest best-effort indicator, never a
+   * precondition for anything, and must never consume generate/regenerate quota.
    *
    * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
    * query-service) — it has no mock-data branch of its own. Comparing that live activity
@@ -1139,29 +1146,29 @@ export class WeeklyBriefService {
     const brief = response.brief;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) return response;
     if (!live) return { ...response, staleness: null };
-    // Upstream marks NEITHER field Required (confirmed against committee-service's Goa design —
-    // neither carries a `dsl.Required` entry), even though `WeeklyBrief` declares both as
-    // non-optional `string` here — this guard is deliberately stricter than the declared type,
-    // not redundant with it. Without it, an absent `updated_at` would reach
-    // `getCommitteeActivity` as `since: undefined`, silently dropping the lower bound and
-    // returning the most recent activity of ANY age as if it were "since generated" (general
-    // review finding); an absent/unparseable `window_end` would make every event fail the
-    // `<= windowEndMs` filter, silently reporting "not stale" instead of "unknown". Widening
-    // `WeeklyBrief.updated_at`/`.window_end` to optional, so every other reader of this type
-    // (briefWindow-adjacent date logic, `listBriefs`, the card's `weekLabel`) gets the same
-    // guarantee, is a larger, riskier change than this fix — a deliberate, currently untracked
-    // trade-off, not attempted here.
-    const sinceMs = Date.parse(brief.updated_at ?? '');
-    const windowEndMs = Date.parse(brief.window_end ?? '');
-    if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) {
-      // Both raw values in the payload (not just the uid) so an operator can tell which of the
-      // four possible causes (either field missing, either field unparseable) actually tripped
-      // this — timestamps, not PII.
-      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at/window_end, degrading staleness to null', {
+    // Deliberately NOT bounded by `brief.window_end`. `briefWindow()`'s own doc comment (and
+    // upstream's identical `WeeklyWindow` selection, confirmed against committee-service's Go
+    // source) means `window_end` is the PREVIOUS, already-closed week on 6 of 7 days — a brief
+    // generated today for that closed window already has `updated_at` after `window_end` by
+    // design, every time. Filtering activity to `<= window_end` therefore intersected an
+    // always-empty range on every day but the one (Saturday) a brief happens to be generated for
+    // the still-open current week — making the very first version of this check a near-total
+    // no-op (general review finding, full-branch sweep). What the tooltip already promises, and
+    // what actually reproduces the reported bug, is simpler: any real committee activity for
+    // this committee since the brief's text was last written, full stop — not scoped to which
+    // nominal "week" that activity falls in.
+    //
+    // Upstream marks `updated_at` NOT Required (confirmed against committee-service's Goa design
+    // — no `dsl.Required` entry), even though `WeeklyBrief` declares it non-optional `string`
+    // here — this guard is deliberately stricter than the declared type, not redundant with it.
+    // Without it, an absent `updated_at` would reach `getCommitteeActivity` as `since: undefined`,
+    // silently dropping the lower bound and returning the most recent activity of ANY age as if
+    // it were "since generated" (general review finding).
+    if (Number.isNaN(Date.parse(brief.updated_at ?? ''))) {
+      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at, degrading staleness to null', {
         committee_id: committeeId,
         brief_uid: brief.uid,
         updated_at: brief.updated_at ?? null,
-        window_end: brief.window_end ?? null,
       });
       return { ...response, staleness: null };
     }
@@ -1172,17 +1179,9 @@ export class WeeklyBriefService {
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
         })
       );
-      const inWindow = data.filter((event) => new Date(event.occurred_at).getTime() <= windowEndMs);
-      // getCommitteeActivity sorts descending by occurred_at, so events newer than window_end
-      // (irrelevant to this brief) sort ahead of genuine in-window ones. If the fetch itself
-      // saturated (page_token set) and nothing in-window turned up on this page, real in-window
-      // activity could still be sitting on a page never fetched — reporting a confident `false`
-      // there would be a false negative, not a floor-qualified true. Degrade to "unknown"
-      // instead (general review finding).
-      if (page_token && inWindow.length === 0) return { ...response, staleness: null };
       const staleness: WeeklyBriefStaleness = {
-        stale: inWindow.length > 0,
-        event_count: inWindow.length,
+        stale: data.length > 0,
+        event_count: data.length,
         event_count_is_floor: !!page_token,
       };
       return { ...response, staleness };

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -13,6 +13,7 @@ import {
   WEEKLY_BRIEF_STALENESS_EVENT_TYPES,
 } from '@lfx-one/shared/constants';
 import {
+  ActivityEvent,
   Committee,
   GenerateWeeklyBriefRequest,
   GenerateWeeklyBriefResponse,
@@ -1153,19 +1154,22 @@ export class WeeklyBriefService {
     const brief = response.brief;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) return response;
     if (!live) return { ...response, staleness: null };
-    // Upstream marks NEITHER field Required (confirmed against committee-service's Goa design —
-    // neither carries a `dsl.Required` entry), even though `WeeklyBrief` declares both as
-    // non-optional `string` here — this guard is deliberately stricter than the declared type,
+    // Upstream marks NONE of these fields Required (confirmed against committee-service's Goa
+    // design — none carries a `dsl.Required` entry), even though `WeeklyBrief` declares all three
+    // as non-optional `string` here — this guard is deliberately stricter than the declared type,
     // not redundant with it. An absent `updated_at` would otherwise reach `getCommitteeActivity`
     // as `since: undefined`, silently dropping the lower bound and returning the most recent
-    // activity of ANY age as if it were "since generated".
+    // activity of ANY age as if it were "since generated"; an absent window bound would silently
+    // disable the per-source window alignment in isNewBriefSourceActivity below.
     const sinceMs = Date.parse(brief.updated_at ?? '');
+    const windowStartMs = Date.parse(brief.window_start ?? '');
     const windowEndMs = Date.parse(brief.window_end ?? '');
-    if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) {
-      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at/window_end, degrading staleness to null', {
+    if (Number.isNaN(sinceMs) || Number.isNaN(windowStartMs) || Number.isNaN(windowEndMs)) {
+      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at/window_start/window_end, degrading staleness to null', {
         committee_id: committeeId,
         brief_uid: brief.uid,
         updated_at: brief.updated_at ?? null,
+        window_start: brief.window_start ?? null,
         window_end: brief.window_end ?? null,
       });
       return { ...response, staleness: null };
@@ -1207,31 +1211,12 @@ export class WeeklyBriefService {
         })
       );
       // WEEKLY_BRIEF_STALENESS_EVENT_TYPES narrows the feed's full event vocabulary down to the
-      // types that actually map onto a brief source kind — the feed also emits survey and
-      // meeting-notes events, which aren't brief sources and would flag activity regenerating
-      // could never reflect (see that constant's own doc comment for the full reasoning,
-      // including the mailing-list/membership blind spot it does NOT solve).
-      const relevant = data.filter((event) => {
-        if (!(WEEKLY_BRIEF_STALENESS_EVENT_TYPES as readonly string[]).includes(event.type)) return false;
-        const ms = Date.parse(event.occurred_at);
-        // `getCommitteeActivity`'s own `since` filter (isAtOrAfterSince) is inclusive (`ms >=
-        // since`), so without this, an event stamped at the exact same instant as brief.updated_at
-        // would count as "new" activity — the strict lower bound here is what actually enforces
-        // "happened after the brief was generated" (GH-1967 review).
-        if (!Number.isNaN(ms) && ms > sinceMs && ms <= ceilingMs) return true;
-        // Collapsed-lifecycle fallback (GH-1967 review): getCommitteeActivity collapses each
-        // vote/survey to one event reflecting only its CURRENT state — a vote/survey that opened
-        // in-window but has since closed shows up only as vote_closed/survey_closed at its (now
-        // out-of-window) close moment, otherwise invisible here. payload.opened_at (always
-        // populated, independent of the event's own type) carries the original open/publish
-        // moment for exactly this check; vote_opened/survey_published events never need it, their
-        // occurred_at already IS the opened_at.
-        if (event.type === 'vote_closed' || event.type === 'survey_closed') {
-          const openedMs = event.payload?.opened_at ? Date.parse(event.payload.opened_at) : NaN;
-          return !Number.isNaN(openedMs) && openedMs > sinceMs && openedMs <= ceilingMs;
-        }
-        return false;
-      });
+      // types that actually map onto a brief source kind (see that constant's own doc comment for
+      // the full reasoning, including the mailing-list/membership blind spot it does NOT solve);
+      // isNewBriefSourceActivity then additionally applies each source's OWN upstream window rule
+      // (meeting start, vote end_time, survey cutoff-date-and-already-passed — GH-1967 Copilot
+      // review) so activity a regeneration could never consume can't flag this brief stale.
+      const relevant = data.filter((event) => this.isNewBriefSourceActivity(event, { sinceMs, ceilingMs, windowStartMs, windowEndMs }));
       // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
       // ahead of relevant ones. If `page_token`/`any_leg_saturated`/`any_leg_failed` are all unset,
       // everything that exists was returned and known-complete, so an all-irrelevant result here is
@@ -1279,6 +1264,68 @@ export class WeeklyBriefService {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
       return { ...response, staleness: null };
+    }
+  }
+
+  /**
+   * Whether one activity-feed event is BOTH new (after the brief's `updated_at`, at or before the
+   * ceiling) AND something a regeneration of this brief could actually consume — aligned with
+   * upstream's per-source window rules (GH-1967 Copilot review), verified against
+   * committee-service's Go sources:
+   *
+   * - `MeetingSource` windows on the meeting's `start_time` (`start_time[gte/lte]`,
+   *   meeting_source.go) — which IS `meeting_held`'s occurred_at, so the in-range occurrence check
+   *   alone is already fully aligned.
+   * - `VoteSource` qualifies a vote SOLELY on `end_time` ∈ [window_start, window_end]
+   *   (`date_field=end_time`, vote_source.go — "we want votes that closed within the window"; no
+   *   already-passed guard) — an open moment alone never qualifies, and even an in-window EARLY
+   *   close doesn't when the scheduled end_time falls outside the window. payload.end_time
+   *   (absent only when the row has no parseable end_time, which upstream's end_time filter treats
+   *   as unselectable too) is what makes that rule checkable here.
+   * - `SurveySource` windows on `survey_cutoff_date` the same way AND drops cutoffs still in the
+   *   future (`cutoff.After(time.Now())`, survey_source.go — "excluding surveys still collecting
+   *   responses"), skipping rows with unparseable cutoffs entirely — so a survey_published event
+   *   (a publish moment) can never qualify on its own. `cutoffMs <= ceilingMs` IS upstream's
+   *   `cutoff <= now` here because the ceiling is min(now, window_end).
+   *
+   * Without the payload gates this predicate was broader than what regeneration consumes: a vote
+   * opened after generation but ending outside the window (or a survey published while still
+   * collecting responses) flagged the brief stale even though regenerating could never pull it
+   * in — a false positive that burns one of the week's regenerations for no new content.
+   *
+   * Newness: strict `> sinceMs` / `<= ceilingMs` on occurred_at — `getCommitteeActivity`'s own
+   * `since` filter (isAtOrAfterSince) is inclusive (`ms >= since`), so the strict lower bound is
+   * what actually enforces "happened after the brief was generated" (GH-1967 review). The
+   * payload.opened_at fallback covers the collapsed lifecycle (GH-1967 review): the feed collapses
+   * each vote/survey to one event reflecting only its CURRENT state, so one that opened in-window
+   * but has since closed shows up only as vote_closed/survey_closed at its (now out-of-window)
+   * close moment, otherwise invisible here. For vote_opened/survey_published the fallback is
+   * provably identical to the occurred_at check (both read the same creation/publish moment) —
+   * applied uniformly anyway so the newness rule lives in exactly one place.
+   */
+  private isNewBriefSourceActivity(event: ActivityEvent, bounds: { sinceMs: number; ceilingMs: number; windowStartMs: number; windowEndMs: number }): boolean {
+    if (!(WEEKLY_BRIEF_STALENESS_EVENT_TYPES as readonly string[]).includes(event.type)) return false;
+    const occurredMs = Date.parse(event.occurred_at);
+    const occurredInRange = !Number.isNaN(occurredMs) && occurredMs > bounds.sinceMs && occurredMs <= bounds.ceilingMs;
+    switch (event.type) {
+      case 'meeting_held':
+        return occurredInRange;
+      case 'vote_opened':
+      case 'vote_closed': {
+        const endMs = Date.parse(event.payload.end_time ?? '');
+        if (Number.isNaN(endMs) || endMs < bounds.windowStartMs || endMs > bounds.windowEndMs) return false;
+        const openedMs = Date.parse(event.payload.opened_at ?? '');
+        return occurredInRange || (!Number.isNaN(openedMs) && openedMs > bounds.sinceMs && openedMs <= bounds.ceilingMs);
+      }
+      case 'survey_published':
+      case 'survey_closed': {
+        const cutoffMs = Date.parse(event.payload.cutoff_date ?? '');
+        if (Number.isNaN(cutoffMs) || cutoffMs < bounds.windowStartMs || cutoffMs > bounds.ceilingMs) return false;
+        const openedMs = Date.parse(event.payload.opened_at ?? '');
+        return occurredInRange || (!Number.isNaN(openedMs) && openedMs > bounds.sinceMs && openedMs <= bounds.ceilingMs);
+      }
+      default:
+        return false;
     }
   }
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -33,7 +33,7 @@ import {
 import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
+import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID, WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS } from '../constants';
 import { AuthenticationError, AuthorizationError, ConflictError, MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { getEffectiveSub, getEffectiveUsername, getRealEmail, resolveRealAccessToken } from '../utils/auth-helper';
@@ -237,8 +237,18 @@ export class WeeklyBriefService {
    */
   public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
     const { response, live } = await this.fetchCurrentBrief(req, committeeId);
-    const withRating = await this.withCallerRating(req, committeeId, response);
-    return this.withStaleness(req, committeeId, withRating, live);
+    // Both enrichments read only `response.brief`, which neither one mutates — run them
+    // concurrently rather than serially chaining rating → staleness, since withStaleness's
+    // committee-activity fetch is the endpoint's single most expensive step (general review
+    // finding, full-branch sweep). Falling back to the original `response` reference when
+    // neither enrichment added anything preserves reference equality for callers that compare
+    // by identity (e.g. the no-brief passthrough case).
+    const [withRating, withStale] = await Promise.all([
+      this.withCallerRating(req, committeeId, response),
+      this.withStaleness(req, committeeId, response, live),
+    ]);
+    if (withRating === response && withStale === response) return response;
+    return { ...withRating, ...withStale };
   }
 
   /**
@@ -1154,10 +1164,12 @@ export class WeeklyBriefService {
       return { ...response, staleness: null };
     }
     try {
-      const { data, page_token } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
-        since: brief.updated_at,
-        limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
-      });
+      const { data, page_token } = await this.withStalenessFetchTimeout(
+        this.committeeActivityService.getCommitteeActivity(req, committeeId, {
+          since: brief.updated_at,
+          limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
+        })
+      );
       const inWindow = data.filter((event) => new Date(event.occurred_at).getTime() <= windowEndMs);
       // getCommitteeActivity sorts descending by occurred_at, so events newer than window_end
       // (irrelevant to this brief) sort ahead of genuine in-window ones. If the fetch itself
@@ -1180,6 +1192,28 @@ export class WeeklyBriefService {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
       return { ...response, staleness: null };
+    }
+  }
+
+  /**
+   * Races the staleness enrichment's committee-activity fetch against
+   * `WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS` — `MicroserviceProxyService` sets no request
+   * timeout of its own, so an upstream hang would otherwise stall `getCurrentBrief` itself for a
+   * purely informational badge. A lost race rejects; `withStaleness`'s own catch handles it the
+   * same as any other fetch fault. Mirrors `ValkeyService#withTimeout`'s pattern: the abandoned
+   * op's eventual settlement is swallowed so a late rejection never surfaces as an unhandled
+   * rejection.
+   */
+  private async withStalenessFetchTimeout<T>(op: Promise<T>): Promise<T> {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error('weekly_brief_staleness_fetch_timeout')), WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS);
+    });
+    op.catch(() => undefined);
+    try {
+      return await Promise.race([op, timeout]);
+    } finally {
+      clearTimeout(timer!);
     }
   }
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1184,7 +1184,6 @@ export class WeeklyBriefService {
         stale: inWindow.length > 0,
         event_count: inWindow.length,
         event_count_is_floor: !!page_token,
-        most_recent_event_at: inWindow[0]?.occurred_at,
       };
       return { ...response, staleness };
     } catch (error) {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1184,7 +1184,14 @@ export class WeeklyBriefService {
     // the rest of that week, since `updated_at` stays before `window_end` regardless of how much
     // later "now" is — gating on "is the window closed right now" instead would wrongly suppress
     // that case.
-    if (sinceMs > windowEndMs) {
+    //
+    // `>=`, not `>` (GH-1967 review): the relevant-events filter below requires a strict
+    // `occurred_at > sinceMs` lower bound and an `occurred_at <= ceilingMs <= windowEndMs` upper
+    // bound — when `sinceMs === windowEndMs` exactly, that interval is provably empty (nothing can
+    // be both strictly greater than and at-most-equal-to the same instant), so `stale: false` is
+    // just as provable here as the strictly-greater case, and skipping the fetch avoids degrading
+    // an already-known-false result to `null` on a timeout/failure/saturation that can't change it.
+    if (sinceMs >= windowEndMs) {
       return { ...response, staleness: { stale: false, event_count: 0, event_count_is_floor: false } };
     }
     // The upper bound is whichever is earlier: the window's own close (activity after it belongs
@@ -1211,7 +1218,19 @@ export class WeeklyBriefService {
         // since`), so without this, an event stamped at the exact same instant as brief.updated_at
         // would count as "new" activity — the strict lower bound here is what actually enforces
         // "happened after the brief was generated" (GH-1967 review).
-        return !Number.isNaN(ms) && ms > sinceMs && ms <= ceilingMs;
+        if (!Number.isNaN(ms) && ms > sinceMs && ms <= ceilingMs) return true;
+        // Collapsed-lifecycle fallback (GH-1967 review): getCommitteeActivity collapses each
+        // vote/survey to one event reflecting only its CURRENT state — a vote/survey that opened
+        // in-window but has since closed shows up only as vote_closed/survey_closed at its (now
+        // out-of-window) close moment, otherwise invisible here. payload.opened_at (always
+        // populated, independent of the event's own type) carries the original open/publish
+        // moment for exactly this check; vote_opened/survey_published events never need it, their
+        // occurred_at already IS the opened_at.
+        if (event.type === 'vote_closed' || event.type === 'survey_closed') {
+          const openedMs = event.payload?.opened_at ? Date.parse(event.payload.opened_at) : NaN;
+          return !Number.isNaN(openedMs) && openedMs > sinceMs && openedMs <= ceilingMs;
+        }
+        return false;
       });
       // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
       // ahead of relevant ones. If `page_token`/`any_leg_saturated`/`any_leg_failed` are all unset,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -240,9 +240,11 @@ export class WeeklyBriefService {
     // Both enrichments read only `response.brief`, which neither one mutates — run them
     // concurrently rather than serially chaining rating → staleness, since withStaleness's
     // committee-activity fetch is the endpoint's single most expensive step (general review
-    // finding, full-branch sweep). Falling back to the original `response` reference when
-    // neither enrichment added anything preserves reference equality for callers that compare
-    // by identity (e.g. the no-brief passthrough case).
+    // finding, full-branch sweep). The no-brief passthrough case is asserted by `toBe` against
+    // the raw upstream object in the existing "getCurrentBrief proxies straight through and
+    // does not swallow a 404" spec — falling back to the original `response` reference when
+    // neither enrichment added anything keeps that pre-existing contract intact rather than
+    // spreading into a fresh object unconditionally.
     const [withRating, withStale] = await Promise.all([
       this.withCallerRating(req, committeeId, response),
       this.withStaleness(req, committeeId, response, live),
@@ -1197,12 +1199,11 @@ export class WeeklyBriefService {
 
   /**
    * Races the staleness enrichment's committee-activity fetch against
-   * `WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS` — `MicroserviceProxyService` sets no request
-   * timeout of its own, so an upstream hang would otherwise stall `getCurrentBrief` itself for a
-   * purely informational badge. A lost race rejects; `withStaleness`'s own catch handles it the
-   * same as any other fetch fault. Mirrors `ValkeyService#withTimeout`'s pattern: the abandoned
-   * op's eventual settlement is swallowed so a late rejection never surfaces as an unhandled
-   * rejection.
+   * `WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS` — see that constant's doc comment for why 3s
+   * tightens, rather than introduces, a deadline on this call. A lost race rejects;
+   * `withStaleness`'s own catch handles it the same as any other fetch fault. Mirrors
+   * `ValkeyService#withTimeout`'s pattern: the abandoned op's eventual settlement is swallowed
+   * so a late rejection never surfaces as an unhandled rejection.
    */
   private async withStalenessFetchTimeout<T>(op: Promise<T>): Promise<T> {
     let timer: NodeJS.Timeout;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -233,25 +233,24 @@ export class WeeklyBriefService {
    * `shareBrief`, `shareToSlack`) call `fetchCurrentBrief` directly instead: `withStaleness`'s
    * committee-activity fan-out is real upstream cost that only the card's own read needs, and
    * paying it on every action-item extraction, share, and rating write for a value those paths
-   * immediately discard would multiply that cost for nothing (general review finding).
+   * immediately discard would multiply that cost for nothing.
    */
   public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
     const { response, live } = await this.fetchCurrentBrief(req, committeeId);
     // Both enrichments read only `response.brief`, which neither one mutates — run them
     // concurrently rather than serially chaining rating → staleness, since withStaleness's
-    // committee-activity fetch is the endpoint's single most expensive step (general review
-    // finding, full-branch sweep). The no-brief passthrough case is asserted by `toBe` against
-    // the raw upstream object in the existing "getCurrentBrief proxies straight through and
-    // does not swallow a 404" spec — falling back to the original `response` reference when
-    // neither enrichment added anything keeps that pre-existing contract intact rather than
-    // spreading into a fresh object unconditionally.
+    // committee-activity fetch is the endpoint's single most expensive step. The no-brief
+    // passthrough case is asserted by `toBe` against the raw upstream object in the existing
+    // "getCurrentBrief proxies straight through and does not swallow a 404" spec — falling back
+    // to the original `response` reference when neither enrichment added anything keeps that
+    // pre-existing contract intact rather than spreading into a fresh object unconditionally.
     const [withRating, withStale] = await Promise.all([
       this.withCallerRating(req, committeeId, response),
       this.withStaleness(req, committeeId, response, live),
     ]);
     // Composed explicitly over `response` (not `{ ...withRating, ...withStale }`) so neither
     // enrichment's key can be silently dropped if the other one's return shape ever changes —
-    // each helper's own object is only a source of its own field (general review finding).
+    // each helper's own object is only a source of its own field.
     if (withRating === response && withStale === response) return response;
     return {
       ...response,
@@ -1135,14 +1134,13 @@ export class WeeklyBriefService {
    * to `staleness: null` rather than throwing. A brief (re)generated after its own window had
    * already closed confidently reports `stale: false` — see the inline comment below for the
    * reasoning, and its caveat: this assumes `updated_at` only ever advances when the brief's
-   * text actually changes. Upstream documents `updated_at` as a generic record-write stamp
-   * (not scoped to text-producing writes) with a separate `last_edited_at` for chair edits only
-   * — `last_edited_at` isn't a safe substitute either, since a regenerate doesn't set it. Using
-   * `updated_at` is still the best available signal (see the git history for the original
-   * reasoning), but a non-text upstream write landing after window close, if one exists, could
-   * in principle move this short-circuit early (general review finding, full-branch sweep — not
-   * resolved here, flagged for review). This is an honest best-effort indicator, never a
-   * precondition for anything, and must never consume generate/regenerate quota.
+   * text actually changes. Upstream documents `updated_at` as a generic record-write stamp (not
+   * scoped to text-producing writes), with a separate `last_edited_at` for chair edits only —
+   * `last_edited_at` isn't a safe substitute either, since a regenerate doesn't set it. Using
+   * `updated_at` is still the best available signal; a non-text upstream write landing after
+   * window close, if one exists, could in principle move this short-circuit early. This is an
+   * honest best-effort indicator, never a precondition for anything, and must never consume
+   * generate/regenerate quota.
    *
    * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
    * query-service) — it has no mock-data branch of its own. Comparing that live activity
@@ -1159,7 +1157,7 @@ export class WeeklyBriefService {
     // non-optional `string` here — this guard is deliberately stricter than the declared type,
     // not redundant with it. An absent `updated_at` would otherwise reach `getCommitteeActivity`
     // as `since: undefined`, silently dropping the lower bound and returning the most recent
-    // activity of ANY age as if it were "since generated" (general review finding).
+    // activity of ANY age as if it were "since generated".
     const sinceMs = Date.parse(brief.updated_at ?? '');
     const windowEndMs = Date.parse(brief.window_end ?? '');
     if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) {
@@ -1177,13 +1175,13 @@ export class WeeklyBriefService {
     // on the next Saturday. A brief first generated any day other than that anchor Saturday is
     // therefore always generated AFTER its own window already closed (`updated_at > window_end`)
     // — and since the generator had the complete, already-closed window available at that exact
-    // moment, nothing can have been missed: `stale: false` here is provable, not a guess, and
+    // moment, nothing can have been missed: `stale: false` here is provable — modulo the
+    // `updated_at` assumption this method's own doc comment caveats above — not a guess, and
     // skipping the fetch entirely avoids paying committee-activity's fan-out for a brief that
-    // can never be stale. An earlier version of this check gated on "is the window closed right
-    // now" instead — that suppressed the one case that actually matters: a brief generated on
-    // the anchor Saturday itself remains checkable for the rest of that week, since `updated_at`
-    // stays before `window_end` regardless of how much later "now" is (general review finding,
-    // full-branch sweep).
+    // can never be stale. A brief generated on the anchor Saturday itself remains checkable for
+    // the rest of that week, since `updated_at` stays before `window_end` regardless of how much
+    // later "now" is — gating on "is the window closed right now" instead would wrongly suppress
+    // that case.
     if (sinceMs > windowEndMs) {
       return { ...response, staleness: { stale: false, event_count: 0, event_count_is_floor: false } };
     }
@@ -1210,11 +1208,16 @@ export class WeeklyBriefService {
       // exists was returned, and if none of it is relevant, that's a confident `false`, not a
       // degrade. Only when `page_token` IS set and nothing relevant turned up on this page could
       // real relevant activity still be sitting on a page never fetched — that's the genuine
-      // false-negative risk. (An earlier version of this broadened the condition to `data.length
-      // > 0` regardless of `page_token`, on the mistaken belief that an untrucated page could
-      // still hide something — general review finding, full-branch sweep: reverted, since that
-      // made the common case (any post-window activity on an anchor-Saturday brief) degrade to
-      // null on every read instead of the provable `stale: false`.)
+      // false-negative risk this guards against.
+      //
+      // Known residual, not covered by this guard: `getCommitteeActivity` can also return
+      // `data: []` with no `page_token` even though a later upstream page (of a saturated leg)
+      // holds rows this caller is authorized to see — its own `hasMore` computation forces
+      // `false` whenever every leg's page happens to filter down to zero FGA-visible rows
+      // (committee-activity.service.ts's own comment on this). That case is indistinguishable
+      // here from "genuinely no activity at all" and reports a confident `stale: false`; fixing
+      // it would mean surfacing `getCommitteeActivity`'s own per-leg saturation flag as a new
+      // field on its response, which is a shared-service change out of scope for this fix.
       if (page_token && relevant.length === 0) {
         logger.warning(req, 'weekly_brief_staleness', 'Activity fetch saturated with no in-range events, degrading staleness to null', {
           committee_id: committeeId,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1091,10 +1091,11 @@ export class WeeklyBriefService {
   }
 
   /**
-   * Enriches a `getCurrentBrief` result with the caller's own rating on that exact brief
-   * revision (LFXV2-3042). Fails soft on every edge: no brief, no resolvable username, or a
-   * cache miss/fault all resolve to `caller_rating: null` rather than throwing — this is a
-   * convenience read for the UI's pre-lit thumb state, not a precondition for anything.
+   * Enriches a current-brief response (from `getCurrentBrief` or `resolveRatableBrief`) with
+   * the caller's own rating on that exact brief revision (LFXV2-3042). Fails soft on every
+   * edge: no brief, no resolvable username, or a cache miss/fault all resolve to
+   * `caller_rating: null` rather than throwing — this is a convenience read for the UI's
+   * pre-lit thumb state, not a precondition for anything.
    */
   private async withCallerRating(req: Request, committeeId: string, response: WeeklyBriefCurrentResponse): Promise<WeeklyBriefCurrentResponse> {
     if (!response.brief) return response;
@@ -1110,11 +1111,13 @@ export class WeeklyBriefService {
    * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
    * committee activity has occurred inside the brief's own window since it was last
    * generated/edited. Fails soft on every edge: no brief or a non-shareable state leave
-   * `staleness` absent entirely (same convention as `caller_rating` on those same edges);
-   * mock mode, an unparseable `updated_at`/`window_end`, an inconclusive fetch (see below), or
-   * a fetch fault all resolve to `staleness: null` rather than throwing. This is an honest
-   * best-effort indicator, never a precondition for anything, and must never consume
-   * generate/regenerate quota.
+   * `staleness` absent entirely — `caller_rating` shares this convention only on the no-brief
+   * edge; unlike `staleness`, `caller_rating` is still populated (as `null`) for a
+   * non-shareable brief, since `withCallerRating` has no state check of its own. Mock mode, an
+   * unparseable `updated_at`/`window_end`, an inconclusive fetch (see below), or a fetch fault
+   * all resolve to `staleness: null` rather than throwing. This is an honest best-effort
+   * indicator, never a precondition for anything, and must never consume generate/regenerate
+   * quota.
    *
    * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
    * query-service) — it has no mock-data branch of its own. Comparing that live activity
@@ -1126,15 +1129,26 @@ export class WeeklyBriefService {
     const brief = response.brief;
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) return response;
     if (!live) return { ...response, staleness: null };
-    // Upstream marks both fields Required, but this BFF proxies the object straight through
-    // with no runtime validation of its own — an absent `updated_at` would otherwise reach
+    // Upstream marks NEITHER field Required (confirmed against committee-service's Goa design —
+    // neither carries a `dsl.Required` entry), even though `WeeklyBrief` declares both as
+    // non-optional `string` here — this guard is deliberately stricter than the declared type,
+    // not redundant with it. Without it, an absent `updated_at` would reach
     // `getCommitteeActivity` as `since: undefined`, silently dropping the lower bound and
     // returning the most recent activity of ANY age as if it were "since generated" (general
     // review finding); an absent/unparseable `window_end` would make every event fail the
-    // `<= windowEndMs` filter, silently reporting "not stale" instead of "unknown".
+    // `<= windowEndMs` filter, silently reporting "not stale" instead of "unknown". Widening
+    // `WeeklyBrief.updated_at`/`.window_end` to optional, so every other reader of this type
+    // (briefWindow-adjacent date logic, `listBriefs`, the card's `weekLabel`) gets the same
+    // guarantee, is a larger, riskier change than this fix — flagged for follow-up, not done here.
     const sinceMs = Date.parse(brief.updated_at ?? '');
     const windowEndMs = Date.parse(brief.window_end ?? '');
-    if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) return { ...response, staleness: null };
+    if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) {
+      logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at/window_end, degrading staleness to null', {
+        committee_id: committeeId,
+        brief_uid: brief.uid,
+      });
+      return { ...response, staleness: null };
+    }
     try {
       const { data, page_token } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
         since: brief.updated_at,
@@ -1186,10 +1200,11 @@ export class WeeklyBriefService {
    * the thumb against content the rater never actually reviewed (PR #1361 review). Matches the
    * optimistic-concurrency contract `saveBrief`/`shareBrief` already enforce for their own writes.
    *
-   * Also returns the brief's `caller_rating` (already resolved by `getCurrentBrief` →
-   * `withCallerRating` for this exact key) as `callerRating`, so `rateBrief`/`clearBriefRating`
-   * can use it as `previous_rating` in their log line without a second, identical Valkey read for
-   * a key this call already read.
+   * Also returns the brief's `caller_rating` (already resolved by this method's own
+   * `withCallerRating` call for this exact key — via `fetchCurrentBrief`, not the full
+   * `getCurrentBrief`, since this call has no need for `staleness`; see GH-1966) as
+   * `callerRating`, so `rateBrief`/`clearBriefRating` can use it as `previous_rating` in their
+   * log line without a second, identical Valkey read for a key this call already read.
    */
   private async resolveRatableBrief(
     req: Request,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  ACTIVITY_FEED_MAX_PAGE_SIZE,
   NEWSLETTER_BODY_MAX_LENGTH,
   NEWSLETTER_SUBJECT_MAX_LENGTH,
   VALKEY_CACHE,
@@ -27,6 +28,7 @@ import {
   WeeklyBriefActionItem,
   WeeklyBriefCurrentResponse,
   WeeklyBriefRating,
+  WeeklyBriefStaleness,
 } from '@lfx-one/shared/interfaces';
 import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
 import { Request } from 'express';
@@ -38,6 +40,7 @@ import { getEffectiveSub, getEffectiveUsername, getRealEmail, resolveRealAccessT
 
 import { AccessCheckService } from './access-check.service';
 import { AiService } from './ai.service';
+import { CommitteeActivityService } from './committee-activity.service';
 import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -215,6 +218,7 @@ export class WeeklyBriefService {
   private newsletterService: NewsletterService = new NewsletterService();
   private accessCheckService: AccessCheckService = new AccessCheckService();
   private aiService: AiService = new AiService();
+  private committeeActivityService: CommitteeActivityService = new CommitteeActivityService();
 
   /**
    * GET /committees/:committeeId/weekly-briefs/current
@@ -225,8 +229,9 @@ export class WeeklyBriefService {
    * over.
    */
   public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
+    const live = this.isLive(req);
     let response: WeeklyBriefCurrentResponse;
-    if (!this.isLive(req)) {
+    if (!live) {
       const brief = currentMockBrief(committeeId);
       response = {
         brief,
@@ -246,7 +251,8 @@ export class WeeklyBriefService {
         'GET'
       );
     }
-    return this.withCallerRating(req, committeeId, response);
+    const withRating = await this.withCallerRating(req, committeeId, response);
+    return this.withStaleness(req, committeeId, withRating, live);
   }
 
   /**
@@ -1085,6 +1091,48 @@ export class WeeklyBriefService {
     if (!key) return response;
     const stored = await valkeyService.getJson<RateWeeklyBriefResponse>(key, isStoredRating);
     return { ...response, caller_rating: stored?.rating ?? null };
+  }
+
+  /**
+   * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
+   * committee activity has occurred inside the brief's own window since it was last
+   * generated/edited. Fails soft on every edge — no brief, non-shareable state, mock mode, or
+   * a fetch fault all resolve to `staleness: null` rather than throwing. This is an honest
+   * best-effort indicator, never a precondition for anything, and must never consume
+   * generate/regenerate quota.
+   *
+   * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
+   * query-service) — it has no mock-data branch of its own. Comparing that live activity
+   * against a synthetic in-memory mock brief would produce a meaningless signal (or simply
+   * fail against an unreachable local stack), so staleness is unconditionally `null` in mock
+   * mode rather than faked. Known gap, not silently papered over — see PR description.
+   */
+  private async withStaleness(req: Request, committeeId: string, response: WeeklyBriefCurrentResponse, live: boolean): Promise<WeeklyBriefCurrentResponse> {
+    const brief = response.brief;
+    if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) return response;
+    if (!live) return { ...response, staleness: null };
+    try {
+      const { data, page_token } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
+        since: brief.updated_at,
+        limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
+      });
+      const windowEndMs = new Date(brief.window_end).getTime();
+      const inWindow = data.filter((event) => new Date(event.occurred_at).getTime() <= windowEndMs);
+      const staleness: WeeklyBriefStaleness = {
+        stale: inWindow.length > 0,
+        event_count: inWindow.length,
+        event_count_is_floor: !!page_token,
+        most_recent_event_at: inWindow[0]?.occurred_at,
+      };
+      return { ...response, staleness };
+    } catch (error) {
+      logger.warning(req, 'weekly_brief_staleness', 'Failed to compute weekly-brief staleness, degrading to null', {
+        committee_id: committeeId,
+        brief_uid: brief.uid,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return { ...response, staleness: null };
+    }
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1199,7 +1199,7 @@ export class WeeklyBriefService {
 
   /**
    * Races the staleness enrichment's committee-activity fetch against
-   * `WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS` — see that constant's doc comment for why 3s
+   * `WEEKLY_BRIEF_STALENESS_FETCH_TIMEOUT_MS` — see that constant's doc comment for why this
    * tightens, rather than introduces, a deadline on this call. A lost race rejects;
    * `withStaleness`'s own catch handles it the same as any other fetch fault. Mirrors
    * `ValkeyService#withTimeout`'s pattern: the abandoned op's eventual settlement is swallowed

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1133,9 +1133,16 @@ export class WeeklyBriefService {
    * non-shareable state leave `staleness` absent entirely. Mock mode, an unparseable
    * `updated_at`/`window_end`, an inconclusive fetch (see below), or a fetch fault all resolve
    * to `staleness: null` rather than throwing. A brief (re)generated after its own window had
-   * already closed confidently reports `stale: false` — see the inline comment below for why
-   * that's provable, not a guess. This is an honest best-effort indicator, never a precondition
-   * for anything, and must never consume generate/regenerate quota.
+   * already closed confidently reports `stale: false` — see the inline comment below for the
+   * reasoning, and its caveat: this assumes `updated_at` only ever advances when the brief's
+   * text actually changes. Upstream documents `updated_at` as a generic record-write stamp
+   * (not scoped to text-producing writes) with a separate `last_edited_at` for chair edits only
+   * — `last_edited_at` isn't a safe substitute either, since a regenerate doesn't set it. Using
+   * `updated_at` is still the best available signal (see the git history for the original
+   * reasoning), but a non-text upstream write landing after window close, if one exists, could
+   * in principle move this short-circuit early (general review finding, full-branch sweep — not
+   * resolved here, flagged for review). This is an honest best-effort indicator, never a
+   * precondition for anything, and must never consume generate/regenerate quota.
    *
    * Mock mode: `CommitteeActivityService` always calls live upstream (committee/meeting/vote/
    * query-service) — it has no mock-data branch of its own. Comparing that live activity
@@ -1172,12 +1179,11 @@ export class WeeklyBriefService {
     // — and since the generator had the complete, already-closed window available at that exact
     // moment, nothing can have been missed: `stale: false` here is provable, not a guess, and
     // skipping the fetch entirely avoids paying committee-activity's fan-out for a brief that
-    // can never be stale. This is also the case the *previous* version of this check got wrong
-    // in the other direction — gating on "is the window closed right now" instead of "was the
-    // window already closed when this brief was written" silently suppressed the one case that
-    // (general review finding, full-branch sweep, ×2): a brief generated on the anchor Saturday
-    // itself remains checkable for the rest of that week, since `updated_at` stays before
-    // `window_end` regardless of how much later "now" is.
+    // can never be stale. An earlier version of this check gated on "is the window closed right
+    // now" instead — that suppressed the one case that actually matters: a brief generated on
+    // the anchor Saturday itself remains checkable for the rest of that week, since `updated_at`
+    // stays before `window_end` regardless of how much later "now" is (general review finding,
+    // full-branch sweep).
     if (sinceMs > windowEndMs) {
       return { ...response, staleness: { stale: false, event_count: 0, event_count_is_floor: false } };
     }
@@ -1198,13 +1204,19 @@ export class WeeklyBriefService {
         return !Number.isNaN(ms) && ms <= ceilingMs;
       });
       // getCommitteeActivity sorts descending by occurred_at, so events past the ceiling sort
-      // ahead of relevant ones. If the fetch returned data at all but every event fell outside
-      // it, genuinely relevant activity could still be sitting on a page never fetched (whether
-      // or not this particular page saturated) — reporting a confident `false` there would be a
-      // false negative, not a floor-qualified true. Degrade to "unknown" instead (general review
-      // finding: originally gated on `page_token` alone, which missed the unpaginated case).
-      if (data.length > 0 && relevant.length === 0) {
-        logger.warning(req, 'weekly_brief_staleness', 'Activity fetch returned only out-of-range events, degrading staleness to null', {
+      // ahead of relevant ones. `page_token` is only ever set when a real `lastPageItem` exists
+      // (committee-activity.service.ts's `hasMore` computation) — so its absence, whenever
+      // `data.length > 0`, is a reliable signal the fetch was NOT truncated: everything that
+      // exists was returned, and if none of it is relevant, that's a confident `false`, not a
+      // degrade. Only when `page_token` IS set and nothing relevant turned up on this page could
+      // real relevant activity still be sitting on a page never fetched — that's the genuine
+      // false-negative risk. (An earlier version of this broadened the condition to `data.length
+      // > 0` regardless of `page_token`, on the mistaken belief that an untrucated page could
+      // still hide something — general review finding, full-branch sweep: reverted, since that
+      // made the common case (any post-window activity on an anchor-Saturday brief) degrade to
+      // null on every read instead of the provable `stale: false`.)
+      if (page_token && relevant.length === 0) {
+        logger.warning(req, 'weekly_brief_staleness', 'Activity fetch saturated with no in-range events, degrading staleness to null', {
           committee_id: committeeId,
           brief_uid: brief.uid,
           fetched: data.length,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1092,10 +1092,10 @@ export class WeeklyBriefService {
 
   /**
    * Enriches a current-brief response (from `getCurrentBrief` or `resolveRatableBrief`) with
-   * the caller's own rating on that exact brief revision (LFXV2-3042). Fails soft on every
-   * edge: no brief, no resolvable username, or a cache miss/fault all resolve to
-   * `caller_rating: null` rather than throwing — this is a convenience read for the UI's
-   * pre-lit thumb state, not a precondition for anything.
+   * the caller's own rating on that exact brief revision (LFXV2-3042). No state check of its
+   * own: no brief, no resolvable username, or an unbuildable rating key leave `caller_rating`
+   * absent entirely (never throwing); only a cache miss/fault resolves it to `null`. This is a
+   * convenience read for the UI's pre-lit thumb state, not a precondition for anything.
    */
   private async withCallerRating(req: Request, committeeId: string, response: WeeklyBriefCurrentResponse): Promise<WeeklyBriefCurrentResponse> {
     if (!response.brief) return response;
@@ -1110,12 +1110,10 @@ export class WeeklyBriefService {
   /**
    * Enriches `getCurrentBrief`'s result with a staleness signal (GH-1966): whether real
    * committee activity has occurred inside the brief's own window since it was last
-   * generated/edited. Fails soft on every edge: no brief or a non-shareable state leave
-   * `staleness` absent entirely — `caller_rating` shares this convention only on the no-brief
-   * edge; unlike `staleness`, `caller_rating` is still populated (as `null`) for a
-   * non-shareable brief, since `withCallerRating` has no state check of its own. Mock mode, an
-   * unparseable `updated_at`/`window_end`, an inconclusive fetch (see below), or a fetch fault
-   * all resolve to `staleness: null` rather than throwing. This is an honest best-effort
+   * generated/edited. No brief or a non-shareable state leave `staleness` absent entirely — a
+   * stricter gate than `withCallerRating`'s (which has no state check of its own). Mock mode,
+   * an unparseable `updated_at`/`window_end`, an inconclusive fetch (see below), or a fetch
+   * fault all resolve to `staleness: null` rather than throwing. This is an honest best-effort
    * indicator, never a precondition for anything, and must never consume generate/regenerate
    * quota.
    *
@@ -1139,13 +1137,19 @@ export class WeeklyBriefService {
     // `<= windowEndMs` filter, silently reporting "not stale" instead of "unknown". Widening
     // `WeeklyBrief.updated_at`/`.window_end` to optional, so every other reader of this type
     // (briefWindow-adjacent date logic, `listBriefs`, the card's `weekLabel`) gets the same
-    // guarantee, is a larger, riskier change than this fix — flagged for follow-up, not done here.
+    // guarantee, is a larger, riskier change than this fix — a deliberate, currently untracked
+    // trade-off, not attempted here.
     const sinceMs = Date.parse(brief.updated_at ?? '');
     const windowEndMs = Date.parse(brief.window_end ?? '');
     if (Number.isNaN(sinceMs) || Number.isNaN(windowEndMs)) {
+      // Both raw values in the payload (not just the uid) so an operator can tell which of the
+      // four possible causes (either field missing, either field unparseable) actually tripped
+      // this — timestamps, not PII.
       logger.warning(req, 'weekly_brief_staleness', 'Brief has an unparseable or missing updated_at/window_end, degrading staleness to null', {
         committee_id: committeeId,
         brief_uid: brief.uid,
+        updated_at: brief.updated_at ?? null,
+        window_end: brief.window_end ?? null,
       });
       return { ...response, staleness: null };
     }

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { ActivityEventType } from '../interfaces/activity-event.interface';
 import { WeeklyBriefSourceSection, WeeklyBriefState } from '../interfaces/weekly-brief.interface';
 
 /**
@@ -102,3 +103,17 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
   { kind: 'doc', label: 'Documents' },
   { kind: 'members', label: 'Membership' },
 ] as const;
+
+/**
+ * Committee-activity-feed event types (GH-1966) that map onto the brief's own source kinds
+ * above — the only ones `WeeklyBriefService#withStaleness` counts toward its staleness signal.
+ * Deliberately narrower than the feed's full `ActivityEventType` union: `survey_published` /
+ * `survey_closed` and `notes_added` are real feed events but not brief sources (surveys and
+ * meeting-notes attachments never feed the generator), so counting them would flag a brief
+ * stale for activity regenerating it could never reflect. Conversely, `mailing-list` and
+ * `members` ARE brief source kinds with no matching feed event at all — `member_joined`/
+ * `member_left` are still `DeferredActivityEvent` (never emitted, see
+ * `activity-event.interface.ts`) and there is no mailing-list event type — so mailing-list and
+ * membership activity is a known, currently unfixable blind spot for this signal.
+ */
+export const WEEKLY_BRIEF_STALENESS_EVENT_TYPES: readonly ActivityEventType[] = ['meeting_held', 'vote_opened', 'vote_closed', 'document_uploaded'];

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -107,13 +107,21 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
 /**
  * Committee-activity-feed event types (GH-1966) that map onto the brief's own source kinds
  * above — the only ones `WeeklyBriefService#withStaleness` counts toward its staleness signal.
- * Deliberately narrower than the feed's full `ActivityEventType` union: `survey_published` /
- * `survey_closed` and `notes_added` are real feed events but not brief sources (surveys and
- * meeting-notes attachments never feed the generator), so counting them would flag a brief
- * stale for activity regenerating it could never reflect. Conversely, `mailing-list` and
- * `members` ARE brief source kinds with no matching feed event at all — `member_joined`/
- * `member_left` are still `DeferredActivityEvent` (never emitted, see
- * `activity-event.interface.ts`) and there is no mailing-list event type — so mailing-list and
- * membership activity is a known, currently unfixable blind spot for this signal.
+ * Deliberately narrower than the feed's full `ActivityEventType` union: verified against
+ * upstream's `buildClaimsAndRefs` (`group_weekly_brief_generator.go`) — it emits `Kind: "survey"`
+ * (fed into `ClaimEvidence`, i.e. the generator's actual LLM input) but never a `"document"`/
+ * `"doc"` kind, so `document_uploaded` doesn't correspond to a real brief source and
+ * `survey_published`/`survey_closed` do. `notes_added` is excluded, meeting-notes attachments
+ * still don't feed the generator. Conversely, `mailing-list` and `members` ARE brief source
+ * kinds with no matching feed event at all — `member_joined`/`member_left` are still
+ * `DeferredActivityEvent` (never emitted, see `activity-event.interface.ts`) and there is no
+ * mailing-list event type — so mailing-list and membership activity is a known, currently
+ * unfixable blind spot for this signal.
  */
-export const WEEKLY_BRIEF_STALENESS_EVENT_TYPES: readonly ActivityEventType[] = ['meeting_held', 'vote_opened', 'vote_closed', 'document_uploaded'];
+export const WEEKLY_BRIEF_STALENESS_EVENT_TYPES: readonly ActivityEventType[] = [
+  'meeting_held',
+  'vote_opened',
+  'vote_closed',
+  'survey_published',
+  'survey_closed',
+];

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -117,6 +117,16 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * `DeferredActivityEvent` (never emitted, see `activity-event.interface.ts`) and there is no
  * mailing-list event type — so mailing-list and membership activity is a known, currently
  * unfixable blind spot for this signal.
+ *
+ * Event-type narrowing is only half of the upstream alignment (GH-1967 Copilot review): these
+ * types alone are broader than what a regeneration can consume — upstream's VoteSource qualifies
+ * votes solely on `end_time` ∈ [window_start, window_end] (`date_field=end_time`, vote_source.go)
+ * and SurveySource on `survey_cutoff_date` ∈ window AND already passed (`cutoff.After(time.Now())`,
+ * survey_source.go) — so an open/publish moment by itself never qualifies a vote or survey.
+ * `WeeklyBriefService#withStaleness` (via `isNewBriefSourceActivity`) therefore additionally gates
+ * each event on its payload's `end_time` / `cutoff_date` — carried on `VoteActivityEventPayload` /
+ * `SurveyActivityEventPayload` for exactly that check — so activity a regeneration could never
+ * reflect can't flag the brief stale.
  */
 export const WEEKLY_BRIEF_STALENESS_EVENT_TYPES: readonly ActivityEventType[] = [
   'meeting_held',

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -57,11 +57,21 @@ export interface MeetingHeldActivityEvent extends BaseActivityEvent {
  * Vote lifecycle payload — shared by both `vote_opened` and `vote_closed`. `status` carries the
  * full upstream `PollStatus` value (not collapsed into the coarse event type) so a client can still
  * render the exact status label ("Vote Disabled: X") the same way the old stop-gap did.
+ *
+ * `opened_at` (GH-1967 review): this leg collapses each vote to a single event reflecting only its
+ * current lifecycle state (`mapVoteToEvent`'s own doc comment) — so once a vote that opened inside
+ * some window has since closed, only its close moment is visible via `occurred_at`, and its opening
+ * is otherwise unrecoverable. Always populated (from the same row already read to build the rest of
+ * this payload) regardless of the event's own type, so a completeness-sensitive caller (e.g.
+ * `WeeklyBriefService#withStaleness`) can check it as a second, independent relevance signal
+ * alongside `occurred_at` — without changing this leg's one-event-per-vote contract for its
+ * original Recent Activity consumer.
  */
 export interface VoteActivityEventPayload {
   vote_uid: string;
   name: string;
   status: string;
+  opened_at?: string;
 }
 
 export interface VoteOpenedActivityEvent extends BaseActivityEvent {
@@ -74,11 +84,16 @@ export interface VoteClosedActivityEvent extends BaseActivityEvent {
   payload: VoteActivityEventPayload;
 }
 
-/** Survey lifecycle payload — shared by `survey_published` and `survey_closed`, same rationale as votes. */
+/**
+ * Survey lifecycle payload — shared by `survey_published` and `survey_closed`, same rationale as
+ * votes. `opened_at` (GH-1967 review) is the survey's publish moment, same reasoning as
+ * `VoteActivityEventPayload.opened_at`.
+ */
 export interface SurveyActivityEventPayload {
   survey_uid: string;
   title: string;
   status: string;
+  opened_at?: string;
 }
 
 export interface SurveyPublishedActivityEvent extends BaseActivityEvent {

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -66,12 +66,21 @@ export interface MeetingHeldActivityEvent extends BaseActivityEvent {
  * `WeeklyBriefService#withStaleness`) can check it as a second, independent relevance signal
  * alongside `occurred_at` — without changing this leg's one-event-per-vote contract for its
  * original Recent Activity consumer.
+ *
+ * `end_time` (GH-1967 Copilot review): the vote's scheduled close — the one field upstream's
+ * weekly-brief `VoteSource` windows on (`date_field=end_time&date_from=windowStart&date_to=windowEnd`,
+ * `vote_source.go`: "we want votes that closed within the window"). Carried so a staleness caller
+ * can tell whether a regeneration could include this vote at all — an open moment alone never
+ * qualifies a vote upstream, so gating on `opened_at`/`occurred_at` without it flags activity a
+ * regenerate could never reflect. Absent when the row has no parseable end_time, which upstream's
+ * end_time filter treats as unselectable too.
  */
 export interface VoteActivityEventPayload {
   vote_uid: string;
   name: string;
   status: string;
   opened_at?: string;
+  end_time?: string;
 }
 
 export interface VoteOpenedActivityEvent extends BaseActivityEvent {
@@ -87,13 +96,19 @@ export interface VoteClosedActivityEvent extends BaseActivityEvent {
 /**
  * Survey lifecycle payload — shared by `survey_published` and `survey_closed`, same rationale as
  * votes. `opened_at` (GH-1967 review) is the survey's publish moment, same reasoning as
- * `VoteActivityEventPayload.opened_at`.
+ * `VoteActivityEventPayload.opened_at`. `cutoff_date` (GH-1967 Copilot review) is
+ * `survey_cutoff_date` — the field upstream's weekly-brief `SurveySource` windows on AND requires
+ * to have already passed (`survey_source.go` skips unparseable cutoffs and drops
+ * `cutoff.After(time.Now())` rows, "excluding surveys still collecting responses") — same
+ * staleness-gating role as `VoteActivityEventPayload.end_time`: publication alone never qualifies
+ * a survey upstream.
  */
 export interface SurveyActivityEventPayload {
   survey_uid: string;
   title: string;
   status: string;
   opened_at?: string;
+  cutoff_date?: string;
 }
 
 export interface SurveyPublishedActivityEvent extends BaseActivityEvent {

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -96,7 +96,10 @@ export interface VoteClosedActivityEvent extends BaseActivityEvent {
 /**
  * Survey lifecycle payload — shared by `survey_published` and `survey_closed`, same rationale as
  * votes. `opened_at` (GH-1967 review) is the survey's publish moment, same reasoning as
- * `VoteActivityEventPayload.opened_at`. `cutoff_date` (GH-1967 Copilot review) is
+ * `VoteActivityEventPayload.opened_at` — but keyed on `survey_send_date` (with `created_at` only
+ * as a fallback for rows with no send date), NOT bare record creation: ITX's survey API is a
+ * schedule API, so a scheduled survey is created before it actually goes out (GH-1967 Copilot
+ * review). `cutoff_date` (GH-1967 Copilot review) is
  * `survey_cutoff_date` — the field upstream's weekly-brief `SurveySource` windows on AND requires
  * to have already passed (`survey_source.go` skips unparseable cutoffs and drops
  * `cutoff.After(time.Now())` rows, "excluding surveys still collecting responses") — same

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { ActivityEvent } from './activity-event.interface';
+import type { PaginatedResponse } from './api.interface';
 import type { AttachmentCategory } from './meeting-attachment.interface';
 
 /**
@@ -44,6 +46,22 @@ export interface CommitteeActivityQuery {
    */
   cursor?: ActivityPageCursor;
   limit: number;
+}
+
+/**
+ * `getCommitteeActivity`'s response (GH-1967 review) — extends the generic `PaginatedResponse`
+ * with `any_leg_failed`: each of the 5 aggregated legs (past meetings, votes, surveys, documents,
+ * notes) is independently caught-and-degraded on failure into `{events: [], saturated: false}`
+ * (see the per-leg `.catch()` calls in `committee-activity.service.ts`), which is otherwise
+ * indistinguishable from a leg that genuinely fetched nothing. `any_leg_failed` surfaces that a
+ * fetch-level failure occurred on at least one leg, so a caller building a completeness-sensitive
+ * signal from this response (e.g. `WeeklyBriefService#withStaleness`) can degrade rather than
+ * silently treat a partial result as exhaustive. Deliberately coarse (which leg, not surfaced) —
+ * a per-leg breakdown isn't needed by today's only completeness-sensitive caller and would widen
+ * this contract further than that caller currently justifies.
+ */
+export interface CommitteeActivityResponse extends PaginatedResponse<ActivityEvent> {
+  any_leg_failed: boolean;
 }
 
 /**

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -50,17 +50,26 @@ export interface CommitteeActivityQuery {
 
 /**
  * `getCommitteeActivity`'s response (GH-1967 review) — extends the generic `PaginatedResponse`
- * with `any_leg_failed`: each of the 5 aggregated legs (past meetings, votes, surveys, documents,
+ * with two completeness signals a caller can't otherwise derive from `data`/`page_token` alone.
+ * Both are deliberately coarse (which leg, not surfaced) — a per-leg breakdown isn't needed by
+ * today's only completeness-sensitive caller (`WeeklyBriefService#withStaleness`) and would widen
+ * this contract further than that caller currently justifies.
+ *
+ * `any_leg_failed`: each of the 5 aggregated legs (past meetings, votes, surveys, documents,
  * notes) is independently caught-and-degraded on failure into `{events: [], saturated: false}`
  * (see the per-leg `.catch()` calls in `committee-activity.service.ts`), which is otherwise
- * indistinguishable from a leg that genuinely fetched nothing. `any_leg_failed` surfaces that a
- * fetch-level failure occurred on at least one leg, so a caller building a completeness-sensitive
- * signal from this response (e.g. `WeeklyBriefService#withStaleness`) can degrade rather than
- * silently treat a partial result as exhaustive. Deliberately coarse (which leg, not surfaced) —
- * a per-leg breakdown isn't needed by today's only completeness-sensitive caller and would widen
- * this contract further than that caller currently justifies.
+ * indistinguishable from a leg that genuinely fetched nothing.
+ *
+ * `any_leg_saturated`: `page_token` alone under-reports this — `committee-activity.service.ts`'s
+ * own `hasMore` computation requires a real `lastPageItem` to anchor a cursor on, so if the
+ * in-memory since/cursor/timestamp pass filters every fetched row out of `windowed` (whether from
+ * FGA-filtered-empty upstream pages, or a leg like surveys whose upstream sort doesn't match its
+ * own occurred_at), `page_token` comes back unset even though a leg's own upstream page was
+ * genuinely saturated. `any_leg_saturated` is read directly off each leg's own `saturated` flag,
+ * independent of whether anything from that leg survived into the returned page.
  */
 export interface CommitteeActivityResponse extends PaginatedResponse<ActivityEvent> {
+  any_leg_saturated: boolean;
   any_leg_failed: boolean;
 }
 

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -154,10 +154,40 @@ export interface WeeklyBriefCurrentResponse {
    * per-user rating store, not upstream — see `weekly-brief.service.ts#getCurrentBrief`.
    */
   caller_rating?: WeeklyBriefRating | null;
+  /**
+   * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
+   * activity has occurred inside `brief`'s own window since it was last touched. `null` when
+   * staleness couldn't be computed — brief is in a non-shareable state, the underlying
+   * committee-activity fetch failed, or mock mode has no comparable live activity source (see
+   * `WeeklyBriefService#withStaleness`'s doc comment). Absent entirely when `brief` is null.
+   * Never a hard failure of `getCurrentBrief`.
+   */
+  staleness?: WeeklyBriefStaleness | null;
 }
 
 /** A caller's one-tap quality rating on a specific weekly-brief revision. BFF-only — no upstream equivalent. */
 export type WeeklyBriefRating = 'up' | 'down';
+
+/**
+ * BFF-side enrichment (GH-1966, not part of upstream's contract): whether real committee
+ * activity has occurred inside this brief's own window since it was last generated/edited
+ * (`updated_at`), and how much. Computed by `WeeklyBriefService#withStaleness` from
+ * `CommitteeActivityService` — purely informational, never affects the brief's own state,
+ * content, or generate/regenerate quota.
+ */
+export interface WeeklyBriefStaleness {
+  /** True when at least one qualifying event was found. */
+  stale: boolean;
+  /** Count of qualifying events found in the fetched page — see `event_count_is_floor`. */
+  event_count: number;
+  /**
+   * True when the underlying committee-activity fetch itself paginated (a `page_token` came
+   * back) — `event_count` is then a floor, not an exact count.
+   */
+  event_count_is_floor: boolean;
+  /** `occurred_at` of the most recent qualifying event, when any exist. */
+  most_recent_event_at?: string;
+}
 
 /**
  * Request body for `POST /committees/:committeeId/weekly-briefs/:briefUid/rating`. `revision` is

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -157,13 +157,14 @@ export interface WeeklyBriefCurrentResponse {
   caller_rating?: WeeklyBriefRating | null;
   /**
    * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
-   * activity has occurred for this committee since `brief` was last touched — NOT scoped to
-   * `brief.window_end` (see `WeeklyBriefService#withStaleness`'s doc comment for why). Absent
-   * entirely when `brief` is null or in a non-shareable state — a stricter gate than
-   * `caller_rating`'s (which has no state check of its own). `null` when staleness
-   * specifically couldn't be computed for a shareable brief — mock mode, an unparseable
-   * `updated_at`, or a fetch fault (see `WeeklyBriefService#withStaleness`'s doc comment).
-   * Never a hard failure of `getCurrentBrief`.
+   * activity has occurred for this committee, since `brief` was last touched, while `brief`'s
+   * own window is still open (see `WeeklyBriefService#withStaleness`'s doc comment for why a
+   * closed window is never actionable). Absent entirely when `brief` is null or in a
+   * non-shareable state — a stricter gate than `caller_rating`'s (which has no state check of
+   * its own). `null` when staleness specifically couldn't be computed, or isn't applicable, for
+   * a shareable brief — an already-closed window, mock mode, an unparseable
+   * `updated_at`/`window_end`, an inconclusive fetch, or a fetch fault (see
+   * `WeeklyBriefService#withStaleness`'s doc comment). Never a hard failure of `getCurrentBrief`.
    */
   staleness?: WeeklyBriefStaleness | null;
 }
@@ -174,10 +175,10 @@ export type WeeklyBriefRating = 'up' | 'down';
 /**
  * BFF-side enrichment (GH-1966, not part of upstream's contract): whether real committee
  * activity has occurred for this committee since this brief's text was last generated/edited
- * (`updated_at`), and how much — NOT scoped to `brief.window_end` (see
- * `WeeklyBriefService#withStaleness`'s doc comment for why). Computed from
- * `CommitteeActivityService` — purely informational, never affects the brief's own state,
- * content, or generate/regenerate quota.
+ * (`updated_at`), while the brief's own window (`window_end`) is still open, and how much (see
+ * `WeeklyBriefService#withStaleness`'s doc comment for why a closed window is excluded).
+ * Computed from `CommitteeActivityService` — purely informational, never affects the brief's
+ * own state, content, or generate/regenerate quota.
  */
 export interface WeeklyBriefStaleness {
   /** True when at least one qualifying event was found. */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -157,13 +157,13 @@ export interface WeeklyBriefCurrentResponse {
   caller_rating?: WeeklyBriefRating | null;
   /**
    * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
-   * activity has occurred inside `brief`'s own window since it was last touched. Absent
+   * activity has occurred for this committee since `brief` was last touched — NOT scoped to
+   * `brief.window_end` (see `WeeklyBriefService#withStaleness`'s doc comment for why). Absent
    * entirely when `brief` is null or in a non-shareable state — a stricter gate than
    * `caller_rating`'s (which has no state check of its own). `null` when staleness
    * specifically couldn't be computed for a shareable brief — mock mode, an unparseable
-   * `updated_at`/`window_end`, an inconclusive committee-activity fetch, or a fetch fault (see
-   * `WeeklyBriefService#withStaleness`'s doc comment). Never a hard failure of
-   * `getCurrentBrief`.
+   * `updated_at`, or a fetch fault (see `WeeklyBriefService#withStaleness`'s doc comment).
+   * Never a hard failure of `getCurrentBrief`.
    */
   staleness?: WeeklyBriefStaleness | null;
 }
@@ -173,8 +173,9 @@ export type WeeklyBriefRating = 'up' | 'down';
 
 /**
  * BFF-side enrichment (GH-1966, not part of upstream's contract): whether real committee
- * activity has occurred inside this brief's own window since it was last generated/edited
- * (`updated_at`), and how much. Computed by `WeeklyBriefService#withStaleness` from
+ * activity has occurred for this committee since this brief's text was last generated/edited
+ * (`updated_at`), and how much — NOT scoped to `brief.window_end` (see
+ * `WeeklyBriefService#withStaleness`'s doc comment for why). Computed from
  * `CommitteeActivityService` — purely informational, never affects the brief's own state,
  * content, or generate/regenerate quota.
  */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -157,10 +157,11 @@ export interface WeeklyBriefCurrentResponse {
   /**
    * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
    * activity has occurred inside `brief`'s own window since it was last touched. Absent
-   * entirely when `brief` is null or in a non-shareable state (same convention as
-   * `caller_rating` on those edges). `null` when staleness specifically couldn't be computed
-   * for a shareable brief — mock mode, an unparseable `updated_at`/`window_end`, an
-   * inconclusive committee-activity fetch, or a fetch fault (see
+   * entirely when `brief` is null or in a non-shareable state — `caller_rating` shares this
+   * convention only on the no-brief edge; unlike `staleness`, `caller_rating` is still
+   * populated (as `null`) for a non-shareable brief. `null` when staleness specifically
+   * couldn't be computed for a shareable brief — mock mode, an unparseable
+   * `updated_at`/`window_end`, an inconclusive committee-activity fetch, or a fetch fault (see
    * `WeeklyBriefService#withStaleness`'s doc comment). Never a hard failure of
    * `getCurrentBrief`.
    */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -157,10 +157,9 @@ export interface WeeklyBriefCurrentResponse {
   /**
    * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
    * activity has occurred inside `brief`'s own window since it was last touched. Absent
-   * entirely when `brief` is null or in a non-shareable state — `caller_rating` shares this
-   * convention only on the no-brief edge; unlike `staleness`, `caller_rating` is still
-   * populated (as `null`) for a non-shareable brief. `null` when staleness specifically
-   * couldn't be computed for a shareable brief — mock mode, an unparseable
+   * entirely when `brief` is null or in a non-shareable state — a stricter gate than
+   * `caller_rating`'s (which has no state check of its own). `null` when staleness
+   * specifically couldn't be computed for a shareable brief — mock mode, an unparseable
    * `updated_at`/`window_end`, an inconclusive committee-activity fetch, or a fetch fault (see
    * `WeeklyBriefService#withStaleness`'s doc comment). Never a hard failure of
    * `getCurrentBrief`.

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -156,11 +156,13 @@ export interface WeeklyBriefCurrentResponse {
   caller_rating?: WeeklyBriefRating | null;
   /**
    * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
-   * activity has occurred inside `brief`'s own window since it was last touched. `null` when
-   * staleness couldn't be computed — brief is in a non-shareable state, the underlying
-   * committee-activity fetch failed, or mock mode has no comparable live activity source (see
-   * `WeeklyBriefService#withStaleness`'s doc comment). Absent entirely when `brief` is null.
-   * Never a hard failure of `getCurrentBrief`.
+   * activity has occurred inside `brief`'s own window since it was last touched. Absent
+   * entirely when `brief` is null or in a non-shareable state (same convention as
+   * `caller_rating` on those edges). `null` when staleness specifically couldn't be computed
+   * for a shareable brief — mock mode, an unparseable `updated_at`/`window_end`, an
+   * inconclusive committee-activity fetch, or a fetch fault (see
+   * `WeeklyBriefService#withStaleness`'s doc comment). Never a hard failure of
+   * `getCurrentBrief`.
    */
   staleness?: WeeklyBriefStaleness | null;
 }

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -183,7 +183,7 @@ export type WeeklyBriefRating = 'up' | 'down';
 export interface WeeklyBriefStaleness {
   /** True when at least one qualifying event was found. */
   stale: boolean;
-  /** Count of qualifying events found in the fetched page — see `event_count_is_floor`. */
+  /** Count of qualifying events found — from the fetched page when a fetch ran; provably `0` on the closed-window short-circuit, where no fetch is needed. See `event_count_is_floor`. */
   event_count: number;
   /**
    * True when the underlying committee-activity fetch itself paginated (a `page_token` came

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -149,9 +149,10 @@ export interface WeeklyBriefCurrentResponse {
   throttle: WeeklyBriefThrottle | null;
   /**
    * BFF-side enrichment (not part of upstream's contract): the calling user's own rating on
-   * this specific `brief.uid` + `brief.revision`, or `null` if they haven't rated it (or no
-   * `brief` was returned). Absent entirely when `brief` is null. Read from the BFF's
-   * per-user rating store, not upstream — see `weekly-brief.service.ts#getCurrentBrief`.
+   * this specific `brief.uid` + `brief.revision`, or `null` on a cache miss/fault. Absent
+   * entirely when `brief` is null, no user identity is resolvable, or no rating cache key
+   * could be built. Read from the BFF's per-user rating store, not upstream — see
+   * `weekly-brief.service.ts#withCallerRating`.
    */
   caller_rating?: WeeklyBriefRating | null;
   /**

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -157,14 +157,14 @@ export interface WeeklyBriefCurrentResponse {
   caller_rating?: WeeklyBriefRating | null;
   /**
    * BFF-side enrichment (not part of upstream's contract, GH-1966): whether real committee
-   * activity has occurred for this committee, since `brief` was last touched, while `brief`'s
-   * own window is still open (see `WeeklyBriefService#withStaleness`'s doc comment for why a
-   * closed window is never actionable). Absent entirely when `brief` is null or in a
-   * non-shareable state — a stricter gate than `caller_rating`'s (which has no state check of
-   * its own). `null` when staleness specifically couldn't be computed, or isn't applicable, for
-   * a shareable brief — an already-closed window, mock mode, an unparseable
-   * `updated_at`/`window_end`, an inconclusive fetch, or a fetch fault (see
-   * `WeeklyBriefService#withStaleness`'s doc comment). Never a hard failure of `getCurrentBrief`.
+   * activity has occurred inside `brief`'s own window, after `brief` was last touched, up to
+   * the earlier of "now" or the window's own close (see `WeeklyBriefService#withStaleness`'s
+   * doc comment for the full reasoning, including why a brief generated after its own window
+   * closed confidently reports `stale: false` rather than `null`). Absent entirely when `brief`
+   * is null or in a non-shareable state — a stricter gate than `caller_rating`'s (which has no
+   * state check of its own). `null` when staleness specifically couldn't be computed for a
+   * shareable brief — mock mode, an unparseable `updated_at`/`window_end`, an inconclusive
+   * fetch, or a fetch fault. Never a hard failure of `getCurrentBrief`.
    */
   staleness?: WeeklyBriefStaleness | null;
 }
@@ -174,11 +174,11 @@ export type WeeklyBriefRating = 'up' | 'down';
 
 /**
  * BFF-side enrichment (GH-1966, not part of upstream's contract): whether real committee
- * activity has occurred for this committee since this brief's text was last generated/edited
- * (`updated_at`), while the brief's own window (`window_end`) is still open, and how much (see
- * `WeeklyBriefService#withStaleness`'s doc comment for why a closed window is excluded).
- * Computed from `CommitteeActivityService` — purely informational, never affects the brief's
- * own state, content, or generate/regenerate quota.
+ * activity has occurred inside this brief's own window (`window_end`), after its text was last
+ * generated/edited (`updated_at`), up to the earlier of "now" or the window's own close, and how
+ * much (see `WeeklyBriefService#withStaleness`'s doc comment for the full reasoning). Computed
+ * from `CommitteeActivityService` — purely informational, never affects the brief's own state,
+ * content, or generate/regenerate quota.
  */
 export interface WeeklyBriefStaleness {
   /** True when at least one qualifying event was found. */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -188,8 +188,6 @@ export interface WeeklyBriefStaleness {
    * back) — `event_count` is then a floor, not an exact count.
    */
   event_count_is_floor: boolean;
-  /** `occurred_at` of the most recent qualifying event, when any exist. */
-  most_recent_event_at?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses part of #1966 — not a full fix. The weekly-brief AI narrative can describe an event as still-upcoming after it already happened, because the brief is never invalidated once real committee activity occurs. Root-cause narrative generation lives entirely upstream in `lfx-v2-committee-service` (GitHub Issues disabled there), so this PR adds the fix that's actually reachable from this repo: a BFF-side **staleness indicator** — not a narrative rewrite — that tells the user when real committee activity has happened since the brief's text was last written, so they can choose to regenerate.

- Never auto-regenerates or consumes generate/regenerate quota — purely informational, next to the existing state badge.
- Additive only: `briefWindow()`'s window-selection logic (shipped separately in PR #1950) is untouched.
- **Does not close #1966.** Live-testing this branch against The Linux Foundation's Board of Directors committee (the exact case #1966 reported) found that a brief generated *after* its own window has already closed is treated by this PR's logic as provably not stale — sound reasoning about activity timing, but it doesn't hold here: the upstream generator produced a wrong narrative even with the complete, closed window already in hand. That's a distinct, more fundamental bug, tracked in #1997. #1966 should stay open until #1997 is resolved.

## What changed

- `WeeklyBriefService#withStaleness` (new): compares real committee activity (via the existing `CommitteeActivityService`) against the brief's own `updated_at`/`window_end`, gated on the brief's window still being open — the only case a regenerate can actually change anything (see "Design decisions" below for why this gate exists).
- Only activity-feed event types that map onto an actual brief source kind count (`meeting_held`, `vote_opened`/`vote_closed`, `survey_published`/`survey_closed`) — document and meeting-notes events are excluded. (Corrected during review — verified against upstream's `buildClaimsAndRefs`: it builds survey claims, not document claims.)
- `fetchCurrentBrief` split off `getCurrentBrief` so `getActionItems`/`shareBrief`/`shareToSlack`/`rateBrief` don't pay the staleness fan-out for a value they never read.
- `caller_rating` and `staleness` now compute in parallel (`Promise.all`), each with a bounded timeout (1.5s, comfortably under the card's own 4s poll-tick budget) so a slow upstream can't stall the brief's own primary content.
- `GET /committees/:id/weekly-briefs/current` now sets `Cache-Control: no-store` (matches the sibling `CommitteeActivityController` — this response carries the same class of per-user, FGA-filtered data).
- New `WeeklyBriefStaleness` type, `weekly-brief-card` UI: a compact warn-severity tag next to the existing state badge, tooltip-only copy (no window language).

## Design decisions to flag for review

1. **UI copy/placement** — "May be out of date" tag next to the state badge is a strawman, not a locked design decision. Compact-tag vs. full-width-banner and exact wording are both open.
2. **No caching** — `withStaleness` pays `CommitteeActivityService`'s full upstream fan-out on every read of a brief whose window is still open (in practice: every card render for the week following an anchor-Saturday generation). Deliberately shipped without a cache for this PR — recommend a short-TTL Valkey cache keyed on `(committee_uid, brief.uid, brief.revision)` as a fast follow-up if this proves costly in practice.
3. **Timeout bounds latency, not upstream cost** — the 1.5s deadline races the fetch (`Promise.race`) rather than aborting it; a slow committee-activity backend still runs the full fan-out to completion even after this endpoint has moved on. A real fix means threading a cancellable deadline through `CommitteeActivityService.getCommitteeActivity`, out of scope here.
4. **Known blind spot: mailing-list and membership activity** — these are real brief source kinds, but the committee-activity feed has no matching event type for either (`member_joined`/`member_left` are still `DeferredActivityEvent`, never emitted; there is no mailing-list event type at all). Mailing-list traffic is plausibly the most common source of real staleness and this signal can never catch it.
5. **`updated_at` assumption** — the window-closed short-circuit assumes `updated_at` only advances when the brief's text actually changes. Upstream documents it as a generic record-write timestamp, not scoped to text-producing writes (there's a separate `last_edited_at` for chair edits only, which isn't a safe substitute since a regenerate doesn't set it). Flagged in the code; not resolved here.
6. **Completeness signals, added during review**: `getCommitteeActivity` now returns `any_leg_saturated`/`any_leg_failed`, and `withStaleness` degrades to `null` on either rather than treating an empty result as exhaustive. Closes two review-caught gaps: a pre-existing `CommitteeActivityService` pagination quirk (an empty page with no `page_token` even when a later, saturated page holds rows the caller is authorized to see — most reachable via the survey leg's `updated_desc` sort not matching its own `occurred_at`), and a per-leg fetch failure being indistinguishable from a leg that genuinely fetched nothing.
7. **Votes' upstream date narrowing** (added during review): `fetchVoteEvents` no longer sends `date_from` — a deadline-driven `vote_closed` can occur with no write to `last_modified_time` at all, so narrowing on it was systematically excluding exactly the votes a completeness check needs, the same failure class already fixed for surveys. `date_to` is still sent (safe: over-inclusive, trimmed in-memory).
8. **Mock mode**: `CommitteeActivityService` has no mock-data branch, so `staleness` is unconditionally `null` in mock/dev mode rather than faked.
9. **Confirmed live gap, not just theoretical**: see #1997 — a brief generated after window-close can still misstate an in-window event, and this PR's staleness check cannot flag it (see Summary).

## PR-shape notes (self-audited via `/lfx-self-serve-pr-readiness`)

- Branch name (`fix/GH-1966-...`) predates this session and doesn't match the `fix/issue-` convention — pre-existing, not renamed mid-work.
- Several interim `fix(review): ...` commit headers exceed the 72-char team-style target (all still under commitlint's 100-char hard limit) — these are iteration commits responding to the review rounds below, not intended as the PR's own summary.
- Diff size: 811 additions / 47 deletions across 10 files — under the 1000-line target.
- Rebased onto current `origin/main`; every commit is DCO-signed-off and GPG-signed (`--signoff -S`).
- No protected files touched.

## Review history

This branch went through 17 commits pre-PR (repeated rounds of the general/self-serve-convention/self-serve-learnings reviewer trio plus full-branch sweeps, including three real correctness bugs caught and fixed in the staleness predicate itself: a near-total no-op from the original window-bound, a gate that suppressed the exact scenario #1966 describes, and an event-type mismatch between the activity feed and actual brief sources), then 2 more post-PR iterations addressing copilot-pull-request-reviewer feedback (the event-type mismatch it independently caught with upstream-verified evidence, the completeness-signal and votes-narrowing gaps in items 6–7 above, plus minor human-reviewer nitpicks) — see the individual commit messages for the specifics.

## Test plan

- [x] `yarn check-types && yarn lint && yarn format:check && yarn test && yarn build` all green
- [x] `./check-headers.sh` passes
- [x] New/updated tests: `weekly-brief.service.spec.ts` (staleness enrichment — window gating, event-type filtering, timeout, degrade paths, perf-regression guards on the four internal callers), `weekly-brief-card.component.spec.ts` (tag rendering, tooltip copy, Regenerate unaffected by staleness), `weekly-brief.controller.spec.ts` (Cache-Control header)
- [x] Manual verification against a live-backed committee: done, live-tested against The Linux Foundation's Board of Directors (`WEEKLY_BRIEF_BACKEND=live`). Confirmed the tag only appears when real activity occurred after the brief's `updated_at` while its window is open, and that Regenerate stays fully functional regardless of the tag's presence. Also confirmed, via the exact committee #1966 reported on, that a brief generated after its own window closes is NOT flagged — see Summary and #1997.

