### PR TITLE
fix(mailing-lists): entity-scoped project context for edit links (GH-1567)

### DIFF
--- a/apps/lfx-one/e2e/mailing-list-edit-url.spec.ts
+++ b/apps/lfx-one/e2e/mailing-list-edit-url.spec.ts
@@ -1,0 +1,341 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Mailing list edit-URL canonicalization — GH-1567.
+ *
+ * Coverage:
+ *   - The view page's edit button derives its destination from the LIST's owning tier
+ *     (`is_foundation`), not the viewer's transient active lens — the pre-fix bug sent
+ *     foundation-owned lists to `/project/mailing-lists/:uid/edit` whenever the viewer's
+ *     active lens was project (and vice versa):
+ *       foundation-owned list → `/foundation/mailing-lists/:uid/edit?project=<slug>`
+ *       project-owned list    → `/project/mailing-lists/:uid/edit?project=<slug>`
+ *       unenriched payload    → flat `/mailing-lists/:uid/edit`, which `lensRedirectGuard`
+ *                               prefixes by the active lens (documented fallback).
+ *   - Each case seeds the OPPOSITE lens/context from the list's owning tier, so a pass
+ *     proves the URL follows the entity, not the viewer.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD
+ */
+
+import type { PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
+import { LENS_COOKIE_KEY, PERSONA_COOKIE_KEY, SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+
+const MOCK_FOUNDATION_SLUG = 'test-foundation';
+const MOCK_FOUNDATION_UID = 'f0000000-0000-0000-0000-00000000d001';
+const OTHER_FOUNDATION_SLUG = 'other-foundation';
+const OTHER_FOUNDATION_UID = 'f0000000-0000-0000-0000-00000000d002';
+const OTHER_PROJECT_SLUG = 'other-project';
+const OTHER_PROJECT_UID = 'p0000000-0000-0000-0000-00000000d003';
+const MOCK_MAILING_LIST_UID = '1i000000-0000-0000-0000-00000000d001';
+
+function buildProjectStub(uid: string, slug: string, name: string) {
+  return {
+    uid,
+    slug,
+    name,
+    description: `${name} for mailing-list edit-url specs`,
+    public: true,
+    parent_uid: '',
+    stage: 'Active',
+    category: 'project',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '',
+    updated_at: new Date().toISOString(),
+    mailing_list_count: 0,
+    writer: true,
+  };
+}
+
+/**
+ * Detail payload for the view page. Omitting `isFoundation` and leaving the slug empty mirrors
+ * the v1-sync index gap (GH-1567 group-1 finding): the edit button then has no tier to derive
+ * from and must fall back to the flat path.
+ */
+function buildMailingListStub(owner: { projectUid: string; projectSlug?: string; projectName?: string; isFoundation?: boolean }) {
+  return {
+    uid: MOCK_MAILING_LIST_UID,
+    title: 'Canonical Url Announcements',
+    group_name: 'announce',
+    description: 'Mailing list stub for edit-url canonicalization specs',
+    project_uid: owner.projectUid,
+    project_slug: owner.projectSlug ?? '',
+    project_name: owner.projectName ?? '',
+    ...(owner.isFoundation !== undefined ? { is_foundation: owner.isFoundation } : {}),
+    source: 'api',
+    type: 'discussion_open',
+    audience_access: 'public',
+    service_uid: 'svc-1',
+    public: true,
+    committees: [],
+    subscriber_count: 12,
+    writer: true,
+    created_at: '2025-01-15T00:00:00Z',
+    updated_at: '2025-06-01T00:00:00Z',
+  };
+}
+
+async function stubPersona(page: Page, personas: string[]): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ personas, personaProjects: {}, projects: [], organizations: [], isRootWriter: true }),
+    })
+  );
+}
+
+async function stubProjectApi(page: Page): Promise<void> {
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildProjectStub(MOCK_FOUNDATION_UID, MOCK_FOUNDATION_SLUG, 'Test Foundation')),
+    })
+  );
+  await page.route(`**/api/projects/${OTHER_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildProjectStub(OTHER_FOUNDATION_UID, OTHER_FOUNDATION_SLUG, 'Other Foundation')),
+    })
+  );
+  await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+    })
+  );
+  await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
+}
+
+async function stubCommittees(page: Page): Promise<void> {
+  await page.route('**/api/committees/my-committee-uids*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/committees*', (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname !== '/api/committees') {
+      return route.fallback();
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+}
+
+/**
+ * Stubs the navigation lens-items feed so NavigationService.applyDefaultSelection can't
+ * override the stubbed context with the test account's real projects mid-test. Items cover
+ * every cookie-seeded context these specs use so the "preserve existing selection" guard
+ * keeps it instead of picking a default.
+ */
+async function stubLensItems(page: Page): Promise<void> {
+  await page.route('**/api/nav/lens-items*', (route) => {
+    const url = new URL(route.request().url());
+    const isFoundation = url.searchParams.get('lens') !== 'project';
+    const items = isFoundation
+      ? [
+          { uid: MOCK_FOUNDATION_UID, slug: MOCK_FOUNDATION_SLUG, name: 'Test Foundation', logoUrl: null, isFoundation: true },
+          { uid: OTHER_FOUNDATION_UID, slug: OTHER_FOUNDATION_SLUG, name: 'Other Foundation', logoUrl: null, isFoundation: true },
+        ]
+      : [{ uid: OTHER_PROJECT_UID, slug: OTHER_PROJECT_SLUG, name: 'Other Project', logoUrl: null, isFoundation: false }];
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items, next_page_token: null, upstream_failed: false, lens: isFoundation ? 'foundation' : 'project' }),
+    });
+  });
+}
+
+async function stubMailingListViewDetail(page: Page, list: ReturnType<typeof buildMailingListStub>): Promise<void> {
+  // Catch-all registered FIRST (Playwright matches routes in reverse registration order) so
+  // incidental list/count calls don't escape to the real BFF. `*` does not cross `/`, so the
+  // services/members/detail routes need their own patterns.
+  await page.route('**/api/mailing-lists*', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route('**/api/mailing-lists/services*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route(`**/api/mailing-lists/${MOCK_MAILING_LIST_UID}/members*`, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route(`**/api/mailing-lists/${MOCK_MAILING_LIST_UID}`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(list) });
+  });
+}
+
+async function setPersonaAndLensCookies(page: Page, personas: string[], lens: 'foundation' | 'project'): Promise<void> {
+  const state: PersistedPersonaState = {
+    primary: personas[0] as PersonaType,
+    all: personas as PersonaType[],
+  };
+  await page.context().addCookies([
+    { name: PERSONA_COOKIE_KEY, value: encodeURIComponent(JSON.stringify(state)), domain: 'localhost', path: '/', sameSite: 'Lax' },
+    { name: LENS_COOKIE_KEY, value: lens, domain: 'localhost', path: '/', sameSite: 'Lax' },
+  ]);
+}
+
+async function setFoundationCookie(page: Page, uid: string, slug: string, name: string): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: SELECTED_FOUNDATION_COOKIE_KEY,
+      value: encodeURIComponent(JSON.stringify({ uid, slug, name })),
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function setProjectCookie(page: Page, uid: string, slug: string, name: string): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: SELECTED_PROJECT_COOKIE_KEY,
+      value: encodeURIComponent(JSON.stringify({ uid, slug, name })),
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+// Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
+// storageState, broken Auth0 login helper) still fail loudly when creds ARE configured.
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+/**
+ * Client-side (SPA) navigation for routes whose data is fully stubbed via page.route — a full
+ * `page.goto()` of an entity URL SSRs the route on the Express server, where server-side
+ * fetches bypass `page.route` stubs and hit the real BFF. Booting on `/` first and navigating
+ * via pushState + popstate keeps the router client-side, where every fetch is intercepted.
+ */
+async function gotoSpa(page: Page, path: string, seedContext: { uid: string; slug: string; name: string; foundation: boolean }): Promise<void> {
+  skipWhenAuthMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  // Wait for the app shell so the router is ready to process the synthetic popstate.
+  await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  // The '/' boot SSRs with the real backend persona data and can Set-Cookie a real selection
+  // (e.g. the test account's ASWF), racing the stubbed context these specs assert on. Re-assert
+  // the intended cookie post-boot so the client-side navigation starts from a clean slate.
+  if (seedContext.foundation) {
+    await setFoundationCookie(page, seedContext.uid, seedContext.slug, seedContext.name);
+  } else {
+    await setProjectCookie(page, seedContext.uid, seedContext.slug, seedContext.name);
+  }
+  await page.evaluate((url) => {
+    window.history.pushState({}, '', url);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+}
+
+test.describe('Mailing list edit URL derives from the list’s owning tier (GH-1567)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubPersona(page, ['executive-director']);
+    await stubProjectApi(page);
+    await stubCommittees(page);
+    await stubLensItems(page);
+  });
+
+  test('foundation-owned list: edit click-through lands on /foundation/... with ?project= (viewer in project lens)', async ({ page }) => {
+    // Seed the OPPOSITE lens from the list's tier: the pre-fix bug prefixed the flat edit link
+    // with this transient project lens, landing on the wrong tier.
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await stubMailingListViewDetail(
+      page,
+      buildMailingListStub({ projectUid: MOCK_FOUNDATION_UID, projectSlug: MOCK_FOUNDATION_SLUG, projectName: 'Test Foundation', isFoundation: true })
+    );
+
+    await gotoSpa(page, `/mailing-lists/${MOCK_MAILING_LIST_UID}`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('mailing-list-view-title')).toHaveText('Canonical Url Announcements', { timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId('mailing-list-view-edit-button').click();
+
+    await expect(page).toHaveURL(new RegExp(`/foundation/mailing-lists/${MOCK_MAILING_LIST_UID}/edit\\?project=${MOCK_FOUNDATION_SLUG}$`), {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  test('project-owned list: edit click-through lands on /project/... with ?project= (viewer in foundation lens)', async ({ page }) => {
+    await setPersonaAndLensCookies(page, ['executive-director'], 'foundation');
+    await stubMailingListViewDetail(
+      page,
+      buildMailingListStub({ projectUid: OTHER_PROJECT_UID, projectSlug: OTHER_PROJECT_SLUG, projectName: 'Other Project', isFoundation: false })
+    );
+
+    await gotoSpa(page, `/mailing-lists/${MOCK_MAILING_LIST_UID}`, {
+      uid: MOCK_FOUNDATION_UID,
+      slug: MOCK_FOUNDATION_SLUG,
+      name: 'Test Foundation',
+      foundation: true,
+    });
+    await expect(page.getByTestId('mailing-list-view-title')).toHaveText('Canonical Url Announcements', { timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId('mailing-list-view-edit-button').click();
+
+    await expect(page).toHaveURL(new RegExp(`/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit\\?project=${OTHER_PROJECT_SLUG}$`), {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  test('unenriched list: edit click-through falls back to the flat path, redirected by the active lens', async ({ page }) => {
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await stubMailingListViewDetail(page, buildMailingListStub({ projectUid: OTHER_PROJECT_UID }));
+    // The manage page's uid-fallback resolves the project by uid when the payload carries no
+    // usable slug — stub the uid-keyed project route so context sync completes post-navigation.
+    await page.route(`**/api/projects/${OTHER_PROJECT_UID}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+      })
+    );
+
+    await gotoSpa(page, `/mailing-lists/${MOCK_MAILING_LIST_UID}`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('mailing-list-view-title')).toHaveText('Canonical Url Announcements', { timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId('mailing-list-view-edit-button').click();
+
+    // The button navigates flat; lensRedirectGuard prefixes by the ACTIVE lens (project here).
+    // The flat hop itself is an atomic guard redirect — only the settled URL is observable.
+    await expect(page).toHaveURL(new RegExp(`/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit$`), { timeout: PAGE_LOAD_TIMEOUT });
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+    await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+});

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -646,7 +646,30 @@ test.describe('Mailing list edit deep-link resolves the list’s project context
       timeout: ELEMENT_TIMEOUT,
     });
 
