### PR TITLE
docs(social-listening): add Social Listening documentation (LFXV2-3337)

### DIFF
--- a/apps/lfx-one/scripts/lib/build-manifest.mjs
+++ b/apps/lfx-one/scripts/lib/build-manifest.mjs
@@ -36,6 +36,7 @@ const DOCS_TAXONOMY_ORDER = [
   'profile',
   'account',
   'crowdfunding',
+  'social-listening',
 ];
 
 /**

--- a/apps/lfx-one/scripts/lib/build-manifest.mjs
+++ b/apps/lfx-one/scripts/lib/build-manifest.mjs
@@ -444,9 +444,7 @@ function htmlToPlainText(html) {
   // pattern matches closing tags only (`</...>`) — a literal `<` cannot
   // match here, so it is not the kind of regex CodeQL flags as incomplete
   // sanitization (the flagged class is `<[^>]+>`-style strippers).
-  const withNewlines = html
-    .replace(/<\/(?:p|h[1-6]|li|tr|blockquote|figure|figcaption|hr)>/gi, '$&\n')
-    .replace(/<br\s*\/?>/gi, '\n');
+  const withNewlines = html.replace(/<\/(?:p|h[1-6]|li|tr|blockquote|figure|figcaption|hr)>/gi, '$&\n').replace(/<br\s*\/?>/gi, '\n');
   // sanitize-html parses the HTML with a real parser, strips every tag,
   // and decodes named entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`,
   // numeric refs) safely — no manual unescape chain that could be
@@ -470,7 +468,11 @@ function htmlToPlainText(html) {
  */
 function derivedDescription(bodyText) {
   if (!bodyText) return '';
-  const firstPara = bodyText.split(/\n{2,}/)[0]?.replace(/\n/g, ' ').trim() ?? '';
+  const firstPara =
+    bodyText
+      .split(/\n{2,}/)[0]
+      ?.replace(/\n/g, ' ')
+      .trim() ?? '';
   if (firstPara.length <= 160) return firstPara;
   const truncated = firstPara.slice(0, 160);
   const lastSpace = truncated.lastIndexOf(' ');

--- a/docs/user/dashboards/navigate-dashboards/index.md
+++ b/docs/user/dashboards/navigate-dashboards/index.md
@@ -4,7 +4,7 @@ description: How to switch lenses and use the LFX Self Serve dashboard effective
 audience: [all]
 product_area: Dashboards
 tags: [dashboard, lens, navigation, persona]
-last_updated: 2026-05-22
+last_updated: 2026-08-31
 intercom_collection: Dashboards
 ---
 
@@ -25,7 +25,7 @@ The **Me** lens (the default view at `/`) shows your personal activity across al
 
 ## Foundation lens
 
-The **Foundation** lens (`/foundation/overview`) is available to board members and executive directors. It shows foundation-level health metrics, project summaries, and governance activity. Executive directors also see additional health metrics at `/foundation/health-metrics`.
+The **Foundation** lens (`/foundation/overview`) is available to board members and executive directors. It shows foundation-level health metrics, project summaries, and governance activity. Executive directors also see additional health metrics at `/foundation/health-metrics`. Executive directors and LF Staff additionally see [Social Listening](../../social-listening/) under **Metrics** in the left navigation (route: `/foundation/social-listening`).
 
 ## Project lens
 

--- a/docs/user/dashboards/navigate-dashboards/index.md
+++ b/docs/user/dashboards/navigate-dashboards/index.md
@@ -25,7 +25,7 @@ The **Me** lens (the default view at `/`) shows your personal activity across al
 
 ## Foundation lens
 
-The **Foundation** lens (`/foundation/overview`) is available to board members and executive directors. It shows foundation-level health metrics, project summaries, and governance activity. Executive directors also see additional health metrics at `/foundation/health-metrics`. Executive directors and LF Staff additionally see [Social Listening](../../social-listening/) under **Metrics** in the left navigation (route: `/foundation/social-listening`).
+The **Foundation** lens (`/foundation/overview`) is available to board members, executive directors, LF Staff, and users with a writer role on the foundation (including root writers). It shows foundation-level health metrics, project summaries, and governance activity. Under **Metrics** in the left navigation, executive directors and LF Staff additionally see **Health Metrics** (`/foundation/health-metrics`) and [Social Listening](../../social-listening/) (`/foundation/social-listening`).
 
 ## Project lens
 

--- a/docs/user/social-listening/analytics/index.md
+++ b/docs/user/social-listening/analytics/index.md
@@ -1,6 +1,7 @@
 ---
 title: Analytics
 description: How to read and export the Social Listening analytics — trends, platform and tag breakdowns, and sentiment distribution — in LFX Self Serve.
+display_order: 2
 audience: [executive-director]
 product_area: Social Listening
 tags: [social listening, analytics, charts, sentiment, trends, export]

--- a/docs/user/social-listening/analytics/index.md
+++ b/docs/user/social-listening/analytics/index.md
@@ -17,7 +17,7 @@ This article applies to users with the **executive-director** persona and to **L
 
 ## Set the scope
 
-The project, platform, and period selectors at the top of the page apply to the Analytics tab, so every panel reflects the same slice of data. The search box, saved views, and the **FILTERS** panel are part of the Feed tab and do not apply here.
+The project, platform, and period selectors at the top of the page apply to the Analytics tab, so every panel reflects the same slice of data. The search query and most Feed tab filters — Sentiment, Relevance, Language, Has Title, Authors, Keywords, and Tags — also apply here, even though their controls stay on the Feed tab; the active-filter pills above the panels show which ones are in effect. Applying a saved view changes those filters, so its search and filter settings carry across too. Only the bookmark and read-state filters are ignored — Analytics is bookmark- and read-state-blind.
 
 - **Project** — every project in the foundation (the default) or a single project
 - **Platform** — every platform (the default) or a single platform

--- a/docs/user/social-listening/analytics/index.md
+++ b/docs/user/social-listening/analytics/index.md
@@ -1,0 +1,68 @@
+---
+title: Analytics
+description: How to read and export the Social Listening analytics — trends, platform and tag breakdowns, and sentiment distribution — in LFX Self Serve.
+audience: [executive-director]
+product_area: Social Listening
+tags: [social listening, analytics, charts, sentiment, trends, export]
+last_updated: 2026-08-31
+intercom_collection: Social Listening
+---
+
+This article applies to users with the **executive-director** persona and to **LF Staff**. The **Analytics** tab of the Social Listening page turns your mentions into charts and summary statistics.
+
+## Open the Analytics tab
+
+1. Open **Social Listening** from the **Metrics** section of the left navigation in the **Foundation** lens.
+2. Select **Analytics** at the top of the page, next to **Feed**.
+
+## Set the scope
+
+The project, platform, and period selectors at the top of the page apply to the Analytics tab, so every panel reflects the same slice of data. The search box, saved views, and the **FILTERS** panel are part of the Feed tab and do not apply here.
+
+- **Project** — every project in the foundation (the default) or a single project
+- **Platform** — every platform (the default) or a single platform
+- **Period** — **Year to Date**, **Last 3 months**, **Last 6 months**, or an individual month
+
+Changing any selector reloads all panels for the new scope.
+
+## Read the panels
+
+### Stat cards
+
+Three cards summarize the current scope:
+
+- **Total Mentions** — the number of mentions, with the count of projects they span
+- **Negative Sentiment** — the share of mentions classified as Negative
+- **Positive Sentiment** — the share of mentions classified as Positive
+
+Each card shows a trend delta comparing the current period with the previous one. For Negative Sentiment the colors invert: an increase in negative mentions shows red, a decrease shows green.
+
+### Mentions Over Time
+
+A line chart of mention volume across the period, with one line per project so you can compare traction between projects.
+
+### Mentions by Platform
+
+The five platforms with the most mentions in the current scope, each with its share of the total. Select a platform row to drill down — the page switches to the **Feed** tab filtered to that platform. (Rows that group several sources, such as **Other**, are display-only.)
+
+### Mentions by Tag
+
+The most common tags on mentions in the current scope, ranked by count.
+
+### Mentions by Project
+
+The five projects with the most mentions, ranked by count.
+
+### Sentiment Distribution
+
+A single bar showing the Positive, Neutral, and Negative split across all mentions in the current scope, with the count and percentage for each segment.
+
+## Export analytics as PNG
+
+Select the download button at the top right of the page to save the entire Analytics view as a PNG image — useful for slides and reports. The button is disabled while any panel is still loading, so exports never capture placeholder skeletons.
+
+## Related
+
+- [Mentions Feed](../mentions-feed/) — the individual mentions behind these numbers
+- [Saved Views](../saved-views/) — save and share feed filter combinations
+- [Social Listening FAQ](../faq/) — data sources and freshness

--- a/docs/user/social-listening/faq/index.md
+++ b/docs/user/social-listening/faq/index.md
@@ -1,0 +1,59 @@
+---
+title: Social Listening FAQ
+description: Frequently asked questions about Social Listening access, data sources, freshness, and limits in LFX Self Serve.
+audience: [executive-director]
+product_area: Social Listening
+tags: [social listening, faq, octolens, access, limits]
+last_updated: 2026-08-31
+intercom_collection: Social Listening
+---
+
+## Who can see Social Listening?
+
+Social Listening is available to users with the **executive-director** persona and to **LF Staff**. It appears in the **Foundation** lens only.
+
+## Why don't I see Social Listening in the navigation?
+
+Check two things:
+
+1. You are viewing a **Foundation** lens — switch lenses using the lens switcher.
+2. Look under **Metrics** in the left navigation sidebar — Social Listening sits alongside Health Metrics.
+
+If you still don't see it, your account doesn't have the executive-director persona or LF Staff access for that foundation.
+
+## Where does the data come from?
+
+All mention data is provided by **Octolens** and consists exclusively of publicly available content sourced from third-party platforms across the web. The Linux Foundation does not independently collect, enrich, or modify this data.
+
+## How fresh is the data?
+
+The **Data as of** timestamp above the mentions feed shows when the underlying data was last refreshed. Mentions published after that time appear on the next refresh.
+
+## Which platforms are monitored?
+
+Twitter / X, Bluesky, Reddit, YouTube, Facebook, Hacker News, DEV, Podcasts, GitHub, LinkedIn, and Other (publicly available sources that don't fit the other categories).
+
+## Why do the numbers on the Campaign Impact tab differ from the Social Listening page?
+
+The **Campaign Impact** page includes a social listening summary tab — KPI cards, a sentiment breakdown, and top mentions — but it queries its data separately from the standalone Social Listening page. The two views are computed differently and are not guaranteed to match; use the standalone page (`/foundation/social-listening`) for detailed exploration and the Campaign Impact tab for an at-a-glance summary alongside your other marketing metrics.
+
+## Do my saved views and bookmarks carry over from PCC?
+
+Yes. Self Serve reads the same saved data as PCC Social Listening, so your saved views, bookmarks, and read state are already here — nothing to migrate.
+
+## What are the limits?
+
+- **Saved views** — up to 50 per foundation, with names up to 50 characters
+- **Bookmarks** — up to 500 bookmarked mentions per foundation
+- **Filter selections** — up to 50 selected values per list filter (Authors, Keywords, Tags)
+- **Feed size** — the feed renders up to 500 mentions at a time; narrow the filters or shorten the period to see more
+
+## Can I see program-level social listening data in Campaign Impact?
+
+Not yet. When a specific program is selected, the Campaign Impact social listening tab shows a notice — "Showing all programs — social listening data is not yet available at the program level" — and continues to display foundation-wide data.
+
+## Related
+
+- [Social Listening](../) — topic overview and key concepts
+- [Mentions Feed](../mentions-feed/) — search, filters, and card actions
+- [Analytics](../analytics/) — charts and PNG export

--- a/docs/user/social-listening/faq/index.md
+++ b/docs/user/social-listening/faq/index.md
@@ -1,6 +1,7 @@
 ---
 title: Social Listening FAQ
 description: Frequently asked questions about Social Listening access, data sources, freshness, and limits in LFX Self Serve.
+display_order: 4
 audience: [executive-director]
 product_area: Social Listening
 tags: [social listening, faq, octolens, access, limits]

--- a/docs/user/social-listening/index.md
+++ b/docs/user/social-listening/index.md
@@ -1,0 +1,43 @@
+---
+title: Social Listening
+description: Track brand mentions and sentiment across social media, forums, and podcasts for your foundation in LFX Self Serve.
+audience: [executive-director]
+product_area: Social Listening
+tags: [social listening, mentions, sentiment, analytics, octolens]
+last_updated: 2026-08-31
+intercom_collection: Social Listening
+---
+
+This page applies to users with the **executive-director** persona and to **LF Staff**.
+
+Social Listening tracks brand mentions and sentiment across social, forums, and podcasts for your foundation and its projects. It collects publicly available posts that mention your foundation, classifies each mention by sentiment and relevance, and presents them in a searchable, filterable feed with analytics.
+
+## What you can do
+
+- Browse a feed of brand mentions across 11 platforms
+- Search mentions and filter by sentiment, relevance, language, author, keyword, tag, and more
+- Save filter combinations as named views and share them by URL
+- Bookmark mentions and track read/unread state
+- View analytics: mentions over time, by platform, by tag, by project, and sentiment distribution
+- Export analytics charts as PNG images
+
+## Navigation
+
+Switch to your **Foundation** lens using the lens switcher, then select **Social Listening** under **Metrics** in the left navigation sidebar (route: `/foundation/social-listening`).
+
+A summary of social listening activity also appears as a tab on the **Campaign Impact** page — see [the FAQ](./faq/) for how the two views differ.
+
+## Key concepts
+
+- **Mention**: A single publicly available post (a tweet, Reddit comment, podcast episode, and so on) that references your foundation or one of its projects
+- **Sentiment**: The tone of a mention — **Positive**, **Neutral**, or **Negative**
+- **Relevance**: How closely a mention relates to your foundation — **High** or **Low**
+- **Platforms**: Twitter / X, Bluesky, Reddit, YouTube, Facebook, Hacker News, DEV, Podcasts, GitHub, LinkedIn, and Other
+- **Saved views**: Named, reusable filter combinations you can apply with one click and share by URL
+- **Bookmarks**: Mentions you flag for follow-up, saved per project
+- **Read state**: Each mention is tracked as read or unread so you can tell at a glance what is new
+- **Octolens**: The third-party data provider that supplies all mention data
+
+## Related sections
+
+- [Dashboards](../dashboards/) — lens-based dashboards, including the Foundation lens where Social Listening lives

--- a/docs/user/social-listening/index.md
+++ b/docs/user/social-listening/index.md
@@ -34,7 +34,7 @@ A summary of social listening activity also appears as a tab on the **Campaign I
 - **Relevance**: How closely a mention relates to your foundation — **High** or **Low**
 - **Platforms**: Twitter / X, Bluesky, Reddit, YouTube, Facebook, Hacker News, DEV, Podcasts, GitHub, LinkedIn, and Other
 - **Saved views**: Named, reusable filter combinations you can apply with one click and share by URL
-- **Bookmarks**: Mentions you flag for follow-up, saved per project
+- **Bookmarks**: Mentions you flag for follow-up, saved per foundation
 - **Read state**: Each mention is tracked as read or unread so you can tell at a glance what is new
 - **Octolens**: The third-party data provider that supplies all mention data
 

--- a/docs/user/social-listening/mentions-feed/index.md
+++ b/docs/user/social-listening/mentions-feed/index.md
@@ -1,6 +1,7 @@
 ---
 title: Mentions Feed
 description: How to search, filter, and manage individual brand mentions in the Social Listening feed in LFX Self Serve.
+display_order: 1
 audience: [executive-director]
 product_area: Social Listening
 tags: [social listening, mentions, feed, filters, search, bookmarks, read state]

--- a/docs/user/social-listening/mentions-feed/index.md
+++ b/docs/user/social-listening/mentions-feed/index.md
@@ -61,7 +61,7 @@ Select anywhere on a card to open the original post in a new tab — this also m
 - **Mark as Read / Mark as Unread** — toggles the mention's read state
 - **Bookmark** — saves the mention so you can find it later with the **Bookmarked** filter (up to 500 bookmarks per foundation)
 
-Above the list, **Mark all as read** and **Mark all as unread** apply to every mention in the current scope. The **Data as of** timestamp next to them shows when the underlying data was last refreshed.
+Above the list, **Mark all as read** and **Mark all as unread** apply to **every mention in the foundation** — not just the ones matching your current filters, search, or period. **Mark all as read** marks everything up to the foundation's newest mention as read, and **Mark all as unread** clears the read state for the whole foundation, including mentions your current scope hides. The **Data as of** timestamp next to them shows when the underlying data was last refreshed.
 
 ## Load more mentions
 

--- a/docs/user/social-listening/mentions-feed/index.md
+++ b/docs/user/social-listening/mentions-feed/index.md
@@ -1,0 +1,82 @@
+---
+title: Mentions Feed
+description: How to search, filter, and manage individual brand mentions in the Social Listening feed in LFX Self Serve.
+audience: [executive-director]
+product_area: Social Listening
+tags: [social listening, mentions, feed, filters, search, bookmarks, read state]
+last_updated: 2026-08-31
+intercom_collection: Social Listening
+---
+
+This article applies to users with the **executive-director** persona and to **LF Staff**. The **Feed** tab is the default view of the Social Listening page — a running list of individual mentions that match your current scope and filters.
+
+## Search mentions
+
+1. Open **Social Listening** from the **Metrics** section of the left navigation in the **Foundation** lens.
+2. Type at least 3 characters into the **Search mentions...** box.
+3. The feed updates automatically, about half a second after you stop typing.
+
+Clear the search box to return to the unfiltered feed.
+
+## Set the scope
+
+Three selectors at the top of the page control which mentions the feed contains:
+
+- **Project** — every project in the foundation (**All Projects**, the default) or a single project. If your foundation has exactly one project, its name appears as a fixed label instead of a selector.
+- **Platform** — every platform (**All Platforms**, the default) or a single platform.
+- **Period** — **Year to Date**, **Last 3 months**, **Last 6 months**, or any individual recent month.
+
+## Filter the feed
+
+Select the filters button (the sliders icon) to open the **FILTERS** panel. A badge on the button shows how many filters are currently active. Nine filters are available:
+
+- **Sentiment** — All, Positive, Neutral, or Negative
+- **Relevance** — All, High, or Low
+- **Language** — the language the mention was written in
+- **Has Title** — All, Yes, or No
+- **Bookmarked** — All, or only mentions you have bookmarked
+- **Read Status** — All, or Unread only
+- **Authors** — one or more specific authors
+- **Keywords** — one or more specific keywords
+- **Tags** — one or more specific tags
+
+For **Authors**, **Keywords**, and **Tags** you can select up to 50 values per filter. Select **Clear all** at the top of the panel to reset every filter at once.
+
+## Read a mention card
+
+Each card in the feed shows one mention:
+
+- A colored rail and icon on the left edge indicate the sentiment (green for Positive, amber for Neutral, red for Negative).
+- The header line reads "Mention of **{project}** in **{platform}**", followed by the author's name — linked to their profile when available — and how long ago the mention was posted. Reddit mentions also link to the subreddit.
+- The mention's title and body appear below; long bodies are truncated with a **Read full post** link.
+- A **High Relevance** or **Low Relevance** chip and any tag chips appear at the bottom.
+- When Octolens has enriched the mention, an expandable analysis appears beneath the chips.
+
+## Act on a mention
+
+Select anywhere on a card to open the original post in a new tab — this also marks the mention as read. Each card also has four action icons:
+
+- **Forward by email** — opens your mail client with the mention contents pre-filled
+- **Copy Link** — copies the URL of the original post
+- **Mark as Read / Mark as Unread** — toggles the mention's read state
+- **Bookmark** — saves the mention so you can find it later with the **Bookmarked** filter (up to 500 bookmarks per foundation)
+
+Above the list, **Mark all as read** and **Mark all as unread** apply to every mention in the current scope. The **Data as of** timestamp next to them shows when the underlying data was last refreshed.
+
+## Load more mentions
+
+The feed loads mentions in batches. Select **Load more mentions** at the bottom to reveal the next batch, and the counter above the list ("20 of 312", for example) shows your position.
+
+The feed renders at most 500 mentions at once. When you reach that limit a notice appears — "Showing the first 500 mentions" — and you can narrow the filters or shorten the period to see different mentions.
+
+## Empty and error states
+
+- **No mentions found** — nothing matches the current scope and filters. Try widening the period or clearing the search.
+- **You're all caught up** — you are viewing unread mentions and none remain.
+- **Couldn't load these mentions** — a batch failed to load; use the retry option to fetch it again.
+
+## Related
+
+- [Saved Views](../saved-views/) — save a filter combination and reuse or share it
+- [Analytics](../analytics/) — charts and trends across your mentions
+- [Social Listening FAQ](../faq/) — data sources, freshness, and limits

--- a/docs/user/social-listening/saved-views/index.md
+++ b/docs/user/social-listening/saved-views/index.md
@@ -38,12 +38,21 @@ Selecting **No Preset View** at the top of the dropdown returns the feed to its 
 
 ## Share a view
 
-The page URL always reflects your current filters, so you can share any view by copying the address bar:
+The page URL always reflects your current filters, so you can share any view by copying the address bar. What your colleague sees depends on whether the link carries a saved view.
 
-1. Apply the saved view (or set the filters up manually).
+**Sharing a saved view:**
+
+1. Apply the saved view.
 2. Copy the page URL and send it to a colleague.
 
-When someone opens your link, the feed loads with those filters applied and a banner explains: "These filters were shared as a preset view — they were saved by the person who shared this link." They can select **Save as my view** in the banner to keep a copy under their own account, or dismiss the banner to use the filters without saving.
+The URL contains the view's ID. When someone opens your link, the feed loads with those filters applied and a banner explains: "These filters were shared as a preset view — they were saved by the person who shared this link." They can select **Save as my view** in the banner to keep a copy under their own account, or dismiss the banner to use the filters without saving.
+
+**Sharing filters you set up manually:**
+
+1. Set the filters up manually.
+2. Copy the page URL and send it to a colleague.
+
+The URL restores those filters for whoever opens it, but no banner or **Save as my view** action appears — those are tied to saved views. Your colleague can still keep the setup by selecting **Save current view** in the views dropdown.
 
 ## Moving from PCC
 

--- a/docs/user/social-listening/saved-views/index.md
+++ b/docs/user/social-listening/saved-views/index.md
@@ -1,0 +1,55 @@
+---
+title: Saved Views
+description: How to save, apply, share, and manage named filter views on the Social Listening feed in LFX Self Serve.
+audience: [executive-director]
+product_area: Social Listening
+tags: [social listening, saved views, filters, sharing, presets]
+last_updated: 2026-08-31
+intercom_collection: Social Listening
+---
+
+This article applies to users with the **executive-director** persona and to **LF Staff**. A saved view is a named snapshot of your current Social Listening setup that you can reapply with one click.
+
+## What a view captures
+
+A saved view stores everything that shapes the **Feed** tab:
+
+- The search query
+- All nine filters (Sentiment, Relevance, Language, Has Title, Bookmarked, Read Status, Authors, Keywords, Tags)
+- The current scope — the period, project, and platform selectors
+
+Views are saved per foundation and are private to you — other users never see your views in their own dropdown.
+
+## Save a view
+
+1. Set up the feed the way you want it — apply any search, filters, and scope selections.
+2. Either open the **FILTERS** panel and select **Save as View**, or open the views dropdown (the bookmark icon, labeled with the active view's name) and select **Save current view**.
+3. Enter a name (up to 50 characters) and select **Save**.
+
+Names must be unique — if you reuse an existing view's name, the dialog asks you to pick another. You can keep up to 50 saved views per foundation; when you reach the limit, delete an existing view before saving a new one.
+
+## Apply or delete a view
+
+1. Open the views dropdown at the top of the feed.
+2. Select a view's name to apply it — the feed reloads with that view's search, filters, and scope.
+3. To delete a view, select its delete icon in the dropdown.
+
+Selecting **No Preset View** at the top of the dropdown returns the feed to its default state.
+
+## Share a view
+
+The page URL always reflects your current filters, so you can share any view by copying the address bar:
+
+1. Apply the saved view (or set the filters up manually).
+2. Copy the page URL and send it to a colleague.
+
+When someone opens your link, the feed loads with those filters applied and a banner explains: "These filters were shared as a preset view — they were saved by the person who shared this link." They can select **Save as my view** in the banner to keep a copy under their own account, or dismiss the banner to use the filters without saving.
+
+## Moving from PCC
+
+Saved views you created in PCC Social Listening are already here — Self Serve reads the same saved data, so your views, bookmarks, and read state carry over automatically.
+
+## Related
+
+- [Mentions Feed](../mentions-feed/) — the filters and scope selectors a view captures
+- [Social Listening FAQ](../faq/) — limits and data carry-over details

--- a/docs/user/social-listening/saved-views/index.md
+++ b/docs/user/social-listening/saved-views/index.md
@@ -1,6 +1,7 @@
 ---
 title: Saved Views
 description: How to save, apply, share, and manage named filter views on the Social Listening feed in LFX Self Serve.
+display_order: 3
 audience: [executive-director]
 product_area: Social Listening
 tags: [social listening, saved views, filters, sharing, presets]

--- a/packages/shared/src/constants/docs.constant.ts
+++ b/packages/shared/src/constants/docs.constant.ts
@@ -52,4 +52,5 @@ export const DOCS_TAXONOMY_ORDER: readonly string[] = [
   'profile',
   'account',
   'crowdfunding',
+  'social-listening',
 ] as const;


### PR DESCRIPTION
## Summary

Adds a complete user-facing documentation topic for Social Listening — the Foundation-lens feature that tracks brand mentions and sentiment for a foundation and its projects. The topic covers the landing overview, the mentions feed, saved views, analytics, and an FAQ, and is registered in the docs taxonomy so it renders in the documentation navigation. UI terminology is sourced from the shipped templates and constants, and the articles document PCC carry-over behavior for saved views, bookmarks, and read state.

Resolves LFXV2-3337

## Behavior changes

| Before | After |
|---|---|
| Social Listening had no user documentation — executive directors and LF Staff landing on the feature had no help articles explaining the mentions feed, saved views, analytics, or access requirements, and the documentation navigation had no Social Listening entry. | A full Social Listening documentation section is available: a landing overview, per-feature articles for the mentions feed, saved views, and analytics, plus an FAQ covering access, data sources, freshness, and limits. The section appears in the docs navigation, and the dashboards navigation article points readers to it. |

## Technical changes

`docs/user/social-listening/` — New documentation topic (5 articles)

- `index.md` — landing page: what Social Listening does, what users can do, navigation path (`/foundation/social-listening` under **Metrics**), key concepts, and the Campaign Impact tab relationship
- `mentions-feed/index.md` — search, scope, filters, mention card anatomy, per-mention actions, load-more pagination, empty/error states
- `saved-views/index.md` — what a view captures, save/apply/delete, URL sharing, and PCC migration notes
- `analytics/index.md` — stat cards, the five chart panels (mentions over time, by platform, by tag, by project, sentiment distribution), and PNG export
- `faq/index.md` — access (executive-director persona + LF Staff, Foundation lens only), data sources, freshness, and limits
- Bookmarks documented as saved per foundation, matching the per user+foundation preference keying

`packages/shared/src/constants/docs.constant.ts`, `apps/lfx-one/scripts/lib/build-manifest.mjs` — Taxonomy registration

- Registers `social-listening` in both copies of `DOCS_TAXONOMY_ORDER` (runtime constant and build-manifest mirror) so the topic renders in the docs navigation
- Reformats two spots in `build-manifest.mjs` to satisfy prettier (no behavior change)

`docs/user/dashboards/navigate-dashboards/index.md` — Cross-link

- Notes that EDs and LF Staff see Social Listening under **Metrics** in the Foundation lens, linking to the new topic; bumps `last_updated`
