### PR TITLE
test(profile): add reauth-branch and forward-degrade coverage

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
@@ -36,6 +36,11 @@ describe('ProfileLinuxEmailComponent — forward re-auth state (#1935)', () => {
     authorizeUrl: 'https://app.dev.lfx.dev/api/profile/auth/start?returnTo=/profile/identities',
   };
 
+  const claimedReauthUnavailable: LinuxAliasData = {
+    ...claimedNeedsReauth,
+    authorizeUrl: undefined,
+  };
+
   const claimedForwardUnset: LinuxAliasData = {
     state: 'claimed',
     domain: 'linux.com',
@@ -140,6 +145,25 @@ describe('ProfileLinuxEmailComponent — forward re-auth state (#1935)', () => {
     // Regression guard: clearing this here would reopen the automatic-redirect loop
     // maybeReauthForForward exists to prevent.
     expect(sessionStorage.getItem(REAUTH_FLAG_KEY)).toBe('1');
+  });
+
+  it('clears the guard and does not redirect once a reload comes back without forwardAuthRequired', async () => {
+    sessionStorage.setItem(REAUTH_FLAG_KEY, '1');
+    const { locationHref } = await setup(claimedWithForward);
+
+    expect(sessionStorage.getItem(REAUTH_FLAG_KEY)).toBeNull();
+    expect(locationHref()).toBe('https://app.dev.lfx.dev/profile/identities');
+  });
+
+  it('neither redirects nor latches the guard when Flow C is unconfigured (no authorizeUrl)', async () => {
+    const { fixture, locationHref } = await setup(claimedReauthUnavailable);
+
+    expect(locationHref()).toBe('https://app.dev.lfx.dev/profile/identities');
+    expect(sessionStorage.getItem(REAUTH_FLAG_KEY)).toBeNull();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('[data-testid="linux-email-forward-reauth"]')).toBeTruthy();
+    expect(compiled.querySelector('[data-testid="linux-email-forward-select"]')).toBeFalsy();
   });
 
   it('keeps the select usable when the forward is genuinely unset (no forwardAuthRequired)', async () => {

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -284,7 +284,10 @@ export class ProfileLinuxEmailComponent {
    * token. When that token is absent the server flags `forwardAuthRequired`;
    * redirect once to load the real target instead of silently showing the
    * primary email. The one-shot guard prevents a loop if the round-trip returns
-   * still tokenless (or the user cancels).
+   * still tokenless (or the user cancels). If `authorizeUrl` is absent (Flow C
+   * isn't configured), this no-ops instead of redirecting — the template shows
+   * the "try again later" variant of the re-auth panel (no Re-authorize action)
+   * in that case.
    */
   private maybeReauthForForward(alias: LinuxAliasData | null): void {
     if (!isPlatformBrowser(this.platformId)) return;

--- a/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
@@ -322,6 +322,27 @@ describe('ProfileController.getLinuxAlias', () => {
     expect(res.json.mock.calls[0][0]).not.toHaveProperty('forwardAuthRequired');
   });
 
+  it('degrades to service_unavailable when a management token is present but the forward is unreadable', async () => {
+    profileAuthSvc.isProfileAuthConfigured.mockReturnValue(true);
+    profileAuthSvc.getManagementToken.mockReturnValue('mgmt-token');
+    forwardsSvc.getForward.mockResolvedValue(null);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getLinuxAlias(buildReq(), res, next);
+
+    expect(res.json).toHaveBeenCalledWith({
+      state: 'service_unavailable',
+      domain: 'linux.com',
+      alias: null,
+      email: null,
+      forwardTo: null,
+      primaryEmail: null,
+    });
+    expect(res.json.mock.calls[0][0]).not.toHaveProperty('forwardAuthRequired');
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('suppresses forwardAuthRequired during impersonation even without a management token', async () => {
     isImpersonatingMock.mockReturnValue(true);
     profileAuthSvc.isProfileAuthConfigured.mockReturnValue(true);


### PR DESCRIPTION
## Summary

- Cover `maybeReauthForForward`'s guard-reset branch (clearing the one-shot re-auth flag when `forwardAuthRequired` is falsy) — previously untested
- Cover the server's `service_unavailable` degrade branch in `getLinuxAlias` (management token present but `getForward` resolves `null`) — previously untested
- Fix `maybeReauthForForward`'s docstring to describe the no-`authorizeUrl` dead-end path (Flow C not configured — no-ops and renders the non-recoverable re-auth panel instead of redirecting)

Follow-up to #1944's review notes.

Refs #1935