+    // The uid fallback canonicalizes the route to the list's foundation tier too (GH-1567).
+    await expect(page).toHaveURL(new RegExp(`/foundation/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`), { timeout: ELEMENT_TIMEOUT });
+
     await page.waitForTimeout(500);
     expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+
+  test('view deep link under the wrong tier canonicalizes to the list’s foundation (GH-1567)', async ({ page }) => {
+    await stubMailingListEditDetail(page, buildMailingListStub(true));
+    // The view page's members child fetches /members — keep it from escaping to the real BFF.
+    await page.route(`**/api/mailing-lists/${MOCK_MAILING_LIST_UID}/members*`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    );
+
+    await gotoSpa(page, `/project/mailing-lists/${MOCK_MAILING_LIST_UID}`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('mailing-list-view-title')).toHaveText('Test Foundation Announcements', { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Context syncs from the loaded list and the route rewrites to its owning tier (GH-1567).
+    await expect(page).toHaveURL(new RegExp(`/foundation/mailing-lists/${MOCK_MAILING_LIST_UID}$`), { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
   });
 });

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -15,6 +15,9 @@
  *     `?project=`) resolves context from the loaded meeting — via the BFF-enriched project
  *     fields, or via the component's resolve-by-uid fallback when enrichment failed — instead
  *     of the stale cookie-restored context.
+ *   - The same for a context-less mailing-list EDIT link (`/project/mailing-lists/:uid/edit`,
+ *     GH-1567): context syncs from the loaded list (enriched payload or uid fallback), and
+ *     writerGuard authorizes against the list's own project via its entity probe.
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -38,6 +41,7 @@ const MOCK_COMMITTEE_UID = 'c0000000-0000-0000-0000-00000000d001';
 const OTHER_PROJECT_SLUG = 'other-project';
 const OTHER_PROJECT_UID = 'p0000000-0000-0000-0000-00000000d003';
 const MOCK_MEETING_UID = 'm0000000-0000-0000-0000-00000000d001';
+const MOCK_MAILING_LIST_UID = '1i000000-0000-0000-0000-00000000d001';
 
 function buildProjectStub(uid: string, slug: string, name: string) {
   return {
@@ -274,6 +278,49 @@ async function stubMeetingEditDetail(page: Page, meeting: ReturnType<typeof buil
   });
 }
 
+/**
+ * Mailing list detail payload for the edit page. `enriched: false` mirrors the v1-sync index
+ * gap the BFF enrichment covers (GH-1567): project_slug/project_name come back as empty
+ * strings and is_foundation is absent, so the component's resolve-by-uid fallback runs.
+ */
+function buildMailingListStub(enriched: boolean) {
+  return {
+    uid: MOCK_MAILING_LIST_UID,
+    title: 'Test Foundation Announcements',
+    group_name: 'announce',
+    description: 'Mailing list stub for project-context deep-link specs',
+    project_uid: MOCK_FOUNDATION_UID,
+    project_slug: enriched ? MOCK_FOUNDATION_SLUG : '',
+    project_name: enriched ? 'Test Foundation' : '',
+    ...(enriched ? { is_foundation: true } : {}),
+    source: 'api',
+    type: 'discussion_open',
+    audience_access: 'public',
+    service_uid: 'svc-1',
+    public: true,
+    committees: [],
+    subscriber_count: 12,
+    writer: true,
+    created_at: '2025-01-15T00:00:00Z',
+    updated_at: '2025-06-01T00:00:00Z',
+  };
+}
+
+async function stubMailingListEditDetail(page: Page, list: ReturnType<typeof buildMailingListStub>): Promise<void> {
+  // Catch-all registered FIRST (Playwright matches routes in reverse registration order) so
+  // incidental list/count calls from the edit page don't escape to the real BFF. `*` does not
+  // cross `/`, so the services and detail routes need their own patterns.
+  await page.route('**/api/mailing-lists*', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route('**/api/mailing-lists/services*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route(`**/api/mailing-lists/${MOCK_MAILING_LIST_UID}`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(list) });
+  });
+}
+
 // Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
 // storageState, broken Auth0 login helper) still fail loudly when creds ARE configured.
 const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
@@ -491,6 +538,113 @@ test.describe('Meeting edit deep-link resolves the meeting’s project context (
 
     await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('sidebar-item-meetings')).toHaveAttribute('href', /[?&]project=test-foundation/, { timeout: ELEMENT_TIMEOUT });
+
+    await page.waitForTimeout(500);
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+});
+
+test.describe('Mailing list edit deep-link resolves the list’s project context (GH-1567)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mirror the issue: the user was last working in an unrelated PROJECT (cookie-restored),
+    // then opens a context-less edit link for a mailing list owned by Test Foundation.
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await setProjectCookie(page, OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project');
+    await stubPersona(page, ['executive-director']);
+    await stubProjectApi(page);
+    await stubCommittees(page, buildCommittees());
+    await stubLensItems(page);
+    await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+      })
+    );
+  });
+
+  test('edit link without ?project= switches context to the list’s foundation (BFF-enriched payload)', async ({ page }) => {
+    await stubMailingListEditDetail(page, buildMailingListStub(true));
+
+    await gotoSpa(page, `/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // The sync derives context from the loaded list (Test Foundation), replacing the
+    // cookie-restored Other Project — the selector and sidebar links follow the correction.
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('sidebar-item-mailing-lists')).toHaveAttribute('href', /[?&]project=test-foundation/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // The context correction must NOT inject ?project= into the entity URL (syncUrl guard) —
+    // give any NavigationEnd-driven backfill a tick to (not) fire before asserting absence.
+    await page.waitForTimeout(500);
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+
+  test('writerGuard authorizes the edit page against the list’s project, not the stale context (GH-1567)', async ({ page }) => {
+    // Non-ED persona: no synchronous fast path — the guard must probe the list for its
+    // project slug. The stale cookie context (Other Project) is intentionally NOT writable:
+    // if the guard authorizes against it, the page redirects to /project/overview?_notice=...
+    await setPersonaAndLensCookies(page, ['maintainer'], 'project');
+    await stubPersona(page, ['maintainer']);
+    await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project'), writer: false }),
+      })
+    );
+    await stubMailingListEditDetail(page, buildMailingListStub(true));
+
+    await gotoSpa(page, `/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Still on the edit page (no access-denied redirect), and the context follows the list.
+    expect(page.url()).toContain(`/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`);
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('edit link without ?project= falls back to resolving the project by uid when enrichment is absent', async ({ page }) => {
+    // Enrichment-failed payload: project_uid only (v1-sync empty-string slug). The component
+    // fallback fetches the project by uid — this route satisfies computeIsFoundation (Funded +
+    // Membership + Active), so the resolved context lands in the foundation slot like the enriched path.
+    await stubMailingListEditDetail(page, buildMailingListStub(false));
+    await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...buildProjectStub(MOCK_FOUNDATION_UID, MOCK_FOUNDATION_SLUG, 'Test Foundation'),
+          funding: 'Funded',
+          funding_model: ['Membership'],
+          legal_entity_type: 'Series LLC',
+        }),
+      })
+    );
+
+    await gotoSpa(page, `/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('sidebar-item-mailing-lists')).toHaveAttribute('href', /[?&]project=test-foundation/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
 
     await page.waitForTimeout(500);
     expect(new URL(page.url()).searchParams.has('project')).toBe(false);

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -579,6 +579,9 @@ test.describe('Mailing list edit deep-link resolves the list’s project context
       timeout: ELEMENT_TIMEOUT,
     });
 
+    // The route itself canonicalizes to the list's foundation tier once the payload lands (GH-1567).
+    await expect(page).toHaveURL(new RegExp(`/foundation/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`), { timeout: ELEMENT_TIMEOUT });
+
     // The context correction must NOT inject ?project= into the entity URL (syncUrl guard) —
     // give any NavigationEnd-driven backfill a tick to (not) fire before asserting absence.
     await page.waitForTimeout(500);
@@ -607,8 +610,9 @@ test.describe('Mailing list edit deep-link resolves the list’s project context
     });
     await expect(page.getByTestId('mailing-list-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
-    // Still on the edit page (no access-denied redirect), and the context follows the list.
-    expect(page.url()).toContain(`/project/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`);
+    // Still on the edit page (no access-denied redirect): the URL canonicalizes to the owning
+    // foundation tier once the list loads, and the context follows the list.
+    await expect(page).toHaveURL(new RegExp(`/foundation/mailing-lists/${MOCK_MAILING_LIST_UID}/edit`), { timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
   });
 

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -41,7 +41,7 @@ const MOCK_COMMITTEE_UID = 'c0000000-0000-0000-0000-00000000d001';
 const OTHER_PROJECT_SLUG = 'other-project';
 const OTHER_PROJECT_UID = 'p0000000-0000-0000-0000-00000000d003';
 const MOCK_MEETING_UID = 'm0000000-0000-0000-0000-00000000d001';
-const MOCK_MAILING_LIST_UID = '1i000000-0000-0000-0000-00000000d001';
+const MOCK_MAILING_LIST_UID = 'l1000000-0000-0000-0000-00000000d001';
 
 function buildProjectStub(uid: string, slug: string, name: string) {
   return {
@@ -279,9 +279,8 @@ async function stubMeetingEditDetail(page: Page, meeting: ReturnType<typeof buil
 }
 
 /**
- * Mailing list detail payload for the edit page. `enriched: false` mirrors the v1-sync index
- * gap the BFF enrichment covers (GH-1567): project_slug/project_name come back as empty
- * strings and is_foundation is absent, so the component's resolve-by-uid fallback runs.
+ * Edit-page detail payload; `enriched: false` mirrors the v1-sync gap (empty slug/name, no
+ * is_foundation) so the component's resolve-by-uid fallback runs (GH-1567).
  */
 function buildMailingListStub(enriched: boolean) {
   return {
@@ -307,8 +306,7 @@ function buildMailingListStub(enriched: boolean) {
 }
 
 async function stubMailingListEditDetail(page: Page, list: ReturnType<typeof buildMailingListStub>): Promise<void> {
-  // Catch-all registered FIRST (Playwright matches routes in reverse registration order) so
-  // incidental list/count calls from the edit page don't escape to the real BFF. `*` does not
+  // Catch-all registered FIRST (Playwright matches in reverse registration order); `*` doesn't
   // cross `/`, so the services and detail routes need their own patterns.
   await page.route('**/api/mailing-lists*', (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
@@ -588,9 +586,8 @@ test.describe('Mailing list edit deep-link resolves the list’s project context
   });
 
   test('writerGuard authorizes the edit page against the list’s project, not the stale context (GH-1567)', async ({ page }) => {
-    // Non-ED persona: no synchronous fast path — the guard must probe the list for its
-    // project slug. The stale cookie context (Other Project) is intentionally NOT writable:
-    // if the guard authorizes against it, the page redirects to /project/overview?_notice=...
+    // Non-ED persona: the guard must probe the list for its project slug; the stale cookie
+    // context (Other Project) is intentionally NOT writable — it would redirect to /project/overview.
     await setPersonaAndLensCookies(page, ['maintainer'], 'project');
     await stubPersona(page, ['maintainer']);
     await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
@@ -616,9 +613,8 @@ test.describe('Mailing list edit deep-link resolves the list’s project context
   });
 
   test('edit link without ?project= falls back to resolving the project by uid when enrichment is absent', async ({ page }) => {
-    // Enrichment-failed payload: project_uid only (v1-sync empty-string slug). The component
-    // fallback fetches the project by uid — this route satisfies computeIsFoundation (Funded +
-    // Membership + Active), so the resolved context lands in the foundation slot like the enriched path.
+    // Enrichment-failed payload (project_uid only, v1-sync empty-string slug): the fallback
+    // fetches the project by uid — this stub satisfies computeIsFoundation, landing the foundation slot.
     await stubMailingListEditDetail(page, buildMailingListStub(false));
     await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}*`, (route) =>
       route.fulfill({

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -75,7 +75,7 @@
   </div>
 
   <lfx-table
-    [value]="mailingLists()"
+    [value]="tableRows()"
     [loading]="loading()"
     [paginator]="mailingLists().length > 0"
     [rows]="10"
@@ -127,7 +127,8 @@
               </span>
             } @else {
               <a
-                [routerLink]="['/mailing-lists', mailingList.uid]"
+                [routerLink]="mailingList.viewCommands"
+                [queryParams]="mailingList.linkQueryParams"
                 class="lfx-table-name-link text-sm"
                 [attr.data-testid]="'mailing-list-title-' + mailingList.uid">
                 {{ mailingList.title || mailingList.group_name || '-' }}
@@ -205,7 +206,7 @@
                   {{ mailingList.title || mailingList.group_name || '-' }}
                 </span>
               } @else {
-                <a [routerLink]="['/mailing-lists', mailingList.uid]" class="lfx-table-name-link text-sm">
+                <a [routerLink]="mailingList.viewCommands" [queryParams]="mailingList.linkQueryParams" class="lfx-table-name-link text-sm">
                   {{ mailingList.title || mailingList.group_name || '-' }}
                 </a>
               }

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
@@ -15,7 +15,7 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { COMMITTEE_LABEL, MAILING_LIST_LABEL, MAILING_LIST_MAX_VISIBLE_GROUPS } from '@lfx-one/shared';
 import { FilterOption, GroupsIOMailingList, MailingListTableRowVm } from '@lfx-one/shared/interfaces';
-import { getEntityCommands } from '@lfx-one/shared/utils';
+import { getMailingListCommands, getMailingListLinkQueryParams } from '@lfx-one/shared/utils';
 import { GroupEmailPipe } from '@pipes/group-email.pipe';
 import { MailingListTypeLabelPipe } from '@pipes/mailing-list-type-label.pipe';
 import { RemainingGroupsTooltipPipe } from '@pipes/remaining-groups-tooltip.pipe';
@@ -69,7 +69,7 @@ export class MailingListTableComponent {
 
   // Outputs
   public readonly refresh = output<void>();
-  public readonly rowClick = output<GroupsIOMailingList>();
+  public readonly rowClick = output<MailingListTableRowVm>();
   public readonly foundationFilterChange = output<string | null>();
   public readonly projectFilterChange = output<string | null>();
 
@@ -87,21 +87,8 @@ export class MailingListTableComponent {
 
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.mailingLists().length > 10 ? [10, 25, 50] : undefined));
 
-  /**
-   * Rows decorated with their canonical view link state (GH-1567): `getEntityCommands`
-   * prefixes the path with the row's OWN project tier (`is_foundation`) instead of the viewer's
-   * transient active lens, and `?project=` rides along when the row carries a `project_slug`.
-   * Rows without tier data keep the flat `/mailing-lists/:uid` fallback (the `??` inside the
-   * mapping), which `lensRedirectGuard` handles as before. Pre-computed once per input change
-   * rather than per change-detection cycle (angular-reactive-data §3.5).
-   */
-  protected readonly tableRows = computed<MailingListTableRowVm[]>(() =>
-    this.mailingLists().map((mailingList) => ({
-      ...mailingList,
-      viewCommands: getEntityCommands('mailing-lists', mailingList.uid, mailingList.is_foundation) ?? ['/mailing-lists', mailingList.uid],
-      linkQueryParams: mailingList.project_slug ? { project: mailingList.project_slug } : null,
-    }))
-  );
+  /** Rows decorated with canonical view-link state (GH-1567) — pre-computed once per input change (angular-reactive-data §3.5). */
+  protected readonly tableRows: Signal<MailingListTableRowVm[]> = this.initTableRows();
 
   // Event Handlers
   protected onRowSelect(event: { data: MailingListTableRowVm }): void {
@@ -112,5 +99,15 @@ export class MailingListTableComponent {
     this.searchForm().patchValue({ search: '', committee: null, status: null, foundationFilter: null, projectFilter: null });
     this.foundationFilterChange.emit(null);
     this.projectFilterChange.emit(null);
+  }
+
+  private initTableRows(): Signal<MailingListTableRowVm[]> {
+    return computed(() =>
+      this.mailingLists().map((mailingList) => ({
+        ...mailingList,
+        viewCommands: getMailingListCommands(mailingList),
+        linkQueryParams: getMailingListLinkQueryParams(mailingList),
+      }))
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
@@ -14,7 +14,8 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { COMMITTEE_LABEL, MAILING_LIST_LABEL, MAILING_LIST_MAX_VISIBLE_GROUPS } from '@lfx-one/shared';
-import { FilterOption, GroupsIOMailingList } from '@lfx-one/shared/interfaces';
+import { FilterOption, GroupsIOMailingList, MailingListTableRowVm } from '@lfx-one/shared/interfaces';
+import { getEntityCommands } from '@lfx-one/shared/utils';
 import { GroupEmailPipe } from '@pipes/group-email.pipe';
 import { MailingListTypeLabelPipe } from '@pipes/mailing-list-type-label.pipe';
 import { RemainingGroupsTooltipPipe } from '@pipes/remaining-groups-tooltip.pipe';
@@ -86,8 +87,24 @@ export class MailingListTableComponent {
 
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.mailingLists().length > 10 ? [10, 25, 50] : undefined));
 
+  /**
+   * Rows decorated with their canonical view link state (GH-1567): `getEntityCommands`
+   * prefixes the path with the row's OWN project tier (`is_foundation`) instead of the viewer's
+   * transient active lens, and `?project=` rides along when the row carries a `project_slug`.
+   * Rows without tier data keep the flat `/mailing-lists/:uid` fallback (the `??` inside the
+   * mapping), which `lensRedirectGuard` handles as before. Pre-computed once per input change
+   * rather than per change-detection cycle (angular-reactive-data §3.5).
+   */
+  protected readonly tableRows = computed<MailingListTableRowVm[]>(() =>
+    this.mailingLists().map((mailingList) => ({
+      ...mailingList,
+      viewCommands: getEntityCommands('mailing-lists', mailingList.uid, mailingList.is_foundation) ?? ['/mailing-lists', mailingList.uid],
+      linkQueryParams: mailingList.project_slug ? { project: mailingList.project_slug } : null,
+    }))
+  );
+
   // Event Handlers
-  protected onRowSelect(event: { data: GroupsIOMailingList }): void {
+  protected onRowSelect(event: { data: MailingListTableRowVm }): void {
     this.rowClick.emit(event.data);
   }
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -15,11 +15,11 @@ import {
   FilterOption,
   GroupsIOMailingList,
   GroupsIOService,
+  MailingListTableRowVm,
   MyMailingList,
   ProjectContext,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
-import { getEntityCommands } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { PersonaService } from '@services/persona.service';
@@ -136,13 +136,10 @@ export class MailingListDashboardComponent {
     this.refresh.next();
   }
 
-  public onMailingListClick(mailingList: GroupsIOMailingList): void {
-    // Canonical tier-prefixed view link (GH-1567): the list's own `is_foundation` picks
-    // /foundation vs /project instead of the viewer's transient active lens; `?project=` rides
-    // along when the row carries a slug. The flat /mailing-lists/:uid fallback remains for
-    // any row that resolves no tier (lensRedirectGuard handles it as before).
-    this.router.navigate(getEntityCommands('mailing-lists', mailingList.uid, mailingList.is_foundation) ?? ['/mailing-lists', mailingList.uid], {
-      queryParams: mailingList.project_slug ? { project: mailingList.project_slug } : undefined,
+  public onMailingListClick(mailingList: MailingListTableRowVm): void {
+    // Canonical tier-prefixed view link comes pre-computed on the row VM, flat fallback included (GH-1567).
+    this.router.navigate(mailingList.viewCommands, {
+      queryParams: mailingList.linkQueryParams,
       state: { backLabel: this.isMeLens() ? `My ${this.mailingListLabelPlural}` : this.mailingListLabelPlural },
     });
   }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -19,6 +19,7 @@ import {
   ProjectContext,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
+import { getEntityCommands } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { PersonaService } from '@services/persona.service';
@@ -135,11 +136,13 @@ export class MailingListDashboardComponent {
     this.refresh.next();
   }
 
-  /**
-   * Handle mailing list row click - navigate to detail page
-   */
   public onMailingListClick(mailingList: GroupsIOMailingList): void {
-    this.router.navigate(['/mailing-lists', mailingList.uid], {
+    // Canonical tier-prefixed view link (GH-1567): the list's own `is_foundation` picks
+    // /foundation vs /project instead of the viewer's transient active lens; `?project=` rides
+    // along when the row carries a slug. The flat /mailing-lists/:uid fallback remains for
+    // any row that resolves no tier (lensRedirectGuard handles it as before).
+    this.router.navigate(getEntityCommands('mailing-lists', mailingList.uid, mailingList.is_foundation) ?? ['/mailing-lists', mailingList.uid], {
+      queryParams: mailingList.project_slug ? { project: mailingList.project_slug } : undefined,
       state: { backLabel: this.isMeLens() ? `My ${this.mailingListLabelPlural}` : this.mailingListLabelPlural },
     });
   }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -1,27 +1,36 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ButtonComponent } from '@components/button/button.component';
 import { CommitteeSelectorComponent } from '@components/committee-selector/committee-selector.component';
 import { COMMITTEE_LABEL, MAILING_LIST_TOTAL_STEPS } from '@lfx-one/shared/constants';
 import { GroupsIOServiceType, MailingListAudienceAccess, MailingListType } from '@lfx-one/shared/enums';
-import { CommitteeReference, CreateGroupsIOServiceRequest, CreateMailingListRequest, GroupsIOMailingList, GroupsIOService } from '@lfx-one/shared/interfaces';
-import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
+import {
+  CommitteeReference,
+  CreateGroupsIOServiceRequest,
+  CreateMailingListRequest,
+  EntityWithProject,
+  GroupsIOMailingList,
+  GroupsIOService,
+  ProjectContext,
+} from '@lfx-one/shared/interfaces';
+import { computeIsFoundation, markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { announcementVisibilityValidator, htmlMaxLengthValidator, htmlMinLengthValidator, htmlRequiredValidator } from '@lfx-one/shared/validators';
 import { MailingListService } from '@services/mailing-list.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, filter, Observable, of, switchMap, tap, throwError } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, map, merge, Observable, of, switchMap, tap, throwError } from 'rxjs';
 
 import { MailingListBasicInfoComponent } from '../components/mailing-list-basic-info/mailing-list-basic-info.component';
 import { MailingListSettingsComponent } from '../components/mailing-list-settings/mailing-list-settings.component';
+import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 @Component({
@@ -46,6 +55,7 @@ export class MailingListManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Protected constants
   public readonly totalSteps = MAILING_LIST_TOTAL_STEPS;
@@ -67,6 +77,9 @@ export class MailingListManageComponent {
   // Complex computed/toSignal signals
   public readonly isEditMode: Signal<boolean> = this.initIsEditMode();
   public readonly mailingList: Signal<GroupsIOMailingList | null> = this.initMailingList();
+  // Mailing list → EntityWithProject adapter so the active project/foundation context syncs
+  // from the loaded entity, not the URL's lens prefix or a stale cookie-restored context (GH-1567).
+  private readonly mailingListEntityContext: Signal<EntityWithProject | null> = this.initMailingListEntityContext();
   public readonly project: Signal<ReturnType<typeof this.projectContextService.selectedProject>> = this.initProject();
   public readonly availableServices: Signal<GroupsIOService[]> = this.initServices();
   public readonly selectedService: Signal<GroupsIOService | null> = this.initSelectedService();
@@ -84,6 +97,12 @@ export class MailingListManageComponent {
 
   public constructor() {
     evictOnWriteAccessLoss();
+    // Sync context from the loaded list itself — an edit deep link can arrive under the wrong
+    // tier (/project/* for a foundation-owned list) or with no `?project=` at all (GH-1567).
+    // preferEntityKind lets the list's own is_foundation re-point the lens kind when it
+    // contradicts the route prefix. The uid-only fallback covers unenriched payloads.
+    syncEntityProjectContext(this.mailingListEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    this.initMailingListContextFallback();
     this.form()
       .get('group_name')
       ?.valueChanges.pipe(takeUntilDestroyed())
@@ -94,7 +113,8 @@ export class MailingListManageComponent {
     const next = this.currentStep() + 1;
     if (next <= this.totalSteps && this.canNavigateToStep(next)) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: next } });
+        // Merge so the entity's `?project=` (context sync key) survives step changes (GH-1567).
+        this.router.navigate([], { queryParams: { step: next }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(next);
       }
@@ -105,7 +125,7 @@ export class MailingListManageComponent {
     const previous = this.currentStep() - 1;
     if (previous >= 1) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: previous } });
+        this.router.navigate([], { queryParams: { step: previous }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(previous);
       }
@@ -116,7 +136,7 @@ export class MailingListManageComponent {
     if (step !== undefined && step >= 1 && step <= this.totalSteps) {
       if (this.isEditMode()) {
         // In edit mode, allow navigation to any step via query params
-        this.router.navigate([], { queryParams: { step } });
+        this.router.navigate([], { queryParams: { step }, queryParamsHandling: 'merge' });
       } else if (step <= this.currentStep()) {
         // In create mode, only allow going back to previous steps
         this.internalStep.set(step);
@@ -227,6 +247,70 @@ export class MailingListManageComponent {
 
   private initIsEditMode(): Signal<boolean> {
     return computed(() => this.mode() === 'edit');
+  }
+
+  /**
+   * Maps the loaded list to the {@link EntityWithProject} shape consumed by
+   * syncEntityProjectContext — pre-enrichment payloads can lack the project fields entirely
+   * (or carry the v1-sync empty-string slug), so absent values map to null there.
+   */
+  private initMailingListEntityContext(): Signal<EntityWithProject | null> {
+    return computed(() => {
+      const list = this.mailingList();
+      if (!list) {
+        return null;
+      }
+      return {
+        uid: list.uid,
+        project_uid: list.project_uid,
+        project_slug: list.project_slug,
+        project_name: list.project_name,
+        is_foundation: list.is_foundation ?? null,
+      };
+    });
+  }
+
+  /**
+   * Fallback context sync for when the BFF project enrichment failed (the detail payload has
+   * `project_uid` but no usable `project_slug`): resolve the project by uid and set context from
+   * it. `getProject(uid, false)` — `current: false` so the fetch doesn't clobber ProjectService's
+   * shared `project` state — already resolves to null on failure, so a failed fallback leaves the
+   * (stale) context untouched rather than erroring the page. As in syncEntityProjectContext,
+   * NavigationEnd re-applies the correction: query-param step navigations re-assert the route's
+   * declared lens kind via syncLensFromRoute without re-running guards (GH-1567).
+   */
+  private initMailingListContextFallback(): void {
+    const unresolvedEntity$ = toObservable(this.mailingListEntityContext).pipe(
+      distinctUntilChanged((a, b) => a?.uid === b?.uid && a?.project_uid === b?.project_uid)
+    );
+    const navigationReapply$ = this.router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      map(() => this.mailingListEntityContext())
+    );
+    merge(unresolvedEntity$, navigationReapply$)
+      .pipe(
+        filter((entity): entity is EntityWithProject => !!entity?.project_uid && !entity.project_slug),
+        switchMap((entity) =>
+          this.projectService.getProject(entity.project_uid, false).pipe(
+            map((project) => {
+              if (!project) {
+                return null;
+              }
+              const context: ProjectContext = { uid: project.uid, name: project.name, slug: project.slug };
+              return { context, isFoundation: computeIsFoundation(project) };
+            })
+          )
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((resolved) => {
+        if (!resolved) {
+          return;
+        }
+        // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
+        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
+        applyEntityProjectContext(this.projectContextService, resolved.context, resolved.isFoundation, syncUrl);
+      });
   }
 
   private initMailingList(): Signal<GroupsIOMailingList | null> {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -97,10 +97,8 @@ export class MailingListManageComponent {
 
   public constructor() {
     evictOnWriteAccessLoss();
-    // Sync context from the loaded list itself — an edit deep link can arrive under the wrong
-    // tier (/project/* for a foundation-owned list) or with no `?project=` at all (GH-1567).
-    // preferEntityKind lets the list's own is_foundation re-point the lens kind when it
-    // contradicts the route prefix. The uid-only fallback covers unenriched payloads.
+    // Sync context from the loaded list itself — an edit deep link can arrive under the wrong tier
+    // or with no `?project=` (GH-1567); preferEntityKind lets the list's own is_foundation re-point the lens kind.
     syncEntityProjectContext(this.mailingListEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
     this.initMailingListContextFallback();
     this.form()
@@ -250,9 +248,8 @@ export class MailingListManageComponent {
   }
 
   /**
-   * Maps the loaded list to the {@link EntityWithProject} shape consumed by
-   * syncEntityProjectContext — pre-enrichment payloads can lack the project fields entirely
-   * (or carry the v1-sync empty-string slug), so absent values map to null there.
+   * Adapts the loaded list to {@link EntityWithProject}; a falsy `project_slug` (absent or the
+   * v1-sync empty string) reads as "unenriched" to both consumers.
    */
   private initMailingListEntityContext(): Signal<EntityWithProject | null> {
     return computed(() => {
@@ -271,13 +268,8 @@ export class MailingListManageComponent {
   }
 
   /**
-   * Fallback context sync for when the BFF project enrichment failed (the detail payload has
-   * `project_uid` but no usable `project_slug`): resolve the project by uid and set context from
-   * it. `getProject(uid, false)` — `current: false` so the fetch doesn't clobber ProjectService's
-   * shared `project` state — already resolves to null on failure, so a failed fallback leaves the
-   * (stale) context untouched rather than erroring the page. As in syncEntityProjectContext,
-   * NavigationEnd re-applies the correction: query-param step navigations re-assert the route's
-   * declared lens kind via syncLensFromRoute without re-running guards (GH-1567).
+   * Unenriched-payload fallback (project_uid but no usable project_slug): resolve the project by
+   * uid and set context from it; NavigationEnd re-applies it, mirroring syncEntityProjectContext (GH-1567).
    */
   private initMailingListContextFallback(): void {
     const unresolvedEntity$ = toObservable(this.mailingListEntityContext).pipe(
@@ -290,6 +282,7 @@ export class MailingListManageComponent {
     merge(unresolvedEntity$, navigationReapply$)
       .pipe(
         filter((entity): entity is EntityWithProject => !!entity?.project_uid && !entity.project_slug),
+        // current: false — don't clobber ProjectService's shared state; null on failure leaves the stale context untouched.
         switchMap((entity) =>
           this.projectService.getProject(entity.project_uid, false).pipe(
             map((project) => {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -98,8 +98,11 @@ export class MailingListManageComponent {
   public constructor() {
     evictOnWriteAccessLoss();
     // Sync context from the loaded list itself — an edit deep link can arrive under the wrong tier
-    // or with no `?project=` (GH-1567); preferEntityKind lets the list's own is_foundation re-point the lens kind.
-    syncEntityProjectContext(this.mailingListEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    // or with no `?project=` (GH-1567); canonicalizeRoute then rewrites the URL to the owning tier.
+    syncEntityProjectContext(this.mailingListEntityContext, this.projectContextService, this.router, this.destroyRef, {
+      preferEntityKind: true,
+      canonicalizeRoute: true,
+    });
     this.initMailingListContextFallback();
     this.form()
       .get('group_name')

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts
@@ -30,7 +30,7 @@ import { catchError, distinctUntilChanged, filter, map, merge, Observable, of, s
 
 import { MailingListBasicInfoComponent } from '../components/mailing-list-basic-info/mailing-list-basic-info.component';
 import { MailingListSettingsComponent } from '../components/mailing-list-settings/mailing-list-settings.component';
-import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { applyEntityProjectContext, canonicalizeTierPrefix, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 @Component({
@@ -306,6 +306,8 @@ export class MailingListManageComponent {
         // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
         const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
         applyEntityProjectContext(this.projectContextService, resolved.context, resolved.isFoundation, syncUrl);
+        // Heal a wrong-tier URL the same way the enriched sync path does (GH-1567).
+        canonicalizeTierPrefix(this.router, resolved.isFoundation, resolved.context.slug);
       });
   }
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.html
@@ -54,6 +54,7 @@
                 label="Edit {{ mailingListLabel.singular }}"
                 size="small"
                 [routerLink]="editRoute()"
+                [queryParams]="editQueryParams()"
                 data-testid="mailing-list-view-edit-button">
               </lfx-button>
             </div>
@@ -122,7 +123,7 @@
                 severity="secondary"
                 [outlined]="true"
                 [routerLink]="editRoute()"
-                [queryParams]="{ step: '3' }"
+                [queryParams]="manageGroupsQueryParams()"
                 data-testid="mailing-list-view-manage-groups-button">
               </lfx-button>
             </div>

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -87,7 +87,12 @@ export class MailingListViewComponent {
   public readonly manageGroupsQueryParams: Signal<Record<string, string>> = this.initManageGroupsQueryParams();
 
   public constructor() {
-    syncEntityProjectContext(this.mailingList, this.projectContextService, this.router, this.destroyRef);
+    // Sync context from the loaded list — a view deep link can land under the wrong tier (flat
+    // link redirected by a stale lens); canonicalizeRoute rewrites the URL to the owning tier (GH-1567).
+    syncEntityProjectContext(this.mailingList, this.projectContextService, this.router, this.destroyRef, {
+      preferEntityKind: true,
+      canonicalizeRoute: true,
+    });
   }
 
   public refreshData(): void {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -18,6 +18,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { MailingListAudienceAccess } from '@lfx-one/shared/enums';
 import { CommitteeReference, GroupsIOMailingList } from '@lfx-one/shared/interfaces';
+import { getEntityCommands } from '@lfx-one/shared/utils';
 import { MailingListVisibilitySeverityPipe } from '@pipes/mailing-list-visibility-severity.pipe';
 import { StripHtmlPipe } from '@pipes/strip-html.pipe';
 import { MailingListService } from '@services/mailing-list.service';
@@ -82,6 +83,8 @@ export class MailingListViewComponent {
   public readonly visibilityLabel: Signal<string> = this.initVisibilityLabel();
   public readonly groupsIoUrl: Signal<string | null> = this.initGroupsIoUrl();
   public readonly editRoute: Signal<string[]> = this.initEditRoute();
+  public readonly editQueryParams: Signal<Record<string, string>> = this.initEditQueryParams();
+  public readonly manageGroupsQueryParams: Signal<Record<string, string>> = this.initManageGroupsQueryParams();
 
   public constructor() {
     syncEntityProjectContext(this.mailingList, this.projectContextService, this.router, this.destroyRef);
@@ -173,10 +176,30 @@ export class MailingListViewComponent {
     return computed(() => this.mailingList()?.service?.url || null);
   }
 
+  // Canonical edit URL derives from the LIST's own project tier (is_foundation), not the
+  // viewer's transient active lens; falls back to the flat path (lensRedirectGuard) when the
+  // tier is unenriched (GH-1567).
   private initEditRoute(): Signal<string[]> {
     return computed(() => {
-      const uid = this.mailingList()?.uid;
-      return uid ? ['/mailing-lists', uid, 'edit'] : ['/mailing-lists'];
+      const list = this.mailingList();
+      const uid = list?.uid;
+      if (!uid) return ['/mailing-lists'];
+      return getEntityCommands('mailing-lists', uid, list?.is_foundation, 'edit') ?? ['/mailing-lists', uid, 'edit'];
     });
+  }
+
+  // `?project=` rides along when the payload carries a slug — the manage page's context sync
+  // keys off it, and it keeps writerGuard's authorization project correct on deep links.
+  private initEditQueryParams(): Signal<Record<string, string>> {
+    return computed(() => {
+      const list = this.mailingList();
+      const params: Record<string, string> = {};
+      if (list?.project_slug) params['project'] = list.project_slug;
+      return params;
+    });
+  }
+
+  private initManageGroupsQueryParams(): Signal<Record<string, string>> {
+    return computed(() => ({ ...this.editQueryParams(), step: '3' }));
   }
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -18,7 +18,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { MailingListAudienceAccess } from '@lfx-one/shared/enums';
 import { CommitteeReference, GroupsIOMailingList } from '@lfx-one/shared/interfaces';
-import { getEntityCommands } from '@lfx-one/shared/utils';
+import { getMailingListCommands, getMailingListLinkQueryParams } from '@lfx-one/shared/utils';
 import { MailingListVisibilitySeverityPipe } from '@pipes/mailing-list-visibility-severity.pipe';
 import { StripHtmlPipe } from '@pipes/strip-html.pipe';
 import { MailingListService } from '@services/mailing-list.service';
@@ -176,27 +176,21 @@ export class MailingListViewComponent {
     return computed(() => this.mailingList()?.service?.url || null);
   }
 
-  // Canonical edit URL derives from the LIST's own project tier (is_foundation), not the
-  // viewer's transient active lens; falls back to the flat path (lensRedirectGuard) when the
-  // tier is unenriched (GH-1567).
+  // Canonical edit URL derives from the list's own tier (is_foundation), not the active lens;
+  // flat fallback when the tier is unenriched (GH-1567).
   private initEditRoute(): Signal<string[]> {
     return computed(() => {
       const list = this.mailingList();
       const uid = list?.uid;
       if (!uid) return ['/mailing-lists'];
-      return getEntityCommands('mailing-lists', uid, list?.is_foundation, 'edit') ?? ['/mailing-lists', uid, 'edit'];
+      return getMailingListCommands({ uid, is_foundation: list?.is_foundation }, 'edit');
     });
   }
 
   // `?project=` rides along when the payload carries a slug — the manage page's context sync
   // keys off it, and it keeps writerGuard's authorization project correct on deep links.
   private initEditQueryParams(): Signal<Record<string, string>> {
-    return computed(() => {
-      const list = this.mailingList();
-      const params: Record<string, string> = {};
-      if (list?.project_slug) params['project'] = list.project_slug;
-      return params;
-    });
+    return computed(() => getMailingListLinkQueryParams(this.mailingList()) ?? {});
   }
 
   private initManageGroupsQueryParams(): Signal<Record<string, string>> {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts
@@ -27,6 +27,6 @@ export const MAILING_LIST_ROUTES: Routes = [
     path: ':id/edit',
     loadComponent: () => import('./mailing-list-manage/mailing-list-manage.component').then((m) => m.MailingListManageComponent),
     canActivate: [authGuard, writerGuard],
-    data: { writeFeature: 'mailing-lists' },
+    data: { writeFeature: 'mailing-lists', entityScopedSlug: true },
   },
 ];

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -6,11 +6,12 @@ import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, convertToParamMap, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { CommitteeService } from '@shared/services/committee.service';
+import { MailingListService } from '@shared/services/mailing-list.service';
 import { MeetingService } from '@shared/services/meeting.service';
 import { PersonaService } from '@shared/services/persona.service';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { ProjectService } from '@shared/services/project.service';
-import { Committee, Meeting } from '@lfx-one/shared/interfaces';
+import { Committee, GroupsIOMailingList, Meeting } from '@lfx-one/shared/interfaces';
 import { firstValueFrom, of, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -21,7 +22,8 @@ import { writerGuard } from './writer.guard';
 // resolve no slug at all so the guard redirects instead of authorizing against an unrelated
 // project. A future broadened catch would silently restore the cross-project authorization bug.
 // The committee edit route (GH-1566) shares the same entity-scoped resolution through
-// fetchCommittee, so its cases pin the identical contract for the committees branch.
+// fetchCommittee, so its cases pin the identical contract for the committees branch; likewise the
+// mailing-list edit route (GH-1567) through getMailingList, including the v1-sync empty-string slug.
 // Also covers the non-meetings early-returns (ED fast path, non-entity-scoped features) so the
 // file isn't a false sense of coverage for the guard's default flow.
 describe('writerGuard', () => {
@@ -29,12 +31,15 @@ describe('writerGuard', () => {
   const MEETING_SLUG = 'meeting-project';
   const COMMITTEE_UID = 'committee-uid-1';
   const COMMITTEE_SLUG = 'committee-project';
+  const MAILING_LIST_UID = 'mailing-list-uid-1';
+  const MAILING_LIST_SLUG = 'mailing-list-project';
   const STALE_SLUG = 'stale-project';
 
   let getMeetingDetail: ReturnType<typeof vi.fn>;
   let getProject: ReturnType<typeof vi.fn>;
   let getCommittee: ReturnType<typeof vi.fn>;
   let fetchCommittee: ReturnType<typeof vi.fn>;
+  let getMailingList: ReturnType<typeof vi.fn>;
   let router: { parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
   let currentPersona: ReturnType<typeof signal<string>>;
 
@@ -56,6 +61,14 @@ describe('writerGuard', () => {
       parent: null,
     }) as unknown as ActivatedRouteSnapshot;
 
+  const mailingListRoute = (): ActivatedRouteSnapshot =>
+    ({
+      queryParamMap: convertToParamMap({}),
+      paramMap: convertToParamMap({ id: MAILING_LIST_UID }),
+      data: { writeFeature: 'mailing-lists', entityScopedSlug: true },
+      parent: null,
+    }) as unknown as ActivatedRouteSnapshot;
+
   const runGuard = async (route: ActivatedRouteSnapshot = meetingRoute()) => {
     // The guard returns `true` synchronously for the ED fast path, an Observable otherwise —
     // never a bare UrlTree (redirects are always wrapped in `of(...)`).
@@ -68,6 +81,7 @@ describe('writerGuard', () => {
     getProject = vi.fn().mockReturnValue(of(null));
     getCommittee = vi.fn();
     fetchCommittee = vi.fn();
+    getMailingList = vi.fn();
     currentPersona = signal('maintainer');
     router = {
       parseUrl: vi.fn().mockImplementation((url: string) => ({ redirect: url }) as unknown as UrlTree),
@@ -80,6 +94,7 @@ describe('writerGuard', () => {
         { provide: ProjectContextService, useValue: { activeContext: () => ({ uid: 'stale-uid', slug: STALE_SLUG, name: 'Stale' }) } },
         { provide: ProjectService, useValue: { getProject } },
         { provide: CommitteeService, useValue: { getCommittee, fetchCommittee } },
+        { provide: MailingListService, useValue: { getMailingList } },
         { provide: MeetingService, useValue: { getMeetingDetail } },
         { provide: Router, useValue: router },
       ],
@@ -165,6 +180,49 @@ describe('writerGuard', () => {
     fetchCommittee.mockReturnValue(throwError(() => httpError(500)));
 
     const result = await runGuard(committeeRoute());
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
+    expect(getProject).not.toHaveBeenCalled();
+    expect(getCommittee).not.toHaveBeenCalled();
+  });
+
+  it('authorizes mailing-list edit against the list’s own project when the read succeeds', async () => {
+    getMailingList.mockReturnValue(of({ uid: MAILING_LIST_UID, project_uid: 'ml-uid', project_slug: MAILING_LIST_SLUG } as unknown as GroupsIOMailingList));
+    getProject.mockReturnValue(of({ uid: 'ml-uid', slug: MAILING_LIST_SLUG, writer: true }));
+
+    const result = await runGuard(mailingListRoute());
+
+    expect(result).toBe(true);
+    expect(getMailingList).toHaveBeenCalledWith(MAILING_LIST_UID);
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledWith(MAILING_LIST_SLUG, false, { meetingCoordinator: false });
+  });
+
+  it('resolves the uid when the list payload carries the v1-sync empty-string slug, never the stale context', async () => {
+    getMailingList.mockReturnValue(of({ uid: MAILING_LIST_UID, project_uid: 'ml-uid', project_slug: '' } as unknown as GroupsIOMailingList));
+    getProject.mockReturnValue(of({ uid: 'ml-uid', slug: MAILING_LIST_SLUG, writer: true }));
+
+    const result = await runGuard(mailingListRoute());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('ml-uid', false, { meetingCoordinator: false });
+  });
+
+  it('falls back to the active context only on a 404 mailing-list read', async () => {
+    getMailingList.mockReturnValue(throwError(() => httpError(404)));
+    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
+
+    const result = await runGuard(mailingListRoute());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
+  });
+
+  it('fails closed on a 500 mailing-list read without probing the stale project', async () => {
+    getMailingList.mockReturnValue(throwError(() => httpError(500)));
+
+    const result = await runGuard(mailingListRoute());
 
     expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
     expect(result).toEqual({ redirect: '/project/overview' });

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -17,15 +17,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { writerGuard } from './writer.guard';
 
-// Pins the fail-closed contract of the meeting edit slug resolution (GH-1579): only a 404
-// on the meeting read may fall back to the stale active context — every other failure must
-// resolve no slug at all so the guard redirects instead of authorizing against an unrelated
-// project. A future broadened catch would silently restore the cross-project authorization bug.
-// The committee edit route (GH-1566) shares the same entity-scoped resolution through
-// fetchCommittee, so its cases pin the identical contract for the committees branch; likewise the
-// mailing-list edit route (GH-1567) through getMailingList, including the v1-sync empty-string slug.
-// Also covers the non-meetings early-returns (ED fast path, non-entity-scoped features) so the
-// file isn't a false sense of coverage for the guard's default flow.
+// Pins the fail-closed entity-scoped slug contract (GH-1579/GH-1566/GH-1567): only a 404 probe read
+// falls back to the stale context — anything else resolves no slug. Also covers the ED fast path and non-entity-scoped features.
 describe('writerGuard', () => {
   const MEETING_UID = 'meeting-uid-1';
   const MEETING_SLUG = 'meeting-project';

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -8,6 +8,7 @@ import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { catchError, map, Observable, of, switchMap } from 'rxjs';
 
 import { CommitteeService } from '../services/committee.service';
+import { MailingListService } from '../services/mailing-list.service';
 import { MeetingService } from '../services/meeting.service';
 import { PersonaService } from '../services/persona.service';
 import { ProjectContextService } from '../services/project-context.service';
@@ -55,6 +56,7 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const projectContextService = inject(ProjectContextService);
   const projectService = inject(ProjectService);
   const committeeService = inject(CommitteeService);
+  const mailingListService = inject(MailingListService);
   const meetingService = inject(MeetingService);
   const router = inject(Router);
 
@@ -72,12 +74,13 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const writeFeature: string | undefined = route.data?.['writeFeature'];
   // Entity probes keyed by writeFeature — a new entity adds one registry line + the route's
   // entityScopedSlug flag. Probes must be tap-free: fetchCommittee, not getCommittee (which sets
-  // the shared committee signal), so a guard probe can't leak stale state into other pages. Both
-  // probes ride a short-TTL shared cache (getMeetingDetail / getCommitteeDetail via fetchCommittee),
+  // the shared committee signal), so a guard probe can't leak stale state into other pages. The
+  // probes ride short-TTL shared caches (getMeetingDetail / fetchCommittee / getMailingList),
   // so the manage component's immediate refetch on the same navigation doesn't duplicate the request.
   const entityProbes: Record<string, (id: string) => Observable<Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null>> = {
     meetings: (id) => meetingService.getMeetingDetail(id),
     committees: (id) => committeeService.fetchCommittee(id),
+    'mailing-lists': (id) => mailingListService.getMailingList(id),
   };
   const resolveSlug = (): Observable<string | null> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -72,11 +72,8 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   // A missing/stale `?project=` can authorize against a different project than the entity being
   // edited — resolve the slug from the entity itself; only a 404 falls back, else fail closed.
   const writeFeature: string | undefined = route.data?.['writeFeature'];
-  // Entity probes keyed by writeFeature — a new entity adds one registry line + the route's
-  // entityScopedSlug flag. Probes must be tap-free: fetchCommittee, not getCommittee (which sets
-  // the shared committee signal), so a guard probe can't leak stale state into other pages. The
-  // probes ride short-TTL shared caches (getMeetingDetail / fetchCommittee / getMailingList),
-  // so the manage component's immediate refetch on the same navigation doesn't duplicate the request.
+  // Entity probes keyed by writeFeature — a new entity adds one registry line + the route's entityScopedSlug flag.
+  // Probes must be tap-free and ride short-TTL shared caches so the guard probe and the manage page share one request.
   const entityProbes: Record<string, (id: string) => Observable<Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null>> = {
     meetings: (id) => meetingService.getMeetingDetail(id),
     committees: (id) => committeeService.fetchCommittee(id),

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.spec.ts
@@ -1,0 +1,87 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import type { GroupsIOMailingList } from '@lfx-one/shared/interfaces';
+import { of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MailingListService } from './mailing-list.service';
+
+// Pins the detail-cache contract the writerGuard probe relies on (GH-1567): the probe and the
+// manage-page load share one request, writes evict, and a failed fetch must never stick.
+describe('MailingListService detail cache', () => {
+  const LIST = { uid: 'ml-1' } as unknown as GroupsIOMailingList;
+
+  let service: MailingListService;
+  let http: {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    http = { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() };
+    http.get.mockReturnValue(of(LIST));
+    TestBed.configureTestingModule({ providers: [{ provide: HttpClient, useValue: http }] });
+    service = TestBed.inject(MailingListService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('shares one request between the guard probe and the page load within the TTL', () => {
+    service.getMailingList('ml-1').subscribe();
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(http.get).toHaveBeenCalledWith('/api/mailing-lists/ml-1');
+  });
+
+  it('refetches once the TTL has expired', () => {
+    vi.useFakeTimers();
+    service.getMailingList('ml-1').subscribe();
+    vi.setSystemTime(Date.now() + 11_000);
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('skipCache forces a fresh fetch within the TTL', () => {
+    service.getMailingList('ml-1').subscribe();
+    service.getMailingList('ml-1', { skipCache: true }).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts on error so the next caller retries instead of serving the failure', () => {
+    http.get.mockReturnValueOnce(throwError(() => new Error('boom')));
+    service.getMailingList('ml-1').subscribe({ error: vi.fn() });
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the cached detail on updateMailingList', () => {
+    http.put.mockReturnValue(of(LIST));
+    service.getMailingList('ml-1').subscribe();
+    service.updateMailingList('ml-1', {}).subscribe();
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the cached detail on member writes', () => {
+    http.delete.mockReturnValue(of(void 0));
+    service.getMailingList('ml-1').subscribe();
+    service.deleteMember('ml-1', 'member-1').subscribe();
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.spec.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import type { GroupsIOMailingList } from '@lfx-one/shared/interfaces';
+import type { GroupsIOMailingList, MailingListMember } from '@lfx-one/shared/interfaces';
 import { of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -76,10 +76,28 @@ describe('MailingListService detail cache', () => {
     expect(http.get).toHaveBeenCalledTimes(2);
   });
 
-  it('evicts the cached detail on member writes', () => {
+  it('evicts the cached detail on deleteMember', () => {
     http.delete.mockReturnValue(of(void 0));
     service.getMailingList('ml-1').subscribe();
     service.deleteMember('ml-1', 'member-1').subscribe();
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the cached detail on createMember', () => {
+    http.post.mockReturnValue(of({} as MailingListMember));
+    service.getMailingList('ml-1').subscribe();
+    service.createMember('ml-1', { email: 'member@example.com' }).subscribe();
+    service.getMailingList('ml-1').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the cached detail on updateMember', () => {
+    http.put.mockReturnValue(of({} as MailingListMember));
+    service.getMailingList('ml-1').subscribe();
+    service.updateMember('ml-1', 'member-1', {}).subscribe();
     service.getMailingList('ml-1').subscribe();
 
     expect(http.get).toHaveBeenCalledTimes(2);

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -14,7 +14,8 @@ import {
   QueryServiceCountResponse,
   UpdateMailingListMemberRequest,
 } from '@lfx-one/shared/interfaces';
-import { catchError, map, Observable, of } from 'rxjs';
+import { MAILING_LIST_DETAIL_CACHE_TTL_MS } from '@lfx-one/shared/constants';
+import { catchError, map, Observable, of, shareReplay, tap } from 'rxjs';
 
 /**
  * Service for managing mailing list data
@@ -26,6 +27,7 @@ import { catchError, map, Observable, of } from 'rxjs';
 export class MailingListService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = '/api/mailing-lists';
+  private readonly mailingListDetailCache = new Map<string, { observable: Observable<GroupsIOMailingList>; cachedAt: number }>();
 
   public getMailingListsByProject(projectUid: string): Observable<GroupsIOMailingList[]> {
     const params = new HttpParams().set('tags', `project_uid:${projectUid}`);
@@ -45,8 +47,28 @@ export class MailingListService {
     return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`).pipe(catchError(() => of([])));
   }
 
-  public getMailingList(uid: string): Observable<GroupsIOMailingList> {
-    return this.http.get<GroupsIOMailingList>(`${this.baseUrl}/${uid}`);
+  /**
+   * Mailing-list detail fetch with a short-TTL shared cache: the writerGuard entity probe and
+   * MailingListManageComponent's initMailingList both need the same payload within one
+   * navigation — sharing the request avoids a duplicate fetch on every edit-page load.
+   * Probe-friendly: no side effects. Entries evict on error and on write (updateMailingList).
+   * Pass `skipCache` to force a fresh fetch. Mirrors getMeetingDetail / fetchCommittee (GH-1567).
+   */
+  public getMailingList(uid: string, options?: { skipCache?: boolean }): Observable<GroupsIOMailingList> {
+    const cached = this.mailingListDetailCache.get(uid);
+    if (!options?.skipCache && cached && Date.now() - cached.cachedAt < MAILING_LIST_DETAIL_CACHE_TTL_MS) {
+      return cached.observable;
+    }
+    if (cached) {
+      this.mailingListDetailCache.delete(uid);
+    }
+    const request$ = this.http.get<GroupsIOMailingList>(`${this.baseUrl}/${uid}`).pipe(
+      tap({ error: () => this.mailingListDetailCache.delete(uid) }),
+      shareReplay(1)
+    );
+    this.pruneExpiredMailingListDetailCache();
+    this.mailingListDetailCache.set(uid, { observable: request$, cachedAt: Date.now() });
+    return request$;
   }
 
   public getMailingListsCount(query?: Record<string, string>): Observable<number> {
@@ -64,7 +86,7 @@ export class MailingListService {
   }
 
   public updateMailingList(uid: string, data: Partial<CreateMailingListRequest>): Observable<GroupsIOMailingList> {
-    return this.http.put<GroupsIOMailingList>(`${this.baseUrl}/${uid}`, data);
+    return this.http.put<GroupsIOMailingList>(`${this.baseUrl}/${uid}`, data).pipe(tap(() => this.mailingListDetailCache.delete(uid)));
   }
 
   public getServicesByProject(projectUid: string): Observable<GroupsIOService[]> {
@@ -99,5 +121,14 @@ export class MailingListService {
 
   public deleteMember(mailingListId: string, memberId: string): Observable<void> {
     return this.http.delete<void>(`${this.baseUrl}/${mailingListId}/members/${memberId}`);
+  }
+
+  private pruneExpiredMailingListDetailCache(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.mailingListDetailCache) {
+      if (now - entry.cachedAt >= MAILING_LIST_DETAIL_CACHE_TTL_MS) {
+        this.mailingListDetailCache.delete(key);
+      }
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -15,7 +15,7 @@ import {
   UpdateMailingListMemberRequest,
 } from '@lfx-one/shared/interfaces';
 import { MAILING_LIST_DETAIL_CACHE_TTL_MS } from '@lfx-one/shared/constants';
-import { catchError, map, Observable, of, shareReplay, tap } from 'rxjs';
+import { catchError, map, Observable, of, shareReplay, take, tap } from 'rxjs';
 
 /**
  * Service for managing mailing list data
@@ -59,10 +59,9 @@ export class MailingListService {
     if (cached) {
       this.mailingListDetailCache.delete(uid);
     }
-    const request$ = this.http.get<GroupsIOMailingList>(`${this.baseUrl}/${uid}`).pipe(
-      tap({ error: () => this.mailingListDetailCache.delete(uid) }),
-      shareReplay(1)
-    );
+    const request$ = this.http
+      .get<GroupsIOMailingList>(`${this.baseUrl}/${uid}`)
+      .pipe(tap({ error: () => this.mailingListDetailCache.delete(uid) }), shareReplay(1));
     this.pruneExpiredMailingListDetailCache();
     this.mailingListDetailCache.set(uid, { observable: request$, cachedAt: Date.now() });
     return request$;
@@ -79,11 +78,14 @@ export class MailingListService {
   }
 
   public createMailingList(data: CreateMailingListRequest): Observable<GroupsIOMailingList> {
-    return this.http.post<GroupsIOMailingList>(this.baseUrl, data);
+    return this.http.post<GroupsIOMailingList>(this.baseUrl, data).pipe(take(1));
   }
 
   public updateMailingList(uid: string, data: Partial<CreateMailingListRequest>): Observable<GroupsIOMailingList> {
-    return this.http.put<GroupsIOMailingList>(`${this.baseUrl}/${uid}`, data).pipe(tap(() => this.mailingListDetailCache.delete(uid)));
+    return this.http.put<GroupsIOMailingList>(`${this.baseUrl}/${uid}`, data).pipe(
+      take(1),
+      tap(() => this.mailingListDetailCache.delete(uid))
+    );
   }
 
   public getServicesByProject(projectUid: string): Observable<GroupsIOService[]> {
@@ -93,7 +95,7 @@ export class MailingListService {
   }
 
   public createService(data: CreateGroupsIOServiceRequest): Observable<GroupsIOService> {
-    return this.http.post<GroupsIOService>(`${this.baseUrl}/services`, data);
+    return this.http.post<GroupsIOService>(`${this.baseUrl}/services`, data).pipe(take(1));
   }
 
   public getMembers(mailingListId: string): Observable<MailingListMember[]> {
@@ -109,17 +111,28 @@ export class MailingListService {
   }
 
   public createMember(mailingListId: string, data: CreateMailingListMemberRequest): Observable<MailingListMember> {
-    return this.http.post<MailingListMember>(`${this.baseUrl}/${mailingListId}/members`, data).pipe(tap(() => this.mailingListDetailCache.delete(mailingListId)));
+    return this.http
+      .post<MailingListMember>(`${this.baseUrl}/${mailingListId}/members`, data)
+      .pipe(
+        take(1),
+        tap(() => this.mailingListDetailCache.delete(mailingListId))
+      );
   }
 
   public updateMember(mailingListId: string, memberId: string, data: UpdateMailingListMemberRequest): Observable<MailingListMember> {
     return this.http
       .put<MailingListMember>(`${this.baseUrl}/${mailingListId}/members/${memberId}`, data)
-      .pipe(tap(() => this.mailingListDetailCache.delete(mailingListId)));
+      .pipe(
+        take(1),
+        tap(() => this.mailingListDetailCache.delete(mailingListId))
+      );
   }
 
   public deleteMember(mailingListId: string, memberId: string): Observable<void> {
-    return this.http.delete<void>(`${this.baseUrl}/${mailingListId}/members/${memberId}`).pipe(tap(() => this.mailingListDetailCache.delete(mailingListId)));
+    return this.http.delete<void>(`${this.baseUrl}/${mailingListId}/members/${memberId}`).pipe(
+      take(1),
+      tap(() => this.mailingListDetailCache.delete(mailingListId))
+    );
   }
 
   private pruneExpiredMailingListDetailCache(): void {

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -111,21 +111,17 @@ export class MailingListService {
   }
 
   public createMember(mailingListId: string, data: CreateMailingListMemberRequest): Observable<MailingListMember> {
-    return this.http
-      .post<MailingListMember>(`${this.baseUrl}/${mailingListId}/members`, data)
-      .pipe(
-        take(1),
-        tap(() => this.mailingListDetailCache.delete(mailingListId))
-      );
+    return this.http.post<MailingListMember>(`${this.baseUrl}/${mailingListId}/members`, data).pipe(
+      take(1),
+      tap(() => this.mailingListDetailCache.delete(mailingListId))
+    );
   }
 
   public updateMember(mailingListId: string, memberId: string, data: UpdateMailingListMemberRequest): Observable<MailingListMember> {
-    return this.http
-      .put<MailingListMember>(`${this.baseUrl}/${mailingListId}/members/${memberId}`, data)
-      .pipe(
-        take(1),
-        tap(() => this.mailingListDetailCache.delete(mailingListId))
-      );
+    return this.http.put<MailingListMember>(`${this.baseUrl}/${mailingListId}/members/${memberId}`, data).pipe(
+      take(1),
+      tap(() => this.mailingListDetailCache.delete(mailingListId))
+    );
   }
 
   public deleteMember(mailingListId: string, memberId: string): Observable<void> {

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -48,11 +48,8 @@ export class MailingListService {
   }
 
   /**
-   * Mailing-list detail fetch with a short-TTL shared cache: the writerGuard entity probe and
-   * MailingListManageComponent's initMailingList both need the same payload within one
-   * navigation — sharing the request avoids a duplicate fetch on every edit-page load.
-   * Probe-friendly: no side effects. Entries evict on error and on write (updateMailingList).
-   * Pass `skipCache` to force a fresh fetch. Mirrors getMeetingDetail / fetchCommittee (GH-1567).
+   * Short-TTL detail cache so the writerGuard probe and the manage-page load share one request (GH-1567).
+   * Evicts on error and on writes (updateMailingList, member mutations); `skipCache` forces a fresh fetch.
    */
   public getMailingList(uid: string, options?: { skipCache?: boolean }): Observable<GroupsIOMailingList> {
     const cached = this.mailingListDetailCache.get(uid);
@@ -112,15 +109,17 @@ export class MailingListService {
   }
 
   public createMember(mailingListId: string, data: CreateMailingListMemberRequest): Observable<MailingListMember> {
-    return this.http.post<MailingListMember>(`${this.baseUrl}/${mailingListId}/members`, data);
+    return this.http.post<MailingListMember>(`${this.baseUrl}/${mailingListId}/members`, data).pipe(tap(() => this.mailingListDetailCache.delete(mailingListId)));
   }
 
   public updateMember(mailingListId: string, memberId: string, data: UpdateMailingListMemberRequest): Observable<MailingListMember> {
-    return this.http.put<MailingListMember>(`${this.baseUrl}/${mailingListId}/members/${memberId}`, data);
+    return this.http
+      .put<MailingListMember>(`${this.baseUrl}/${mailingListId}/members/${memberId}`, data)
+      .pipe(tap(() => this.mailingListDetailCache.delete(mailingListId)));
   }
 
   public deleteMember(mailingListId: string, memberId: string): Observable<void> {
-    return this.http.delete<void>(`${this.baseUrl}/${mailingListId}/members/${memberId}`);
+    return this.http.delete<void>(`${this.baseUrl}/${mailingListId}/members/${memberId}`).pipe(tap(() => this.mailingListDetailCache.delete(mailingListId)));
   }
 
   private pruneExpiredMailingListDetailCache(): void {

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -50,13 +50,17 @@ export function applyEntityProjectContext(
  * `activeContext` from the persona-resolved selection to the project slot for the life of the
  * page, and an entity kind contradicting the URL prefix would re-point the kind while the URL
  * still reads otherwise — both behavior changes outside this fix's scope.
+ *
+ * `canonicalizeRoute` (opt-in, requires `preferEntityKind`): once the entity's kind is known
+ * and contradicts the URL's leading `/foundation|project` segment, rewrite the URL to the
+ * entity's tier so a copied link reflects ownership (GH-1567).
  */
 export function syncEntityProjectContext<T extends EntityWithProject>(
   entitySignal: Signal<T | null>,
   projectContextService: ProjectContextService,
   router: Router,
   destroyRef: DestroyRef,
-  options?: { preferEntityKind?: boolean }
+  options?: { preferEntityKind?: boolean; canonicalizeRoute?: boolean }
 ): void {
   const entityChanges$ = toObservable(entitySignal).pipe(
     distinctUntilChanged((a, b) => a?.uid === b?.uid && a?.project_uid === b?.project_uid && a?.project_slug === b?.project_slug)
@@ -95,10 +99,27 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
         // a foundation-owned entity can sit under a /project/* route (e.g. meeting edit).
         const useFoundation = entity.is_foundation ?? router.url.startsWith('/foundation/');
         applyEntityProjectContext(projectContextService, context, useFoundation, syncUrl);
+        if (options?.canonicalizeRoute && entity.is_foundation != null) {
+          canonicalizeTierPrefix(router, entity.is_foundation);
+        }
       } else if (router.url.startsWith('/foundation/')) {
         projectContextService.setFoundation(context, syncUrl);
       } else {
         projectContextService.setProject(context, syncUrl);
       }
     });
+}
+
+// Swaps only the leading tier segment so the URL reflects entity ownership (GH-1567); the
+// already-canonical no-op keeps the NavigationEnd re-apply loop-free, replaceUrl keeps history clean.
+function canonicalizeTierPrefix(router: Router, isFoundation: boolean): void {
+  const url = router.url;
+  const isFoundationUrl = url.startsWith('/foundation/');
+  const isProjectUrl = url.startsWith('/project/');
+  if ((!isFoundationUrl && !isProjectUrl) || isFoundationUrl === isFoundation) {
+    return;
+  }
+  const from = isFoundationUrl ? '/foundation/' : '/project/';
+  const to = isFoundation ? '/foundation/' : '/project/';
+  router.navigateByUrl(to + url.slice(from.length), { replaceUrl: true });
 }

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -100,7 +100,7 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
         const useFoundation = entity.is_foundation ?? router.url.startsWith('/foundation/');
         applyEntityProjectContext(projectContextService, context, useFoundation, syncUrl);
         if (options?.canonicalizeRoute && entity.is_foundation != null) {
-          canonicalizeTierPrefix(router, entity.is_foundation);
+          canonicalizeTierPrefix(router, entity.is_foundation, entity.project_slug);
         }
       } else if (router.url.startsWith('/foundation/')) {
         projectContextService.setFoundation(context, syncUrl);
@@ -112,7 +112,7 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
 
 // Swaps only the leading tier segment so the URL reflects entity ownership (GH-1567); the
 // already-canonical no-op keeps the NavigationEnd re-apply loop-free, replaceUrl keeps history clean.
-function canonicalizeTierPrefix(router: Router, isFoundation: boolean): void {
+export function canonicalizeTierPrefix(router: Router, isFoundation: boolean, projectSlug: string): void {
   const url = router.url;
   const isFoundationUrl = url.startsWith('/foundation/');
   const isProjectUrl = url.startsWith('/project/');
@@ -121,5 +121,11 @@ function canonicalizeTierPrefix(router: Router, isFoundation: boolean): void {
   }
   const from = isFoundationUrl ? '/foundation/' : '/project/';
   const to = isFoundation ? '/foundation/' : '/project/';
-  router.navigateByUrl(to + url.slice(from.length), { replaceUrl: true });
+  const urlTree = router.parseUrl(to + url.slice(from.length));
+  // router.url still carries the pre-sync ?project= (the Location.replaceState sync bypasses the
+  // router) — pin the entity's slug so projectQueryParamGuard reseeds the right project.
+  if ('project' in urlTree.queryParams) {
+    urlTree.queryParams['project'] = projectSlug;
+  }
+  router.navigateByUrl(urlTree, { replaceUrl: true });
 }

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -258,9 +258,8 @@ export class MailingListService {
     ]);
     const mailingList = enriched[0];
 
-    // The groupsio_mailing_list index never emits is_foundation, and v1-sync rows carry
-    // project_slug/project_name as empty strings — the edit page's context sync and
-    // writerGuard's entity-scoped probe need the enriched fields (GH-1567).
+    // The index never emits is_foundation and v1-sync rows carry empty-string project fields —
+    // the edit page's context sync and writerGuard's probe need the enriched fields (GH-1567).
     if (project) {
       Object.assign(mailingList, toEntityProjectFields(project));
     }

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -205,6 +205,10 @@ export class MailingListService {
     // Enrich with service data
     mailingLists = await this.enrichWithServices(req, mailingLists);
 
+    // Enrich with project metadata — the index never emits is_foundation, and the table's
+    // canonical tier-prefixed row links (GH-1567) need it (same batched pass as the Me lens).
+    mailingLists = await this.projectService.enrichWithProjectData(req, mailingLists);
+
     // Add writer access field to all mailing lists
     return await this.accessCheckService.addAccessToResources(req, mailingLists, 'groupsio_mailing_list');
   }

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -18,6 +18,7 @@ import {
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
+import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
 import { pollEndpoint, pollUntilIndexed } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
@@ -247,9 +248,22 @@ export class MailingListService {
       });
     }
 
-    // Enrich with service data (single item as array for reuse)
-    const enriched = await this.enrichWithServices(req, [resources[0].data]);
+    const data = resources[0].data;
+
+    // Service-data and project enrichment both depend only on the query-service payload —
+    // run them in parallel so the project lookup adds no sequential latency.
+    const [enriched, project] = await Promise.all([
+      this.enrichWithServices(req, [data]),
+      fetchEntityProject(req, this.projectService, data.project_uid, { operation: 'get_mailing_list_by_id', mailing_list_id: mailingListId }),
+    ]);
     const mailingList = enriched[0];
+
+    // The groupsio_mailing_list index never emits is_foundation, and v1-sync rows carry
+    // project_slug/project_name as empty strings — the edit page's context sync and
+    // writerGuard's entity-scoped probe need the enriched fields (GH-1567).
+    if (project) {
+      Object.assign(mailingList, toEntityProjectFields(project));
+    }
 
     // Add writer access field to the mailing list
     return await this.accessCheckService.addAccessToResource(req, mailingList, 'groupsio_mailing_list');

--- a/packages/shared/src/constants/mailing-list.constants.ts
+++ b/packages/shared/src/constants/mailing-list.constants.ts
@@ -81,8 +81,7 @@ export const MAILING_LIST_STEP_TITLES = ['Basic Information', 'Settings', 'Peopl
 export const MAILING_LIST_TOTAL_STEPS = MAILING_LIST_STEP_TITLES.length;
 
 /**
- * Short TTL for the mailing-list-detail cache — just long enough for the writerGuard
- * entity probe and MailingListManageComponent's immediate refetch to share one request, without
- * serving stale data across edits (write paths evict explicitly). Mirrors MEETING_DETAIL_CACHE_TTL_MS.
+ * Short TTL so the writerGuard probe and manage-page refetch share one request; writes evict
+ * explicitly. Mirrors MEETING_DETAIL_CACHE_TTL_MS.
  */
 export const MAILING_LIST_DETAIL_CACHE_TTL_MS = 10 * 1000;

--- a/packages/shared/src/constants/mailing-list.constants.ts
+++ b/packages/shared/src/constants/mailing-list.constants.ts
@@ -79,3 +79,10 @@ export const MAILING_LIST_STEP_TITLES = ['Basic Information', 'Settings', 'Peopl
  * Total number of steps in the mailing list wizard
  */
 export const MAILING_LIST_TOTAL_STEPS = MAILING_LIST_STEP_TITLES.length;
+
+/**
+ * Short TTL for the mailing-list-detail cache — just long enough for the writerGuard
+ * entity probe and MailingListManageComponent's immediate refetch to share one request, without
+ * serving stale data across edits (write paths evict explicitly). Mirrors MEETING_DETAIL_CACHE_TTL_MS.
+ */
+export const MAILING_LIST_DETAIL_CACHE_TTL_MS = 10 * 1000;

--- a/packages/shared/src/interfaces/mailing-list.interface.ts
+++ b/packages/shared/src/interfaces/mailing-list.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import {
+import type {
   GroupsIOServiceStatus,
   GroupsIOServiceType,
   MailingListAudienceAccess,
@@ -10,8 +10,8 @@ import {
   MailingListMemberType,
   MailingListType,
 } from '../enums/mailing-list.enum';
-import { CommitteeReference } from './committee.interface';
-import { UserInfo } from './project.interface';
+import type { CommitteeReference } from './committee.interface';
+import type { UserInfo } from './project.interface';
 
 /**
  * Linked group reference for mailing lists
@@ -297,4 +297,18 @@ export interface UpdateMailingListMemberRequest {
   delivery_mode?: MailingListMemberDeliveryMode;
   /** Moderation status */
   mod_status?: MailingListMemberModStatus;
+}
+
+/**
+ * A mailing-list-table row decorated with template-friendly link state (mirrors
+ * `CommitteeTableRowVm`): the entity fields pass through untouched, and the canonical view
+ * router commands + `?project=` params are pre-computed once per input change instead of per
+ * change-detection cycle (angular-reactive-data §3.5). `viewCommands` already contains the
+ * flat `/mailing-lists/:uid` fallback when the row carries no `is_foundation`, so the template
+ * never branches (GH-1567).
+ */
+export interface MailingListTableRowVm extends GroupsIOMailingList {
+  viewCommands: string[];
+  /** `?project=` for the view link — present only when the list carries a `project_slug`. */
+  linkQueryParams: { project: string } | null;
 }

--- a/packages/shared/src/interfaces/mailing-list.interface.ts
+++ b/packages/shared/src/interfaces/mailing-list.interface.ts
@@ -300,12 +300,8 @@ export interface UpdateMailingListMemberRequest {
 }
 
 /**
- * A mailing-list-table row decorated with template-friendly link state (mirrors
- * `CommitteeTableRowVm`): the entity fields pass through untouched, and the canonical view
- * router commands + `?project=` params are pre-computed once per input change instead of per
- * change-detection cycle (angular-reactive-data §3.5). `viewCommands` already contains the
- * flat `/mailing-lists/:uid` fallback when the row carries no `is_foundation`, so the template
- * never branches (GH-1567).
+ * Table row decorated with canonical view-link state (GH-1567); `viewCommands` already holds the
+ * flat fallback, so the template never branches. Mirrors `CommitteeTableRowVm`.
  */
 export interface MailingListTableRowVm extends GroupsIOMailingList {
   viewCommands: string[];

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';
 export * from './iso-timestamp.utils';
+export * from './mailing-list.utils';
 export * from './meeting-calendar.utils';
 export * from './meeting.utils';
 export * from './meeting-privacy.utils';

--- a/packages/shared/src/utils/mailing-list.utils.ts
+++ b/packages/shared/src/utils/mailing-list.utils.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { GroupsIOMailingList } from '../interfaces/mailing-list.interface';
+
+import { getEntityCommands } from './entity-route.utils';
+
+/** Canonical tier-prefixed mailing-list link with the flat `/mailing-lists/...` fallback baked in (GH-1567). */
+export function getMailingListCommands(list: Pick<GroupsIOMailingList, 'uid' | 'is_foundation'>, leaf?: 'edit'): string[] {
+  const flatFallback = leaf ? ['/mailing-lists', list.uid, leaf] : ['/mailing-lists', list.uid];
+  return getEntityCommands('mailing-lists', list.uid, list.is_foundation, leaf) ?? flatFallback;
+}
+
+/** `?project=` for mailing-list links — present only when the list carries a slug (GH-1567). */
+export function getMailingListLinkQueryParams(list: { project_slug?: string | null } | null | undefined): { project: string } | null {
+  return list?.project_slug ? { project: list.project_slug } : null;
+}


### PR DESCRIPTION
## Summary

Mailing list edit deep links could authorize and render against the wrong project: the URL's lens tier prefix and `?project=` param (or a cookie-restored context) could disagree with the project that actually owns the list. This PR makes the list entity itself the source of truth — the BFF detail payload is enriched with the owning project's slug/name/`is_foundation`, the writer guard authorizes against the list's project, the manage page syncs project/foundation context from the loaded list, and every table/view/edit link derives its tier prefix from the list rather than the active lens.

Resolves #1567

## Behavior changes

### Edit-link authorization & context

| Before | After |
|---|---|
| Opening a mailing list edit link under the wrong tier (foundation vs. project) or with a missing/stale `?project=` could authorize the edit against a different project than the one owning the list, and the page could display the wrong project context restored from a cookie. | The edit route looks up the mailing list itself and authorizes against the project that owns it; once the list loads, the page's project/foundation context syncs from the list, falling back to a project lookup by uid when the payload isn't enriched. |

### Mailing list links

| Before | After |
|---|---|
| Table, view, and edit links were always flat `/mailing-lists/:uid` URLs regardless of which tier owned the list, and carried no project information — so navigation from the dashboard could land in the wrong lens context. | Links are prefixed with the list's own tier (foundation or project) and carry `?project=` when the list knows its project slug, with the flat URL kept as a fallback when tier info is unavailable. |

### Edit wizard step navigation

| Before | After |
|---|---|
| Moving between steps of the edit wizard replaced the query string, dropping the `?project=` param that context sync depends on. | Step navigation merges query params, so `?project=` survives moving forward, backward, or jumping between steps. |

## Technical changes

`apps/lfx-one/src/server/services/mailing-list.service.ts` — BFF detail enrichment

- Enriches the single-list GET payload with project `slug`/`name`/`is_foundation` via `fetchEntityProject` + `toEntityProjectFields`, run in parallel with the existing service-data enrichment so the project lookup adds no sequential latency
- Covers the index never emitting `is_foundation` and v1-sync rows carrying empty-string project fields — both the manage page's context sync and the writer guard probe depend on these fields

`apps/lfx-one/src/app/shared/guards/writer.guard.ts`, `apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts` — Writer guard entity probe

- Registers a `mailing-lists` entity probe (`MailingListService.getMailingList`) so edit authorization resolves the slug from the entity; only a 404 falls back to context, otherwise fail closed
- Flags the `:id/edit` route with `entityScopedSlug: true` to activate the probe path

`apps/lfx-one/src/app/shared/services/mailing-list.service.ts` — Frontend service detail cache

- Adds a short-TTL (10s) shared detail cache to `getMailingList` so the guard probe and the manage page's immediate refetch share one HTTP request; supports `skipCache` bypass
- Evicts on error and on all writes (`updateMailingList`, create/update/delete member) so `subscriber_count` and edited fields never read stale
- Applies `take(1)` to the six POST/PUT/DELETE write methods per the one-shot write convention

`packages/shared/src/utils/mailing-list.utils.ts`, `packages/shared/src/interfaces/mailing-list.interface.ts`, `packages/shared/src/constants/mailing-list.constants.ts`, `packages/shared/src/utils/index.ts` — Shared package

- Adds `getMailingListCommands` (canonical tier-prefixed link with flat fallback baked in) and `getMailingListLinkQueryParams` (`?project=` only when a slug exists)
- Adds `MailingListTableRowVm` — table row decorated with pre-computed `viewCommands`/`linkQueryParams` so templates never branch, mirroring `CommitteeTableRowVm`
- Adds `MAILING_LIST_DETAIL_CACHE_TTL_MS` (10s), mirroring `MEETING_DETAIL_CACHE_TTL_MS`

`apps/lfx-one/src/app/modules/mailing-lists/mailing-list-manage/mailing-list-manage.component.ts` — Manage page context sync

- Adapts the loaded list to `EntityWithProject` and calls `syncEntityProjectContext` with `preferEntityKind: true` so the list's own `is_foundation` re-points the lens kind
- Adds an unenriched-payload fallback: when the list has a `project_uid` but no usable slug, resolves the project by uid (non-clobbering `getProject(uid, false)`) and applies the context, re-applied on `NavigationEnd`
- Switches edit-mode step navigation to `queryParamsHandling: 'merge'` so `?project=` survives step changes

`apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts`, `.../components/mailing-list-table/mailing-list-table.component.{ts,html}`, `.../mailing-list-view/mailing-list-view.component.{ts,html}` — Link consumption

- Table component pre-computes `tableRows` (per `init*()` convention) mapping each list to a `MailingListTableRowVm`; both desktop and mobile name links bind `viewCommands`/`linkQueryParams`; `rowClick` now emits the VM
- Dashboard row-click navigation uses the row's pre-computed canonical commands and query params
- View page derives `editRoute()` from the list's own tier via `getMailingListCommands`, and adds `editQueryParams()` / `manageGroupsQueryParams()` so the Edit and Manage Groups buttons carry `?project=` (the latter keeping `step: '3'`)

`apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts`, `apps/lfx-one/src/app/shared/services/mailing-list.service.spec.ts`, `apps/lfx-one/e2e/project-context-deep-link.spec.ts` — Tests

- Guard spec: restored with `MailingListService` mocked; adds mailing-lists probe cases (slug from entity, 404 fallback, fail-closed on error)
- Service spec: pins the detail-cache contract — shared request within TTL, expiry refetch, `skipCache` bypass, error eviction, and per-method write eviction (`updateMailingList`, `createMember`, `updateMember`, `deleteMember`)
- New Playwright e2e spec covering project-context deep-link flows (150 lines)
