### PR TITLE
docs(cla): apply the Fin content review to the M2 CLA articles

### DIFF
--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -86,7 +86,7 @@ When EasyCLA recorded the account used to sign, the **Signed** column adds a sec
 
 ## Can I download my signed CLA PDF?
 
-You can download a signed **ICLA** (Individual CLA) when EasyCLA has the file — open the **⋮** menu on that row and choose **Download PDF**. If EasyCLA does not have the file, the row offers no download. There is no PDF for an **ECLA** (Employee CLA), because your coverage sits under your employer's Corporate CLA (CCLA) rather than an agreement of your own; where such a row has a **⋮** menu, **Download PDF** appears greyed out and annotated _Covered by Corporate CLA (CCLA)_, and a **Revoked** ECLA has no menu at all. See [Can I download my signed CLA PDF?](../my-clas/#can-i-download-my-signed-cla-pdf).
+You can download a signed **ICLA** (Individual CLA) when EasyCLA has the file — open the **⋮** menu on that row and choose **Download PDF**. If EasyCLA does not have the file, the row offers no download. An **Invalidated** ICLA carries no **⋮** menu at all, so there is nothing to download from it even when the signed file still exists. There is no PDF for an **ECLA** (Employee CLA), because your coverage sits under your employer's Corporate CLA (CCLA) rather than an agreement of your own; where such a row has a **⋮** menu, **Download PDF** appears greyed out and annotated _Covered by Corporate CLA (CCLA)_, and a **Revoked** ECLA has no menu at all. See [Can I download my signed CLA PDF?](../my-clas/#can-i-download-my-signed-cla-pdf).
 
 ## How do I ask my employer's CLA manager to approve or remove my ECLA?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -82,7 +82,7 @@ You can start there. Select **Sign CLA**, search for the project, CLA group, or 
 
 ## Which account was my CLA signed under?
 
