### PR TITLE
fix(social-listening): per-foundation limit toast copy (LFXV2-3373)

### DIFF
--- a/apps/lfx-one/src/app/shared/services/mention-bookmark.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/mention-bookmark.service.spec.ts
@@ -152,7 +152,7 @@ describe('MentionBookmarkService', () => {
     expect(messageService.add).toHaveBeenCalledWith({
       severity: 'warn',
       summary: 'Bookmark limit reached',
-      detail: `You can bookmark up to ${MENTION_IDS_MAX_VALUES} mentions per project.`,
+      detail: `You can bookmark up to ${MENTION_IDS_MAX_VALUES} mentions per foundation.`,
     });
     expect(socialListeningService.upsertPreference).not.toHaveBeenCalled();
     expect(service.state().data.has('new-mention')).toBe(false);

--- a/apps/lfx-one/src/app/shared/services/mention-bookmark.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mention-bookmark.service.ts
@@ -69,7 +69,7 @@ export class MentionBookmarkService {
       this.messageService.add({
         severity: 'warn',
         summary: 'Bookmark limit reached',
-        detail: `You can bookmark up to ${MENTION_IDS_MAX_VALUES} mentions per project.`,
+        detail: `You can bookmark up to ${MENTION_IDS_MAX_VALUES} mentions per foundation.`,
       });
       return;
     }

--- a/apps/lfx-one/src/app/shared/services/saved-filter.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/saved-filter.service.spec.ts
@@ -184,7 +184,7 @@ describe('SavedFilterService', () => {
     expect(messageService.add).toHaveBeenCalledWith({
       severity: 'warn',
       summary: 'Saved view limit reached',
-      detail: `You can save up to ${MAX_SAVED_FILTERS_PER_PROJECT} views per project.`,
+      detail: `You can save up to ${MAX_SAVED_FILTERS_PER_PROJECT} views per foundation.`,
     });
     expect(socialListeningService.upsertPreference).not.toHaveBeenCalled();
   });

--- a/apps/lfx-one/src/app/shared/services/saved-filter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/saved-filter.service.ts
@@ -89,7 +89,7 @@ export class SavedFilterService {
       this.messageService.add({
         severity: 'warn',
         summary: 'Saved view limit reached',
-        detail: `You can save up to ${MAX_SAVED_FILTERS_PER_PROJECT} views per project.`,
+        detail: `You can save up to ${MAX_SAVED_FILTERS_PER_PROJECT} views per foundation.`,
       });
       return null;
     }


### PR DESCRIPTION
## Summary

In Social Listening, the limits for mention bookmarks and saved views are enforced per foundation, but the limit-reached toasts told users the cap was "per project". This PR corrects that copy so the message matches how the limit is actually applied.

Resolves LFXV2-3373

## Behavior changes

| Before | After |
|---|---|
| When a user hit the mention bookmark or saved view limit, the warning toast said they could save up to N items "per project" — misleading, since the cap is scoped to the foundation. | The same toasts now say the limit applies "per foundation", matching how the cap is actually enforced and avoiding confusion for users working across multiple projects in one foundation. |

## Technical changes

`apps/lfx-one/src/app/shared/services/mention-bookmark.service.ts` — Mention bookmark limit toast
- Updates the "Bookmark limit reached" toast detail from "mentions per project" to "mentions per foundation"

`apps/lfx-one/src/app/shared/services/saved-filter.service.ts` — Saved view limit toast
- Updates the "Saved view limit reached" toast detail from "views per project" to "views per foundation"

`apps/lfx-one/src/app/shared/services/mention-bookmark.service.spec.ts, apps/lfx-one/src/app/shared/services/saved-filter.service.spec.ts` — Tests
- Aligns both spec expectations with the new "per foundation" copy