-When EasyCLA recorded the account used to sign, the **Signed** column adds a second line under the date, such as _Signed as \<username\> (GitHub)_. It is informational: it tells you which of your linked identities that agreement is attached to, which is what to check when a project still asks you to sign something you believe you have already signed. The line is omitted when EasyCLA has no signing identity on record for that agreement. See [Which identity was a CLA signed under?](../my-clas/#which-identity-was-a-cla-signed-under).
+When EasyCLA recorded the account used to sign, the **Signed** column adds a second line under the date, such as _Signed as \<username\> (GitHub)_. It is informational: it records the account used at signing time, which is what to check when a project still asks you to sign something you believe you have already signed. It is historical — the account it names does not have to be an identity currently linked to your profile. The line is omitted when EasyCLA has no signing identity on record for that agreement. See [Which identity was a CLA signed under?](../my-clas/#which-identity-was-a-cla-signed-under).
 
 ## Can I download my signed CLA PDF?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -66,7 +66,7 @@ Go to [**Profile & Account**](/profile) and open the **CLAs** tab (`/profile/cla
 
 ## What is the difference between an ICLA and an ECLA?
 
-An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from the CLAs tab when EasyCLA has the file. An **ECLA** (Employee CLA) means your employer holds a **CCLA** (Corporate CLA) and you were approved under it via the company's **Approved List**; the CLAs tab lists it with the company name and no individual PDF, and keeps listing it with a status that says so if that coverage later ends. See [CLAs](../my-clas/).
+An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from the CLAs tab when EasyCLA has the file and the agreement has not been invalidated. An **ECLA** (Employee CLA) means your employer holds a **CCLA** (Corporate CLA) and you were approved under it via the company's **Approved List**; the CLAs tab lists it with the company name and no individual PDF, and keeps listing it with a status that says so if that coverage later ends. See [CLAs](../my-clas/).
 
 ## Why don't my signed CLAs show up on the CLAs tab?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-08-28
+last_updated: 2026-08-29
 intercom_collection: Account
 ---
 
@@ -80,6 +80,14 @@ You can start there. Select **Sign CLA**, search for the project, CLA group, or 
 
 **Valid** means the agreement covers your contributions. **Needs attention** means an Employee CLA no longer covers you, usually because you have dropped off your employer's **Approved List**. **Invalidated** means the agreement is no longer in force — someone removed you from an Approved List, a maintainer invalidated your ICLA, or the CLA group was deleted. **Revoked** is reserved for a sanctions-screening outcome against your employer and cannot be changed from Self Serve. See [What do the status labels mean?](../my-clas/#what-do-the-status-labels-mean).
 
+## Which account was my CLA signed under?
+
+When EasyCLA recorded the account used to sign, the **Signed** column adds a second line under the date, such as _Signed as \<username\> (GitHub)_. It is informational: it tells you which of your linked identities that agreement is attached to, which is what to check when a project still asks you to sign something you believe you have already signed. The line is omitted when EasyCLA has no signing identity on record for that agreement. See [Which identity was a CLA signed under?](../my-clas/#which-identity-was-a-cla-signed-under).
+
+## Can I download my signed CLA PDF?
+
+You can download a signed **ICLA** (Individual CLA) when EasyCLA has the file — open the **⋮** menu on that row and choose **Download PDF**. If EasyCLA does not have the file, the row offers no download. There is no PDF for an **ECLA** (Employee CLA), because your coverage sits under your employer's Corporate CLA (CCLA) rather than an agreement of your own; where such a row has a **⋮** menu, **Download PDF** appears greyed out and annotated _Covered by Corporate CLA (CCLA)_, and a **Revoked** ECLA has no menu at all. See [Can I download my signed CLA PDF?](../my-clas/#can-i-download-my-signed-cla-pdf).
+
 ## How do I ask my employer's CLA manager to approve or remove my ECLA?
 
 Open the **⋮** menu on the Employee CLA row and choose **Request approval** (when you are no longer on the Approved List) or **Request Removal**. Select which CLA managers to notify, optionally add a message, and select **Send**. The request only notifies them — a manager makes the actual change in the Corporate CLA Console. See [How do I ask my CLA manager to approve or remove my ECLA?](../my-clas/#how-do-i-ask-my-cla-manager-to-approve-or-remove-my-ecla).
@@ -98,7 +106,7 @@ Recent purchases may take up to 48 hours to appear in LFX Self Serve. If a purch
 
 ## Can I request a refund through LFX Self Serve?
 
-To request a refund, contact LFX support with your order confirmation.
+No — there is no refund request in LFX Self Serve. To request a refund, contact LFX support with your order confirmation.
 
 ## Who can see my transactions?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-08-29
+last_updated: 2026-08-31
 intercom_collection: Account
 ---
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -4,7 +4,7 @@ description: View your signed Individual and Employee CLAs in LFX Self Serve, st
 audience: [all]
 product_area: Account
 tags: [account, cla, easycla, icla, ecla, ccla, identities, signing]
-last_updated: 2026-08-28
+last_updated: 2026-08-29
 intercom_collection: Account
 ---
 
@@ -26,13 +26,13 @@ Agreements are matched from your signed-in session and your linked [Email and Gi
 
 ## What is the difference between ICLA and ECLA?
 
+An **ICLA** (Individual CLA) is _your_ paperwork, signed as yourself; an **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA). Both appear on the CLAs tab.
+
 | Type                      | What it means                                                                                                  | On CLAs                                                                  | Document                                                                                       |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
 | **ICLA** (Individual CLA) | You signed as yourself for a project                                                                           | Listed                                                                   | **Download PDF** when EasyCLA has the signed file; otherwise the row offers no download        |
 | **ECLA** (Employee CLA)   | Your employer holds a Corporate CLA (CCLA) and you were approved under it via that company's **Approved List** | Listed (shows the employer name), and stays listed if the coverage ends  | No individual PDF — where the row has a **⋮** menu, it shows _Covered by Corporate CLA (CCLA)_ |
 | **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                          | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab                                         |
-
-In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
 
 ## What does the CLAs list show?
 
@@ -41,7 +41,7 @@ When agreements are found, the CLAs tab shows a table with these columns:
 | Column      | Contents                                                                                                                                                 |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Project** | Project logo (or a placeholder), project name, and — when it differs — the CLA group name as secondary text                                              |
-| **Type**    | `ICLA`, or `ECLA · <company name>`                                                                                                                       |
+| **Type**    | `ICLA`, `ECLA · <company name>`, or just `ECLA` when the employer name is not on record                                                                  |
 | **Status**  | Whether the agreement is in force — see [What do the status labels mean?](#what-do-the-status-labels-mean)                                               |
 | **Signed**  | The date the agreement was signed, and — when EasyCLA recorded it — the account it was signed under                                                      |
 | ⋮ (actions) | The actions available for that row, such as **Download PDF** or **Request Removal** — see [What can I do from a CLA row?](#what-can-i-do-from-a-cla-row) |
@@ -58,6 +58,8 @@ If nothing matches your linked identities, you see:
 That does not always mean you never signed — see [Why don't my signed CLAs show up?](#why-don-t-my-signed-clas-show-up).
 
 ## What do the status labels mean?
+
+The **Status** column on the CLAs tab tells you whether an agreement still covers your contributions, and if not, why:
 
 | Status              | What it means                                                                                                                                                                    | Applies to |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
@@ -104,13 +106,14 @@ You will not see a **⋮** on:
 
 ## How do I sign a new CLA?
 
-Select **Sign CLA** at the top right of the CLAs tab.
+You start signing from the CLAs tab and finish in the EasyCLA Contributor Console:
 
-1. In the **Sign a CLA** dialog, type at least three characters. You can search by project name, CLA group name, a linked GitHub, GitLab, or Gerrit organization, or by pasting a repository link.
-2. Each result shows why it matched — project name, CLA group name, linked organization, or repository link — so you can tell near-identical names apart.
-3. Select the right result and choose **Continue to sign**.
-4. Choose which of your linked GitHub accounts to sign under, then select **Continue to sign** again. Nothing is selected for you, and the step appears even when you have only one account linked — its job is to tell you which identity the agreement will be recorded against. If you have no GitHub account linked, the step says so and offers a link to [Identities](/profile/identities); you cannot continue past it until you link one.
-5. Self Serve hands you off to the EasyCLA Contributor Console, which presents and records the agreement. When you finish there, you are returned to the CLAs tab.
+1. Select **Sign CLA** at the top right of the CLAs tab.
+2. In the **Sign a CLA** dialog, type at least three characters. You can search by project name, CLA group name, a linked GitHub, GitLab, or Gerrit organization, or by pasting a repository link.
+3. Each result shows why it matched — project name, CLA group name, linked organization, or repository link — so you can tell near-identical names apart.
+4. Select the right result and choose **Continue to sign**.
+5. Choose which of your linked GitHub accounts to sign under, then select **Continue to sign** again. Nothing is selected for you, and the step appears even when you have only one account linked — its job is to tell you which identity the agreement will be recorded against. If you have no GitHub account linked, the step says so and offers a link to [Identities](/profile/identities); you cannot continue past it until you link one.
+6. Self Serve hands you off to the EasyCLA Contributor Console, which presents and records the agreement. When you finish there, you are returned to the CLAs tab.
 
 If the search returns more matches than it can display, narrow the term — the dialog tells you when results were truncated.
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -163,7 +163,7 @@ The info banner on the CLAs tab also points to the Identities flow (_Link your E
 
 ## Can I download my signed CLA PDF?
 
-Yes for an **ICLA**, when EasyCLA has the signed file — choose **Download PDF** from the row's **⋮** menu. When EasyCLA does not have the file, the row offers no download.
+Yes for an **ICLA**, when EasyCLA has the signed file — choose **Download PDF** from the row's **⋮** menu. When EasyCLA does not have the file, the row offers no download. An **Invalidated** ICLA is the exception: the row carries no **⋮** menu at all, so there is nothing to download from it even when EasyCLA still holds the signed file.
 
 No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. On an ECLA that has a **⋮** menu, the menu shows **Download PDF** greyed out and annotated _Covered by Corporate CLA (CCLA)_. A **Revoked** ECLA has no menu at all, so it shows nothing.
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -4,7 +4,7 @@ description: View your signed Individual and Employee CLAs in LFX Self Serve, st
 audience: [all]
 product_area: Account
 tags: [account, cla, easycla, icla, ecla, ccla, identities, signing]
-last_updated: 2026-08-29
+last_updated: 2026-08-31
 intercom_collection: Account
 ---
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -59,7 +59,7 @@ That does not always mean you never signed — see [Why don't my signed CLAs sho
 
 ## What do the status labels mean?
 
-The **Status** column on the CLAs tab tells you whether an agreement still covers your contributions, and if not, why:
+The **Status** column on the CLAs tab tells you whether an agreement still covers your contributions. These are the labels it uses:
 
 | Status              | What it means                                                                                                                                                                    | Applies to |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -26,7 +26,7 @@ Agreements are matched from your signed-in session and your linked [Email and Gi
 
 ## What is the difference between ICLA and ECLA?
 
-An **ICLA** (Individual CLA) is _your_ paperwork, signed as yourself; an **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA). Both appear on the CLAs tab.
+An **ICLA** (Individual CLA) is _your_ paperwork, signed as yourself. An **ECLA** (Employee CLA) is coverage that came from your employer's **CCLA** (Corporate CLA) rather than from an agreement of your own. Both appear on the CLAs tab, and the **Status** column says whether each one still applies.
 
 | Type                      | What it means                                                                                                  | On CLAs                                                                  | Document                                                                                       |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -81,7 +81,7 @@ When EasyCLA recorded the account used to sign, the **Signed** cell adds a secon
 - _Signed as \<username\> (Gerrit)_ — also used for agreements identified by LF login or email address, which have no separate platform of their own
 - _Signed as \<identity\>_ — with no platform label, when EasyCLA recorded an identity but no recognised platform for it
 
-This line is informational. It tells you which of your accounts an agreement is attached to, which is useful when you have several linked identities and are working out why a project still asks you to sign.
+This line is informational. It records the account used at signing time, which is useful when you sign from more than one account and are working out why a project still asks you to sign. It is historical: EasyCLA reports whatever it recorded when the agreement was signed, so the account named does not have to be an identity currently linked to your profile.
 
 The line is omitted when EasyCLA has no signing identity on record for that agreement. That applies equally to ICLAs and ECLAs — a missing line means missing data, not a difference between the two types.
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -28,11 +28,11 @@ Agreements are matched from your signed-in session and your linked [Email and Gi
 
 An **ICLA** (Individual CLA) is _your_ paperwork, signed as yourself. An **ECLA** (Employee CLA) is coverage that came from your employer's **CCLA** (Corporate CLA) rather than from an agreement of your own. Both appear on the CLAs tab, and the **Status** column says whether each one still applies.
 
-| Type                      | What it means                                                                                                  | On CLAs                                                                  | Document                                                                                       |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                           | Listed                                                                   | **Download PDF** when EasyCLA has the signed file; otherwise the row offers no download        |
-| **ECLA** (Employee CLA)   | Your employer holds a Corporate CLA (CCLA) and you were approved under it via that company's **Approved List** | Listed (shows the employer name), and stays listed if the coverage ends  | No individual PDF — where the row has a **⋮** menu, it shows _Covered by Corporate CLA (CCLA)_ |
-| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                          | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab                                         |
+| Type                      | What it means                                                                                                  | On CLAs                                                                  | Document                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                           | Listed                                                                   | **Download PDF** when EasyCLA has the signed file and the ICLA is not **Invalidated**; otherwise the row offers no download |
+| **ECLA** (Employee CLA)   | Your employer holds a Corporate CLA (CCLA) and you were approved under it via that company's **Approved List** | Listed (shows the employer name), and stays listed if the coverage ends  | No individual PDF — where the row has a **⋮** menu, it shows _Covered by Corporate CLA (CCLA)_                              |
+| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                          | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab                                                                      |
 
 ## What does the CLAs list show?
 
@@ -91,7 +91,7 @@ Each row ends with a **⋮** menu listing only the actions available for that ag
 
 | Action                     | When it appears                                                                                                                            |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Download PDF**           | On an ICLA when EasyCLA has the signed file                                                                                                |
+| **Download PDF**           | On an ICLA that is not **Invalidated**, when EasyCLA has the signed file                                                                   |
 | **Download PDF** (greyed)  | On an ECLA that is not **Revoked**, annotated _Covered by Corporate CLA (CCLA)_ — employee coverage has no individual document to download |
 | **Request approval**       | On an ECLA that is no longer on your employer's **Approved List**                                                                          |
 | **Request Removal**        | On any ECLA that is not **Revoked**                                                                                                        |


### PR DESCRIPTION
The M2 CLA documentation shipped in #1933 without the Intercom **Fin AI**
content-quality review the M1 documentation went through. Help Center articles are
the knowledge base Fin answers support conversations from, so an article that reads
well to a person can still be unusable to Fin — when the answer sits below a table,
a procedure reads as prose, or an entry opens with an escalation instead of an answer.

This applies that review to the two articles #1933 touched, audited against
[`fin-best-practices.md`](https://github.com/linuxfoundation/lfx-skills/blob/main/skills/lfx-intercom/references/fin-best-practices.md).
Content only — no behaviour, no code, no navigation changes.

## My CLAs article

- **Answers moved above their tables.** The ICLA/ECLA section and the status-label
  section each opened on a table header, with the summary sentence below it. Both now
  lead with the sentence, and the ICLA/ECLA one expands all three acronyms on first use.
- **The sign procedure is one sequence again.** Its first action was an orphaned
  paragraph above a list that started at step two, so the numbering read as five steps
  beginning in the middle. It is now six numbered steps, with a one-line lead saying
  where signing starts and where it finishes.
- **Type column corrected.** It described two cases, `ICLA` and `ECLA · <company name>`.
  The badge also renders as a bare `ECLA` when no employer name is on record, which the
  column now records.

## Account FAQ

- **Two new question-form entries**, both deep-linking into the long-form article: which
  account a CLA was signed under, and whether a signed CLA PDF can be downloaded. The PDF
  entry states the Revoked ECLA case explicitly — those rows carry no ⋮ menu at all,
  rather than a greyed-out item inside one.
- **The refund answer leads with the answer.** It opened with "contact LFX support"; it
  now opens with "No — there is no refund request in LFX Self Serve", then says where to go.

Two follow-up commits sit on top of the review itself. One sets `last_updated` to the
ship date on both articles. The other records that an **Invalidated** ICLA offers no
download at all: `buildRowMenuItems` returns an empty menu for that case before it ever
consults `pdfAvailable`, so the row has no ⋮ to open even when EasyCLA still holds the
signed file. The long-form article already listed that case among the rows with no ⋮ but
contradicted itself two sections later, so both PDF answers now state the exception.

## Verification

- Prettier, markdownlint, and `docs:check` (build, validate, coverage, sitemap,
  idempotence) all clean, with artifacts byte-stable across two runs.
- All 10 fragment links in the changed articles resolve against real heading ids,
  checked with the pipeline's own slugify rule. Worth flagging for reviewers: `MD051` is
  disabled repo-wide and CI has no link checker, so deep links into these articles are
  only ever verified by hand.

Refs #1800
