### PR TITLE
feat(formation): badge, card and staff deep links on the project page

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
@@ -4,4 +4,7 @@
 <aside class="flex flex-col gap-8 w-full" data-testid="dashboard-sidebar">
   <lfx-dashboard-quicklinks layout="sidebar" class="empty:hidden" />
   <lfx-project-staff-card [projectUid]="projectUid()" [heading]="staffHeading()" class="empty:hidden" />
+  @if (formationFlagEnabled() && isFormation()) {
+    <lfx-formation-card [projectUid]="projectUid()" class="empty:hidden" />
+  }
 </aside>

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
@@ -5,6 +5,6 @@
   <lfx-dashboard-quicklinks layout="sidebar" class="empty:hidden" />
   <lfx-project-staff-card [projectUid]="projectUid()" [heading]="staffHeading()" class="empty:hidden" />
   @if (formationFlagEnabled() && isFormation()) {
-    <lfx-formation-card [projectUid]="projectUid()" class="empty:hidden" />
+    <lfx-formation-card class="empty:hidden" />
   }
 </aside>

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
@@ -4,7 +4,7 @@
 <aside class="flex flex-col gap-8 w-full" data-testid="dashboard-sidebar">
   <lfx-dashboard-quicklinks layout="sidebar" class="empty:hidden" />
   <lfx-project-staff-card [projectUid]="projectUid()" [heading]="staffHeading()" class="empty:hidden" />
-  @if (formationFlagEnabled() && isFormation()) {
+  @if (showFormationCard() && formationFlagEnabled() && isFormation()) {
     <lfx-formation-card class="empty:hidden" />
   }
 </aside>

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.spec.ts
@@ -1,0 +1,91 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { describe, expect, it } from 'vitest';
+
+import { DashboardQuicklinksComponent } from '../dashboard-quicklinks/dashboard-quicklinks.component';
+import { FormationCardComponent } from '../formation-card/formation-card.component';
+import { ProjectStaffCardComponent } from '../project-staff-card/project-staff-card.component';
+import { DashboardSidebarComponent } from './dashboard-sidebar.component';
+
+@Component({ selector: 'lfx-dashboard-quicklinks', standalone: true, template: '' })
+class StubDashboardQuicklinksComponent {
+  public readonly layout = input<'header' | 'sidebar'>('header');
+}
+
+@Component({ selector: 'lfx-project-staff-card', standalone: true, template: '' })
+class StubProjectStaffCardComponent {
+  public readonly projectUid = input<string>('');
+  public readonly heading = input<string>('');
+}
+
+@Component({ selector: 'lfx-formation-card', standalone: true, template: 'formation-card-rendered' })
+class StubFormationCardComponent {}
+
+/**
+ * GH-1955 — locks in the `showFormationCard` opt-in gate. `FormationCardComponent` reads
+ * `ProjectContextService.activeProject` globally, ignoring this component's own `projectUid`
+ * input — the executive-director and board-member dashboards pass a *different* entity's uid
+ * here, so the card must stay opt-in (default `false`) rather than following `isFormation()` alone.
+ */
+describe('DashboardSidebarComponent — Formation card opt-in (GH-1955)', () => {
+  let fixture: ComponentFixture<DashboardSidebarComponent>;
+
+  async function render(showFormationCard: boolean | undefined, flagEnabled: boolean, isFormation: boolean): Promise<void> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [DashboardSidebarComponent],
+      providers: [
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: () => signal(flagEnabled) } },
+        { provide: ProjectContextService, useValue: { isActiveProjectInFormation: signal(isFormation) } },
+      ],
+    })
+      .overrideComponent(DashboardSidebarComponent, {
+        remove: { imports: [DashboardQuicklinksComponent, ProjectStaffCardComponent, FormationCardComponent] },
+        add: { imports: [StubDashboardQuicklinksComponent, StubProjectStaffCardComponent, StubFormationCardComponent] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(DashboardSidebarComponent);
+    fixture.componentRef.setInput('projectUid', 'proj-1');
+    fixture.componentRef.setInput('staffHeading', 'Project Staff');
+    if (showFormationCard !== undefined) {
+      fixture.componentRef.setInput('showFormationCard', showFormationCard);
+    }
+    await fixture.whenStable();
+  }
+
+  it('hides the Formation card by default when showFormationCard is not set, even when flagged on and in Formation', async () => {
+    await render(undefined, true, true);
+
+    expect(fixture.nativeElement.textContent).not.toContain('formation-card-rendered');
+  });
+
+  it('hides the Formation card when showFormationCard is explicitly false (the ED/board-member dashboards)', async () => {
+    await render(false, true, true);
+
+    expect(fixture.nativeElement.textContent).not.toContain('formation-card-rendered');
+  });
+
+  it('shows the Formation card only when showFormationCard, the flag, and isFormation all agree', async () => {
+    await render(true, true, true);
+
+    expect(fixture.nativeElement.textContent).toContain('formation-card-rendered');
+  });
+
+  it('hides the Formation card when showFormationCard is true but the flag is off', async () => {
+    await render(true, false, true);
+
+    expect(fixture.nativeElement.textContent).not.toContain('formation-card-rendered');
+  });
+
+  it('hides the Formation card when showFormationCard is true but the project is not in Formation', async () => {
+    await render(true, true, false);
+
+    expect(fixture.nativeElement.textContent).not.toContain('formation-card-rendered');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.ts
@@ -21,6 +21,15 @@ export class DashboardSidebarComponent {
 
   public readonly projectUid = input.required<string>();
   public readonly staffHeading = input.required<string>();
+  /**
+   * GH-1955 — opt-in only. `FormationCardComponent` reads `ProjectContextService.activeProject`
+   * (the "project" lens slot), not this component's own `projectUid` input — the executive-director
+   * and board-member dashboards pass a *different* entity's uid here (`selectedProject`/
+   * `selectedFoundation`, not `activeContext`), so rendering the card there would silently describe
+   * the wrong project. Only `ProjectDashboardComponent`, where `projectUid` and `activeProject` are
+   * guaranteed to agree, sets this `true`.
+   */
+  public readonly showFormationCard = input<boolean>(false);
 
   /** GH-1955 — see `FORMATION_ENABLED_FLAG`'s doc comment for what this does and doesn't gate. */
   protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.ts
@@ -1,17 +1,28 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
+import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { DashboardQuicklinksComponent } from '../dashboard-quicklinks/dashboard-quicklinks.component';
+import { FormationCardComponent } from '../formation-card/formation-card.component';
 import { ProjectStaffCardComponent } from '../project-staff-card/project-staff-card.component';
 
 @Component({
   selector: 'lfx-dashboard-sidebar',
   host: { class: 'block w-full shrink-0 xl:w-64' },
-  imports: [DashboardQuicklinksComponent, ProjectStaffCardComponent],
+  imports: [DashboardQuicklinksComponent, ProjectStaffCardComponent, FormationCardComponent],
   templateUrl: './dashboard-sidebar.component.html',
 })
 export class DashboardSidebarComponent {
+  private readonly featureFlagService = inject(FeatureFlagService);
+  private readonly projectContextService = inject(ProjectContextService);
+
   public readonly projectUid = input.required<string>();
   public readonly staffHeading = input.required<string>();
+
+  /** GH-1955 — see `FORMATION_ENABLED_FLAG`'s doc comment for what this does and doesn't gate. */
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
+  protected readonly isFormation = this.projectContextService.isActiveProjectInFormation;
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -23,7 +23,7 @@
     } @else if (hasError()) {
       <div class="flex flex-col items-center justify-center gap-2 py-4" data-testid="formation-card-error">
         <i class="fa-light fa-circle-exclamation text-xl text-gray-400"></i>
-        <span class="text-xs text-gray-600">Couldn&apos;t load Formation contacts</span>
+        <span class="text-xs text-gray-600">Couldn&apos;t load the announcement date or contacts</span>
         <span class="text-xs text-gray-400">Refresh the page to try again</span>
       </div>
     } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -21,7 +21,7 @@
       <div class="flex flex-col items-center justify-center gap-2 py-4" data-testid="formation-card-error">
         <i class="fa-light fa-circle-exclamation text-xl text-gray-400"></i>
         <span class="text-xs text-gray-600">Couldn&apos;t load Formation details</span>
-        <span class="text-[11px] text-gray-400">Refresh the page to try again</span>
+        <span class="text-xs text-gray-400">Refresh the page to try again</span>
       </div>
     } @else {
       <div class="flex flex-col gap-4">
@@ -31,7 +31,7 @@
 
         <div class="flex flex-col gap-1">
           <span class="text-xs text-gray-500">Announcement date</span>
-          <span class="text-sm text-gray-900">{{ settings()?.announcement_date || 'Not set' }}</span>
+          <span class="text-sm text-gray-900">{{ (settings()?.announcement_date | date) || 'Not set' }}</span>
         </div>
 
         <div class="flex flex-col gap-3">
@@ -61,12 +61,18 @@
           <span class="text-sm text-gray-900">{{ project()?.slug }}</span>
         </div>
 
-        @if (project()?.repository_url || project()?.logo_url) {
+        @if (repositoryUrl() || project()?.logo_url) {
           <div class="flex flex-col gap-2" data-testid="formation-card-intake">
             <span class="text-xs text-gray-500">Intake</span>
-            @if (project()?.repository_url; as repositoryUrl) {
-              <a [href]="repositoryUrl" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-500 hover:underline truncate">
-                {{ repositoryUrl }}
+            @if (repositoryUrl(); as url) {
+              <a
+                [href]="url"
+                [title]="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm text-blue-500 hover:underline truncate"
+                data-testid="formation-card-repository-link">
+                {{ url }}
               </a>
             }
             @if (project()?.logo_url; as logoUrl) {
@@ -77,14 +83,28 @@
 
         <p class="text-xs text-gray-500">Stage and legal entity are set by the formation team in the admin tool and appear here within minutes.</p>
 
-        @if (isBrowser && isLFStaff() && sfid()) {
+        @if (isLFStaff() && sfid()) {
           <div class="flex flex-col gap-2 pt-2 border-t border-gray-200" data-testid="formation-card-admin-links">
             <div class="flex items-center gap-2">
-              <button type="button" class="text-sm text-blue-500 hover:underline" (click)="openAdminTool(editStageUrl())">Edit stage in admin tool ↗</button>
+              <a
+                [href]="editStageUrl()"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm text-blue-500 hover:underline"
+                data-testid="formation-card-edit-stage-link">
+                Edit stage in admin tool ↗
+              </a>
               <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
             </div>
             <div class="flex items-center gap-2">
-              <button type="button" class="text-sm text-blue-500 hover:underline" (click)="openAdminTool(setUpUrl())">Set up in admin tool ↗</button>
+              <a
+                [href]="setUpUrl()"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm text-blue-500 hover:underline"
+                data-testid="formation-card-set-up-link">
+                Set up in admin tool ↗
+              </a>
               <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
             </div>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -40,7 +40,7 @@
 
     <p class="text-xs text-gray-500">Stage and legal entity are set by the formation team in the admin tool and appear here within minutes.</p>
 
-    @if (isLFStaff() && sfid()) {
+    @if (isAuditor() && sfid()) {
       <div class="flex flex-col gap-2 pt-2 border-t border-gray-200" data-testid="formation-card-admin-links">
         <div class="flex items-center gap-2">
           <a

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -86,22 +86,11 @@
       <div class="flex flex-col gap-2 pt-2 border-t border-gray-200" data-testid="formation-card-admin-links">
         <div class="flex items-center gap-2">
           <a
-            [href]="editStageUrl()"
+            [href]="adminToolUrl()"
             target="_blank"
             rel="noopener noreferrer"
             class="text-sm text-blue-500 hover:underline"
-            data-testid="formation-card-edit-stage-link">
-            Edit stage in admin tool ↗
-          </a>
-          <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
-        </div>
-        <div class="flex items-center gap-2">
-          <a
-            [href]="setUpUrl()"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-sm text-blue-500 hover:underline"
-            data-testid="formation-card-set-up-link">
+            data-testid="formation-card-admin-tool-link">
             Set up in admin tool ↗
           </a>
           <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -23,7 +23,7 @@
     } @else if (hasError()) {
       <div class="flex flex-col items-center justify-center gap-2 py-4" data-testid="formation-card-error">
         <i class="fa-light fa-circle-exclamation text-xl text-gray-400"></i>
-        <span class="text-xs text-gray-600">Couldn&apos;t load the announcement date or contacts</span>
+        <span class="text-xs text-gray-600">Couldn&apos;t load the announcement date</span>
         <span class="text-xs text-gray-400">Refresh the page to try again</span>
       </div>
     } @else {
@@ -31,54 +31,12 @@
         <span class="text-xs text-gray-500">Announcement date</span>
         <span class="text-sm text-gray-900">{{ announcementDateLabel() }}</span>
       </div>
-
-      <div class="flex flex-col gap-3">
-        @for (row of staff(); track row.key) {
-          <div class="flex items-start gap-3" [attr.data-testid]="'formation-card-row-' + row.key">
-            @if (row.user; as u) {
-              <lfx-avatar [image]="u.avatar ?? ''" [label]="u.name || u.email" shape="circle" size="normal" styleClass="w-9 h-9 text-xs" />
-              <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                <span class="text-sm font-medium text-gray-900 truncate" [attr.title]="u.name || u.email">{{ u.name || u.email }}</span>
-                <span class="text-xs text-gray-500">{{ row.label }}</span>
-              </div>
-            } @else {
-              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 shrink-0">
-                <i class="fa-light fa-user text-gray-400 text-sm"></i>
-              </div>
-              <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                <span class="text-sm text-gray-500">Not Set</span>
-                <span class="text-xs text-gray-500">{{ row.label }}</span>
-              </div>
-            }
-          </div>
-        }
-      </div>
     }
 
     <div class="flex flex-col gap-1">
       <span class="text-xs text-gray-500">Slug</span>
       <span class="text-sm text-gray-900">{{ p.slug }}</span>
     </div>
-
-    @if (repositoryUrl() || p.logo_url) {
-      <div class="flex flex-col gap-2" data-testid="formation-card-intake">
-        <span class="text-xs text-gray-500">Intake</span>
-        @if (repositoryUrl(); as url) {
-          <a
-            [href]="url"
-            [title]="url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-sm text-blue-500 hover:underline truncate"
-            data-testid="formation-card-repository-link">
-            {{ url }}
-          </a>
-        }
-        @if (p.logo_url; as logoUrl) {
-          <img [src]="logoUrl" alt="Project logo" class="h-8 w-auto object-contain" />
-        }
-      </div>
-    }
 
     <p class="text-xs text-gray-500">Stage and legal entity are set by the formation team in the admin tool and appear here within minutes.</p>
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-@if (loading() || hasError() || loaded()) {
+@if (project(); as p) {
   <div class="flex flex-col gap-4 w-full" data-testid="formation-card">
     <div class="flex items-center gap-3">
       <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
@@ -11,104 +11,101 @@
       <div class="flex-1 border-t border-gray-200 self-center"></div>
     </div>
 
+    @if (formationSubStage(); as subStage) {
+      <lfx-tag [value]="subStage" [rounded]="true" styleClass="!bg-violet-100 !text-violet-700 border border-violet-200 self-start" />
+    }
+
     @if (loading()) {
       <div class="flex flex-col gap-3">
-        <p-skeleton width="6rem" height="1.25rem" />
         <p-skeleton width="10rem" height="0.875rem" />
         <p-skeleton width="100%" height="0.875rem" />
       </div>
     } @else if (hasError()) {
       <div class="flex flex-col items-center justify-center gap-2 py-4" data-testid="formation-card-error">
         <i class="fa-light fa-circle-exclamation text-xl text-gray-400"></i>
-        <span class="text-xs text-gray-600">Couldn&apos;t load Formation details</span>
+        <span class="text-xs text-gray-600">Couldn&apos;t load Formation contacts</span>
         <span class="text-xs text-gray-400">Refresh the page to try again</span>
       </div>
     } @else {
-      <div class="flex flex-col gap-4">
-        @if (formationSubStage(); as subStage) {
-          <lfx-tag [value]="subStage" [rounded]="true" styleClass="!bg-violet-100 !text-violet-700 border border-violet-200 self-start" />
-        }
+      <div class="flex flex-col gap-1">
+        <span class="text-xs text-gray-500">Announcement date</span>
+        <span class="text-sm text-gray-900">{{ announcementDateLabel() }}</span>
+      </div>
 
-        <div class="flex flex-col gap-1">
-          <span class="text-xs text-gray-500">Announcement date</span>
-          <span class="text-sm text-gray-900">{{ (settings()?.announcement_date | date) || 'Not set' }}</span>
-        </div>
-
-        <div class="flex flex-col gap-3">
-          @for (row of staff(); track row.key) {
-            <div class="flex items-start gap-3" [attr.data-testid]="'formation-card-row-' + row.key">
-              @if (row.user; as u) {
-                <lfx-avatar [image]="u.avatar ?? ''" [label]="u.name || u.email" shape="circle" size="normal" styleClass="w-9 h-9 text-xs" />
-                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                  <span class="text-sm font-medium text-gray-900 truncate" [attr.title]="u.name || u.email">{{ u.name || u.email }}</span>
-                  <span class="text-xs text-gray-500">{{ row.label }}</span>
-                </div>
-              } @else {
-                <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 shrink-0">
-                  <i class="fa-light fa-user text-gray-400 text-sm"></i>
-                </div>
-                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                  <span class="text-sm text-gray-500">Not Set</span>
-                  <span class="text-xs text-gray-500">{{ row.label }}</span>
-                </div>
-              }
-            </div>
-          }
-        </div>
-
-        <div class="flex flex-col gap-1">
-          <span class="text-xs text-gray-500">Slug</span>
-          <span class="text-sm text-gray-900">{{ project()?.slug }}</span>
-        </div>
-
-        @if (repositoryUrl() || project()?.logo_url) {
-          <div class="flex flex-col gap-2" data-testid="formation-card-intake">
-            <span class="text-xs text-gray-500">Intake</span>
-            @if (repositoryUrl(); as url) {
-              <a
-                [href]="url"
-                [title]="url"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-sm text-blue-500 hover:underline truncate"
-                data-testid="formation-card-repository-link">
-                {{ url }}
-              </a>
-            }
-            @if (project()?.logo_url; as logoUrl) {
-              <img [src]="logoUrl" alt="Project logo" class="h-8 w-auto object-contain" />
+      <div class="flex flex-col gap-3">
+        @for (row of staff(); track row.key) {
+          <div class="flex items-start gap-3" [attr.data-testid]="'formation-card-row-' + row.key">
+            @if (row.user; as u) {
+              <lfx-avatar [image]="u.avatar ?? ''" [label]="u.name || u.email" shape="circle" size="normal" styleClass="w-9 h-9 text-xs" />
+              <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                <span class="text-sm font-medium text-gray-900 truncate" [attr.title]="u.name || u.email">{{ u.name || u.email }}</span>
+                <span class="text-xs text-gray-500">{{ row.label }}</span>
+              </div>
+            } @else {
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 shrink-0">
+                <i class="fa-light fa-user text-gray-400 text-sm"></i>
+              </div>
+              <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                <span class="text-sm text-gray-500">Not Set</span>
+                <span class="text-xs text-gray-500">{{ row.label }}</span>
+              </div>
             }
           </div>
         }
+      </div>
+    }
 
-        <p class="text-xs text-gray-500">Stage and legal entity are set by the formation team in the admin tool and appear here within minutes.</p>
+    <div class="flex flex-col gap-1">
+      <span class="text-xs text-gray-500">Slug</span>
+      <span class="text-sm text-gray-900">{{ p.slug }}</span>
+    </div>
 
-        @if (isLFStaff() && sfid()) {
-          <div class="flex flex-col gap-2 pt-2 border-t border-gray-200" data-testid="formation-card-admin-links">
-            <div class="flex items-center gap-2">
-              <a
-                [href]="editStageUrl()"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-sm text-blue-500 hover:underline"
-                data-testid="formation-card-edit-stage-link">
-                Edit stage in admin tool ↗
-              </a>
-              <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
-            </div>
-            <div class="flex items-center gap-2">
-              <a
-                [href]="setUpUrl()"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-sm text-blue-500 hover:underline"
-                data-testid="formation-card-set-up-link">
-                Set up in admin tool ↗
-              </a>
-              <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
-            </div>
-          </div>
+    @if (repositoryUrl() || p.logo_url) {
+      <div class="flex flex-col gap-2" data-testid="formation-card-intake">
+        <span class="text-xs text-gray-500">Intake</span>
+        @if (repositoryUrl(); as url) {
+          <a
+            [href]="url"
+            [title]="url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-500 hover:underline truncate"
+            data-testid="formation-card-repository-link">
+            {{ url }}
+          </a>
         }
+        @if (p.logo_url; as logoUrl) {
+          <img [src]="logoUrl" alt="Project logo" class="h-8 w-auto object-contain" />
+        }
+      </div>
+    }
+
+    <p class="text-xs text-gray-500">Stage and legal entity are set by the formation team in the admin tool and appear here within minutes.</p>
+
+    @if (isLFStaff() && sfid()) {
+      <div class="flex flex-col gap-2 pt-2 border-t border-gray-200" data-testid="formation-card-admin-links">
+        <div class="flex items-center gap-2">
+          <a
+            [href]="editStageUrl()"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-500 hover:underline"
+            data-testid="formation-card-edit-stage-link">
+            Edit stage in admin tool ↗
+          </a>
+          <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
+        </div>
+        <div class="flex items-center gap-2">
+          <a
+            [href]="setUpUrl()"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-500 hover:underline"
+            data-testid="formation-card-set-up-link">
+            Set up in admin tool ↗
+          </a>
+          <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
+        </div>
       </div>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -1,0 +1,95 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (loading() || hasError() || loaded()) {
+  <div class="flex flex-col gap-4 w-full" data-testid="formation-card">
+    <div class="flex items-center gap-3">
+      <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
+        <i class="fa-light fa-flag text-lg"></i>
+        <span>Formation</span>
+      </h2>
+      <div class="flex-1 border-t border-gray-200 self-center"></div>
+    </div>
+
+    @if (loading()) {
+      <div class="flex flex-col gap-3">
+        <p-skeleton width="6rem" height="1.25rem" />
+        <p-skeleton width="10rem" height="0.875rem" />
+        <p-skeleton width="100%" height="0.875rem" />
+      </div>
+    } @else if (hasError()) {
+      <div class="flex flex-col items-center justify-center gap-2 py-4" data-testid="formation-card-error">
+        <i class="fa-light fa-circle-exclamation text-xl text-gray-400"></i>
+        <span class="text-xs text-gray-600">Couldn&apos;t load Formation details</span>
+        <span class="text-[11px] text-gray-400">Refresh the page to try again</span>
+      </div>
+    } @else {
+      <div class="flex flex-col gap-4">
+        @if (formationSubStage(); as subStage) {
+          <lfx-tag [value]="subStage" [rounded]="true" styleClass="!bg-violet-100 !text-violet-700 border border-violet-200 self-start" />
+        }
+
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-gray-500">Announcement date</span>
+          <span class="text-sm text-gray-900">{{ settings()?.announcement_date || 'Not set' }}</span>
+        </div>
+
+        <div class="flex flex-col gap-3">
+          @for (row of staff(); track row.key) {
+            <div class="flex items-start gap-3" [attr.data-testid]="'formation-card-row-' + row.key">
+              @if (row.user; as u) {
+                <lfx-avatar [image]="u.avatar ?? ''" [label]="u.name || u.email" shape="circle" size="normal" styleClass="w-9 h-9 text-xs" />
+                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                  <span class="text-sm font-medium text-gray-900 truncate" [attr.title]="u.name || u.email">{{ u.name || u.email }}</span>
+                  <span class="text-xs text-gray-500">{{ row.label }}</span>
+                </div>
+              } @else {
+                <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 shrink-0">
+                  <i class="fa-light fa-user text-gray-400 text-sm"></i>
+                </div>
+                <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                  <span class="text-sm text-gray-500">Not Set</span>
+                  <span class="text-xs text-gray-500">{{ row.label }}</span>
+                </div>
+              }
+            </div>
+          }
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <span class="text-xs text-gray-500">Slug</span>
+          <span class="text-sm text-gray-900">{{ project()?.slug }}</span>
+        </div>
+
+        @if (project()?.repository_url || project()?.logo_url) {
+          <div class="flex flex-col gap-2" data-testid="formation-card-intake">
+            <span class="text-xs text-gray-500">Intake</span>
+            @if (project()?.repository_url; as repositoryUrl) {
+              <a [href]="repositoryUrl" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-500 hover:underline truncate">
+                {{ repositoryUrl }}
+              </a>
+            }
+            @if (project()?.logo_url; as logoUrl) {
+              <img [src]="logoUrl" alt="Project logo" class="h-8 w-auto object-contain" />
+            }
+          </div>
+        }
+
+        <p class="text-xs text-gray-500">Stage and legal entity are set by the formation team in the admin tool and appear here within minutes.</p>
+
+        @if (isBrowser && isLFStaff() && sfid()) {
+          <div class="flex flex-col gap-2 pt-2 border-t border-gray-200" data-testid="formation-card-admin-links">
+            <div class="flex items-center gap-2">
+              <button type="button" class="text-sm text-blue-500 hover:underline" (click)="openAdminTool(editStageUrl())">Edit stage in admin tool ↗</button>
+              <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
+            </div>
+            <div class="flex items-center gap-2">
+              <button type="button" class="text-sm text-blue-500 hover:underline" (click)="openAdminTool(setUpUrl())">Set up in admin tool ↗</button>
+              <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -51,7 +51,7 @@
             data-testid="formation-card-admin-tool-link">
             Open in admin tool ↗
           </a>
-          <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
+          <lfx-tag value="Admin only" severity="secondary" [rounded]="true" />
         </div>
       </div>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.html
@@ -91,7 +91,7 @@
             rel="noopener noreferrer"
             class="text-sm text-blue-500 hover:underline"
             data-testid="formation-card-admin-tool-link">
-            Set up in admin tool ↗
+            Open in admin tool ↗
           </a>
           <lfx-tag value="Staff only" severity="secondary" [rounded]="true" />
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -32,7 +32,7 @@ function project(stage: string, overrides: Partial<Project> = {}): Project {
     autojoin_enabled: false,
     formation_date: '',
     logo_url: '',
-    repository_url: 'https://github.com/example/repo',
+    repository_url: '',
     website_url: '',
     created_at: '',
     updated_at: '',
@@ -142,19 +142,6 @@ describe('FormationCardComponent', () => {
 
     await render('Formation - Engaged', false, { settingsResult: of({ ...settings(), announcement_date: '' }) });
     expect(text()).toContain('Not set');
-  });
-
-  it('renders the intake repository link', async () => {
-    await render('Formation - Engaged', false);
-
-    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-intake"]')).not.toBeNull();
-    expect(text()).toContain('https://github.com/example/repo');
-  });
-
-  it('never binds a repository_url with an unsafe scheme to the intake link', async () => {
-    await render('Formation - Engaged', false, { projectOverrides: { repository_url: 'javascript:alert(1)' } });
-
-    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-repository-link"]')).toBeNull();
   });
 
   it('shows the error state when the settings fetch fails, without hiding data that already loaded (the sub-stage pill, slug, and admin links)', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -126,7 +126,7 @@ describe('FormationCardComponent', () => {
     expect(text()).toContain('Staff only');
     expect(text()).toContain('Set up in admin tool');
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-tool-link"]').getAttribute('href')).toBe(
-      'https://pcc.dev.platform.linuxfoundation.org/project/sfid-1/setup'
+      'https://pcc.dev.platform.linuxfoundation.org/project/sfid-1'
     );
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -9,7 +9,7 @@ import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { Observable, of, throwError } from 'rxjs';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { FormationCardComponent } from './formation-card.component';
 
@@ -56,14 +56,21 @@ function settings(): ProjectSettings {
 
 describe('FormationCardComponent', () => {
   let fixture: ComponentFixture<FormationCardComponent>;
+  let getProjectSpy: ReturnType<typeof vi.fn>;
 
   async function render(
     stage: string,
-    staff: boolean,
-    options: { sfid?: string | null; settingsResult?: Observable<ProjectSettings>; projectOverrides?: Partial<Project> } = {}
+    auditor: boolean,
+    options: {
+      sfid?: string | null;
+      settingsResult?: Observable<ProjectSettings>;
+      projectOverrides?: Partial<Project>;
+      getProjectResult?: Partial<Project>;
+    } = {}
   ): Promise<void> {
-    const { sfid = 'sfid-1', settingsResult = of(settings()), projectOverrides = {} } = options;
+    const { sfid = 'sfid-1', settingsResult = of(settings()), projectOverrides = {}, getProjectResult } = options;
     TestBed.resetTestingModule();
+    getProjectSpy = vi.fn(() => of(getProjectResult ? project(stage, getProjectResult) : project(stage, { ...projectOverrides, auditor })));
     await TestBed.configureTestingModule({
       imports: [FormationCardComponent],
       providers: [
@@ -71,7 +78,7 @@ describe('FormationCardComponent', () => {
           provide: ProjectService,
           useValue: {
             getProjectSfid: () => of(sfid),
-            getProject: () => of(project(stage, { ...projectOverrides, auditor: staff })),
+            getProject: getProjectSpy,
           },
         },
         { provide: PermissionsService, useValue: { getProjectSettings: () => settingsResult } },
@@ -114,25 +121,34 @@ describe('FormationCardComponent', () => {
     expect(text()).not.toContain('PCC');
   });
 
-  it('hides the admin-tool links and "Staff only" chip for a non-staff user', async () => {
+  it('hides the admin-tool links and "Admin only" chip for a non-auditor, non-writer user', async () => {
     await render('Formation - Engaged', false);
 
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
   });
 
-  it('shows the admin-tool link and "Staff only" chip for an LF-staff user with a resolved SFID', async () => {
+  it('shows the admin-tool link and "Admin only" chip for an auditor with a resolved SFID', async () => {
     await render('Formation - Engaged', true, { sfid: 'sfid-1' });
 
     const links = fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]');
     expect(links).not.toBeNull();
-    expect(text()).toContain('Staff only');
+    expect(text()).toContain('Admin only');
     expect(text()).toContain('Open in admin tool');
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-tool-link"]').getAttribute('href')).toBe(
       'https://pcc.dev.platform.linuxfoundation.org/project/sfid-1'
     );
+    expect(getProjectSpy).toHaveBeenCalledWith('proj-1', false, { auditor: true });
   });
 
-  it('hides the admin-tool links for an LF-staff user with no v1 mapping (null SFID)', async () => {
+  it('shows the admin-tool link for a project writer even though the server omits `auditor` for writers', async () => {
+    // Mirrors the server: getProjectById returns early for writers, so `auditor` comes back
+    // undefined rather than true. `isAuditor`'s `writer === true` OR-branch must still admit them.
+    await render('Formation - Engaged', true, { sfid: 'sfid-1', getProjectResult: { writer: true, auditor: undefined } });
+
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).not.toBeNull();
+  });
+
+  it('hides the admin-tool links for an auditor with no v1 mapping (null SFID)', async () => {
     await render('Formation - Engaged', true, { sfid: null });
 
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
@@ -152,7 +168,7 @@ describe('FormationCardComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-error"]')).not.toBeNull();
     expect(text()).toContain('Engaged');
     expect(text()).toContain('project-one');
-    // Admin links depend on isLFStaff/sfid, not on the failed settings fetch — they must still show.
+    // Admin links depend on isAuditor/sfid, not on the failed settings fetch — they must still show.
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).not.toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -4,15 +4,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal, WritableSignal } from '@angular/core';
 import { Project, ProjectSettings } from '@lfx-one/shared/interfaces';
+import { getFormationSubStageLabel } from '@lfx-one/shared/utils';
 import { PermissionsService } from '@services/permissions.service';
 import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
-import { of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
 import { FormationCardComponent } from './formation-card.component';
 
-function project(stage: string): Project {
+function project(stage: string, overrides: Partial<Project> = {}): Project {
   return {
     uid: 'proj-1',
     slug: 'project-one',
@@ -35,6 +37,7 @@ function project(stage: string): Project {
     created_at: '',
     updated_at: '',
     mailing_list_count: 0,
+    ...overrides,
   } as Project;
 }
 
@@ -56,15 +59,27 @@ describe('FormationCardComponent', () => {
   let fixture: ComponentFixture<FormationCardComponent>;
   let isLFStaff: WritableSignal<boolean>;
 
-  async function render(stage: string, staff: boolean, sfid: string | null = 'sfid-1'): Promise<void> {
+  async function render(
+    stage: string,
+    staff: boolean,
+    options: { sfid?: string | null; settingsResult?: Observable<ProjectSettings>; projectOverrides?: Partial<Project> } = {}
+  ): Promise<void> {
+    const { sfid = 'sfid-1', settingsResult = of(settings()), projectOverrides = {} } = options;
     isLFStaff = signal(staff);
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [FormationCardComponent],
       providers: [
-        { provide: ProjectService, useValue: { getProject: () => of(project(stage)), getProjectSfid: () => of(sfid) } },
-        { provide: PermissionsService, useValue: { getProjectSettings: () => of(settings()) } },
+        { provide: ProjectService, useValue: { getProjectSfid: () => of(sfid) } },
+        { provide: PermissionsService, useValue: { getProjectSettings: () => settingsResult } },
         { provide: PersonaService, useValue: { isLFStaff } },
+        {
+          provide: ProjectContextService,
+          useValue: {
+            activeProject: signal(project(stage, projectOverrides)),
+            activeProjectFormationSubStage: signal(getFormationSubStageLabel(stage)),
+          },
+        },
       ],
     }).compileComponents();
 
@@ -105,7 +120,7 @@ describe('FormationCardComponent', () => {
   });
 
   it('shows the admin-tool links and "Staff only" chip for an LF-staff user with a resolved SFID', async () => {
-    await render('Formation - Engaged', true, 'sfid-1');
+    await render('Formation - Engaged', true, { sfid: 'sfid-1' });
 
     const links = fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]');
     expect(links).not.toBeNull();
@@ -115,7 +130,7 @@ describe('FormationCardComponent', () => {
   });
 
   it('hides the admin-tool links for an LF-staff user with no v1 mapping (null SFID)', async () => {
-    await render('Formation - Engaged', true, null);
+    await render('Formation - Engaged', true, { sfid: null });
 
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
   });
@@ -125,5 +140,18 @@ describe('FormationCardComponent', () => {
 
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-intake"]')).not.toBeNull();
     expect(text()).toContain('https://github.com/example/repo');
+  });
+
+  it('never binds a repository_url with an unsafe scheme to the intake link', async () => {
+    await render('Formation - Engaged', false, { projectOverrides: { repository_url: 'javascript:alert(1)' } });
+
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-repository-link"]')).toBeNull();
+  });
+
+  it('shows the error state when the settings fetch fails, and hides the admin-tool links', async () => {
+    await render('Formation - Engaged', true, { settingsResult: throwError(() => new Error('network error')) });
+
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-error"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -124,7 +124,7 @@ describe('FormationCardComponent', () => {
     const links = fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]');
     expect(links).not.toBeNull();
     expect(text()).toContain('Staff only');
-    expect(text()).toContain('Set up in admin tool');
+    expect(text()).toContain('Open in admin tool');
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-tool-link"]').getAttribute('href')).toBe(
       'https://pcc.dev.platform.linuxfoundation.org/project/sfid-1'
     );

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -84,7 +84,6 @@ describe('FormationCardComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(FormationCardComponent);
-    fixture.componentRef.setInput('projectUid', 'proj-1');
     await fixture.whenStable();
     fixture.detectChanges();
   }
@@ -135,6 +134,14 @@ describe('FormationCardComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
   });
 
+  it('formats the announcement date via the shared ISO-date label, and falls back to "Not set"', async () => {
+    await render('Formation - Engaged', false);
+    expect(text()).toContain('Sep 1, 2026');
+
+    await render('Formation - Engaged', false, { settingsResult: of({ ...settings(), announcement_date: '' }) });
+    expect(text()).toContain('Not set');
+  });
+
   it('renders the intake repository link', async () => {
     await render('Formation - Engaged', false);
 
@@ -148,10 +155,13 @@ describe('FormationCardComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-repository-link"]')).toBeNull();
   });
 
-  it('shows the error state when the settings fetch fails, and hides the admin-tool links', async () => {
+  it('shows the error state when the settings fetch fails, without hiding data that already loaded (the sub-stage pill, slug, and admin links)', async () => {
     await render('Formation - Engaged', true, { settingsResult: throwError(() => new Error('network error')) });
 
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-error"]')).not.toBeNull();
-    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
+    expect(text()).toContain('Engaged');
+    expect(text()).toContain('project-one');
+    // Admin links depend on isLFStaff/sfid, not on the failed settings fetch — they must still show.
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).not.toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { signal, WritableSignal } from '@angular/core';
+import { signal } from '@angular/core';
 import { Project, ProjectSettings } from '@lfx-one/shared/interfaces';
 import { getFormationSubStageLabel } from '@lfx-one/shared/utils';
 import { PermissionsService } from '@services/permissions.service';
-import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { Observable, of, throwError } from 'rxjs';
@@ -57,7 +56,6 @@ function settings(): ProjectSettings {
 
 describe('FormationCardComponent', () => {
   let fixture: ComponentFixture<FormationCardComponent>;
-  let isLFStaff: WritableSignal<boolean>;
 
   async function render(
     stage: string,
@@ -65,14 +63,18 @@ describe('FormationCardComponent', () => {
     options: { sfid?: string | null; settingsResult?: Observable<ProjectSettings>; projectOverrides?: Partial<Project> } = {}
   ): Promise<void> {
     const { sfid = 'sfid-1', settingsResult = of(settings()), projectOverrides = {} } = options;
-    isLFStaff = signal(staff);
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [FormationCardComponent],
       providers: [
-        { provide: ProjectService, useValue: { getProjectSfid: () => of(sfid) } },
+        {
+          provide: ProjectService,
+          useValue: {
+            getProjectSfid: () => of(sfid),
+            getProject: () => of(project(stage, { ...projectOverrides, auditor: staff })),
+          },
+        },
         { provide: PermissionsService, useValue: { getProjectSettings: () => settingsResult } },
-        { provide: PersonaService, useValue: { isLFStaff } },
         {
           provide: ProjectContextService,
           useValue: {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -70,7 +70,7 @@ describe('FormationCardComponent', () => {
   ): Promise<void> {
     const { sfid = 'sfid-1', settingsResult = of(settings()), projectOverrides = {}, getProjectResult } = options;
     TestBed.resetTestingModule();
-    getProjectSpy = vi.fn(() => of(getProjectResult ? project(stage, getProjectResult) : project(stage, { ...projectOverrides, auditor })));
+    getProjectSpy = vi.fn(() => of(project(stage, { ...projectOverrides, auditor, ...getProjectResult })));
     await TestBed.configureTestingModule({
       imports: [FormationCardComponent],
       providers: [
@@ -143,7 +143,7 @@ describe('FormationCardComponent', () => {
   it('shows the admin-tool link for a project writer even though the server omits `auditor` for writers', async () => {
     // Mirrors the server: getProjectById returns early for writers, so `auditor` comes back
     // undefined rather than true. `isAuditor`'s `writer === true` OR-branch must still admit them.
-    await render('Formation - Engaged', true, { sfid: 'sfid-1', getProjectResult: { writer: true, auditor: undefined } });
+    await render('Formation - Engaged', false, { sfid: 'sfid-1', getProjectResult: { writer: true, auditor: undefined } });
 
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).not.toBeNull();
   });

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -118,14 +118,16 @@ describe('FormationCardComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
   });
 
-  it('shows the admin-tool links and "Staff only" chip for an LF-staff user with a resolved SFID', async () => {
+  it('shows the admin-tool link and "Staff only" chip for an LF-staff user with a resolved SFID', async () => {
     await render('Formation - Engaged', true, { sfid: 'sfid-1' });
 
     const links = fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]');
     expect(links).not.toBeNull();
     expect(text()).toContain('Staff only');
-    expect(text()).toContain('Edit stage in admin tool');
     expect(text()).toContain('Set up in admin tool');
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-tool-link"]').getAttribute('href')).toBe(
+      'https://pcc.dev.platform.linuxfoundation.org/project/sfid-1/setup'
+    );
   });
 
   it('hides the admin-tool links for an LF-staff user with no v1 mapping (null SFID)', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -1,0 +1,129 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal, WritableSignal } from '@angular/core';
+import { Project, ProjectSettings } from '@lfx-one/shared/interfaces';
+import { PermissionsService } from '@services/permissions.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectService } from '@services/project.service';
+import { of } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+
+import { FormationCardComponent } from './formation-card.component';
+
+function project(stage: string): Project {
+  return {
+    uid: 'proj-1',
+    slug: 'project-one',
+    description: '',
+    name: 'Project One',
+    public: true,
+    parent_uid: '',
+    stage,
+    category: '',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: 'https://github.com/example/repo',
+    website_url: '',
+    created_at: '',
+    updated_at: '',
+    mailing_list_count: 0,
+  } as Project;
+}
+
+function settings(): ProjectSettings {
+  return {
+    uid: 'proj-1',
+    announcement_date: '2026-09-01',
+    writers: [],
+    auditors: [],
+    executive_director: { name: 'Ada Lovelace', email: 'ada@example.com' },
+    program_manager: null,
+    opportunity_owner: null,
+    created_at: '',
+    updated_at: '',
+  };
+}
+
+describe('FormationCardComponent', () => {
+  let fixture: ComponentFixture<FormationCardComponent>;
+  let isLFStaff: WritableSignal<boolean>;
+
+  async function render(stage: string, staff: boolean, sfid: string | null = 'sfid-1'): Promise<void> {
+    isLFStaff = signal(staff);
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [FormationCardComponent],
+      providers: [
+        { provide: ProjectService, useValue: { getProject: () => of(project(stage)), getProjectSfid: () => of(sfid) } },
+        { provide: PermissionsService, useValue: { getProjectSettings: () => of(settings()) } },
+        { provide: PersonaService, useValue: { isLFStaff } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormationCardComponent);
+    fixture.componentRef.setInput('projectUid', 'proj-1');
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function text(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it.each([
+    ['Formation - Exploratory', 'Exploratory'],
+    ['Formation - Engaged', 'Engaged'],
+    ['Formation - On Hold', 'On Hold'],
+    ['Formation - Disengaged', 'Disengaged'],
+    ['Formation - Confidential', 'Confidential'],
+  ])('renders the %s sub-stage as %s', async (stage, label) => {
+    await render(stage, false);
+
+    expect(text()).toContain(label);
+  });
+
+  it('never renders the literal string "PCC", staff or not', async () => {
+    await render('Formation - Engaged', false);
+    expect(text()).not.toContain('PCC');
+
+    await render('Formation - Engaged', true);
+    expect(text()).not.toContain('PCC');
+  });
+
+  it('hides the admin-tool links and "Staff only" chip for a non-staff user', async () => {
+    await render('Formation - Engaged', false);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
+  });
+
+  it('shows the admin-tool links and "Staff only" chip for an LF-staff user with a resolved SFID', async () => {
+    await render('Formation - Engaged', true, 'sfid-1');
+
+    const links = fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]');
+    expect(links).not.toBeNull();
+    expect(text()).toContain('Staff only');
+    expect(text()).toContain('Edit stage in admin tool');
+    expect(text()).toContain('Set up in admin tool');
+  });
+
+  it('hides the admin-tool links for an LF-staff user with no v1 mapping (null SFID)', async () => {
+    await render('Formation - Engaged', true, null);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-admin-links"]')).toBeNull();
+  });
+
+  it('renders the intake repository link', async () => {
+    await render('Formation - Engaged', false);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="formation-card-intake"]')).not.toBeNull();
+    expect(text()).toContain('https://github.com/example/repo');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.spec.ts
@@ -5,10 +5,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { Project, ProjectSettings } from '@lfx-one/shared/interfaces';
 import { getFormationSubStageLabel } from '@lfx-one/shared/utils';
-import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
-import { Observable, of, throwError } from 'rxjs';
+import { catchError, map, Observable, of, tap, throwError } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { FormationCardComponent } from './formation-card.component';
@@ -71,6 +70,27 @@ describe('FormationCardComponent', () => {
     const { sfid = 'sfid-1', settingsResult = of(settings()), projectOverrides = {}, getProjectResult } = options;
     TestBed.resetTestingModule();
     getProjectSpy = vi.fn(() => of(project(stage, { ...projectOverrides, auditor, ...getProjectResult })));
+
+    // Mirrors ProjectContextService's own tri-state pipeline so the mock behaves like the real
+    // shared signals (loading flips false, hasError flips true) rather than hardcoding both false.
+    const announcementDateLoading = signal(true);
+    const announcementDateHasError = signal(false);
+    const announcementDate = signal<string | null>(null);
+    settingsResult
+      .pipe(
+        map((s) => s.announcement_date || null),
+        tap((date) => {
+          announcementDate.set(date);
+          announcementDateLoading.set(false);
+        }),
+        catchError(() => {
+          announcementDateLoading.set(false);
+          announcementDateHasError.set(true);
+          return of(null);
+        })
+      )
+      .subscribe();
+
     await TestBed.configureTestingModule({
       imports: [FormationCardComponent],
       providers: [
@@ -81,12 +101,14 @@ describe('FormationCardComponent', () => {
             getProject: getProjectSpy,
           },
         },
-        { provide: PermissionsService, useValue: { getProjectSettings: () => settingsResult } },
         {
           provide: ProjectContextService,
           useValue: {
             activeProject: signal(project(stage, projectOverrides)),
             activeProjectFormationSubStage: signal(getFormationSubStageLabel(stage)),
+            activeProjectAnnouncementDate: announcementDate,
+            activeProjectAnnouncementDateLoading: announcementDateLoading,
+            activeProjectAnnouncementDateHasError: announcementDateHasError,
           },
         },
       ],

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -1,23 +1,20 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { environment } from '@environments/environment';
 import { PROJECT_STAFF_ROWS } from '@lfx-one/shared/constants';
-import { Project, ProjectSettings, ProjectStaffRowConfig, UserInfo } from '@lfx-one/shared/interfaces';
-import { getFormationSubStageLabel } from '@lfx-one/shared/utils';
+import { ProjectSettings, ProjectStaffRow } from '@lfx-one/shared/interfaces';
 import { PermissionsService } from '@services/permissions.service';
 import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
-
-type StaffRow = ProjectStaffRowConfig & { user: UserInfo | null | undefined };
+import { catchError, filter, of, switchMap, tap } from 'rxjs';
 
 /**
  * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, the same
@@ -25,61 +22,39 @@ type StaffRow = ProjectStaffRowConfig & { user: UserInfo | null | undefined };
  * shows above it, intake fields (repository/logo), and — for `PersonaService.isLFStaff` only —
  * deep links into the admin tool. Rendered only while the project is Draft/Formation; see
  * `ProjectContextService.isActiveProjectInFormation`.
+ *
+ * Reads `ProjectContextService.activeProject` for project fields rather than an independent
+ * `getProject` call — this card only ever renders for the currently active project, so the
+ * context service's already-in-flight fetch is the correct (and only) source.
  */
 @Component({
   selector: 'lfx-formation-card',
-  imports: [AvatarComponent, TagComponent, SkeletonModule, TooltipModule],
+  imports: [AvatarComponent, TagComponent, SkeletonModule, DatePipe],
   templateUrl: './formation-card.component.html',
 })
 export class FormationCardComponent {
   private readonly permissionsService = inject(PermissionsService);
   private readonly personaService = inject(PersonaService);
-  private readonly platformId = inject(PLATFORM_ID);
+  private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
   public readonly projectUid = input.required<string>();
 
-  // `loading`, `hasError`, and `loaded` are tracked separately so the template can distinguish
-  // fetching, fetch failed, and fetch succeeded — mirrors `ProjectStaffCardComponent`.
+  // `loading`, `hasError`, and `loaded` track the settings fetch only — mirrors
+  // `ProjectStaffCardComponent`. `project` comes from `ProjectContextService`, which already
+  // resolves fetch failures to `null` (same convention as `canWrite`), so there's no separate
+  // error state to track for it.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
   protected readonly loaded = signal(false);
 
-  protected readonly isBrowser = isPlatformBrowser(this.platformId);
   protected readonly isLFStaff = computed(() => this.personaService.isLFStaff());
 
-  private readonly combined: Signal<{ project: Project | null; settings: ProjectSettings | null } | null> = toSignal(
-    toObservable(this.projectUid).pipe(
-      filter((uid): uid is string => !!uid),
-      tap(() => {
-        this.loading.set(true);
-        this.hasError.set(false);
-        this.loaded.set(false);
-      }),
-      switchMap((uid) =>
-        combineLatest([this.projectService.getProject(uid, false), this.permissionsService.getProjectSettings(uid)]).pipe(
-          map(([project, settings]) => ({ project, settings })),
-          tap(() => {
-            this.loading.set(false);
-            this.loaded.set(true);
-          }),
-          catchError(() => {
-            this.loading.set(false);
-            this.hasError.set(true);
-            this.loaded.set(false);
-            return of(null);
-          })
-        )
-      )
-    ),
-    { initialValue: null }
-  );
+  protected readonly project = this.projectContextService.activeProject;
+  protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
 
-  protected readonly project: Signal<Project | null> = computed(() => this.combined()?.project ?? null);
-  protected readonly settings: Signal<ProjectSettings | null> = computed(() => this.combined()?.settings ?? null);
-  protected readonly formationSubStage: Signal<string | null> = computed(() => getFormationSubStageLabel(this.project()?.stage));
-
-  protected readonly staff: Signal<StaffRow[]> = computed(() => {
+  protected readonly settings: Signal<ProjectSettings | null> = this.initSettings();
+  protected readonly staff: Signal<ProjectStaffRow[]> = computed(() => {
     const s = this.settings();
     return PROJECT_STAFF_ROWS.map((row) => ({
       ...row,
@@ -87,13 +62,19 @@ export class FormationCardComponent {
     }));
   });
 
-  protected readonly sfid: Signal<string | null> = toSignal(
-    toObservable(this.projectUid).pipe(
-      filter((uid): uid is string => !!uid),
-      switchMap((uid) => this.projectService.getProjectSfid(uid).pipe(catchError(() => of(null))))
-    ),
-    { initialValue: null }
-  );
+  /** `null` when missing, or when the scheme isn't http(s) — never bind an unvalidated URL to `[href]`. */
+  protected readonly repositoryUrl: Signal<string | null> = computed(() => {
+    const url = this.project()?.repository_url;
+    if (!url) return null;
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? url : null;
+    } catch {
+      return null;
+    }
+  });
+
+  protected readonly sfid: Signal<string | null> = this.initSfid();
 
   /**
    * Both deep links use the same `/project/:sfid` PCC route with a distinguishing query param —
@@ -109,10 +90,45 @@ export class FormationCardComponent {
     return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=setup` : '';
   });
 
-  protected openAdminTool(url: string): void {
-    if (typeof window !== 'undefined' && url) {
-      window.open(url, '_blank', 'noopener,noreferrer');
-    }
+  private initSettings(): Signal<ProjectSettings | null> {
+    return toSignal(
+      toObservable(this.projectUid).pipe(
+        filter((uid): uid is string => !!uid),
+        tap(() => {
+          this.loading.set(true);
+          this.hasError.set(false);
+          this.loaded.set(false);
+        }),
+        switchMap((uid) =>
+          this.permissionsService.getProjectSettings(uid).pipe(
+            tap(() => {
+              this.loading.set(false);
+              this.loaded.set(true);
+            }),
+            catchError((error) => {
+              console.error('Formation card: failed to load project settings', error);
+              this.loading.set(false);
+              this.hasError.set(true);
+              this.loaded.set(false);
+              return of(null);
+            })
+          )
+        )
+      ),
+      { initialValue: null }
+    );
+  }
+
+  // `ProjectService.getProjectSfid` already logs and resolves to `null` on failure — no additional
+  // catchError needed here.
+  private initSfid(): Signal<string | null> {
+    return toSignal(
+      toObservable(this.projectUid).pipe(
+        filter((uid): uid is string => !!uid),
+        switchMap((uid) => this.projectService.getProjectSfid(uid))
+      ),
+      { initialValue: null }
+    );
   }
 
   private pccBaseUrl(): string {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -62,18 +62,7 @@ export class FormationCardComponent {
     }));
   });
 
-  /** `null` when missing, or when the scheme isn't http(s) — never bind an unvalidated URL to `[href]`. */
-  protected readonly repositoryUrl: Signal<string | null> = computed(() => {
-    const url = this.project()?.repository_url;
-    if (!url) return null;
-    try {
-      const parsed = new URL(url);
-      return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? url : null;
-    } catch {
-      return null;
-    }
-  });
-
+  protected readonly repositoryUrl: Signal<string | null> = this.initRepositoryUrl();
   protected readonly sfid: Signal<string | null> = this.initSfid();
 
   /**
@@ -117,6 +106,20 @@ export class FormationCardComponent {
       ),
       { initialValue: null }
     );
+  }
+
+  /** `null` when missing, or when the scheme isn't http(s) — never bind an unvalidated URL to `[href]`. */
+  private initRepositoryUrl(): Signal<string | null> {
+    return computed(() => {
+      const url = this.project()?.repository_url;
+      if (!url) return null;
+      try {
+        const parsed = new URL(url);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? url : null;
+      } catch {
+        return null;
+      }
+    });
   }
 
   // `ProjectService.getProjectSfid` already logs and resolves to `null` on failure — no additional

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -8,15 +8,14 @@ import { environment } from '@environments/environment';
 import { ProjectSettings } from '@lfx-one/shared/interfaces';
 import { formatAnnouncementDateLabel } from '@lfx-one/shared/utils';
 import { PermissionsService } from '@services/permissions.service';
-import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, filter, of, switchMap, tap } from 'rxjs';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
 
 /**
  * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, slug, and — for
- * `PersonaService.isLFStaff` only — a deep link into the admin tool. Rendered only while the
+ * project `auditor`s (and writers) only — a deep link into the admin tool. Rendered only while the
  * project is Draft/Formation; see `ProjectContextService.isActiveProjectInFormation`.
  *
  * Epic 1 scope (revised #1955, 2 Sep 2026): the card renders only fields the synced record already
@@ -26,10 +25,10 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
  * directly above this card in the sidebar already covers `executive_director`/`program_manager`/
  * `opportunity_owner`.
  *
- * **Staff-only gating**: the ticket specifies a `formation_admin` permission, which exists nowhere
- * in this repo or elsewhere in the `linuxfoundation` org (verified via `gh api` `search/code`).
- * `isLFStaff` is the closest available gate. See the `// TODO(#2148)` at its declaration below for
- * the open FGA-relation question this substitution raises.
+ * **Staff-only gating**: FGA defines `writer`/`auditor`/`participant`/`item_owner` on `formation`;
+ * GH-1954 grants LF Staff `auditor` (not `writer`) on non-public projects, so the guard checks
+ * `auditor` OR `writer` on the project (see `initIsAuditor` below) — a `writer`-only guard would
+ * hide this deep link from most of staff.
  *
  * The ticket also asked for two distinct admin-tool links ("Edit stage" and "Set up"). Neither a
  * `?tab=` param nor a `/setup` sub-route exists on `environment.urls.pcc` (verified — see
@@ -48,7 +47,6 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
 })
 export class FormationCardComponent {
   private readonly permissionsService = inject(PermissionsService);
-  private readonly personaService = inject(PersonaService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
@@ -61,11 +59,6 @@ export class FormationCardComponent {
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
 
-  // TODO(#2148): FGA defines writer/auditor/participant/item_owner on `formation`; #1954 grants LF
-  // Staff `auditor`, not `writer`, so a `writer`-based guard would hide this deep link from most of
-  // staff. The correct relation for this gate is an open architecture decision.
-  protected readonly isLFStaff = computed(() => this.personaService.isLFStaff());
-
   protected readonly project = this.projectContextService.activeProject;
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
   private readonly projectUid = computed(() => this.project()?.uid ?? null);
@@ -73,6 +66,7 @@ export class FormationCardComponent {
   protected readonly settings: Signal<ProjectSettings | null> = this.initSettings();
   protected readonly announcementDateLabel: Signal<string> = this.initAnnouncementDateLabel();
 
+  protected readonly isAuditor: Signal<boolean> = this.initIsAuditor();
   protected readonly sfid: Signal<string | null> = this.initSfid();
   protected readonly adminToolUrl: Signal<string> = this.initAdminToolUrl();
 
@@ -106,12 +100,30 @@ export class FormationCardComponent {
     return computed(() => formatAnnouncementDateLabel(this.settings()?.announcement_date));
   }
 
-  // Only fetched for LF staff — everyone else can never see the admin-tool link this resolves for,
-  // so a non-staff viewer shouldn't pay for the round trip. `ProjectService.getProjectSfid` already
-  // logs and resolves to `null` on failure — no additional catchError needed here.
+  // Dedicated `auditor` FGA check (GH-1955) — independent of `ProjectContextService.activeProject`,
+  // which doesn't request this flag. `writer === true` is load-bearing, not redundant: the server
+  // skips the auditor check entirely once a caller is already a writer (a strict superset of
+  // access), so a writer's `auditor` field comes back `undefined` — without the OR, a project
+  // writer would be wrongly denied this deep link.
+  private initIsAuditor(): Signal<boolean> {
+    return toSignal(
+      toObservable(this.projectUid).pipe(
+        filter((uid): uid is string => !!uid),
+        switchMap((uid) => this.projectService.getProject(uid, false, { auditor: true })),
+        map((project) => project?.writer === true || project?.auditor === true),
+        catchError(() => of(false))
+      ),
+      { initialValue: false }
+    );
+  }
+
+  // Only fetched once `isAuditor()` resolves true — everyone else can never see the admin-tool link
+  // this resolves for, so a non-auditor viewer shouldn't pay for the round trip.
+  // `ProjectService.getProjectSfid` already logs and resolves to `null` on failure — no additional
+  // catchError needed here.
   private initSfid(): Signal<string | null> {
     return toSignal(
-      toObservable(computed(() => (this.isLFStaff() ? this.projectUid() : null))).pipe(
+      toObservable(computed(() => (this.isAuditor() ? this.projectUid() : null))).pipe(
         filter((uid): uid is string => !!uid),
         switchMap((uid) => this.projectService.getProjectSfid(uid))
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -8,7 +8,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { environment } from '@environments/environment';
 import { PROJECT_STAFF_ROWS } from '@lfx-one/shared/constants';
 import { ProjectSettings, ProjectStaffRow } from '@lfx-one/shared/interfaces';
-import { formatIsoDateLabel, isValidUrl } from '@lfx-one/shared/utils';
+import { formatAnnouncementDateLabel, isValidUrl } from '@lfx-one/shared/utils';
 import { PermissionsService } from '@services/permissions.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -38,11 +38,12 @@ export class FormationCardComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
-  // `loading`/`hasError` track the settings fetch only — the sub-stage pill, slug, intake fields,
-  // and admin links all come from `project()`/`sfid()`, which are already resolved by the time
-  // this card can render at all (the sidebar only mounts it once `isActiveProjectInFormation()` is
-  // true, which requires a non-null `activeProject`). The template renders those independently of
-  // this two-state gate, which only covers the staff-rows and announcement-date section.
+  // `loading`/`hasError` track the settings fetch only. The sub-stage pill, slug, and intake fields
+  // come from `project()`, which is already resolved by the time this card can render at all (the
+  // sidebar only mounts it once `isActiveProjectInFormation()` is true, which requires a non-null
+  // `activeProject`) — the admin links additionally wait on `sfid()`, its own independent fetch
+  // that starts `null`. The template renders all of that independently of this two-state gate,
+  // which only covers the staff-rows and announcement-date section.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
 
@@ -98,10 +99,7 @@ export class FormationCardComponent {
   }
 
   private initAnnouncementDateLabel(): Signal<string> {
-    return computed(() => {
-      const date = this.settings()?.announcement_date;
-      return date ? formatIsoDateLabel(date) : 'Not set';
-    });
+    return computed(() => formatAnnouncementDateLabel(this.settings()?.announcement_date));
   }
 
   /** `null` when missing, or when the scheme isn't a validated http(s) URL — never bind an unvalidated URL to `[href]`. */

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -20,8 +20,12 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
  * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, the same
  * `executive_director`/`program_manager`/`opportunity_owner` contacts `ProjectStaffCardComponent`
  * shows above it, intake fields (repository/logo), and — for `PersonaService.isLFStaff` only —
- * deep links into the admin tool. Rendered only while the project is Draft/Formation; see
- * `ProjectContextService.isActiveProjectInFormation`.
+ * a deep link into the admin tool's project-setup page. Rendered only while the project is
+ * Draft/Formation; see `ProjectContextService.isActiveProjectInFormation`.
+ *
+ * The ticket originally asked for two admin-tool links ("Edit stage" and "Set up"), but PCC has
+ * no stage-specific route — only `/project/:id/setup` is confirmed. Both actions point there for
+ * now; a distinct "Edit stage" destination needs a product/PCC decision (see `initAdminToolUrl`).
  *
  * Reads `ProjectContextService.activeProject` for project fields and its own `uid` (no
  * `projectUid` input) — this card only ever renders for the currently active project, so there's
@@ -59,8 +63,7 @@ export class FormationCardComponent {
 
   protected readonly repositoryUrl: Signal<string | null> = this.initRepositoryUrl();
   protected readonly sfid: Signal<string | null> = this.initSfid();
-  protected readonly editStageUrl: Signal<string> = this.initAdminToolUrl('stage');
-  protected readonly setUpUrl: Signal<string> = this.initAdminToolUrl('setup');
+  protected readonly adminToolUrl: Signal<string> = this.initAdminToolUrl();
 
   private initSettings(): Signal<ProjectSettings | null> {
     return toSignal(
@@ -110,11 +113,12 @@ export class FormationCardComponent {
     });
   }
 
-  // `ProjectService.getProjectSfid` already logs and resolves to `null` on failure — no additional
-  // catchError needed here.
+  // Only fetched for LF staff — everyone else can never see the admin-tool link this resolves for,
+  // so a non-staff viewer shouldn't pay for the round trip. `ProjectService.getProjectSfid` already
+  // logs and resolves to `null` on failure — no additional catchError needed here.
   private initSfid(): Signal<string | null> {
     return toSignal(
-      toObservable(this.projectUid).pipe(
+      toObservable(computed(() => (this.isLFStaff() ? this.projectUid() : null))).pipe(
         filter((uid): uid is string => !!uid),
         switchMap((uid) => this.projectService.getProjectSfid(uid))
       ),
@@ -123,14 +127,16 @@ export class FormationCardComponent {
   }
 
   /**
-   * Both deep links use the same `/project/:sfid` PCC route with a distinguishing query param —
-   * unverified against the admin tool's actual routing; confirm with product/design before
-   * treating either link as final.
+   * `/project/:sfid/setup` is PCC's real project-setup route (confirmed against
+   * `lfx-pcc`'s `project-routing.module.ts`, which declares `:id/setup` — a "Set up" and an
+   * "Edit stage" action share this one destination until PCC exposes a stage-specific sub-route;
+   * flagged for product/design rather than guessing one (`?tab=` params don't exist in PCC's
+   * routing at all — that was this card's original, now-corrected assumption).
    */
-  private initAdminToolUrl(tab: 'stage' | 'setup'): Signal<string> {
+  private initAdminToolUrl(): Signal<string> {
     return computed(() => {
       const sfid = this.sfid();
-      return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=${tab}` : '';
+      return sfid ? `${this.pccBaseUrl()}/project/${sfid}/setup` : '';
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -19,11 +19,23 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
 /**
  * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, the same
  * `executive_director`/`program_manager`/`opportunity_owner` contacts `ProjectStaffCardComponent`
- * shows above it, intake fields (repository/logo), and — for `PersonaService.isLFStaff` only —
- * a deep link into the admin tool. Rendered only while the project is Draft/Formation; see
+ * shows above it (deliberately — no formation-specific contact fields exist yet; see below), intake
+ * fields (repository/logo), and — for `PersonaService.isLFStaff` only — a deep link into the admin
+ * tool. Rendered only while the project is Draft/Formation; see
  * `ProjectContextService.isActiveProjectInFormation`.
  *
- * The ticket asked for two distinct admin-tool links ("Edit stage" and "Set up"). Neither a
+ * Two intentional substitutions for fields/permissions the ticket asked for that don't exist yet:
+ * - **Staff-only gating**: the ticket specifies a `formation_admin` permission, which exists
+ *   nowhere in this repo or elsewhere in the `linuxfoundation` org (verified via `gh api`
+ *   `search/code`). `isLFStaff` is the closest available gate — narrow this to a real
+ *   `formation_admin` grant once one is modeled.
+ * - **Contact rows**: the ticket asked for formation lead/coordinator/partner/product-contact
+ *   fields, none of which exist upstream (confirmed against `lfx-v2-project-service`'s live
+ *   contract). Showing `executive_director`/`program_manager`/`opportunity_owner` here duplicates
+ *   `ProjectStaffCardComponent` directly above it in the sidebar — an explicit, approved trade-off
+ *   (matches ticket intent over de-duplication) pending those fields landing upstream.
+ *
+ * The ticket also asked for two distinct admin-tool links ("Edit stage" and "Set up"). Neither a
  * `?tab=` param nor a `/setup` sub-route exists on `environment.urls.pcc` (verified — see
  * `initAdminToolUrl`), so this ships a single link to the bare project page, the only destination
  * actually confirmed to resolve. Both the specific "Edit stage" destination and any dedicated
@@ -138,6 +150,10 @@ export class FormationCardComponent {
    * two attempts at guessing one (`?tab=` params, then a v1-only `/setup` route neither of which
    * exists on v2) were both wrong. `/project/:id` is the one route confirmed to resolve — use that
    * until product/PCC names the real destination.
+   *
+   * v2 also declares a `project-formation` route (`projectFormationGuard`), deliberately not used
+   * here: it takes no `:id` param, so it can't serve a per-project deep link — it looks like the
+   * global Formations queue (#1956), not a per-project stage editor.
    */
   private initAdminToolUrl(): Signal<string> {
     return computed(() => {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -142,7 +142,7 @@ export class FormationCardComponent {
   private initAdminToolUrl(): Signal<string> {
     return computed(() => {
       const sfid = this.sfid();
-      return sfid ? `${this.pccBaseUrl()}/project/${sfid}` : '';
+      return sfid ? `${this.pccBaseUrl()}/project/${encodeURIComponent(sfid)}` : '';
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -1,0 +1,122 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { environment } from '@environments/environment';
+import { PROJECT_STAFF_ROWS } from '@lfx-one/shared/constants';
+import { Project, ProjectSettings, ProjectStaffRowConfig, UserInfo } from '@lfx-one/shared/interfaces';
+import { getFormationSubStageLabel } from '@lfx-one/shared/utils';
+import { PermissionsService } from '@services/permissions.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectService } from '@services/project.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
+import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
+
+type StaffRow = ProjectStaffRowConfig & { user: UserInfo | null | undefined };
+
+/**
+ * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, the same
+ * `executive_director`/`program_manager`/`opportunity_owner` contacts `ProjectStaffCardComponent`
+ * shows above it, intake fields (repository/logo), and — for `PersonaService.isLFStaff` only —
+ * deep links into the admin tool. Rendered only while the project is Draft/Formation; see
+ * `ProjectContextService.isActiveProjectInFormation`.
+ */
+@Component({
+  selector: 'lfx-formation-card',
+  imports: [AvatarComponent, TagComponent, SkeletonModule, TooltipModule],
+  templateUrl: './formation-card.component.html',
+})
+export class FormationCardComponent {
+  private readonly permissionsService = inject(PermissionsService);
+  private readonly personaService = inject(PersonaService);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly projectService = inject(ProjectService);
+
+  public readonly projectUid = input.required<string>();
+
+  // `loading`, `hasError`, and `loaded` are tracked separately so the template can distinguish
+  // fetching, fetch failed, and fetch succeeded — mirrors `ProjectStaffCardComponent`.
+  protected readonly loading = signal(true);
+  protected readonly hasError = signal(false);
+  protected readonly loaded = signal(false);
+
+  protected readonly isBrowser = isPlatformBrowser(this.platformId);
+  protected readonly isLFStaff = computed(() => this.personaService.isLFStaff());
+
+  private readonly combined: Signal<{ project: Project | null; settings: ProjectSettings | null } | null> = toSignal(
+    toObservable(this.projectUid).pipe(
+      filter((uid): uid is string => !!uid),
+      tap(() => {
+        this.loading.set(true);
+        this.hasError.set(false);
+        this.loaded.set(false);
+      }),
+      switchMap((uid) =>
+        combineLatest([this.projectService.getProject(uid, false), this.permissionsService.getProjectSettings(uid)]).pipe(
+          map(([project, settings]) => ({ project, settings })),
+          tap(() => {
+            this.loading.set(false);
+            this.loaded.set(true);
+          }),
+          catchError(() => {
+            this.loading.set(false);
+            this.hasError.set(true);
+            this.loaded.set(false);
+            return of(null);
+          })
+        )
+      )
+    ),
+    { initialValue: null }
+  );
+
+  protected readonly project: Signal<Project | null> = computed(() => this.combined()?.project ?? null);
+  protected readonly settings: Signal<ProjectSettings | null> = computed(() => this.combined()?.settings ?? null);
+  protected readonly formationSubStage: Signal<string | null> = computed(() => getFormationSubStageLabel(this.project()?.stage));
+
+  protected readonly staff: Signal<StaffRow[]> = computed(() => {
+    const s = this.settings();
+    return PROJECT_STAFF_ROWS.map((row) => ({
+      ...row,
+      user: s?.[row.key],
+    }));
+  });
+
+  protected readonly sfid: Signal<string | null> = toSignal(
+    toObservable(this.projectUid).pipe(
+      filter((uid): uid is string => !!uid),
+      switchMap((uid) => this.projectService.getProjectSfid(uid).pipe(catchError(() => of(null))))
+    ),
+    { initialValue: null }
+  );
+
+  /**
+   * Both deep links use the same `/project/:sfid` PCC route with a distinguishing query param —
+   * unverified against the admin tool's actual routing; confirm with product/design before
+   * treating either link as final.
+   */
+  protected readonly editStageUrl: Signal<string> = computed(() => {
+    const sfid = this.sfid();
+    return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=stage` : '';
+  });
+  protected readonly setUpUrl: Signal<string> = computed(() => {
+    const sfid = this.sfid();
+    return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=setup` : '';
+  });
+
+  protected openAdminTool(url: string): void {
+    if (typeof window !== 'undefined' && url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  }
+
+  private pccBaseUrl(): string {
+    const base = environment.urls.pcc;
+    return base.endsWith('/') ? base.slice(0, -1) : base;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -1,14 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe } from '@angular/common';
-import { Component, computed, inject, input, signal, Signal } from '@angular/core';
+import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { environment } from '@environments/environment';
 import { PROJECT_STAFF_ROWS } from '@lfx-one/shared/constants';
 import { ProjectSettings, ProjectStaffRow } from '@lfx-one/shared/interfaces';
+import { formatIsoDateLabel, isValidUrl } from '@lfx-one/shared/utils';
 import { PermissionsService } from '@services/permissions.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -23,13 +23,13 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
  * deep links into the admin tool. Rendered only while the project is Draft/Formation; see
  * `ProjectContextService.isActiveProjectInFormation`.
  *
- * Reads `ProjectContextService.activeProject` for project fields rather than an independent
- * `getProject` call — this card only ever renders for the currently active project, so the
- * context service's already-in-flight fetch is the correct (and only) source.
+ * Reads `ProjectContextService.activeProject` for project fields and its own `uid` (no
+ * `projectUid` input) — this card only ever renders for the currently active project, so there's
+ * no other project it could mean, and no independent `getProject` call.
  */
 @Component({
   selector: 'lfx-formation-card',
-  imports: [AvatarComponent, TagComponent, SkeletonModule, DatePipe],
+  imports: [AvatarComponent, TagComponent, SkeletonModule],
   templateUrl: './formation-card.component.html',
 })
 export class FormationCardComponent {
@@ -38,12 +38,12 @@ export class FormationCardComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
-  public readonly projectUid = input.required<string>();
-
-  // `loading`, `hasError`, and `loaded` track the settings fetch only — mirrors
-  // `ProjectStaffCardComponent`. `project` comes from `ProjectContextService`, which already
-  // resolves fetch failures to `null` (same convention as `canWrite`), so there's no separate
-  // error state to track for it.
+  // `loading`, `hasError`, and `loaded` track the settings fetch only — the sub-stage pill, slug,
+  // intake fields, and admin links all come from `project()`/`sfid()`, which are already resolved
+  // by the time this card can render at all (the sidebar only mounts it once
+  // `isActiveProjectInFormation()` is true, which requires a non-null `activeProject`). The
+  // template renders those independently of this tri-state, which only gates the staff-rows and
+  // announcement-date section.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
   protected readonly loaded = signal(false);
@@ -52,32 +52,16 @@ export class FormationCardComponent {
 
   protected readonly project = this.projectContextService.activeProject;
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
+  private readonly projectUid = computed(() => this.project()?.uid ?? null);
 
   protected readonly settings: Signal<ProjectSettings | null> = this.initSettings();
-  protected readonly staff: Signal<ProjectStaffRow[]> = computed(() => {
-    const s = this.settings();
-    return PROJECT_STAFF_ROWS.map((row) => ({
-      ...row,
-      user: s?.[row.key],
-    }));
-  });
+  protected readonly staff: Signal<ProjectStaffRow[]> = this.initStaff();
+  protected readonly announcementDateLabel: Signal<string> = this.initAnnouncementDateLabel();
 
   protected readonly repositoryUrl: Signal<string | null> = this.initRepositoryUrl();
   protected readonly sfid: Signal<string | null> = this.initSfid();
-
-  /**
-   * Both deep links use the same `/project/:sfid` PCC route with a distinguishing query param —
-   * unverified against the admin tool's actual routing; confirm with product/design before
-   * treating either link as final.
-   */
-  protected readonly editStageUrl: Signal<string> = computed(() => {
-    const sfid = this.sfid();
-    return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=stage` : '';
-  });
-  protected readonly setUpUrl: Signal<string> = computed(() => {
-    const sfid = this.sfid();
-    return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=setup` : '';
-  });
+  protected readonly editStageUrl: Signal<string> = this.initAdminToolUrl('stage');
+  protected readonly setUpUrl: Signal<string> = this.initAdminToolUrl('setup');
 
   private initSettings(): Signal<ProjectSettings | null> {
     return toSignal(
@@ -108,17 +92,28 @@ export class FormationCardComponent {
     );
   }
 
-  /** `null` when missing, or when the scheme isn't http(s) — never bind an unvalidated URL to `[href]`. */
+  private initStaff(): Signal<ProjectStaffRow[]> {
+    return computed(() => {
+      const s = this.settings();
+      return PROJECT_STAFF_ROWS.map((row) => ({
+        ...row,
+        user: s?.[row.key],
+      }));
+    });
+  }
+
+  private initAnnouncementDateLabel(): Signal<string> {
+    return computed(() => {
+      const date = this.settings()?.announcement_date;
+      return date ? formatIsoDateLabel(date) : 'Not set';
+    });
+  }
+
+  /** `null` when missing, or when the scheme isn't a validated http(s) URL — never bind an unvalidated URL to `[href]`. */
   private initRepositoryUrl(): Signal<string | null> {
     return computed(() => {
       const url = this.project()?.repository_url;
-      if (!url) return null;
-      try {
-        const parsed = new URL(url);
-        return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? url : null;
-      } catch {
-        return null;
-      }
+      return url && isValidUrl(url) ? url : null;
     });
   }
 
@@ -132,6 +127,18 @@ export class FormationCardComponent {
       ),
       { initialValue: null }
     );
+  }
+
+  /**
+   * Both deep links use the same `/project/:sfid` PCC route with a distinguishing query param —
+   * unverified against the admin tool's actual routing; confirm with product/design before
+   * treating either link as final.
+   */
+  private initAdminToolUrl(tab: 'stage' | 'setup'): Signal<string> {
+    return computed(() => {
+      const sfid = this.sfid();
+      return sfid ? `${this.pccBaseUrl()}/project/${sfid}?tab=${tab}` : '';
+    });
   }
 
   private pccBaseUrl(): string {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -38,15 +38,13 @@ export class FormationCardComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
-  // `loading`, `hasError`, and `loaded` track the settings fetch only — the sub-stage pill, slug,
-  // intake fields, and admin links all come from `project()`/`sfid()`, which are already resolved
-  // by the time this card can render at all (the sidebar only mounts it once
-  // `isActiveProjectInFormation()` is true, which requires a non-null `activeProject`). The
-  // template renders those independently of this tri-state, which only gates the staff-rows and
-  // announcement-date section.
+  // `loading`/`hasError` track the settings fetch only — the sub-stage pill, slug, intake fields,
+  // and admin links all come from `project()`/`sfid()`, which are already resolved by the time
+  // this card can render at all (the sidebar only mounts it once `isActiveProjectInFormation()` is
+  // true, which requires a non-null `activeProject`). The template renders those independently of
+  // this two-state gate, which only covers the staff-rows and announcement-date section.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
-  protected readonly loaded = signal(false);
 
   protected readonly isLFStaff = computed(() => this.personaService.isLFStaff());
 
@@ -70,19 +68,16 @@ export class FormationCardComponent {
         tap(() => {
           this.loading.set(true);
           this.hasError.set(false);
-          this.loaded.set(false);
         }),
         switchMap((uid) =>
           this.permissionsService.getProjectSettings(uid).pipe(
             tap(() => {
               this.loading.set(false);
-              this.loaded.set(true);
             }),
             catchError((error) => {
               console.error('Formation card: failed to load project settings', error);
               this.loading.set(false);
               this.hasError.set(true);
-              this.loaded.set(false);
               return of(null);
             })
           )

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -25,10 +25,12 @@ import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
  * directly above this card in the sidebar already covers `executive_director`/`program_manager`/
  * `opportunity_owner`.
  *
- * **Staff-only gating**: FGA defines `writer`/`auditor`/`participant`/`item_owner` on `formation`;
- * GH-1954 grants LF Staff `auditor` (not `writer`) on non-public projects, so the guard checks
- * `auditor` OR `writer` on the project (see `initIsAuditor` below) — a `writer`-only guard would
- * hide this deep link from most of staff.
+ * **Admin-link gating**: the guard checks `auditor` OR `writer` on the *project* FGA type (see
+ * `initIsAuditor` below) — GH-1954 grants LF Staff `auditor` (not `writer`) on non-public
+ * projects, so a `writer`-only guard would hide this deep link from most of staff. Note this
+ * check resolves wider than "staff": project `writer`s (maintainers, EDs) and `auditor`s
+ * inherited from the parent foundation (`project#auditor` cascades from `parent`) also pass it —
+ * the chip below is worded accordingly rather than as a literal staff-only claim.
  *
  * The ticket also asked for two distinct admin-tool links ("Edit stage" and "Set up"). Neither a
  * `?tab=` param nor a `/setup` sub-route exists on `environment.urls.pcc` (verified — see
@@ -38,7 +40,9 @@ import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
  *
  * Reads `ProjectContextService.activeProject` for project fields and its own `uid` (no
  * `projectUid` input) — this card only ever renders for the currently active project, so there's
- * no other project it could mean, and no independent `getProject` call.
+ * no other project it could mean. The `auditor` gate is the one exception: it needs a flag
+ * `activeProject` doesn't carry, so `initIsAuditor` makes its own dedicated
+ * `getProject(uid, false, { auditor: true })` call.
  */
 @Component({
   selector: 'lfx-formation-card',
@@ -105,13 +109,15 @@ export class FormationCardComponent {
   // skips the auditor check entirely once a caller is already a writer (a strict superset of
   // access), so a writer's `auditor` field comes back `undefined` — without the OR, a project
   // writer would be wrongly denied this deep link.
+  // No catchError here — ProjectService.getProject already resolves any HTTP failure to `null`
+  // internally (logging as it does so), so `project?.writer`/`project?.auditor` on a failed fetch
+  // are both `undefined`, and the map below already yields `false` for that case.
   private initIsAuditor(): Signal<boolean> {
     return toSignal(
       toObservable(this.projectUid).pipe(
         filter((uid): uid is string => !!uid),
         switchMap((uid) => this.projectService.getProject(uid, false, { auditor: true })),
-        map((project) => project?.writer === true || project?.auditor === true),
-        catchError(() => of(false))
+        map((project) => project?.writer === true || project?.auditor === true)
       ),
       { initialValue: false }
     );

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -20,12 +20,14 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
  * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, the same
  * `executive_director`/`program_manager`/`opportunity_owner` contacts `ProjectStaffCardComponent`
  * shows above it, intake fields (repository/logo), and — for `PersonaService.isLFStaff` only —
- * a deep link into the admin tool's project-setup page. Rendered only while the project is
- * Draft/Formation; see `ProjectContextService.isActiveProjectInFormation`.
+ * a deep link into the admin tool. Rendered only while the project is Draft/Formation; see
+ * `ProjectContextService.isActiveProjectInFormation`.
  *
- * The ticket originally asked for two admin-tool links ("Edit stage" and "Set up"), but PCC has
- * no stage-specific route — only `/project/:id/setup` is confirmed. Both actions point there for
- * now; a distinct "Edit stage" destination needs a product/PCC decision (see `initAdminToolUrl`).
+ * The ticket asked for two distinct admin-tool links ("Edit stage" and "Set up"). Neither a
+ * `?tab=` param nor a `/setup` sub-route exists on `environment.urls.pcc` (verified — see
+ * `initAdminToolUrl`), so this ships a single link to the bare project page, the only destination
+ * actually confirmed to resolve. Both the specific "Edit stage" destination and any dedicated
+ * "Set up" sub-page need a product/PCC decision before a more specific link can be built.
  *
  * Reads `ProjectContextService.activeProject` for project fields and its own `uid` (no
  * `projectUid` input) — this card only ever renders for the currently active project, so there's
@@ -127,16 +129,20 @@ export class FormationCardComponent {
   }
 
   /**
-   * `/project/:sfid/setup` is PCC's real project-setup route (confirmed against
-   * `lfx-pcc`'s `project-routing.module.ts`, which declares `:id/setup` — a "Set up" and an
-   * "Edit stage" action share this one destination until PCC exposes a stage-specific sub-route;
-   * flagged for product/design rather than guessing one (`?tab=` params don't exist in PCC's
-   * routing at all — that was this card's original, now-corrected assumption).
+   * `environment.urls.pcc` resolves to PCC's v2 frontend (`pcc.dev.platform.linuxfoundation.org` /
+   * `projectadmin.lfx.linuxfoundation.org` in prod — confirmed via `lfx-pcc`'s
+   * `apps/v2-frontend/serverless.yml` host mappings), whose routing (`pages-routing.module.ts`)
+   * declares `project/:id`, `project/:id/operations`, `project/:id/collaboration`,
+   * `project/:id/onboarding`, `project/:id/development`, `project/:id/reports`, and no `**`
+   * fallback. None of those is an obvious "stage" or "setup" destination, and this card's first
+   * two attempts at guessing one (`?tab=` params, then a v1-only `/setup` route neither of which
+   * exists on v2) were both wrong. `/project/:id` is the one route confirmed to resolve — use that
+   * until product/PCC names the real destination.
    */
   private initAdminToolUrl(): Signal<string> {
     return computed(() => {
       const sfid = this.sfid();
-      return sfid ? `${this.pccBaseUrl()}/project/${sfid}/setup` : '';
+      return sfid ? `${this.pccBaseUrl()}/project/${sfid}` : '';
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -3,12 +3,10 @@
 
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { AvatarComponent } from '@components/avatar/avatar.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { environment } from '@environments/environment';
-import { PROJECT_STAFF_ROWS } from '@lfx-one/shared/constants';
-import { ProjectSettings, ProjectStaffRow } from '@lfx-one/shared/interfaces';
-import { formatAnnouncementDateLabel, isValidUrl } from '@lfx-one/shared/utils';
+import { ProjectSettings } from '@lfx-one/shared/interfaces';
+import { formatAnnouncementDateLabel } from '@lfx-one/shared/utils';
 import { PermissionsService } from '@services/permissions.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -17,23 +15,21 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, filter, of, switchMap, tap } from 'rxjs';
 
 /**
- * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, the same
- * `executive_director`/`program_manager`/`opportunity_owner` contacts `ProjectStaffCardComponent`
- * shows above it (deliberately — no formation-specific contact fields exist yet; see below), intake
- * fields (repository/logo), and — for `PersonaService.isLFStaff` only — a deep link into the admin
- * tool. Rendered only while the project is Draft/Formation; see
- * `ProjectContextService.isActiveProjectInFormation`.
+ * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, slug, and — for
+ * `PersonaService.isLFStaff` only — a deep link into the admin tool. Rendered only while the
+ * project is Draft/Formation; see `ProjectContextService.isActiveProjectInFormation`.
  *
- * Two intentional substitutions for fields/permissions the ticket asked for that don't exist yet:
- * - **Staff-only gating**: the ticket specifies a `formation_admin` permission, which exists
- *   nowhere in this repo or elsewhere in the `linuxfoundation` org (verified via `gh api`
- *   `search/code`). `isLFStaff` is the closest available gate — narrow this to a real
- *   `formation_admin` grant once one is modeled.
- * - **Contact rows**: the ticket asked for formation lead/coordinator/partner/product-contact
- *   fields, none of which exist upstream (confirmed against `lfx-v2-project-service`'s live
- *   contract). Showing `executive_director`/`program_manager`/`opportunity_owner` here duplicates
- *   `ProjectStaffCardComponent` directly above it in the sidebar — an explicit, approved trade-off
- *   (matches ticket intent over de-duplication) pending those fields landing upstream.
+ * Epic 1 scope (revised #1955, 2 Sep 2026): the card renders only fields the synced record already
+ * carries. Formation lead/coordinator/partner contacts and the intake block (repository, assigning
+ * org, trademark status, logo) came from the Epic 2 application form — with no intake in Epic 1
+ * there's no source for those fields, so they're not on this card. `ProjectStaffCardComponent`
+ * directly above this card in the sidebar already covers `executive_director`/`program_manager`/
+ * `opportunity_owner`.
+ *
+ * **Staff-only gating**: the ticket specifies a `formation_admin` permission, which exists nowhere
+ * in this repo or elsewhere in the `linuxfoundation` org (verified via `gh api` `search/code`).
+ * `isLFStaff` is the closest available gate. See the `// TODO(#2148)` at its declaration below for
+ * the open FGA-relation question this substitution raises.
  *
  * The ticket also asked for two distinct admin-tool links ("Edit stage" and "Set up"). Neither a
  * `?tab=` param nor a `/setup` sub-route exists on `environment.urls.pcc` (verified — see
@@ -47,7 +43,7 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
  */
 @Component({
   selector: 'lfx-formation-card',
-  imports: [AvatarComponent, TagComponent, SkeletonModule],
+  imports: [TagComponent, SkeletonModule],
   templateUrl: './formation-card.component.html',
 })
 export class FormationCardComponent {
@@ -56,15 +52,18 @@ export class FormationCardComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
-  // `loading`/`hasError` track the settings fetch only. The sub-stage pill, slug, and intake fields
-  // come from `project()`, which is already resolved by the time this card can render at all (the
-  // sidebar only mounts it once `isActiveProjectInFormation()` is true, which requires a non-null
-  // `activeProject`) — the admin links additionally wait on `sfid()`, its own independent fetch
-  // that starts `null`. The template renders all of that independently of this two-state gate,
-  // which only covers the staff-rows and announcement-date section.
+  // `loading`/`hasError` track the settings fetch only (it backs the announcement date). The
+  // sub-stage pill and slug come from `project()`, which is already resolved by the time this card
+  // can render at all (the sidebar only mounts it once `isActiveProjectInFormation()` is true, which
+  // requires a non-null `activeProject`) — the admin links additionally wait on `sfid()`, its own
+  // independent fetch that starts `null`. The template renders all of that independently of this
+  // two-state gate.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
 
+  // TODO(#2148): FGA defines writer/auditor/participant/item_owner on `formation`; #1954 grants LF
+  // Staff `auditor`, not `writer`, so a `writer`-based guard would hide this deep link from most of
+  // staff. The correct relation for this gate is an open architecture decision.
   protected readonly isLFStaff = computed(() => this.personaService.isLFStaff());
 
   protected readonly project = this.projectContextService.activeProject;
@@ -72,10 +71,8 @@ export class FormationCardComponent {
   private readonly projectUid = computed(() => this.project()?.uid ?? null);
 
   protected readonly settings: Signal<ProjectSettings | null> = this.initSettings();
-  protected readonly staff: Signal<ProjectStaffRow[]> = this.initStaff();
   protected readonly announcementDateLabel: Signal<string> = this.initAnnouncementDateLabel();
 
-  protected readonly repositoryUrl: Signal<string | null> = this.initRepositoryUrl();
   protected readonly sfid: Signal<string | null> = this.initSfid();
   protected readonly adminToolUrl: Signal<string> = this.initAdminToolUrl();
 
@@ -105,26 +102,8 @@ export class FormationCardComponent {
     );
   }
 
-  private initStaff(): Signal<ProjectStaffRow[]> {
-    return computed(() => {
-      const s = this.settings();
-      return PROJECT_STAFF_ROWS.map((row) => ({
-        ...row,
-        user: s?.[row.key],
-      }));
-    });
-  }
-
   private initAnnouncementDateLabel(): Signal<string> {
     return computed(() => formatAnnouncementDateLabel(this.settings()?.announcement_date));
-  }
-
-  /** `null` when missing, or when the scheme isn't a validated http(s) URL — never bind an unvalidated URL to `[href]`. */
-  private initRepositoryUrl(): Signal<string | null> {
-    return computed(() => {
-      const url = this.project()?.repository_url;
-      return url && isValidUrl(url) ? url : null;
-    });
   }
 
   // Only fetched for LF staff — everyone else can never see the admin-tool link this resolves for,

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-card/formation-card.component.ts
@@ -1,17 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { Component, computed, inject, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { TagComponent } from '@components/tag/tag.component';
 import { environment } from '@environments/environment';
-import { ProjectSettings } from '@lfx-one/shared/interfaces';
 import { formatAnnouncementDateLabel } from '@lfx-one/shared/utils';
-import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+import { filter, map, switchMap } from 'rxjs';
 
 /**
  * The Formation sidebar card (GH-1955) — sub-stage pill, announcement date, slug, and — for
@@ -40,9 +38,19 @@ import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
  *
  * Reads `ProjectContextService.activeProject` for project fields and its own `uid` (no
  * `projectUid` input) — this card only ever renders for the currently active project, so there's
- * no other project it could mean. The `auditor` gate is the one exception: it needs a flag
- * `activeProject` doesn't carry, so `initIsAuditor` makes its own dedicated
+ * no other project it could mean. The announcement date rides `ProjectContextService`'s shared
+ * `activeProjectAnnouncementDate`/`Loading`/`HasError` signals (GH-1955) rather than a fetch of its
+ * own. The `auditor` gate is the one exception that still needs its own fetch: it requires a flag
+ * `activeProject` doesn't carry, so `initIsAuditorState` makes its own dedicated
  * `getProject(uid, false, { auditor: true })` call.
+ *
+ * `isAuditor`/`sfid` are derived from uid-tagged resolved state (`isAuditorState`/`sfidState`),
+ * not read directly off the raw `toSignal` result: during a project switch, `activeProject` (and
+ * therefore `projectUid`) can advance to the new project before this card's own in-flight
+ * `getProject`/`getProjectSfid` calls for the *previous* uid resolve. Gating on `state.uid ===
+ * projectUid()` suppresses that stale window instead of briefly showing the previous project's
+ * admin-tool link/SFID — mirrors the uid-tagging pattern in `committee-view.component.ts`'s
+ * `meetingCoordinatorState`.
  */
 @Component({
   selector: 'lfx-formation-card',
@@ -50,59 +58,32 @@ import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
   templateUrl: './formation-card.component.html',
 })
 export class FormationCardComponent {
-  private readonly permissionsService = inject(PermissionsService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
-  // `loading`/`hasError` track the settings fetch only (it backs the announcement date). The
-  // sub-stage pill and slug come from `project()`, which is already resolved by the time this card
-  // can render at all (the sidebar only mounts it once `isActiveProjectInFormation()` is true, which
-  // requires a non-null `activeProject`) — the admin links additionally wait on `sfid()`, its own
-  // independent fetch that starts `null`. The template renders all of that independently of this
-  // two-state gate.
-  protected readonly loading = signal(true);
-  protected readonly hasError = signal(false);
-
   protected readonly project = this.projectContextService.activeProject;
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
+  protected readonly loading = this.projectContextService.activeProjectAnnouncementDateLoading;
+  protected readonly hasError = this.projectContextService.activeProjectAnnouncementDateHasError;
   private readonly projectUid = computed(() => this.project()?.uid ?? null);
 
-  protected readonly settings: Signal<ProjectSettings | null> = this.initSettings();
-  protected readonly announcementDateLabel: Signal<string> = this.initAnnouncementDateLabel();
+  protected readonly announcementDateLabel: Signal<string> = computed(() =>
+    formatAnnouncementDateLabel(this.projectContextService.activeProjectAnnouncementDate())
+  );
 
-  protected readonly isAuditor: Signal<boolean> = this.initIsAuditor();
-  protected readonly sfid: Signal<string | null> = this.initSfid();
+  private readonly isAuditorState: Signal<{ uid: string; isAuditor: boolean } | null> = this.initIsAuditorState();
+  protected readonly isAuditor: Signal<boolean> = computed(() => {
+    const state = this.isAuditorState();
+    return state !== null && state.uid === this.projectUid() ? state.isAuditor : false;
+  });
+
+  private readonly sfidState: Signal<{ uid: string; sfid: string | null } | null> = this.initSfidState();
+  protected readonly sfid: Signal<string | null> = computed(() => {
+    const state = this.sfidState();
+    return state !== null && state.uid === this.projectUid() ? state.sfid : null;
+  });
+
   protected readonly adminToolUrl: Signal<string> = this.initAdminToolUrl();
-
-  private initSettings(): Signal<ProjectSettings | null> {
-    return toSignal(
-      toObservable(this.projectUid).pipe(
-        filter((uid): uid is string => !!uid),
-        tap(() => {
-          this.loading.set(true);
-          this.hasError.set(false);
-        }),
-        switchMap((uid) =>
-          this.permissionsService.getProjectSettings(uid).pipe(
-            tap(() => {
-              this.loading.set(false);
-            }),
-            catchError((error) => {
-              console.error('Formation card: failed to load project settings', error);
-              this.loading.set(false);
-              this.hasError.set(true);
-              return of(null);
-            })
-          )
-        )
-      ),
-      { initialValue: null }
-    );
-  }
-
-  private initAnnouncementDateLabel(): Signal<string> {
-    return computed(() => formatAnnouncementDateLabel(this.settings()?.announcement_date));
-  }
 
   // Dedicated `auditor` FGA check (GH-1955) — independent of `ProjectContextService.activeProject`,
   // which doesn't request this flag. `writer === true` is load-bearing, not redundant: the server
@@ -112,14 +93,17 @@ export class FormationCardComponent {
   // No catchError here — ProjectService.getProject already resolves any HTTP failure to `null`
   // internally (logging as it does so), so `project?.writer`/`project?.auditor` on a failed fetch
   // are both `undefined`, and the map below already yields `false` for that case.
-  private initIsAuditor(): Signal<boolean> {
+  private initIsAuditorState(): Signal<{ uid: string; isAuditor: boolean } | null> {
     return toSignal(
       toObservable(this.projectUid).pipe(
         filter((uid): uid is string => !!uid),
-        switchMap((uid) => this.projectService.getProject(uid, false, { auditor: true })),
-        map((project) => project?.writer === true || project?.auditor === true)
+        switchMap((uid) =>
+          this.projectService
+            .getProject(uid, false, { auditor: true })
+            .pipe(map((project) => ({ uid, isAuditor: project?.writer === true || project?.auditor === true })))
+        )
       ),
-      { initialValue: false }
+      { initialValue: null }
     );
   }
 
@@ -127,11 +111,11 @@ export class FormationCardComponent {
   // this resolves for, so a non-auditor viewer shouldn't pay for the round trip.
   // `ProjectService.getProjectSfid` already logs and resolves to `null` on failure — no additional
   // catchError needed here.
-  private initSfid(): Signal<string | null> {
+  private initSfidState(): Signal<{ uid: string; sfid: string | null } | null> {
     return toSignal(
       toObservable(computed(() => (this.isAuditor() ? this.projectUid() : null))).pipe(
         filter((uid): uid is string => !!uid),
-        switchMap((uid) => this.projectService.getProjectSfid(uid))
+        switchMap((uid) => this.projectService.getProjectSfid(uid).pipe(map((sfid) => ({ uid, sfid }))))
       ),
       { initialValue: null }
     );

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
@@ -5,13 +5,11 @@ import { Component, computed, inject, input, signal, Signal } from '@angular/cor
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { PROJECT_STAFF_ROWS } from '@lfx-one/shared/constants';
-import { ProjectSettings, ProjectStaffRowConfig, UserInfo } from '@lfx-one/shared/interfaces';
+import { ProjectSettings, ProjectStaffRow } from '@lfx-one/shared/interfaces';
 import { PermissionsService } from '@services/permissions.service';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 import { catchError, filter, of, switchMap, tap } from 'rxjs';
-
-type StaffRow = ProjectStaffRowConfig & { user: UserInfo | null | undefined };
 
 @Component({
   selector: 'lfx-project-staff-card',
@@ -57,7 +55,7 @@ export class ProjectStaffCardComponent {
     { initialValue: null }
   );
 
-  protected readonly staff: Signal<StaffRow[]> = computed(() => {
+  protected readonly staff: Signal<ProjectStaffRow[]> = computed(() => {
     const s = this.settings();
     return PROJECT_STAFF_ROWS.map((row) => ({
       ...row,

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -13,7 +13,9 @@
       @if (formationFlagEnabled() && isFormation()) {
         <p class="text-sm text-gray-500" data-testid="project-dashboard-formation-subtitle">
           Stage Formation · {{ formationSubStage() }}
-          @if (!announcementDateLoading() && !announcementDateHasError()) {
+          @if (announcementDateLoading()) {
+            · Announcement date —
+          } @else if (!announcementDateHasError()) {
             · Announcement date {{ announcementDateLabel() }}
           }
         </p>

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -7,7 +7,13 @@
       <div class="flex items-center gap-2">
         <h1 class="font-display font-light text-2xl">{{ selectedProject()?.name }} Overview</h1>
         @if (formationFlagEnabled() && isFormation()) {
-          <lfx-tag [value]="'FORMATION · ' + formationSubStage()" [rounded]="true" styleClass="!bg-violet-100 !text-violet-700 border border-violet-200" />
+          <lfx-tag
+            [value]="'FORMATION · ' + formationSubStage()"
+            [rounded]="true"
+            [icon]="isConfidential() ? 'fa-light fa-lock' : undefined"
+            [styleClass]="
+              isConfidential() ? '!bg-amber-100 !text-amber-700 border border-amber-200' : '!bg-violet-100 !text-violet-700 border border-violet-200'
+            " />
         }
       </div>
       @if (formationFlagEnabled() && isFormation()) {
@@ -17,6 +23,9 @@
             · Announcement date —
           } @else if (!announcementDateHasError()) {
             · Announcement date {{ announcementDateLabel() }}
+          }
+          @if (isConfidential()) {
+            · Not visible outside LF Formation and LF Legal until invited
           }
         </p>
       }

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -12,7 +12,7 @@
       </div>
       @if (formationFlagEnabled() && isFormation()) {
         <p class="text-sm text-gray-500" data-testid="project-dashboard-formation-subtitle">
-          Stage Formation · {{ formationSubStage() }} · Announcement date {{ announcementDate() | date }}
+          Stage Formation · {{ formationSubStage() }} · Announcement date {{ (announcementDate() | date) || 'Not set' }}
         </p>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -13,7 +13,7 @@
       @if (formationFlagEnabled() && isFormation()) {
         <p class="text-sm text-gray-500" data-testid="project-dashboard-formation-subtitle">
           Stage Formation · {{ formationSubStage() }}
-          @if (!announcementDateLoading()) {
+          @if (!announcementDateLoading() && !announcementDateHasError()) {
             · Announcement date {{ announcementDateLabel() }}
           }
         </p>

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -12,7 +12,10 @@
       </div>
       @if (formationFlagEnabled() && isFormation()) {
         <p class="text-sm text-gray-500" data-testid="project-dashboard-formation-subtitle">
-          Stage Formation · {{ formationSubStage() }} · Announcement date {{ announcementDateLabel() }}
+          Stage Formation · {{ formationSubStage() }}
+          @if (!announcementDateLoading()) {
+            · Announcement date {{ announcementDateLabel() }}
+          }
         </p>
       }
     </div>
@@ -88,7 +91,7 @@
     </div>
 
     @if (selectedProject()?.uid; as uid) {
-      <lfx-dashboard-sidebar [projectUid]="uid" [staffHeading]="staffHeading" />
+      <lfx-dashboard-sidebar [projectUid]="uid" [staffHeading]="staffHeading" [showFormationCard]="true" />
     }
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -12,7 +12,7 @@
       </div>
       @if (formationFlagEnabled() && isFormation()) {
         <p class="text-sm text-gray-500" data-testid="project-dashboard-formation-subtitle">
-          Stage Formation · {{ formationSubStage() }} · Announcement date {{ (announcementDate() | date) || 'Not set' }}
+          Stage Formation · {{ formationSubStage() }} · Announcement date {{ announcementDateLabel() }}
         </p>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -3,8 +3,18 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="project-dashboard-container">
   @if (selectedProject()) {
-    <div class="mt-3 mb-6" data-testid="project-dashboard-foundation-project">
-      <h1 class="font-display font-light text-2xl">{{ selectedProject()?.name }} Overview</h1>
+    <div class="mt-3 mb-6 flex flex-col gap-2" data-testid="project-dashboard-foundation-project">
+      <div class="flex items-center gap-2">
+        <h1 class="font-display font-light text-2xl">{{ selectedProject()?.name }} Overview</h1>
+        @if (formationFlagEnabled() && isFormation()) {
+          <lfx-tag [value]="'FORMATION · ' + formationSubStage()" [rounded]="true" styleClass="!bg-violet-100 !text-violet-700 border border-violet-200" />
+        }
+      </div>
+      @if (formationFlagEnabled() && isFormation()) {
+        <p class="text-sm text-gray-500" data-testid="project-dashboard-formation-subtitle">
+          Stage Formation · {{ formationSubStage() }} · Announcement date {{ announcementDate() | date }}
+        </p>
+      }
     </div>
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
@@ -1,0 +1,117 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, signal, WritableSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProjectContext, ProjectSettings } from '@lfx-one/shared/interfaces';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { PermissionsService } from '@services/permissions.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { Observable, of, Subject } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+
+import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
+import { DashboardSidebarComponent } from '../components/dashboard-sidebar/dashboard-sidebar.component';
+import { ProjectDashboardComponent } from './project-dashboard.component';
+
+const CONTEXT: ProjectContext = { uid: 'proj-1', name: 'Project One', slug: 'project-one' };
+
+@Component({ selector: 'lfx-dashboard-sidebar', standalone: true, template: '' })
+class StubDashboardSidebarComponent {
+  public readonly projectUid = input<string>('');
+  public readonly staffHeading = input<string>('');
+  public readonly showFormationCard = input<boolean>(false);
+}
+
+@Component({ selector: 'lfx-dashboard-cast-drawer-host', standalone: true, template: '' })
+class StubDashboardCastDrawerHostComponent {}
+
+function settings(announcementDate: string): ProjectSettings {
+  return {
+    uid: 'proj-1',
+    announcement_date: announcementDate,
+    writers: [],
+    auditors: [],
+    executive_director: null,
+    program_manager: null,
+    opportunity_owner: null,
+    created_at: '',
+    updated_at: '',
+  };
+}
+
+describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () => {
+  let fixture: ComponentFixture<ProjectDashboardComponent>;
+  let flagEnabled: WritableSignal<boolean>;
+
+  async function render(isFormation: boolean, settingsResult: Observable<ProjectSettings> = of(settings('2026-09-01'))): Promise<void> {
+    flagEnabled = signal(true);
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ProjectDashboardComponent],
+      providers: [
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: () => flagEnabled } },
+        { provide: PermissionsService, useValue: { getProjectSettings: () => settingsResult } },
+        { provide: ProjectService, useValue: { getPendingActions: () => of([]) } },
+        {
+          provide: ProjectContextService,
+          useValue: {
+            activeContext: signal(CONTEXT),
+            isActiveProjectInFormation: signal(isFormation),
+            activeProjectFormationSubStage: signal(isFormation ? 'Engaged' : null),
+          },
+        },
+      ],
+    })
+      .overrideComponent(ProjectDashboardComponent, {
+        remove: { imports: [DashboardSidebarComponent, DashboardCastDrawerHostComponent] },
+        add: { imports: [StubDashboardSidebarComponent, StubDashboardCastDrawerHostComponent] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ProjectDashboardComponent);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function text(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  it('renders no badge or subtitle when the flag is off', async () => {
+    await render(true);
+    flagEnabled.set(false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')).toBeNull();
+  });
+
+  it('renders no badge or subtitle when the project is not in Formation', async () => {
+    await render(false);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')).toBeNull();
+    expect(text()).not.toContain('FORMATION');
+  });
+
+  it('renders the badge and subtitle when flagged on and in Formation', async () => {
+    await render(true);
+
+    expect(text()).toContain('FORMATION · Engaged');
+    expect(fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')).not.toBeNull();
+  });
+
+  it('omits the "Announcement date" clause entirely until the settings fetch resolves, rather than asserting "Not set" prematurely', async () => {
+    const pending = new Subject<ProjectSettings>();
+    await render(true, pending);
+
+    const subtitle = () => fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')?.textContent ?? '';
+    expect(subtitle()).toContain('Stage Formation · Engaged');
+    expect(subtitle()).not.toContain('Announcement date');
+
+    pending.next(settings('2026-09-01'));
+    fixture.detectChanges();
+
+    expect(subtitle()).toContain('Announcement date Sep 1, 2026');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
@@ -127,13 +127,14 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
     expect(fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')).not.toBeNull();
   });
 
-  it('omits the "Announcement date" clause entirely until the settings fetch resolves, rather than asserting "Not set" prematurely', async () => {
+  it('shows an em dash placeholder, not "Not set", until the settings fetch resolves', async () => {
     const pending = new Subject<ProjectSettings>();
     await render(true, pending);
 
     const subtitle = () => fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')?.textContent ?? '';
     expect(subtitle()).toContain('Stage Formation · Engaged');
-    expect(subtitle()).not.toContain('Announcement date');
+    expect(subtitle()).toContain('Announcement date —');
+    expect(subtitle()).not.toContain('Not set');
 
     pending.next(settings('2026-09-01'));
     await fixture.whenStable();

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
@@ -8,11 +8,14 @@ import { FeatureFlagService } from '@services/feature-flag.service';
 import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
-import { Observable, of, Subject } from 'rxjs';
+import { Observable, of, Subject, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardSidebarComponent } from '../components/dashboard-sidebar/dashboard-sidebar.component';
+import { MyMeetingsComponent } from '../components/my-meetings/my-meetings.component';
+import { PendingActionsComponent } from '../components/pending-actions/pending-actions.component';
+import { RecentProgressComponent } from '../components/recent-progress/recent-progress.component';
 import { ProjectDashboardComponent } from './project-dashboard.component';
 
 const CONTEXT: ProjectContext = { uid: 'proj-1', name: 'Project One', slug: 'project-one' };
@@ -26,6 +29,20 @@ class StubDashboardSidebarComponent {
 
 @Component({ selector: 'lfx-dashboard-cast-drawer-host', standalone: true, template: '' })
 class StubDashboardCastDrawerHostComponent {}
+
+// The three `@defer (on idle)` children below are stubbed out too — `await fixture.whenStable()`
+// (unlike a bare `detectChanges()`) waits for the idle callback that resolves those blocks, so
+// without stubs their real, service-heavy implementations would instantiate and need a full DI tree.
+@Component({ selector: 'lfx-recent-progress', standalone: true, template: '' })
+class StubRecentProgressComponent {}
+
+@Component({ selector: 'lfx-my-meetings', standalone: true, template: '' })
+class StubMyMeetingsComponent {}
+
+@Component({ selector: 'lfx-pending-actions', standalone: true, template: '' })
+class StubPendingActionsComponent {
+  public readonly pendingActions = input<unknown[]>([]);
+}
 
 function settings(announcementDate: string): ProjectSettings {
   return {
@@ -65,14 +82,23 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
       ],
     })
       .overrideComponent(ProjectDashboardComponent, {
-        remove: { imports: [DashboardSidebarComponent, DashboardCastDrawerHostComponent] },
-        add: { imports: [StubDashboardSidebarComponent, StubDashboardCastDrawerHostComponent] },
+        remove: {
+          imports: [DashboardSidebarComponent, DashboardCastDrawerHostComponent, RecentProgressComponent, MyMeetingsComponent, PendingActionsComponent],
+        },
+        add: {
+          imports: [
+            StubDashboardSidebarComponent,
+            StubDashboardCastDrawerHostComponent,
+            StubRecentProgressComponent,
+            StubMyMeetingsComponent,
+            StubPendingActionsComponent,
+          ],
+        },
       })
       .compileComponents();
 
     fixture = TestBed.createComponent(ProjectDashboardComponent);
     await fixture.whenStable();
-    fixture.detectChanges();
   }
 
   function text(): string {
@@ -82,7 +108,7 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
   it('renders no badge or subtitle when the flag is off', async () => {
     await render(true);
     flagEnabled.set(false);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')).toBeNull();
   });
@@ -110,8 +136,19 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
     expect(subtitle()).not.toContain('Announcement date');
 
     pending.next(settings('2026-09-01'));
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(subtitle()).toContain('Announcement date Sep 1, 2026');
+  });
+
+  it('omits the "Announcement date" clause on a failed settings fetch, rather than falsely asserting "Not set"', async () => {
+    await render(
+      true,
+      throwError(() => new Error('network error'))
+    );
+
+    const subtitle = () => fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')?.textContent ?? '';
+    expect(subtitle()).toContain('Stage Formation · Engaged');
+    expect(subtitle()).not.toContain('Announcement date');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
@@ -62,7 +62,7 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
   let fixture: ComponentFixture<ProjectDashboardComponent>;
   let flagEnabled: WritableSignal<boolean>;
 
-  async function render(isFormation: boolean, settingsResult: Observable<ProjectSettings> = of(settings('2026-09-01'))): Promise<void> {
+  async function render(isFormation: boolean, settingsResult: Observable<ProjectSettings> = of(settings('2026-09-01')), subStage = 'Engaged'): Promise<void> {
     flagEnabled = signal(true);
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
@@ -76,7 +76,7 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
           useValue: {
             activeContext: signal(CONTEXT),
             isActiveProjectInFormation: signal(isFormation),
-            activeProjectFormationSubStage: signal(isFormation ? 'Engaged' : null),
+            activeProjectFormationSubStage: signal(isFormation ? subStage : null),
           },
         },
       ],
@@ -151,5 +151,25 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
     const subtitle = () => fixture.nativeElement.querySelector('[data-testid="project-dashboard-formation-subtitle"]')?.textContent ?? '';
     expect(subtitle()).toContain('Stage Formation · Engaged');
     expect(subtitle()).not.toContain('Announcement date');
+  });
+
+  it('gives the Confidential sub-stage a distinct amber/lock tag and appends the visibility caption', async () => {
+    await render(true, of(settings('2026-09-01')), 'Confidential');
+
+    const tagEl = fixture.nativeElement.querySelector('.p-tag');
+    expect(tagEl.className).toContain('amber');
+    expect(tagEl.className).not.toContain('violet');
+    expect(fixture.nativeElement.querySelector('.fa-lock')).not.toBeNull();
+    expect(text()).toContain('Not visible outside LF Formation and LF Legal until invited');
+  });
+
+  it('keeps the violet tag and omits the caption for a non-Confidential sub-stage', async () => {
+    await render(true, of(settings('2026-09-01')), 'Engaged');
+
+    const tagEl = fixture.nativeElement.querySelector('.p-tag');
+    expect(tagEl.className).toContain('violet');
+    expect(tagEl.className).not.toContain('amber');
+    expect(fixture.nativeElement.querySelector('.fa-lock')).toBeNull();
+    expect(text()).not.toContain('Not visible outside LF Formation and LF Legal until invited');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.spec.ts
@@ -5,10 +5,9 @@ import { Component, input, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectContext, ProjectSettings } from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
-import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
-import { Observable, of, Subject, throwError } from 'rxjs';
+import { catchError, map, Observable, of, Subject, tap, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
@@ -65,11 +64,31 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
   async function render(isFormation: boolean, settingsResult: Observable<ProjectSettings> = of(settings('2026-09-01')), subStage = 'Engaged'): Promise<void> {
     flagEnabled = signal(true);
     TestBed.resetTestingModule();
+
+    // Mirrors ProjectContextService's own tri-state pipeline so the mock behaves like the real
+    // shared signals (loading flips false, hasError flips true) rather than hardcoding both false.
+    const announcementDateLoading = signal(true);
+    const announcementDateHasError = signal(false);
+    const announcementDate = signal<string | null>(null);
+    settingsResult
+      .pipe(
+        map((s) => s.announcement_date || null),
+        tap((date) => {
+          announcementDate.set(date);
+          announcementDateLoading.set(false);
+        }),
+        catchError(() => {
+          announcementDateLoading.set(false);
+          announcementDateHasError.set(true);
+          return of(null);
+        })
+      )
+      .subscribe();
+
     await TestBed.configureTestingModule({
       imports: [ProjectDashboardComponent],
       providers: [
         { provide: FeatureFlagService, useValue: { getBooleanFlag: () => flagEnabled } },
-        { provide: PermissionsService, useValue: { getProjectSettings: () => settingsResult } },
         { provide: ProjectService, useValue: { getPendingActions: () => of([]) } },
         {
           provide: ProjectContextService,
@@ -77,6 +96,10 @@ describe('ProjectDashboardComponent — Formation badge/subtitle (GH-1955)', () 
             activeContext: signal(CONTEXT),
             isActiveProjectInFormation: signal(isFormation),
             activeProjectFormationSubStage: signal(isFormation ? subStage : null),
+            isActiveProjectConfidential: signal(isFormation && subStage === 'Confidential'),
+            activeProjectAnnouncementDate: announcementDate,
+            activeProjectAnnouncementDateLoading: announcementDateLoading,
+            activeProjectAnnouncementDateHasError: announcementDateHasError,
           },
         },
       ],

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -90,7 +90,10 @@ export class ProjectDashboardComponent {
         switchMap((project) =>
           this.permissionsService.getProjectSettings(project.uid).pipe(
             map((settings) => settings.announcement_date || null),
-            catchError(() => of(null))
+            catchError((error) => {
+              console.error('Project dashboard: failed to load announcement date', error);
+              return of(null);
+            })
           )
         )
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
 import { PendingActionItem } from '@lfx-one/shared/interfaces';
-import { formatIsoDateLabel } from '@lfx-one/shared/utils';
+import { formatAnnouncementDateLabel } from '@lfx-one/shared/utils';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -103,9 +103,6 @@ export class ProjectDashboardComponent {
   }
 
   private initAnnouncementDateLabel(): Signal<string> {
-    return computed(() => {
-      const date = this.announcementDate();
-      return date ? formatIsoDateLabel(date) : 'Not set';
-    });
+    return computed(() => formatAnnouncementDateLabel(this.announcementDate()));
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal } from '@angular/core';
+import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
 import { PendingActionItem } from '@lfx-one/shared/interfaces';
@@ -12,7 +12,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { TagComponent } from '@components/tag/tag.component';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardSidebarComponent } from '../components/dashboard-sidebar/dashboard-sidebar.component';
@@ -51,6 +51,8 @@ export class ProjectDashboardComponent {
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
 
   public readonly pendingActions: Signal<PendingActionItem[]>;
+  /** True until the announcement-date fetch for the current project settles — gates the subtitle's date clause so it never asserts "Not set" before the real value is known. */
+  protected readonly announcementDateLoading = signal(true);
   private readonly announcementDate: Signal<string | null>;
   protected readonly announcementDateLabel: Signal<string>;
 
@@ -88,13 +90,15 @@ export class ProjectDashboardComponent {
     return toSignal(
       toObservable(this.selectedProject).pipe(
         filter((project): project is NonNullable<typeof project> => !!project?.uid),
+        tap(() => this.announcementDateLoading.set(true)),
         switchMap((project) =>
           this.permissionsService.getProjectSettings(project.uid).pipe(
             map((settings) => settings.announcement_date || null),
             catchError((error) => {
               console.error('Project dashboard: failed to load announcement date', error);
               return of(null);
-            })
+            }),
+            tap(() => this.announcementDateLoading.set(false))
           )
         )
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -49,6 +49,8 @@ export class ProjectDashboardComponent {
   protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
   protected readonly isFormation = this.projectContextService.isActiveProjectInFormation;
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
+  /** Confidential is its own `ProjectStage`, mutually exclusive with the other sub-stages — never layered on top of one. */
+  protected readonly isConfidential = computed(() => this.formationSubStage() === 'Confidential');
 
   /**
    * `announcementDateLoading`/`announcementDateHasError` gate the subtitle's date clause so it

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -1,11 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe } from '@angular/common';
 import { Component, computed, inject, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
 import { PendingActionItem } from '@lfx-one/shared/interfaces';
+import { formatIsoDateLabel } from '@lfx-one/shared/utils';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -30,7 +30,6 @@ import { RecentProgressComponent } from '../components/recent-progress/recent-pr
     DashboardSidebarComponent,
     DashboardCastDrawerHostComponent,
     TagComponent,
-    DatePipe,
   ],
   templateUrl: './project-dashboard.component.html',
   styleUrl: './project-dashboard.component.scss',
@@ -52,11 +51,13 @@ export class ProjectDashboardComponent {
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
 
   public readonly pendingActions: Signal<PendingActionItem[]>;
-  protected readonly announcementDate: Signal<string | null>;
+  private readonly announcementDate: Signal<string | null>;
+  protected readonly announcementDateLabel: Signal<string>;
 
   public constructor() {
     this.pendingActions = this.initPendingActions();
     this.announcementDate = this.initAnnouncementDate();
+    this.announcementDateLabel = this.initAnnouncementDateLabel();
   }
 
   public handleActionClick(): void {
@@ -99,5 +100,12 @@ export class ProjectDashboardComponent {
       ),
       { initialValue: null }
     );
+  }
+
+  private initAnnouncementDateLabel(): Signal<string> {
+    return computed(() => {
+      const date = this.announcementDate();
+      return date ? formatIsoDateLabel(date) : 'Not set';
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -1,13 +1,18 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DatePipe } from '@angular/common';
 import { Component, computed, inject, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
 import { PendingActionItem } from '@lfx-one/shared/interfaces';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
+import { TagComponent } from '@components/tag/tag.component';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, combineLatest, of, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap } from 'rxjs';
 
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardSidebarComponent } from '../components/dashboard-sidebar/dashboard-sidebar.component';
@@ -17,11 +22,22 @@ import { RecentProgressComponent } from '../components/recent-progress/recent-pr
 
 @Component({
   selector: 'lfx-project-dashboard',
-  imports: [RecentProgressComponent, MyMeetingsComponent, PendingActionsComponent, SkeletonModule, DashboardSidebarComponent, DashboardCastDrawerHostComponent],
+  imports: [
+    RecentProgressComponent,
+    MyMeetingsComponent,
+    PendingActionsComponent,
+    SkeletonModule,
+    DashboardSidebarComponent,
+    DashboardCastDrawerHostComponent,
+    TagComponent,
+    DatePipe,
+  ],
   templateUrl: './project-dashboard.component.html',
   styleUrl: './project-dashboard.component.scss',
 })
 export class ProjectDashboardComponent {
+  private readonly featureFlagService = inject(FeatureFlagService);
+  private readonly permissionsService = inject(PermissionsService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
@@ -30,10 +46,17 @@ export class ProjectDashboardComponent {
   public readonly selectedProject = computed(() => this.projectContextService.activeContext());
   protected readonly staffHeading = 'Project Staff';
 
+  /** GH-1955 — see `FORMATION_ENABLED_FLAG`'s doc comment for what this does and doesn't gate. */
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
+  protected readonly isFormation = this.projectContextService.isActiveProjectInFormation;
+  protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
+
   public readonly pendingActions: Signal<PendingActionItem[]>;
+  protected readonly announcementDate: Signal<string | null>;
 
   public constructor() {
     this.pendingActions = this.initPendingActions();
+    this.announcementDate = this.initAnnouncementDate();
   }
 
   public handleActionClick(): void {
@@ -56,6 +79,22 @@ export class ProjectDashboardComponent {
         })
       ),
       { initialValue: [] }
+    );
+  }
+
+  /** Shares `PermissionsService`'s per-uid cache with `FormationCardComponent` — no duplicate fetch. */
+  private initAnnouncementDate(): Signal<string | null> {
+    return toSignal(
+      toObservable(this.selectedProject).pipe(
+        filter((project): project is NonNullable<typeof project> => !!project?.uid),
+        switchMap((project) =>
+          this.permissionsService.getProjectSettings(project.uid).pipe(
+            map((settings) => settings.announcement_date || null),
+            catchError(() => of(null))
+          )
+        )
+      ),
+      { initialValue: null }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -50,9 +50,15 @@ export class ProjectDashboardComponent {
   protected readonly isFormation = this.projectContextService.isActiveProjectInFormation;
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
 
-  public readonly pendingActions: Signal<PendingActionItem[]>;
-  /** True until the announcement-date fetch for the current project settles — gates the subtitle's date clause so it never asserts "Not set" before the real value is known. */
+  /**
+   * `announcementDateLoading`/`announcementDateHasError` gate the subtitle's date clause so it
+   * never asserts "Not set" — either before the real value is known, or when the fetch failed and
+   * "Not set" would misreport a genuinely unknown date as a confirmed absence.
+   */
   protected readonly announcementDateLoading = signal(true);
+  protected readonly announcementDateHasError = signal(false);
+
+  public readonly pendingActions: Signal<PendingActionItem[]>;
   private readonly announcementDate: Signal<string | null>;
   protected readonly announcementDateLabel: Signal<string>;
 
@@ -90,15 +96,20 @@ export class ProjectDashboardComponent {
     return toSignal(
       toObservable(this.selectedProject).pipe(
         filter((project): project is NonNullable<typeof project> => !!project?.uid),
-        tap(() => this.announcementDateLoading.set(true)),
+        tap(() => {
+          this.announcementDateLoading.set(true);
+          this.announcementDateHasError.set(false);
+        }),
         switchMap((project) =>
           this.permissionsService.getProjectSettings(project.uid).pipe(
             map((settings) => settings.announcement_date || null),
+            tap(() => this.announcementDateLoading.set(false)),
             catchError((error) => {
               console.error('Project dashboard: failed to load announcement date', error);
+              this.announcementDateLoading.set(false);
+              this.announcementDateHasError.set(true);
               return of(null);
-            }),
-            tap(() => this.announcementDateLoading.set(false))
+            })
           )
         )
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -1,18 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { Component, computed, inject, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
 import { PendingActionItem } from '@lfx-one/shared/interfaces';
 import { formatAnnouncementDateLabel } from '@lfx-one/shared/utils';
 import { FeatureFlagService } from '@services/feature-flag.service';
-import { PermissionsService } from '@services/permissions.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { TagComponent } from '@components/tag/tag.component';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, of, switchMap } from 'rxjs';
 
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
 import { DashboardSidebarComponent } from '../components/dashboard-sidebar/dashboard-sidebar.component';
@@ -36,7 +35,6 @@ import { RecentProgressComponent } from '../components/recent-progress/recent-pr
 })
 export class ProjectDashboardComponent {
   private readonly featureFlagService = inject(FeatureFlagService);
-  private readonly permissionsService = inject(PermissionsService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
 
@@ -49,25 +47,19 @@ export class ProjectDashboardComponent {
   protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
   protected readonly isFormation = this.projectContextService.isActiveProjectInFormation;
   protected readonly formationSubStage = this.projectContextService.activeProjectFormationSubStage;
-  /** Confidential is its own `ProjectStage`, mutually exclusive with the other sub-stages — never layered on top of one. */
-  protected readonly isConfidential = computed(() => this.formationSubStage() === 'Confidential');
+  protected readonly isConfidential = this.projectContextService.isActiveProjectConfidential;
 
-  /**
-   * `announcementDateLoading`/`announcementDateHasError` gate the subtitle's date clause so it
-   * never asserts "Not set" — either before the real value is known, or when the fetch failed and
-   * "Not set" would misreport a genuinely unknown date as a confirmed absence.
-   */
-  protected readonly announcementDateLoading = signal(true);
-  protected readonly announcementDateHasError = signal(false);
+  /** Shared with `FormationCardComponent` via `ProjectContextService` — no duplicate fetch. */
+  protected readonly announcementDateLoading = this.projectContextService.activeProjectAnnouncementDateLoading;
+  protected readonly announcementDateHasError = this.projectContextService.activeProjectAnnouncementDateHasError;
+  protected readonly announcementDateLabel: Signal<string> = computed(() =>
+    formatAnnouncementDateLabel(this.projectContextService.activeProjectAnnouncementDate())
+  );
 
   public readonly pendingActions: Signal<PendingActionItem[]>;
-  private readonly announcementDate: Signal<string | null>;
-  protected readonly announcementDateLabel: Signal<string>;
 
   public constructor() {
     this.pendingActions = this.initPendingActions();
-    this.announcementDate = this.initAnnouncementDate();
-    this.announcementDateLabel = this.initAnnouncementDateLabel();
   }
 
   public handleActionClick(): void {
@@ -91,35 +83,5 @@ export class ProjectDashboardComponent {
       ),
       { initialValue: [] }
     );
-  }
-
-  /** Shares `PermissionsService`'s per-uid cache with `FormationCardComponent` — no duplicate fetch. */
-  private initAnnouncementDate(): Signal<string | null> {
-    return toSignal(
-      toObservable(this.selectedProject).pipe(
-        filter((project): project is NonNullable<typeof project> => !!project?.uid),
-        tap(() => {
-          this.announcementDateLoading.set(true);
-          this.announcementDateHasError.set(false);
-        }),
-        switchMap((project) =>
-          this.permissionsService.getProjectSettings(project.uid).pipe(
-            map((settings) => settings.announcement_date || null),
-            tap(() => this.announcementDateLoading.set(false)),
-            catchError((error) => {
-              console.error('Project dashboard: failed to load announcement date', error);
-              this.announcementDateLoading.set(false);
-              this.announcementDateHasError.set(true);
-              return of(null);
-            })
-          )
-        )
-      ),
-      { initialValue: null }
-    );
-  }
-
-  private initAnnouncementDateLabel(): Signal<string> {
-    return computed(() => formatAnnouncementDateLabel(this.announcementDate()));
   }
 }

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
@@ -120,7 +120,12 @@
             </div>
 
             <div class="flex-1 min-w-0">
-              <p class="font-medium text-sm text-gray-900 mb-0 truncate">{{ displayItem.item.name || displayItem.item.slug }}</p>
+              <div class="flex items-center gap-1.5 min-w-0">
+                <p class="font-medium text-sm text-gray-900 mb-0 truncate">{{ displayItem.item.name || displayItem.item.slug }}</p>
+                @if (formationFlagEnabled() && displayItem.item.formationSubStage) {
+                  <lfx-tag value="Formation" [rounded]="true" styleClass="!bg-violet-100 !text-violet-700 border border-violet-200 shrink-0" />
+                }
+              </div>
               @if (displayItem.roleLabel) {
                 <p class="text-xs text-gray-400 leading-none mt-0.5 truncate">
                   <i [ngClass]="displayItem.roleIcon" class="mr-1" aria-hidden="true"></i>{{ displayItem.roleLabel }}

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
@@ -19,7 +19,7 @@
   </div>
 
   <div class="flex flex-col gap-1.5 grow items-start relative min-w-0 overflow-hidden">
-    <p class="sidebar-project-name" [attr.title]="displayName()">{{ displayName() }}</p>
+    <p class="sidebar-project-name" [pTooltip]="displayName()" tooltipPosition="top">{{ displayName() }}</p>
     <div class="flex items-center gap-1 w-full min-w-0 text-left">
       <span class="text-xs font-normal text-gray-400 leading-none truncate">{{ lensTypeLabel() }}</span>
       @if (selectedRoleLabel()) {

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
@@ -7,7 +7,10 @@
 }
 
 .sidebar-project-name {
-  @apply font-medium leading-5 relative text-base text-gray-900 tracking-tight truncate w-full text-left;
+  // GH-1955 follow-up: a long formation/project name wraps up to 2 lines instead of being cut to
+  // one — `line-clamp-2` still caps runaway names, and the `pTooltip` on the element in the
+  // template surfaces the full name when even that clamps.
+  @apply font-medium leading-5 relative text-base text-gray-900 tracking-tight line-clamp-2 w-full text-left;
 }
 
 // PrimeNG Popover cosmetics — hide arrow, radius, padding. Applies to both the sidebar panel

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.spec.ts
@@ -23,9 +23,9 @@ describe('ProjectSelectorComponent ordering', () => {
   // Deliberately not alphabetical, and every entry matches "cloud" so the search assertion is
   // about ordering rather than filtering.
   const items: LensItem[] = [
-    { uid: 'u1', slug: 'zeta-cloud', name: 'Zeta Cloud', logoUrl: null, isFoundation: false },
-    { uid: 'u2', slug: 'alpha-cloud', name: 'Alpha Cloud', logoUrl: null, isFoundation: false },
-    { uid: 'u3', slug: 'mid-cloud', name: 'Mid Cloud', logoUrl: null, isFoundation: false },
+    { uid: 'u1', slug: 'zeta-cloud', name: 'Zeta Cloud', logoUrl: null, isFoundation: false, formationSubStage: null },
+    { uid: 'u2', slug: 'alpha-cloud', name: 'Alpha Cloud', logoUrl: null, isFoundation: false, formationSubStage: null },
+    { uid: 'u3', slug: 'mid-cloud', name: 'Mid Cloud', logoUrl: null, isFoundation: false, formationSubStage: null },
   ];
 
   let fixture: ComponentFixture<ProjectSelectorComponent>;
@@ -105,12 +105,12 @@ describe('ProjectSelectorComponent ordering', () => {
  */
 describe('ProjectSelectorComponent nav-backed ordering', () => {
   const foundations: LensItem[] = [
-    { uid: 'f2', slug: 'zeta-foundation', name: 'Zeta Foundation', logoUrl: null, isFoundation: true },
-    { uid: 'f1', slug: 'alpha-foundation', name: 'Alpha Foundation', logoUrl: null, isFoundation: true },
+    { uid: 'f2', slug: 'zeta-foundation', name: 'Zeta Foundation', logoUrl: null, isFoundation: true, formationSubStage: null },
+    { uid: 'f1', slug: 'alpha-foundation', name: 'Alpha Foundation', logoUrl: null, isFoundation: true, formationSubStage: null },
   ];
   const projects: LensItem[] = [
-    { uid: 'p2', slug: 'zeta-project', name: 'Zeta Project', logoUrl: null, isFoundation: false },
-    { uid: 'p1', slug: 'alpha-project', name: 'Alpha Project', logoUrl: null, isFoundation: false },
+    { uid: 'p2', slug: 'zeta-project', name: 'Zeta Project', logoUrl: null, isFoundation: false, formationSubStage: null },
+    { uid: 'p1', slug: 'alpha-project', name: 'Alpha Project', logoUrl: null, isFoundation: false, formationSubStage: null },
   ];
 
   let fixture: ComponentFixture<ProjectSelectorComponent>;

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -5,12 +5,14 @@ import { isPlatformBrowser, NgClass } from '@angular/common';
 import { Component, computed, ElementRef, inject, input, model, output, PLATFORM_ID, signal, Signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { BOARD_SCOPED_PERSONA_PRIORITY, PROJECT_SCOPED_PERSONA_PRIORITY } from '@lfx-one/shared/constants';
+import { BOARD_SCOPED_PERSONA_PRIORITY, FORMATION_ENABLED_FLAG, PROJECT_SCOPED_PERSONA_PRIORITY } from '@lfx-one/shared/constants';
 import { DisplayLensItem, LensItem, NavLens, PersonaType, ProjectContext, SelectorTab } from '@lfx-one/shared/interfaces';
+import { FeatureFlagService } from '@services/feature-flag.service';
 import { NavigationService } from '@services/navigation.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
+import { TagComponent } from '@components/tag/tag.component';
 import { AutoFocus } from 'primeng/autofocus';
 import { InputTextModule } from 'primeng/inputtext';
 import { Popover, PopoverModule } from 'primeng/popover';
@@ -18,15 +20,19 @@ import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'lfx-project-selector',
-  imports: [NgClass, ReactiveFormsModule, PopoverModule, InputTextModule, AutoFocus, OnRenderDirective, TooltipModule],
+  imports: [NgClass, ReactiveFormsModule, PopoverModule, InputTextModule, AutoFocus, OnRenderDirective, TooltipModule, TagComponent],
   templateUrl: './project-selector.component.html',
   styleUrl: './project-selector.component.scss',
 })
 export class ProjectSelectorComponent {
+  private readonly featureFlagService = inject(FeatureFlagService);
   private readonly navigationService = inject(NavigationService);
   private readonly personaService = inject(PersonaService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly platformId = inject(PLATFORM_ID);
+
+  /** GH-1955 — see `FORMATION_ENABLED_FLAG`'s doc comment for what this does and doesn't gate. */
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
 
   private readonly popoverRef = viewChild<Popover>('popover');
   private readonly triggerRef = viewChild<ElementRef<HTMLElement>>('selectorTrigger');

--- a/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
@@ -1,0 +1,127 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Location } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { ApplicationRef, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { SsrCookieService } from 'ngx-cookie-service-ssr';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CookieRegistryService } from './cookie-registry.service';
+import { FeatureFlagService } from './feature-flag.service';
+import { LensService } from './lens.service';
+import { PersonaService } from './persona.service';
+import { ProjectContextService } from './project-context.service';
+import { ProjectService } from './project.service';
+import { UserService } from './user.service';
+
+const CONTEXT: ProjectContext = { uid: 'proj-1', name: 'Project One', slug: 'project-one' };
+
+/** Minimal fixture; only `stage` matters for the assertions below. */
+function project(stage: string): Project {
+  return {
+    uid: 'proj-1',
+    slug: 'project-one',
+    description: '',
+    name: 'Project One',
+    public: true,
+    parent_uid: '',
+    stage,
+    category: '',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '',
+    updated_at: '',
+    mailing_list_count: 0,
+  } as Project;
+}
+
+describe('ProjectContextService — Formation signals (GH-1955)', () => {
+  let getProject: ReturnType<typeof vi.fn>;
+  let userService: UserService;
+  let service: ProjectContextService;
+
+  beforeEach(() => {
+    getProject = vi.fn().mockReturnValue(of(project('Active')));
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ProjectService, useValue: { getProject, getProjectSfid: vi.fn().mockReturnValue(of(null)) } },
+        { provide: SsrCookieService, useValue: { get: vi.fn(), set: vi.fn(), delete: vi.fn() } },
+        { provide: CookieRegistryService, useValue: { registerCookie: vi.fn(), unregisterCookie: vi.fn() } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: () => signal(false) } },
+        { provide: LensService, useValue: { activeLens: signal('project') } },
+        {
+          provide: PersonaService,
+          useValue: { isMarketingAuditor: signal(false), isCampaignManager: signal(false), marketingGrantSlug: signal(null), currentPersona: signal(null) },
+        },
+        { provide: Router, useValue: { getCurrentNavigation: () => null, parseUrl: vi.fn(), serializeUrl: vi.fn(), url: '/' } },
+        { provide: Location, useValue: { replaceState: vi.fn() } },
+        { provide: HttpClient, useValue: { get: vi.fn().mockReturnValue(of({})), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+
+    userService = TestBed.inject(UserService);
+    userService.authenticated.set(true);
+    service = TestBed.inject(ProjectContextService);
+    service.setRouteLensKind('project');
+    // `syncUrl: false` — this suite only cares about the Formation signals, not URL sync.
+    service.setProject(CONTEXT, false);
+    TestBed.inject(ApplicationRef).tick();
+  });
+
+  it.each([
+    ['Formation - Exploratory', 'Exploratory'],
+    ['Formation - Engaged', 'Engaged'],
+    ['Formation - On Hold', 'On Hold'],
+    ['Formation - Disengaged', 'Disengaged'],
+    ['Formation - Confidential', 'Confidential'],
+    ['Draft', 'Draft'],
+  ])('reports isActiveProjectInFormation=true and the %s sub-stage label for stage %s', (stage, expectedLabel) => {
+    getProject.mockReturnValue(of(project(stage)));
+    service.setProject({ ...CONTEXT, uid: `${CONTEXT.uid}-${stage}` }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.activeProjectFormationSubStage()).toBe(expectedLabel);
+    expect(service.isActiveProjectInFormation()).toBe(true);
+  });
+
+  it.each(['Active', 'Archived', 'Prospect'])('reports isActiveProjectInFormation=false for stage %s', (stage) => {
+    getProject.mockReturnValue(of(project(stage)));
+    service.setProject({ ...CONTEXT, uid: `${CONTEXT.uid}-${stage}` }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.activeProjectFormationSubStage()).toBeNull();
+    expect(service.isActiveProjectInFormation()).toBe(false);
+  });
+
+  it('stays false with no active project fetched when unauthenticated (LFXV2-3266 auth gate)', () => {
+    userService.authenticated.set(false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.isActiveProjectInFormation()).toBe(false);
+    expect(service.canWrite()).toBe(false);
+  });
+
+  it('derives canWrite from the same shared fetch as the Formation signals', () => {
+    getProject.mockReturnValue(of({ ...project('Active'), writer: true }));
+    service.setProject({ ...CONTEXT, uid: 'writer-project' }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.canWrite()).toBe(true);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CookieRegistryService } from './cookie-registry.service';
@@ -123,5 +123,25 @@ describe('ProjectContextService — Formation signals (GH-1955)', () => {
     TestBed.inject(ApplicationRef).tick();
 
     expect(service.canWrite()).toBe(true);
+  });
+
+  it('never emits a transient null/false while a project switch is in flight — evictOnWriteAccessLoss (vote/survey/mailing-list manage pages) takes the first canWrite=false as a permanent access loss', () => {
+    getProject.mockReturnValue(of({ ...project('Active'), writer: true }));
+    service.setProject({ ...CONTEXT, uid: 'p1' }, false);
+    TestBed.inject(ApplicationRef).tick();
+    expect(service.canWrite()).toBe(true);
+
+    const pending = new Subject<Project | null>();
+    getProject.mockReturnValue(pending);
+    service.setProject({ ...CONTEXT, uid: 'p2' }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    // Still p1's value while p2's fetch is in flight — no premature false/null flip.
+    expect(service.activeProject()).not.toBeNull();
+    expect(service.canWrite()).toBe(true);
+
+    pending.next({ ...project('Active'), writer: false });
+    TestBed.inject(ApplicationRef).tick();
+    expect(service.canWrite()).toBe(false);
   });
 });

--- a/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CookieRegistryService } from './cookie-registry.service';
@@ -22,10 +22,17 @@ import { UserService } from './user.service';
 
 const CONTEXT: ProjectContext = { uid: 'proj-1', name: 'Project One', slug: 'project-one' };
 
-/** Minimal fixture; only `stage` matters for the assertions below. */
-function project(stage: string): Project {
+/**
+ * Minimal fixture; `stage` is what most assertions care about. `uid` defaults to the shared
+ * `proj-1` but must be overridden with a fresh value in any test that also asserts on
+ * `activeProjectAnnouncementDate`/`Loading`/`HasError` — `PermissionsService.getProjectSettings`
+ * caches per uid (`shareReplay(1)`), so reusing `proj-1` would replay the *first* call this suite
+ * ever made for that uid (in the outer `beforeEach`, against the default `{}` HTTP mock) instead of
+ * hitting the test's own overridden mock.
+ */
+function project(stage: string, uid = 'proj-1'): Project {
   return {
-    uid: 'proj-1',
+    uid,
     slug: 'project-one',
     description: '',
     name: 'Project One',
@@ -107,6 +114,44 @@ describe('ProjectContextService — Formation signals (GH-1955)', () => {
 
     expect(service.activeProjectFormationSubStage()).toBeNull();
     expect(service.isActiveProjectInFormation()).toBe(false);
+  });
+
+  it('reports isActiveProjectConfidential only for the Confidential stage', () => {
+    getProject.mockReturnValue(of(project('Formation - Confidential')));
+    service.setProject({ ...CONTEXT, uid: 'confidential-project' }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.isActiveProjectConfidential()).toBe(true);
+    expect(service.activeProjectFormationSubStage()).toBe('Confidential');
+
+    getProject.mockReturnValue(of(project('Formation - Engaged')));
+    service.setProject({ ...CONTEXT, uid: 'engaged-project' }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.isActiveProjectConfidential()).toBe(false);
+  });
+
+  it('resolves the announcement date via PermissionsService, triggered by the active-project fetch', () => {
+    const httpGet = TestBed.inject(HttpClient).get as ReturnType<typeof vi.fn>;
+    httpGet.mockReturnValue(of({ announcement_date: '2026-09-01' }));
+    getProject.mockReturnValue(of(project('Formation - Engaged', 'announce-project')));
+    service.setProject({ ...CONTEXT, uid: 'announce-project' }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.activeProjectAnnouncementDate()).toBe('2026-09-01');
+    expect(service.activeProjectAnnouncementDateLoading()).toBe(false);
+    expect(service.activeProjectAnnouncementDateHasError()).toBe(false);
+  });
+
+  it('reports the announcement-date error state independently of the Formation signals', () => {
+    const httpGet = TestBed.inject(HttpClient).get as ReturnType<typeof vi.fn>;
+    httpGet.mockReturnValue(throwError(() => new Error('network error')));
+    getProject.mockReturnValue(of(project('Formation - Engaged', 'error-project')));
+    service.setProject({ ...CONTEXT, uid: 'error-project' }, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.activeProjectAnnouncementDateHasError()).toBe(true);
+    expect(service.activeProjectFormationSubStage()).toBe('Engaged');
   });
 
   it('stays false with no active project fetched when unauthenticated (LFXV2-3266 auth gate)', () => {

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -7,7 +7,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { MARKETING_OPS_FGA_ENABLED_FLAG, SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
-import { getFormationSubStageLabel, isBoardScopedPersona, isSameProjectContext } from '@lfx-one/shared/utils';
+import { getFormationSubStageLabel, isBoardScopedPersona, isFormationStage, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { catchError, combineLatest, filter, of, startWith, switchMap } from 'rxjs';
 
@@ -81,22 +81,26 @@ export class ProjectContextService {
   /** The context kind the current route declares (see {@link routeLensKind}), exposed read-only. */
   public readonly activeRouteLensKind: Signal<'foundation' | 'project' | null> = computed(() => this.routeLensKind());
 
-  /** Full `Project` for the current active context — shared by `canWrite` and the Formation signals below so both ride one fetch. */
-  private readonly activeProjectDetails: Signal<Project | null> = this.initActiveProjectDetails();
+  /**
+   * Full `Project` for the current active context — shared by `canWrite` and the Formation
+   * signals below so all three ride one fetch. Read this (not a fresh `getProject` call) for any
+   * other field the currently active project needs — see `FormationCardComponent` (GH-1955).
+   */
+  public readonly activeProject: Signal<Project | null> = this.initActiveProjectDetails();
 
   /** Writer permission for the current active context — drives CTA visibility across dashboards. */
-  public readonly canWrite: Signal<boolean> = computed(() => this.activeProjectDetails()?.writer === true);
+  public readonly canWrite: Signal<boolean> = computed(() => this.activeProject()?.writer === true);
 
   /**
    * Formation sub-stage label for the current active context (e.g. `'Engaged'`), or `null`
    * outside Formation. Single source of truth for the project dashboard's Formation badge and
-   * sidebar card, and the stage-scoped Formation nav item (GH-1955) — do not add a fourth
-   * independent `getProject` fetch for this; read these two signals instead.
+   * sidebar card (GH-1955) — do not add a fourth independent `getProject` fetch for this; read
+   * these two signals instead.
    */
-  public readonly activeProjectFormationSubStage: Signal<string | null> = computed(() => getFormationSubStageLabel(this.activeProjectDetails()?.stage));
+  public readonly activeProjectFormationSubStage: Signal<string | null> = computed(() => getFormationSubStageLabel(this.activeProject()?.stage));
 
   /** True when the current active context is in Draft or any Formation sub-stage. */
-  public readonly isActiveProjectInFormation: Signal<boolean> = computed(() => this.activeProjectFormationSubStage() !== null);
+  public readonly isActiveProjectInFormation: Signal<boolean> = computed(() => isFormationStage(this.activeProject()?.stage));
 
   /** Salesforce 18-char ID for the active foundation — resolves PCC deep-link targets. `null` while resolving or unavailable. */
   public readonly selectedFoundationSfid: Signal<string | null> = this.initSelectedFoundationSfid();

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -6,10 +6,10 @@ import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@a
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { MARKETING_OPS_FGA_ENABLED_FLAG, SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
-import { ProjectContext } from '@lfx-one/shared/interfaces';
-import { isBoardScopedPersona, isSameProjectContext } from '@lfx-one/shared/utils';
+import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
+import { getFormationSubStageLabel, isBoardScopedPersona, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { catchError, combineLatest, filter, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, filter, of, startWith, switchMap } from 'rxjs';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
@@ -81,8 +81,22 @@ export class ProjectContextService {
   /** The context kind the current route declares (see {@link routeLensKind}), exposed read-only. */
   public readonly activeRouteLensKind: Signal<'foundation' | 'project' | null> = computed(() => this.routeLensKind());
 
+  /** Full `Project` for the current active context — shared by `canWrite` and the Formation signals below so both ride one fetch. */
+  private readonly activeProjectDetails: Signal<Project | null> = this.initActiveProjectDetails();
+
   /** Writer permission for the current active context — drives CTA visibility across dashboards. */
-  public readonly canWrite: Signal<boolean> = this.initCanWrite();
+  public readonly canWrite: Signal<boolean> = computed(() => this.activeProjectDetails()?.writer === true);
+
+  /**
+   * Formation sub-stage label for the current active context (e.g. `'Engaged'`), or `null`
+   * outside Formation. Single source of truth for the project dashboard's Formation badge and
+   * sidebar card, and the stage-scoped Formation nav item (GH-1955) — do not add a fourth
+   * independent `getProject` fetch for this; read these two signals instead.
+   */
+  public readonly activeProjectFormationSubStage: Signal<string | null> = computed(() => getFormationSubStageLabel(this.activeProjectDetails()?.stage));
+
+  /** True when the current active context is in Draft or any Formation sub-stage. */
+  public readonly isActiveProjectInFormation: Signal<boolean> = computed(() => this.activeProjectFormationSubStage() !== null);
 
   /** Salesforce 18-char ID for the active foundation — resolves PCC deep-link targets. `null` while resolving or unavailable. */
   public readonly selectedFoundationSfid: Signal<string | null> = this.initSelectedFoundationSfid();
@@ -254,21 +268,18 @@ export class ProjectContextService {
     });
   }
 
-  private initCanWrite(): Signal<boolean> {
+  private initActiveProjectDetails(): Signal<Project | null> {
     return toSignal(
       combineLatest([toObservable(this.activeContext), toObservable(this.userService.authenticated)]).pipe(
         switchMap(([ctx, authenticated]) => {
           // Anonymous/public routes have no session — /api/projects/:slug would just 401 (LFXV2-3266).
           if (!ctx?.slug || !authenticated) {
-            return of(false);
+            return of(null);
           }
-          return this.projectService.getProject(ctx.slug, false).pipe(
-            map((project) => project?.writer === true),
-            catchError(() => of(false))
-          );
+          return this.projectService.getProject(ctx.slug, false).pipe(catchError(() => of(null)));
         })
       ),
-      { initialValue: false }
+      { initialValue: null }
     );
   }
 

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -281,7 +281,10 @@ export class ProjectContextService {
             return of(null);
           }
           // getProject already catches its own errors and logs, resolving to null — no outer catchError needed.
-          return this.projectService.getProject(ctx.slug, false);
+          // startWith(null) clears the previous project immediately on switch, so canWrite/Formation
+          // signals don't briefly read the prior project while the new fetch is in flight (matches
+          // initSelectedFoundationSfid's pattern below).
+          return this.projectService.getProject(ctx.slug, false).pipe(startWith(null));
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -281,10 +281,15 @@ export class ProjectContextService {
             return of(null);
           }
           // getProject already catches its own errors and logs, resolving to null — no outer catchError needed.
-          // startWith(null) clears the previous project immediately on switch, so canWrite/Formation
-          // signals don't briefly read the prior project while the new fetch is in flight (matches
-          // initSelectedFoundationSfid's pattern below).
-          return this.projectService.getProject(ctx.slug, false).pipe(startWith(null));
+          //
+          // Deliberately no startWith(null) here, unlike initSelectedFoundationSfid below: canWrite
+          // reads this signal, and evictOnWriteAccessLoss() (vote/survey/mailing-list manage pages)
+          // takes the *first* true→false transition as a genuine access loss and navigates away. A
+          // transient null on every project switch — not just a real loss of access — would evict an
+          // organizer mid-edit. Formation's badge/card briefly showing the previous project's stage
+          // during a switch is an accepted, pre-existing trade-off (this is the same staleness
+          // canWrite itself already had before this ticket).
+          return this.projectService.getProject(ctx.slug, false);
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -9,7 +9,7 @@ import { MARKETING_OPS_FGA_ENABLED_FLAG, SELECTED_FOUNDATION_COOKIE_KEY, SELECTE
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { getFormationSubStageLabel, isBoardScopedPersona, isFormationStage, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { catchError, combineLatest, filter, of, startWith, switchMap } from 'rxjs';
+import { combineLatest, filter, of, startWith, switchMap } from 'rxjs';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
@@ -280,7 +280,8 @@ export class ProjectContextService {
           if (!ctx?.slug || !authenticated) {
             return of(null);
           }
-          return this.projectService.getProject(ctx.slug, false).pipe(catchError(() => of(null)));
+          // getProject already catches its own errors and logs, resolving to null — no outer catchError needed.
+          return this.projectService.getProject(ctx.slug, false);
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -6,14 +6,16 @@ import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@a
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { MARKETING_OPS_FGA_ENABLED_FLAG, SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { ProjectStage } from '@lfx-one/shared/enums';
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { getFormationSubStageLabel, isBoardScopedPersona, isFormationStage, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { combineLatest, filter, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, filter, map, of, startWith, switchMap, tap } from 'rxjs';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
 import { LensService } from './lens.service';
+import { PermissionsService } from './permissions.service';
 import { PersonaService } from './persona.service';
 import { ProjectService } from './project.service';
 import { UserService } from './user.service';
@@ -35,6 +37,7 @@ export class ProjectContextService {
   private readonly featureFlagService = inject(FeatureFlagService);
   private readonly lensService = inject(LensService);
   private readonly location = inject(Location);
+  private readonly permissionsService = inject(PermissionsService);
   private readonly personaService = inject(PersonaService);
   private readonly projectService = inject(ProjectService);
   private readonly router = inject(Router);
@@ -52,6 +55,8 @@ export class ProjectContextService {
 
   private readonly foundationSelection: WritableSignal<ProjectContext | null> = signal<ProjectContext | null>(null);
   private readonly projectSelection: WritableSignal<ProjectContext | null> = signal<ProjectContext | null>(null);
+  private readonly announcementDateLoading: WritableSignal<boolean> = signal(true);
+  private readonly announcementDateHasError: WritableSignal<boolean> = signal(false);
 
   /**
    * The context kind declared by the current route (`route.data.lens`), when it declares one.
@@ -94,13 +99,33 @@ export class ProjectContextService {
   /**
    * Formation sub-stage label for the current active context (e.g. `'Engaged'`), or `null`
    * outside Formation. Single source of truth for the project dashboard's Formation badge and
-   * sidebar card (GH-1955) — do not add a fourth independent `getProject` fetch for this; read
-   * these two signals instead.
+   * sidebar card (GH-1955) — do not add another independent `getProject`/`getProjectSettings`
+   * fetch for Formation-derived state; read this signal and its siblings below
+   * (`isActiveProjectInFormation`, `isActiveProjectConfidential`, `activeProjectAnnouncementDate`)
+   * instead.
    */
   public readonly activeProjectFormationSubStage: Signal<string | null> = computed(() => getFormationSubStageLabel(this.activeProject()?.stage));
 
   /** True when the current active context is in Draft or any Formation sub-stage. */
   public readonly isActiveProjectInFormation: Signal<boolean> = computed(() => isFormationStage(this.activeProject()?.stage));
+
+  /**
+   * True only for the `FormationConfidential` stage — mutually exclusive with the other Formation
+   * sub-stages, never layered on top of one. Read this instead of comparing
+   * `activeProjectFormationSubStage()` against the label string `'Confidential'`, which is a
+   * display label, not a stage identity, and can drift independently of the stage enum.
+   */
+  public readonly isActiveProjectConfidential: Signal<boolean> = computed(() => this.activeProject()?.stage === ProjectStage.FormationConfidential);
+
+  /**
+   * Announcement-date tri-state for the current active context, shared by `FormationCardComponent`
+   * and `ProjectDashboardComponent` (GH-1955) so both ride one `PermissionsService.getProjectSettings`
+   * fetch instead of two independent ones. Read {@link activeProjectAnnouncementDateLoading} /
+   * {@link activeProjectAnnouncementDateHasError} alongside this for the loading/error state.
+   */
+  public readonly activeProjectAnnouncementDate: Signal<string | null> = this.initActiveProjectAnnouncementDate();
+  public readonly activeProjectAnnouncementDateLoading: Signal<boolean> = this.announcementDateLoading.asReadonly();
+  public readonly activeProjectAnnouncementDateHasError: Signal<boolean> = this.announcementDateHasError.asReadonly();
 
   /** Salesforce 18-char ID for the active foundation — resolves PCC deep-link targets. `null` while resolving or unavailable. */
   public readonly selectedFoundationSfid: Signal<string | null> = this.initSelectedFoundationSfid();
@@ -291,6 +316,31 @@ export class ProjectContextService {
           // canWrite itself already had before this ticket).
           return this.projectService.getProject(ctx.slug, false);
         })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initActiveProjectAnnouncementDate(): Signal<string | null> {
+    return toSignal(
+      toObservable(this.activeProject).pipe(
+        filter((project): project is NonNullable<typeof project> => !!project?.uid),
+        tap(() => {
+          this.announcementDateLoading.set(true);
+          this.announcementDateHasError.set(false);
+        }),
+        switchMap((project) =>
+          this.permissionsService.getProjectSettings(project.uid).pipe(
+            map((settings) => settings.announcement_date || null),
+            tap(() => this.announcementDateLoading.set(false)),
+            catchError((error) => {
+              console.error('ProjectContextService: failed to load announcement date', error);
+              this.announcementDateLoading.set(false);
+              this.announcementDateHasError.set(true);
+              return of(null);
+            })
+          )
+        )
       ),
       { initialValue: null }
     );

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -98,10 +98,16 @@ export class ProjectService {
    * resolves them via getProjectById, so callers holding either identifier can use this method.
    * Note the two identifiers cache under separate keys for the same project.
    */
-  public getProject(slugOrUid: string, current: boolean = true, options?: { meetingCoordinator?: boolean }): Observable<Project | null> {
-    const cacheKey = `${slugOrUid}:${current}${options?.meetingCoordinator ? ':mc' : ''}`;
+  public getProject(slugOrUid: string, current: boolean = true, options?: { meetingCoordinator?: boolean; auditor?: boolean }): Observable<Project | null> {
+    const cacheKey = `${slugOrUid}:${current}${options?.meetingCoordinator ? ':mc' : ''}${options?.auditor ? ':aud' : ''}`;
     if (!this.projectCache.has(cacheKey)) {
-      const params = options?.meetingCoordinator ? new HttpParams().set('meeting_coordinator', 'true') : undefined;
+      let params: HttpParams | undefined;
+      if (options?.meetingCoordinator) {
+        params = new HttpParams().set('meeting_coordinator', 'true');
+      }
+      if (options?.auditor) {
+        params = (params ?? new HttpParams()).set('auditor', 'true');
+      }
       const project$ = this.http.get<Project>(`/api/projects/${slugOrUid}`, { params }).pipe(
         // Evict on source error, before catchError/shareReplay: shareReplay keeps its source
         // subscription alive after downstream unsubscribes (refCount: false), so a canceled

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -528,11 +528,13 @@ export class SidebarNavService {
   // card already surface "you are in Formation" on that page; a real destination (a distinct route)
   // is needed before a dedicated nav item can ship — flagged for product/design.
   //
-  // Also GH-1955: EasyCLA, Crowdfunding, and "public stats" have no project-scoped nav surface today
-  // to gate on `isActiveProjectInFormation` — EasyCLA is a personal Me-lens tab (my-clas-enabled.guard.ts),
-  // Crowdfunding is a static Me-lens section (see meLensItems above), and no "public stats" component/route
-  // exists anywhere in the app. Nothing is gated here for those three; flagged in the PR description
-  // for product/design rather than inventing a surface to hide.
+  // Also GH-1955: Insights, EasyCLA, Crowdfunding, and "public stats" have no project-scoped nav
+  // surface today to gate on `isActiveProjectInFormation` — Insights is an external link built by
+  // buildInsightsUrl() and rendered unconditionally in lens-switcher.component.html, EasyCLA is a
+  // personal Me-lens tab (my-clas-enabled.guard.ts), Crowdfunding is a static Me-lens section (see
+  // meLensItems above), and no "public stats" component/route exists anywhere in the app. Nothing is
+  // gated here for any of the four; flagged in the PR description for product/design rather than
+  // inventing a surface to hide.
   private readonly projectLensItems: SidebarMenuItem[] = [
     {
       label: 'Dashboard',

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -7,6 +7,7 @@ import {
   AKRITES_ENABLED_FLAG,
   COMMITTEE_LABEL,
   DOCUMENT_LABEL,
+  FORMATION_ENABLED_FLAG,
   MAILING_LIST_LABEL,
   MARKETING_OPS_FGA_ENABLED_FLAG,
   MENTORSHIP_ENABLED_FLAG,
@@ -62,6 +63,8 @@ export class SidebarNavService {
   private readonly isOrgLensClaM3Enabled = this.featureFlagService.getBooleanFlag(ORG_LENS_CLA_M3_ENABLED_FLAG, false);
   /** Dual-gated with `ServerFeatureFlag.MarketingOpsFga` — unlocks Marketing nav for marketing_auditor/campaign_manager grants (LFXV2-2235/LFXV2-2236). */
   private readonly isMarketingOpsFgaEnabled = this.featureFlagService.getBooleanFlag(MARKETING_OPS_FGA_ENABLED_FLAG, false);
+  /** GH-1955 — see `FORMATION_ENABLED_FLAG`'s doc comment for what this does and doesn't gate. */
+  private readonly isFormationEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
 
   /**
    * True when the user has non-marketing foundation access (board role, root-writer, LF-staff, or
@@ -521,33 +524,54 @@ export class SidebarNavService {
   });
 
   // --- Project Lens Items (base) ---
-  private readonly projectLensItems: SidebarMenuItem[] = [
-    {
-      label: 'Dashboard',
-      icon: 'fa-light fa-grid-2',
-      routerLink: '/project/overview',
-    },
-    {
-      label: 'Meetings',
-      icon: 'fa-light fa-calendar',
-      routerLink: '/project/meetings',
-    },
-    {
-      label: MAILING_LIST_LABEL.plural,
-      icon: 'fa-light fa-envelope',
-      routerLink: '/project/mailing-lists',
-    },
-    {
-      label: COMMITTEE_LABEL.plural,
-      icon: 'fa-light fa-users-rectangle',
-      routerLink: '/project/groups',
-    },
-    {
-      label: DOCUMENT_LABEL.plural,
-      icon: 'fa-light fa-folder-open',
-      routerLink: '/project/documents',
-    },
-  ];
+  // GH-1955: EasyCLA, Crowdfunding, and "public stats" have no project-scoped nav surface today
+  // to gate on `isActiveProjectInFormation` — EasyCLA is a personal Me-lens tab (my-clas-enabled.guard.ts),
+  // Crowdfunding is a static Me-lens section (see meLensItems above), and no "public stats" component/route
+  // exists anywhere in the app. Nothing is gated here for those three; flagged in the PR description
+  // for product/design rather than inventing a surface to hide.
+  private readonly projectLensItems = computed((): SidebarMenuItem[] => {
+    const items: SidebarMenuItem[] = [
+      {
+        label: 'Dashboard',
+        icon: 'fa-light fa-grid-2',
+        routerLink: '/project/overview',
+      },
+    ];
+
+    if (this.isFormationEnabled() && this.projectContextService.isActiveProjectInFormation()) {
+      items.push({
+        label: 'Formation',
+        icon: 'fa-light fa-flag',
+        routerLink: '/project/overview',
+        testId: 'sidebar-project-formation',
+      });
+    }
+
+    items.push(
+      {
+        label: 'Meetings',
+        icon: 'fa-light fa-calendar',
+        routerLink: '/project/meetings',
+      },
+      {
+        label: MAILING_LIST_LABEL.plural,
+        icon: 'fa-light fa-envelope',
+        routerLink: '/project/mailing-lists',
+      },
+      {
+        label: COMMITTEE_LABEL.plural,
+        icon: 'fa-light fa-users-rectangle',
+        routerLink: '/project/groups',
+      },
+      {
+        label: DOCUMENT_LABEL.plural,
+        icon: 'fa-light fa-folder-open',
+        routerLink: '/project/documents',
+      }
+    );
+
+    return items;
+  });
 
   // --- Project / Foundation — Mktg OS agents (dark-launched; inserted directly under Documents) ---
   private readonly mktgOsAgentsNavItem: SidebarMenuItem = {

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -7,7 +7,6 @@ import {
   AKRITES_ENABLED_FLAG,
   COMMITTEE_LABEL,
   DOCUMENT_LABEL,
-  FORMATION_ENABLED_FLAG,
   MAILING_LIST_LABEL,
   MARKETING_OPS_FGA_ENABLED_FLAG,
   MENTORSHIP_ENABLED_FLAG,
@@ -63,8 +62,6 @@ export class SidebarNavService {
   private readonly isOrgLensClaM3Enabled = this.featureFlagService.getBooleanFlag(ORG_LENS_CLA_M3_ENABLED_FLAG, false);
   /** Dual-gated with `ServerFeatureFlag.MarketingOpsFga` — unlocks Marketing nav for marketing_auditor/campaign_manager grants (LFXV2-2235/LFXV2-2236). */
   private readonly isMarketingOpsFgaEnabled = this.featureFlagService.getBooleanFlag(MARKETING_OPS_FGA_ENABLED_FLAG, false);
-  /** GH-1955 — see `FORMATION_ENABLED_FLAG`'s doc comment for what this does and doesn't gate. */
-  private readonly isFormationEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
 
   /**
    * True when the user has non-marketing foundation access (board role, root-writer, LF-staff, or
@@ -524,54 +521,45 @@ export class SidebarNavService {
   });
 
   // --- Project Lens Items (base) ---
-  // GH-1955: EasyCLA, Crowdfunding, and "public stats" have no project-scoped nav surface today
+  // GH-1955: a separate "Formation" nav item was tried here and removed on review — pointing it at
+  // the same '/project/overview' route as Dashboard means both entries render highlighted-active
+  // simultaneously (sidebar.component.html's routerLinkActive ignores fragment and queryParams, so
+  // neither can disambiguate two entries sharing one path). The Formation badge/subtitle and sidebar
+  // card already surface "you are in Formation" on that page; a real destination (a distinct route)
+  // is needed before a dedicated nav item can ship — flagged for product/design.
+  //
+  // Also GH-1955: EasyCLA, Crowdfunding, and "public stats" have no project-scoped nav surface today
   // to gate on `isActiveProjectInFormation` — EasyCLA is a personal Me-lens tab (my-clas-enabled.guard.ts),
   // Crowdfunding is a static Me-lens section (see meLensItems above), and no "public stats" component/route
   // exists anywhere in the app. Nothing is gated here for those three; flagged in the PR description
   // for product/design rather than inventing a surface to hide.
-  private readonly projectLensItems = computed((): SidebarMenuItem[] => {
-    const items: SidebarMenuItem[] = [
-      {
-        label: 'Dashboard',
-        icon: 'fa-light fa-grid-2',
-        routerLink: '/project/overview',
-      },
-    ];
-
-    if (this.isFormationEnabled() && this.projectContextService.isActiveProjectInFormation()) {
-      items.push({
-        label: 'Formation',
-        icon: 'fa-light fa-flag',
-        routerLink: '/project/overview',
-        testId: 'sidebar-project-formation',
-      });
-    }
-
-    items.push(
-      {
-        label: 'Meetings',
-        icon: 'fa-light fa-calendar',
-        routerLink: '/project/meetings',
-      },
-      {
-        label: MAILING_LIST_LABEL.plural,
-        icon: 'fa-light fa-envelope',
-        routerLink: '/project/mailing-lists',
-      },
-      {
-        label: COMMITTEE_LABEL.plural,
-        icon: 'fa-light fa-users-rectangle',
-        routerLink: '/project/groups',
-      },
-      {
-        label: DOCUMENT_LABEL.plural,
-        icon: 'fa-light fa-folder-open',
-        routerLink: '/project/documents',
-      }
-    );
-
-    return items;
-  });
+  private readonly projectLensItems: SidebarMenuItem[] = [
+    {
+      label: 'Dashboard',
+      icon: 'fa-light fa-grid-2',
+      routerLink: '/project/overview',
+    },
+    {
+      label: 'Meetings',
+      icon: 'fa-light fa-calendar',
+      routerLink: '/project/meetings',
+    },
+    {
+      label: MAILING_LIST_LABEL.plural,
+      icon: 'fa-light fa-envelope',
+      routerLink: '/project/mailing-lists',
+    },
+    {
+      label: COMMITTEE_LABEL.plural,
+      icon: 'fa-light fa-users-rectangle',
+      routerLink: '/project/groups',
+    },
+    {
+      label: DOCUMENT_LABEL.plural,
+      icon: 'fa-light fa-folder-open',
+      routerLink: '/project/documents',
+    },
+  ];
 
   // --- Project / Foundation — Mktg OS agents (dark-launched; inserted directly under Documents) ---
   private readonly mktgOsAgentsNavItem: SidebarMenuItem = {

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -24,6 +24,7 @@ const { computeIsFoundationMock, generateM2MTokenMock, isUuidMock, meetingSvc, p
   projectSvc: {
     getProjectIdBySlug: vi.fn(),
     getProjectById: vi.fn(),
+    getProjectBySlug: vi.fn(),
     getProjectSlugs: vi.fn(),
   },
 }));
@@ -307,6 +308,64 @@ describe('ProjectController.getProjectSlugs', () => {
     const next = vi.fn();
 
     await controller.getProjectSlugs(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProjectController.getProjectBySlug', () => {
+  let controller: ProjectController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new ProjectController();
+  });
+
+  function buildSlugReqRes(slug: string, query: Record<string, string> = {}) {
+    const req = { params: { slug }, query, headers: {}, bearerToken: undefined, method: 'GET' } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+    return { req, res, next };
+  }
+
+  it('fetches by id, forwards the meeting_coordinator/auditor query flags, and logs success', async () => {
+    isUuidMock.mockReturnValue(true);
+    const project = buildProject();
+    projectSvc.getProjectById.mockResolvedValue(project);
+    const { req, res, next } = buildSlugReqRes(PROJECT_UID, { meeting_coordinator: 'true', auditor: 'true' });
+
+    await controller.getProjectBySlug(req, res, next);
+
+    expect(projectSvc.getProjectById).toHaveBeenCalledWith(req, PROJECT_UID, true, true, true);
+    expect(projectSvc.getProjectBySlug).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(project);
+    expect(logger.success).toHaveBeenCalledWith(req, 'get_project_by_slug', 0, { slug: PROJECT_UID, project_uid: project.uid });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('fetches by slug when not a uuid, defaulting the flags to false when the query params are absent', async () => {
+    isUuidMock.mockReturnValue(false);
+    const project = buildProject();
+    projectSvc.getProjectBySlug.mockResolvedValue(project);
+    const { req, res, next } = buildSlugReqRes(SLUG);
+
+    await controller.getProjectBySlug(req, res, next);
+
+    expect(projectSvc.getProjectBySlug).toHaveBeenCalledWith(req, SLUG, false, false);
+    expect(projectSvc.getProjectById).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(project);
+    expect(logger.success).toHaveBeenCalledWith(req, 'get_project_by_slug', 0, { slug: SLUG, project_uid: project.uid });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('forwards errors to next() without calling res.json', async () => {
+    isUuidMock.mockReturnValue(false);
+    const boom = new Error('upstream-down');
+    projectSvc.getProjectBySlug.mockRejectedValue(boom);
+    const { req, res, next } = buildSlugReqRes(SLUG);
+
+    await controller.getProjectBySlug(req, res, next);
 
     expect(next).toHaveBeenCalledWith(boom);
     expect(res.json).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -161,11 +161,12 @@ export class ProjectController {
       }
 
       const includeMeetingCoordinator = req.query['meeting_coordinator'] === 'true';
+      const includeAuditor = req.query['auditor'] === 'true';
 
       // Check if slug is a uuid
       if (isUuid(slug)) {
         // If the slug is a uuid, get the project by id
-        const project = await this.projectService.getProjectById(req, slug, true, includeMeetingCoordinator);
+        const project = await this.projectService.getProjectById(req, slug, true, includeMeetingCoordinator, includeAuditor);
         res.json(project);
         return;
       }

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -167,12 +167,18 @@ export class ProjectController {
       if (isUuid(slug)) {
         // If the slug is a uuid, get the project by id
         const project = await this.projectService.getProjectById(req, slug, true, includeMeetingCoordinator, includeAuditor);
+
+        logger.success(req, 'get_project_by_slug', startTime, {
+          slug,
+          project_uid: project.uid,
+        });
+
         res.json(project);
         return;
       }
 
       // If the slug is not a uuid, get the project by slug
-      const project = await this.projectService.getProjectBySlug(req, slug, includeMeetingCoordinator);
+      const project = await this.projectService.getProjectBySlug(req, slug, includeMeetingCoordinator, includeAuditor);
 
       // Log the success
       logger.success(req, 'get_project_by_slug', startTime, {

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -163,24 +163,11 @@ export class ProjectController {
       const includeMeetingCoordinator = req.query['meeting_coordinator'] === 'true';
       const includeAuditor = req.query['auditor'] === 'true';
 
-      // Check if slug is a uuid
-      if (isUuid(slug)) {
-        // If the slug is a uuid, get the project by id
-        const project = await this.projectService.getProjectById(req, slug, true, includeMeetingCoordinator, includeAuditor);
+      // A uuid slug fetches by id; otherwise resolve by slug
+      const project = isUuid(slug)
+        ? await this.projectService.getProjectById(req, slug, true, includeMeetingCoordinator, includeAuditor)
+        : await this.projectService.getProjectBySlug(req, slug, includeMeetingCoordinator, includeAuditor);
 
-        logger.success(req, 'get_project_by_slug', startTime, {
-          slug,
-          project_uid: project.uid,
-        });
-
-        res.json(project);
-        return;
-      }
-
-      // If the slug is not a uuid, get the project by slug
-      const project = await this.projectService.getProjectBySlug(req, slug, includeMeetingCoordinator, includeAuditor);
-
-      // Log the success
       logger.success(req, 'get_project_by_slug', startTime, {
         slug,
         project_uid: project.uid,

--- a/apps/lfx-one/src/server/services/navigation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.spec.ts
@@ -1,0 +1,118 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { LensItemsQuery, Project, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors project.service.spec.ts / org-navigation.service.spec.ts: the `@lfx-one/shared/*`
+// alias isn't wired into this app's vitest config, so every runtime (non-type-only) import
+// needs a stub.
+const { proxyRequest } = vi.hoisted(() => ({ proxyRequest: vi.fn() }));
+
+vi.mock('@lfx-one/shared/enums', () => ({
+  // Real enum, not a stub: PROJECT_LENS_ALLOWED_STAGES and getFormationSubStageLabel both
+  // compare against actual string values.
+  ProjectStage: {
+    FormationExploratory: 'Formation - Exploratory',
+    FormationEngaged: 'Formation - Engaged',
+    FormationOnHold: 'Formation - On Hold',
+    FormationDisengaged: 'Formation - Disengaged',
+    FormationConfidential: 'Formation - Confidential',
+    Active: 'Active',
+    Archived: 'Archived',
+    Prospect: 'Prospect',
+  },
+  ProjectFunding: { Funded: 'Funded' },
+}));
+// computeIsFoundation and getFormationSubStageLabel are pulled from the REAL implementation
+// (not hand-copied), so stage-classification drift fails these tests too — see
+// packages/shared/src/utils/project.utils.spec.ts for the exhaustive per-stage coverage.
+// Deep-imports the single pure file rather than `vi.importActual('@lfx-one/shared/utils')`:
+// the barrel re-exports Angular-dependent utils that throw at module-load time under this
+// plain-Node Vitest environment.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/project.utils')>(
+    '../../../../../packages/shared/src/utils/project.utils'
+  );
+  return {
+    computeIsFoundation: actual.computeIsFoundation,
+    getFormationSubStageLabel: actual.getFormationSubStageLabel,
+  };
+});
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
+vi.mock('./logger.service', () => ({
+  logger: { debug: vi.fn(), warning: vi.fn(), error: vi.fn(), startOperation: vi.fn(), success: vi.fn() },
+}));
+
+const { NavigationService } = await import('./navigation.service');
+
+const req = {} as Request;
+
+function pageOf(projects: Partial<Project>[]): QueryServiceResponse<Project> {
+  return { resources: projects.map((p) => ({ type: 'project', id: `project:${p.uid}`, data: p as Project })), page_token: undefined };
+}
+
+/** The query object sent to the query-service `/query/resources` call. */
+function lastQuerySent(): LensItemsQuery {
+  return proxyRequest.mock.calls[proxyRequest.mock.calls.length - 1][4];
+}
+
+beforeEach(() => {
+  proxyRequest.mockReset();
+});
+
+describe('NavigationService — toLensItem formationSubStage', () => {
+  it.each([
+    ['Formation - Exploratory', 'Exploratory'],
+    ['Formation - Engaged', 'Engaged'],
+    ['Formation - On Hold', 'On Hold'],
+    ['Formation - Disengaged', 'Disengaged'],
+    ['Formation - Confidential', 'Confidential'],
+    ['Active', null],
+    ['Archived', null],
+    ['Prospect', null],
+  ])('maps stage %s to formationSubStage %s', async (stage, expected) => {
+    proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'p1', slug: 'p1', name: 'Project 1', stage: stage as Project['stage'], logo_url: '' }]));
+
+    const response = await new NavigationService().getLensItems(req, { lens: 'project' });
+
+    expect(response.items[0].formationSubStage).toBe(expected);
+  });
+});
+
+describe('NavigationService — PROJECT_LENS_ALLOWED_STAGES', () => {
+  it('includes Active plus every pre-launch Formation stage except Confidential', async () => {
+    proxyRequest.mockResolvedValueOnce(pageOf([]));
+
+    await new NavigationService().getLensItems(req, { lens: 'project' });
+
+    expect(lastQuerySent().filters_or).toEqual(
+      expect.arrayContaining([
+        'stage:Active',
+        'stage:Formation - Engaged',
+        'stage:Formation - Exploratory',
+        'stage:Formation - On Hold',
+        'stage:Formation - Disengaged',
+      ])
+    );
+    expect(lastQuerySent().filters_or).not.toContain('stage:Formation - Confidential');
+  });
+
+  it('excludes a Confidential-stage selection from fetchSelectedItem re-injection', async () => {
+    // First page: normal query returns nothing.
+    proxyRequest.mockResolvedValueOnce(pageOf([]));
+    // Second call: fetchSelectedItem's uid-scoped lookup returns the Confidential project.
+    proxyRequest.mockResolvedValueOnce(
+      pageOf([{ uid: 'confidential-1', slug: 'confidential-1', name: 'Secret', stage: 'Formation - Confidential' as Project['stage'] }])
+    );
+
+    const response = await new NavigationService().getLensItems(req, { lens: 'project', selectedUid: 'confidential-1' });
+
+    expect(response.items).toHaveLength(0);
+  });
+});

--- a/apps/lfx-one/src/server/services/navigation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.spec.ts
@@ -5,26 +5,13 @@ import type { LensItemsQuery, Project, QueryServiceResponse } from '@lfx-one/sha
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mirrors project.service.spec.ts / org-navigation.service.spec.ts: the `@lfx-one/shared/*`
-// alias isn't wired into this app's vitest config, so every runtime (non-type-only) import
-// needs a stub.
 const { proxyRequest } = vi.hoisted(() => ({ proxyRequest: vi.fn() }));
 
-vi.mock('@lfx-one/shared/enums', () => ({
-  // Real enum, not a stub: PROJECT_LENS_ALLOWED_STAGES and getFormationSubStageLabel both
-  // compare against actual string values.
-  ProjectStage: {
-    FormationExploratory: 'Formation - Exploratory',
-    FormationEngaged: 'Formation - Engaged',
-    FormationOnHold: 'Formation - On Hold',
-    FormationDisengaged: 'Formation - Disengaged',
-    FormationConfidential: 'Formation - Confidential',
-    Active: 'Active',
-    Archived: 'Archived',
-    Prospect: 'Prospect',
-  },
-  ProjectFunding: { Funded: 'Funded' },
-}));
+// `@lfx-one/shared/enums` needs no stub: it resolves through the real barrel via the
+// `@lfx-one/shared` alias in vitest.config.ts (no Angular-dependent code lives under enums/), so
+// PROJECT_LENS_ALLOWED_STAGES and getFormationSubStageLabel compare against the real ProjectStage.
+// `@lfx-one/shared/utils` still needs the stub below — that barrel re-exports Angular-dependent
+// utils that throw at module-load time under this plain-Node Vitest environment.
 // computeIsFoundation and getFormationSubStageLabel are pulled from the REAL implementation
 // (not hand-copied), so stage-classification drift fails these tests too — see
 // packages/shared/src/utils/project.utils.spec.ts for the exhaustive per-stage coverage.
@@ -103,8 +90,8 @@ describe('NavigationService — PROJECT_LENS_ALLOWED_STAGES', () => {
     expect(lastQuerySent().filters_or).not.toContain('stage:Formation - Confidential');
   });
 
-  it('excludes a Confidential-stage selection from fetchSelectedItem re-injection', async () => {
-    // First page: normal query returns nothing.
+  it('re-injects a Confidential-stage selection via fetchSelectedItem despite being hidden from the general listing', async () => {
+    // First page: normal query returns nothing — Confidential is excluded from the listing filter.
     proxyRequest.mockResolvedValueOnce(pageOf([]));
     // Second call: fetchSelectedItem's uid-scoped lookup returns the Confidential project.
     proxyRequest.mockResolvedValueOnce(
@@ -113,6 +100,7 @@ describe('NavigationService — PROJECT_LENS_ALLOWED_STAGES', () => {
 
     const response = await new NavigationService().getLensItems(req, { lens: 'project', selectedUid: 'confidential-1' });
 
-    expect(response.items).toHaveLength(0);
+    expect(response.items).toHaveLength(1);
+    expect(response.items[0].uid).toBe('confidential-1');
   });
 });

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -14,6 +14,15 @@ import { MicroserviceProxyService } from './microservice-proxy.service';
  * `FormationConfidential` is intentionally excluded (GH-1955): the name implies pre-announcement
  * secrecy, so a Confidential project should not be listed by name in the shared project picker.
  * Its own dashboard page still renders normally for anyone already authorized to view it.
+ *
+ * `FormationOnHold`/`FormationDisengaged` are an accepted rollout trade-off: this set is server-side
+ * and un-flagged (unlike `FORMATION_ENABLED_FLAG`, which only gates client-rendered UI), so these two
+ * stages become picker-visible for every user immediately, before any Formation-specific labeling
+ * ships to a given user. This doesn't widen data access — the picker is a UX convenience list over
+ * projects the caller can already reach by direct link, not an authorization boundary — but it does
+ * mean an On Hold/Disengaged project can appear in the picker unlabeled ahead of the flagged UI. A
+ * server-side kill switch (mirroring `ServerFeatureFlag.WeeklyBriefSlack`) would close that gap but
+ * is out of this ticket's scope.
  */
 const PROJECT_LENS_ALLOWED_STAGES = new Set<string>([
   ProjectStage.Active,

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -3,14 +3,25 @@
 
 import { ProjectFunding, ProjectStage } from '@lfx-one/shared/enums';
 import { GetLensItemsParams, LensItem, LensItemsQuery, LensItemsResponse, NavLens, Project, QueryServiceResponse } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation } from '@lfx-one/shared/utils';
+import { computeIsFoundation, getFormationSubStageLabel } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
-/** Stages eligible for the project lens — Active plus supported pre-launch formation stages. */
-const PROJECT_LENS_ALLOWED_STAGES = new Set<string>([ProjectStage.Active, ProjectStage.FormationEngaged, ProjectStage.FormationExploratory]);
+/**
+ * Stages eligible for the project lens — Active plus supported pre-launch formation stages.
+ * `FormationConfidential` is intentionally excluded (GH-1955): the name implies pre-announcement
+ * secrecy, so a Confidential project should not be listed by name in the shared project picker.
+ * Its own dashboard page still renders normally for anyone already authorized to view it.
+ */
+const PROJECT_LENS_ALLOWED_STAGES = new Set<string>([
+  ProjectStage.Active,
+  ProjectStage.FormationEngaged,
+  ProjectStage.FormationExploratory,
+  ProjectStage.FormationOnHold,
+  ProjectStage.FormationDisengaged,
+]);
 
 /** Powers the foundation/project lens dropdown. Access is gated entirely by the user's bearer token via the query service. */
 export class NavigationService {
@@ -142,6 +153,7 @@ export class NavigationService {
       name: project.name,
       logoUrl: project.logo_url || null,
       isFoundation: computeIsFoundation(project),
+      formationSubStage: getFormationSubStageLabel(project.stage),
     };
   }
 }

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -10,10 +10,17 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
 /**
- * Stages eligible for the project lens — Active plus supported pre-launch formation stages.
- * `FormationConfidential` is intentionally excluded (GH-1955): the name implies pre-announcement
- * secrecy, so a Confidential project should not be listed by name in the shared project picker.
- * Its own dashboard page still renders normally for anyone already authorized to view it.
+ * Stages eligible for the project lens **listing** — Active plus supported pre-launch formation
+ * stages. `FormationConfidential` is intentionally excluded from this listing set (GH-1955): the
+ * name implies pre-announcement secrecy, so a Confidential project should not be listed by name
+ * in the shared project picker's general (unfiltered) results.
+ *
+ * This set gates `buildQuery`'s listing/search results only. `fetchSelectedItem` — which exists
+ * to preserve an *already-selected* item that didn't come back on the first listing page, e.g. a
+ * deep link — deliberately also admits `FormationConfidential` alongside this set: a Confidential
+ * project must not be evicted from an explicit prior selection just because it's hidden from the
+ * general listing. Its own dashboard page renders normally for anyone already authorized to view
+ * it, so the selection must survive too.
  *
  * `FormationOnHold`/`FormationDisengaged` are an accepted rollout trade-off: this set is server-side
  * and un-flagged (unlike `FORMATION_ENABLED_FLAG`, which only gates client-rendered UI), so these two
@@ -108,11 +115,12 @@ export class NavigationService {
       });
       const project = response?.resources?.[0]?.data;
       if (!project) return null;
-      // Mirror the main-pipeline contract so an archived selection doesn't get re-injected.
+      // Mirror the main-pipeline contract so an archived selection doesn't get re-injected —
+      // except FormationConfidential, which the listing hides but a prior selection must survive.
       if (lens === 'foundation') {
         if (!computeIsFoundation(project)) return null;
       } else {
-        if (!PROJECT_LENS_ALLOWED_STAGES.has(project.stage)) return null;
+        if (!PROJECT_LENS_ALLOWED_STAGES.has(project.stage) && project.stage !== ProjectStage.FormationConfidential) return null;
       }
       return this.toLensItem(project);
     } catch (error) {

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -9,10 +9,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // vitest config, so every runtime (non-type-only) import needs a stub. `ProjectService`'s
 // constructor also builds `NatsService`/`SnowflakeService`/`ETagService`; the Snowflake-backed
 // suites below use only the `execute` mock, while the others stay trivial.
-const { proxyRequest, addAccessToResources, checkAccess, execute, warning } = vi.hoisted(() => ({
+const { proxyRequest, addAccessToResources, addAccessToResource, checkAccess, checkSingleAccessStrict, execute, warning } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   addAccessToResources: vi.fn(),
+  addAccessToResource: vi.fn(),
   checkAccess: vi.fn(),
+  checkSingleAccessStrict: vi.fn(),
   execute: vi.fn(),
   warning: vi.fn(),
 }));
@@ -106,7 +108,9 @@ vi.mock('./microservice-proxy.service', () => ({
 vi.mock('./access-check.service', () => ({
   AccessCheckService: class {
     public addAccessToResources = addAccessToResources;
+    public addAccessToResource = addAccessToResource;
     public checkAccess = checkAccess;
+    public checkSingleAccessStrict = checkSingleAccessStrict;
   },
 }));
 vi.mock('./nats.service', () => ({ NatsService: class {} }));
@@ -1599,6 +1603,52 @@ describe('ProjectService — getProjectsByIds', () => {
       batch_size: 2,
       error: 'query failed',
     });
+  });
+});
+
+describe('ProjectService — getProjectById / getProjectBySlug (GH-1955 auditor/meeting_coordinator gating)', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    addAccessToResource.mockReset();
+    checkSingleAccessStrict.mockReset();
+    warning.mockReset();
+    service = new ProjectService();
+  });
+
+  it('does not run the meeting_coordinator/auditor checks and returns neither field for a writer', async () => {
+    proxyRequest.mockResolvedValueOnce({ uid: 'p1', slug: 'p1' });
+    addAccessToResource.mockResolvedValueOnce({ uid: 'p1', slug: 'p1', writer: true });
+
+    const result = await service.getProjectById(req, 'p1', true, true, true);
+
+    expect(checkSingleAccessStrict).not.toHaveBeenCalled();
+    expect(result.meetingCoordinator).toBeUndefined();
+    expect(result.auditor).toBeUndefined();
+  });
+
+  it('leaves auditor undefined and warns when the strict FGA check rejects, rather than reporting false', async () => {
+    proxyRequest.mockResolvedValueOnce({ uid: 'p1', slug: 'p1' });
+    addAccessToResource.mockResolvedValueOnce({ uid: 'p1', slug: 'p1', writer: false });
+    checkSingleAccessStrict.mockRejectedValueOnce(new Error('fga unavailable'));
+
+    const result = await service.getProjectById(req, 'p1', true, false, true);
+
+    expect(result.auditor).toBeUndefined();
+    expect(warning).toHaveBeenCalledWith(req, 'get_project_by_id', 'auditor check failed, skipping field', {
+      project_uid: 'p1',
+      err: expect.any(Error),
+    });
+  });
+
+  it('forwards includeAuditor from getProjectBySlug through to getProjectById', async () => {
+    const spy = vi.spyOn(service, 'getProjectById').mockResolvedValueOnce({ uid: 'p1', slug: 'p1' } as Project);
+    vi.spyOn(service, 'getProjectIdBySlug').mockResolvedValueOnce({ exists: true, uid: 'p1', slug: 'p1' });
+
+    await service.getProjectBySlug(req, 'p1', false, true);
+
+    expect(spy).toHaveBeenCalledWith(req, 'p1', true, false, true);
   });
 });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -332,7 +332,13 @@ export class ProjectService {
   /**
    * Fetches a single project by ID
    */
-  public async getProjectById(req: Request, uid: string, access: boolean = true, includeMeetingCoordinator: boolean = false): Promise<Project> {
+  public async getProjectById(
+    req: Request,
+    uid: string,
+    access: boolean = true,
+    includeMeetingCoordinator: boolean = false,
+    includeAuditor: boolean = false
+  ): Promise<Project> {
     const project = await this.microserviceProxy.proxyRequest<Project>(req, 'LFX_V2_SERVICE', `/projects/${uid}`, 'GET');
 
     if (!project) {
@@ -345,32 +351,46 @@ export class ProjectService {
 
     if (access) {
       const writerProject = await this.accessCheckService.addAccessToResource(req, project, 'project');
-      // Skip meeting_coordinator check when already a writer — the guard allows writer OR
-      // meeting_coordinator, so the extra round trip can't change the outcome.
+      // Skip meeting_coordinator/auditor checks when already a writer — writer is a superset of
+      // both, so the extra round trips can't change the outcome.
       // Return the field as undefined (omitted) rather than false — false would be a
       // false-negative assertion since the role was never actually checked for writers.
       if (writerProject.writer) {
         return writerProject;
       }
+      let result = writerProject;
       // Only run the meeting_coordinator FGA check when the caller explicitly requests it.
       // This field is consumed by exactly one branch of writer.guard.ts; running it on every
       // GET /api/projects/:slug call would add a second sequential access-check round-trip
       // for all non-writer callers (guards, components, etc.) that never read the field.
-      if (!includeMeetingCoordinator) {
-        return writerProject;
+      if (includeMeetingCoordinator) {
+        const isMeetingCoordinator = await this.accessCheckService
+          .checkSingleAccess(req, { resource: 'project', id: project.uid, access: 'meeting_coordinator' })
+          .catch((error) => {
+            logger.warning(req, 'get_project_by_id', 'meeting coordinator check failed, skipping field', {
+              project_uid: project.uid,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            // Return undefined rather than false — false implies the check ran clean and found no
+            // role; undefined preserves the "unknown" semantics documented on Project.meetingCoordinator.
+            return undefined;
+          });
+        result = { ...result, meetingCoordinator: isMeetingCoordinator };
       }
-      const isMeetingCoordinator = await this.accessCheckService
-        .checkSingleAccess(req, { resource: 'project', id: project.uid, access: 'meeting_coordinator' })
-        .catch((error) => {
-          logger.warning(req, 'get_project_by_id', 'meeting coordinator check failed, skipping field', {
+      // Only run the auditor FGA check when the caller explicitly requests it (FormationCardComponent's
+      // staff deep-link guard) — same rationale as meeting_coordinator above.
+      if (includeAuditor) {
+        const isAuditor = await this.accessCheckService.checkSingleAccess(req, { resource: 'project', id: project.uid, access: 'auditor' }).catch((error) => {
+          logger.warning(req, 'get_project_by_id', 'auditor check failed, skipping field', {
             project_uid: project.uid,
             error: error instanceof Error ? error.message : String(error),
           });
-          // Return undefined rather than false — false implies the check ran clean and found no
-          // role; undefined preserves the "unknown" semantics documented on Project.meetingCoordinator.
+          // Return undefined rather than false — see meeting_coordinator comment above.
           return undefined;
         });
-      return { ...writerProject, meetingCoordinator: isMeetingCoordinator };
+        result = { ...result, auditor: isAuditor };
+      }
+      return result;
     }
 
     return project;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -351,10 +351,14 @@ export class ProjectService {
 
     if (access) {
       const writerProject = await this.accessCheckService.addAccessToResource(req, project, 'project');
-      // Skip meeting_coordinator/auditor checks when already a writer: per model.fga, `auditor:
-      // … or writer or …` — writer already implies auditor, and writer is the sole grant path
-      // meeting_coordinator's guard also accepts — so neither extra round trip can change the
-      // outcome.
+      // Skip the meeting_coordinator/auditor checks when already a writer. Per model.fga,
+      // `auditor: … or writer or …` — writer already implies auditor, so that round trip can't
+      // change the outcome. `meeting_coordinator: [user]` is a direct-only grant — writer does NOT
+      // imply it at the FGA level — but every consumer of this field (e.g. writer.guard.ts) already
+      // treats `writer === true` as sufficient on its own before ever reading meetingCoordinator,
+      // and upstream `meetings_creator: writer or meeting_coordinator` makes the same true one level
+      // up. So the round trip could return a different raw value for a writer, but never a
+      // different access outcome — skipping it is safe for that reason alone.
       // Return the field as undefined (omitted) rather than false — false would be a
       // false-negative assertion since the role was never actually checked for writers.
       if (writerProject.writer) {
@@ -375,7 +379,7 @@ export class ProjectService {
           .catch((error) => {
             logger.warning(req, 'get_project_by_id', 'meeting coordinator check failed, skipping field', {
               project_uid: project.uid,
-              error: error instanceof Error ? error.message : String(error),
+              err: error,
             });
             // Return undefined rather than false — false implies the check ran clean and found no
             // role; undefined preserves the "unknown" semantics documented on Project.meetingCoordinator.
@@ -384,14 +388,14 @@ export class ProjectService {
         result = { ...result, meetingCoordinator: isMeetingCoordinator };
       }
       // Only run the auditor FGA check when the caller explicitly requests it (FormationCardComponent's
-      // staff deep-link guard) — same rationale, and the same Strict variant, as meeting_coordinator above.
+      // admin-link guard) — same rationale, and the same Strict variant, as meeting_coordinator above.
       if (includeAuditor) {
         const isAuditor = await this.accessCheckService
           .checkSingleAccessStrict(req, { resource: 'project', id: project.uid, access: 'auditor' })
           .catch((error) => {
             logger.warning(req, 'get_project_by_id', 'auditor check failed, skipping field', {
               project_uid: project.uid,
-              error: error instanceof Error ? error.message : String(error),
+              err: error,
             });
             // Return undefined rather than false — see meeting_coordinator comment above.
             return undefined;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -351,8 +351,10 @@ export class ProjectService {
 
     if (access) {
       const writerProject = await this.accessCheckService.addAccessToResource(req, project, 'project');
-      // Skip meeting_coordinator/auditor checks when already a writer — writer is a superset of
-      // both, so the extra round trips can't change the outcome.
+      // Skip meeting_coordinator/auditor checks when already a writer: per model.fga, `auditor:
+      // … or writer or …` — writer already implies auditor, and writer is the sole grant path
+      // meeting_coordinator's guard also accepts — so neither extra round trip can change the
+      // outcome.
       // Return the field as undefined (omitted) rather than false — false would be a
       // false-negative assertion since the role was never actually checked for writers.
       if (writerProject.writer) {
@@ -363,9 +365,13 @@ export class ProjectService {
       // This field is consumed by exactly one branch of writer.guard.ts; running it on every
       // GET /api/projects/:slug call would add a second sequential access-check round-trip
       // for all non-writer callers (guards, components, etc.) that never read the field.
+      // Uses the Strict variant, which propagates upstream failures instead of degrading to
+      // `false` — checkSingleAccess's fallback would otherwise report a transient outage as a
+      // definitive "not a meeting coordinator", which the field's documented undefined-on-failure
+      // semantics promise not to do.
       if (includeMeetingCoordinator) {
         const isMeetingCoordinator = await this.accessCheckService
-          .checkSingleAccess(req, { resource: 'project', id: project.uid, access: 'meeting_coordinator' })
+          .checkSingleAccessStrict(req, { resource: 'project', id: project.uid, access: 'meeting_coordinator' })
           .catch((error) => {
             logger.warning(req, 'get_project_by_id', 'meeting coordinator check failed, skipping field', {
               project_uid: project.uid,
@@ -378,16 +384,18 @@ export class ProjectService {
         result = { ...result, meetingCoordinator: isMeetingCoordinator };
       }
       // Only run the auditor FGA check when the caller explicitly requests it (FormationCardComponent's
-      // staff deep-link guard) — same rationale as meeting_coordinator above.
+      // staff deep-link guard) — same rationale, and the same Strict variant, as meeting_coordinator above.
       if (includeAuditor) {
-        const isAuditor = await this.accessCheckService.checkSingleAccess(req, { resource: 'project', id: project.uid, access: 'auditor' }).catch((error) => {
-          logger.warning(req, 'get_project_by_id', 'auditor check failed, skipping field', {
-            project_uid: project.uid,
-            error: error instanceof Error ? error.message : String(error),
+        const isAuditor = await this.accessCheckService
+          .checkSingleAccessStrict(req, { resource: 'project', id: project.uid, access: 'auditor' })
+          .catch((error) => {
+            logger.warning(req, 'get_project_by_id', 'auditor check failed, skipping field', {
+              project_uid: project.uid,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            // Return undefined rather than false — see meeting_coordinator comment above.
+            return undefined;
           });
-          // Return undefined rather than false — see meeting_coordinator comment above.
-          return undefined;
-        });
         result = { ...result, auditor: isAuditor };
       }
       return result;
@@ -575,7 +583,12 @@ export class ProjectService {
    * Fetches a single project by slug using NATS for slug resolution
    * First resolves slug to ID via NATS, then fetches project data
    */
-  public async getProjectBySlug(req: Request, projectSlug: string, includeMeetingCoordinator: boolean = false): Promise<Project> {
+  public async getProjectBySlug(
+    req: Request,
+    projectSlug: string,
+    includeMeetingCoordinator: boolean = false,
+    includeAuditor: boolean = false
+  ): Promise<Project> {
     const natsResult = await this.getProjectIdBySlug(req, projectSlug);
 
     if (!natsResult.exists || !natsResult.uid) {
@@ -587,7 +600,7 @@ export class ProjectService {
     }
 
     // Now fetch the project using the resolved ID
-    return this.getProjectById(req, natsResult.uid, true, includeMeetingCoordinator);
+    return this.getProjectById(req, natsResult.uid, true, includeMeetingCoordinator, includeAuditor);
   }
 
   public async getProjectSettings(req: Request, uid: string): Promise<ProjectSettings> {

--- a/docs/architecture/frontend/lens-system.md
+++ b/docs/architecture/frontend/lens-system.md
@@ -113,6 +113,16 @@ class ProjectContextService {
   isFoundationContext: Signal<boolean>; // true when the active context is a foundation
   canWrite: Signal<boolean>; // resolved via ProjectService.getProject()
 
+  // Formation signals (GH-1955) — derived off the same activeProject fetch as canWrite, so
+  // consumers (e.g. FormationCardComponent, ProjectDashboardComponent) share one call instead
+  // of each fetching the active project independently.
+  isActiveProjectInFormation: Signal<boolean>;
+  activeProjectFormationSubStage: Signal<string | null>;
+  isActiveProjectConfidential: Signal<boolean>; // true only for ProjectStage.FormationConfidential
+  activeProjectAnnouncementDate: Signal<string | null>; // via PermissionsService.getProjectSettings
+  activeProjectAnnouncementDateLoading: Signal<boolean>;
+  activeProjectAnnouncementDateHasError: Signal<boolean>;
+
   setFoundation(ctx: ProjectContext): void;
   setProject(ctx: ProjectContext): void;
   clearFoundation(): void;

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -107,9 +107,11 @@ export const FEATURE_FLAG_OVERRIDE_STORAGE_KEY = 'lfx-feature-flag-overrides';
 
 /**
  * Gates the Formation Checklist Epic 1 surfaces (GH-1955/1958/1959/1962) — the project dashboard's
- * Formation badge/subtitle/sidebar card, the stage-scoped Formation nav item, and the project
- * selector's Formation tag. LaunchDarkly targets a small internal audience while the formation
- * flow is validated; default false so an unflagged evaluation renders the pre-Formation UI.
+ * Formation badge/subtitle/sidebar card, and the project selector's Formation tag. (A stage-scoped
+ * Formation nav item was tried and removed on review — see the comment on `projectLensItems` in
+ * `sidebar-nav.service.ts` — since it had nowhere distinct to route to.) LaunchDarkly targets a
+ * small internal audience while the formation flow is validated; default false so an unflagged
+ * evaluation renders the pre-Formation UI.
  *
  * **UI-only** — evaluated through `FeatureFlagService.getBooleanFlag`. Does not gate the BFF or any
  * endpoint: the underlying `stage`/formation fields on `/api/projects/:slugOrUid` are already

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -104,3 +104,16 @@ export const MENTORSHIP_ENABLED_FLAG = 'mentorship-enabled';
  * lands.
  */
 export const FEATURE_FLAG_OVERRIDE_STORAGE_KEY = 'lfx-feature-flag-overrides';
+
+/**
+ * Gates the Formation Checklist Epic 1 surfaces (GH-1955/1958/1959/1962) — the project dashboard's
+ * Formation badge/subtitle/sidebar card, the stage-scoped Formation nav item, and the project
+ * selector's Formation tag. LaunchDarkly targets a small internal audience while the formation
+ * flow is validated; default false so an unflagged evaluation renders the pre-Formation UI.
+ *
+ * **UI-only** — evaluated through `FeatureFlagService.getBooleanFlag`. Does not gate the BFF or any
+ * endpoint: the underlying `stage`/formation fields on `/api/projects/:slugOrUid` are already
+ * visible to anyone authorized to view the project regardless of this flag — it only controls
+ * whether Self Serve *renders* Formation-specific UI around already-reachable data.
+ */
+export const FORMATION_ENABLED_FLAG = 'formation-enabled';

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -86,6 +86,7 @@ export * from './mktg-os-agents.constants';
 export * from './mktg-run.constants';
 
 export * from './project-context.constants';
+export * from './project-formation.constants';
 export * from './project-staff.constants';
 export * from './org-lens-project-detail.constants';
 export * from './org-leaderboard-detail-drawer.constants';

--- a/packages/shared/src/constants/project-formation.constants.ts
+++ b/packages/shared/src/constants/project-formation.constants.ts
@@ -19,7 +19,8 @@ export const FORMATION_SUB_STAGE_LABELS: Partial<Record<ProjectStage, string>> =
 /**
  * Sentinel value referenced by ticket GH-1955 ("Draft status or any Formation sub-stage") with
  * no backing `ProjectStage` member today. Kept as a defensive literal check in
- * `isFormationStage`/`getFormationSubStageLabel` so a future upstream addition of this value
- * doesn't silently fall outside the gate — not evidence that upstream currently emits it.
+ * `getFormationSubStageLabel` (which `isFormationStage` delegates to) so a future upstream
+ * addition of this value doesn't silently fall outside the gate — not evidence that upstream
+ * currently emits it.
  */
 export const DRAFT_STAGE_SENTINEL = 'Draft';

--- a/packages/shared/src/constants/project-formation.constants.ts
+++ b/packages/shared/src/constants/project-formation.constants.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ProjectStage } from '../enums/project-stage.enum';
+
+/**
+ * Short display labels for the Formation sub-stages, used to build strings like
+ * `FORMATION · Engaged` and the sidebar Formation card's sub-stage pill. Each label is the
+ * `ProjectStage` enum value with its `Formation - ` prefix dropped.
+ */
+export const FORMATION_SUB_STAGE_LABELS: Partial<Record<ProjectStage, string>> = {
+  [ProjectStage.FormationExploratory]: 'Exploratory',
+  [ProjectStage.FormationEngaged]: 'Engaged',
+  [ProjectStage.FormationOnHold]: 'On Hold',
+  [ProjectStage.FormationDisengaged]: 'Disengaged',
+  [ProjectStage.FormationConfidential]: 'Confidential',
+};
+
+/**
+ * Sentinel value referenced by ticket GH-1955 ("Draft status or any Formation sub-stage") with
+ * no backing `ProjectStage` member today. Kept as a defensive literal check in
+ * `isFormationStage`/`getFormationSubStageLabel` so a future upstream addition of this value
+ * doesn't silently fall outside the gate — not evidence that upstream currently emits it.
+ */
+export const DRAFT_STAGE_SENTINEL = 'Draft';

--- a/packages/shared/src/constants/project-formation.constants.ts
+++ b/packages/shared/src/constants/project-formation.constants.ts
@@ -7,8 +7,13 @@ import { ProjectStage } from '../enums/project-stage.enum';
  * Short display labels for the Formation sub-stages, used to build strings like
  * `FORMATION · Engaged` and the sidebar Formation card's sub-stage pill. Each label is the
  * `ProjectStage` enum value with its `Formation - ` prefix dropped.
+ *
+ * Keyed by `ProjectStage` (5 values, including `Disengaged` and `Confidential`) — a different map
+ * from the canonical `FORMATION_SUB_STAGE_LABELS` in `formation.constants.ts` (GH-2163), which is
+ * keyed by the `FormationSubStage` union. Named distinctly so the two don't collide as re-exports
+ * of the same barrel.
  */
-export const FORMATION_SUB_STAGE_LABELS: Partial<Record<ProjectStage, string>> = {
+export const PROJECT_FORMATION_STAGE_LABELS: Partial<Record<ProjectStage, string>> = {
   [ProjectStage.FormationExploratory]: 'Exploratory',
   [ProjectStage.FormationEngaged]: 'Engaged',
   [ProjectStage.FormationOnHold]: 'On Hold',

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -14,6 +14,8 @@ export interface LensItem {
   name: string;
   logoUrl: string | null;
   isFoundation: boolean;
+  /** Formation sub-stage label from `getFormationSubStageLabel`, or `null` outside Formation. */
+  formationSubStage: string | null;
 }
 
 export interface LensItemsResponse {

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -77,6 +77,9 @@ export interface ProjectStaffRowConfig {
   icon: string;
 }
 
+/** A `ProjectStaffRowConfig` resolved against a project's actual settings — shared by `ProjectStaffCardComponent` and `FormationCardComponent`. */
+export type ProjectStaffRow = ProjectStaffRowConfig & { user: UserInfo | null | undefined };
+
 export interface ProjectSlugToIdResponse {
   uid: string;
   slug: string;

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -21,6 +21,16 @@ export interface Project {
    *   transiently. Do NOT treat as a definitive role denial.
    */
   meetingCoordinator?: boolean;
+  /**
+   * Response-only — present only when the caller requested the auditor check (`?auditor=true`)
+   * and the user is not already a writer.
+   *
+   * - `true`      — user holds the `auditor` role on this project.
+   * - `false`     — check ran clean; user does not hold the role.
+   * - `undefined` — check was not requested, was skipped (user is a writer), or failed
+   *   transiently. Do NOT treat as a definitive role denial.
+   */
+  auditor?: boolean;
   public: boolean;
   parent_uid: string;
   stage: ProjectStage | string;

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -87,7 +87,7 @@ export interface ProjectStaffRowConfig {
   icon: string;
 }
 
-/** A `ProjectStaffRowConfig` resolved against a project's actual settings — shared by `ProjectStaffCardComponent` and `FormationCardComponent`. */
+/** A `ProjectStaffRowConfig` resolved against a project's actual settings — used by `ProjectStaffCardComponent`. */
 export type ProjectStaffRow = ProjectStaffRowConfig & { user: UserInfo | null | undefined };
 
 export interface ProjectSlugToIdResponse {

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -630,6 +630,11 @@ export function formatIsoDateLabel(iso: string): string {
   });
 }
 
+/** `formatIsoDateLabel`, with a `'Not set'` fallback for an absent date — shared by the project dashboard's Formation subtitle and the Formation sidebar card (GH-1955). */
+export function formatAnnouncementDateLabel(date: string | null | undefined): string {
+  return date ? formatIsoDateLabel(date) : 'Not set';
+}
+
 /**
  * Render a HubSpot `updatedAt` for a marketing-email row.
  *

--- a/packages/shared/src/utils/project.utils.spec.ts
+++ b/packages/shared/src/utils/project.utils.spec.ts
@@ -3,10 +3,11 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { DRAFT_STAGE_SENTINEL } from '../constants/project-formation.constants';
 import { ProjectFunding } from '../enums/project-funding.enum';
 import { ProjectStage } from '../enums/project-stage.enum';
 import { Project } from '../interfaces';
-import { summarizeWriterGrants } from './project.utils';
+import { getFormationSubStageLabel, isFormationStage, summarizeWriterGrants } from './project.utils';
 
 /** Builds a Project fixture, defaulting every field so tests set only what they assert on. */
 function project(partial: Partial<Project>): Project {
@@ -70,5 +71,49 @@ describe('summarizeWriterGrants', () => {
 
   it('treats writer as false when the field is undefined (not requested / not access-checked)', () => {
     expect(summarizeWriterGrants([project({ uid: 'unchecked' })])).toEqual({ hasWriterFoundation: false, hasWriterProject: false });
+  });
+});
+
+describe('isFormationStage', () => {
+  it.each([
+    [ProjectStage.FormationExploratory, true],
+    [ProjectStage.FormationEngaged, true],
+    [ProjectStage.FormationOnHold, true],
+    [ProjectStage.FormationDisengaged, true],
+    [ProjectStage.FormationConfidential, true],
+    [DRAFT_STAGE_SENTINEL, true],
+    [ProjectStage.Active, false],
+    [ProjectStage.Archived, false],
+    [ProjectStage.Prospect, false],
+  ])('returns %s for stage %s', (stage, expected) => {
+    expect(isFormationStage(stage)).toBe(expected);
+  });
+
+  it('returns false for undefined/null/empty stage', () => {
+    expect(isFormationStage(undefined)).toBe(false);
+    expect(isFormationStage(null)).toBe(false);
+    expect(isFormationStage('')).toBe(false);
+  });
+});
+
+describe('getFormationSubStageLabel', () => {
+  it.each([
+    [ProjectStage.FormationExploratory, 'Exploratory'],
+    [ProjectStage.FormationEngaged, 'Engaged'],
+    [ProjectStage.FormationOnHold, 'On Hold'],
+    [ProjectStage.FormationDisengaged, 'Disengaged'],
+    [ProjectStage.FormationConfidential, 'Confidential'],
+    [DRAFT_STAGE_SENTINEL, 'Draft'],
+    [ProjectStage.Active, null],
+    [ProjectStage.Archived, null],
+    [ProjectStage.Prospect, null],
+  ])('returns %s for stage %s', (stage, expected) => {
+    expect(getFormationSubStageLabel(stage)).toBe(expected);
+  });
+
+  it('returns null for undefined/null/empty stage', () => {
+    expect(getFormationSubStageLabel(undefined)).toBeNull();
+    expect(getFormationSubStageLabel(null)).toBeNull();
+    expect(getFormationSubStageLabel('')).toBeNull();
   });
 });

--- a/packages/shared/src/utils/project.utils.spec.ts
+++ b/packages/shared/src/utils/project.utils.spec.ts
@@ -94,6 +94,12 @@ describe('isFormationStage', () => {
     expect(isFormationStage(null)).toBe(false);
     expect(isFormationStage('')).toBe(false);
   });
+
+  it('returns false for a stage string colliding with an inherited Object.prototype member name', () => {
+    expect(isFormationStage('toString')).toBe(false);
+    expect(isFormationStage('constructor')).toBe(false);
+    expect(isFormationStage('hasOwnProperty')).toBe(false);
+  });
 });
 
 describe('getFormationSubStageLabel', () => {
@@ -115,5 +121,11 @@ describe('getFormationSubStageLabel', () => {
     expect(getFormationSubStageLabel(undefined)).toBeNull();
     expect(getFormationSubStageLabel(null)).toBeNull();
     expect(getFormationSubStageLabel('')).toBeNull();
+  });
+
+  it('returns null (not an inherited function) for a stage string colliding with an Object.prototype member name', () => {
+    expect(getFormationSubStageLabel('toString')).toBeNull();
+    expect(getFormationSubStageLabel('constructor')).toBeNull();
+    expect(getFormationSubStageLabel('hasOwnProperty')).toBeNull();
   });
 });

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DRAFT_STAGE_SENTINEL, FORMATION_SUB_STAGE_LABELS } from '../constants/project-formation.constants';
+import { DRAFT_STAGE_SENTINEL, PROJECT_FORMATION_STAGE_LABELS } from '../constants/project-formation.constants';
 import { ProjectFunding } from '../enums/project-funding.enum';
 import { ProjectStage } from '../enums/project-stage.enum';
 import type { EnrichedPersonaProject, LensItem, Project, ProjectContext, WriterSummary } from '../interfaces';
@@ -73,9 +73,10 @@ export function isFormationStage(stage: string | undefined | null): boolean {
  * `stage` isn't a Formation sub-stage. Single source of truth for every Formation UI surface —
  * the dashboard badge/subtitle, the sidebar Formation card, and the project-selector tag.
  *
- * `Object.hasOwn` (not `stage in FORMATION_SUB_STAGE_LABELS` / a bare index) so an upstream stage
- * string that happens to collide with an inherited `Object.prototype` member name (`toString`,
- * `constructor`, ...) can never read a function off the prototype chain instead of `null`.
+ * `Object.hasOwn` (not `stage in PROJECT_FORMATION_STAGE_LABELS` / a bare index) so an upstream
+ * stage string that happens to collide with an inherited `Object.prototype` member name
+ * (`toString`, `constructor`, ...) can never read a function off the prototype chain instead of
+ * `null`.
  */
 export function getFormationSubStageLabel(stage: string | undefined | null): string | null {
   if (!stage) {
@@ -84,7 +85,7 @@ export function getFormationSubStageLabel(stage: string | undefined | null): str
   if (stage === DRAFT_STAGE_SENTINEL) {
     return DRAFT_STAGE_SENTINEL;
   }
-  return Object.hasOwn(FORMATION_SUB_STAGE_LABELS, stage) ? (FORMATION_SUB_STAGE_LABELS[stage as ProjectStage] ?? null) : null;
+  return Object.hasOwn(PROJECT_FORMATION_STAGE_LABELS, stage) ? (PROJECT_FORMATION_STAGE_LABELS[stage as ProjectStage] ?? null) : null;
 }
 
 /**

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -65,7 +65,7 @@ export function computeIsFoundation(project: Project | null): boolean {
  * literal (GH-1955 — see that constant's doc comment for why "Draft" is handled at all).
  */
 export function isFormationStage(stage: string | undefined | null): boolean {
-  return !!stage && (stage === DRAFT_STAGE_SENTINEL || getFormationSubStageLabel(stage) !== null);
+  return getFormationSubStageLabel(stage) !== null;
 }
 
 /**

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -65,16 +65,17 @@ export function computeIsFoundation(project: Project | null): boolean {
  * literal (GH-1955 — see that constant's doc comment for why "Draft" is handled at all).
  */
 export function isFormationStage(stage: string | undefined | null): boolean {
-  if (!stage) {
-    return false;
-  }
-  return stage === DRAFT_STAGE_SENTINEL || stage in FORMATION_SUB_STAGE_LABELS;
+  return !!stage && (stage === DRAFT_STAGE_SENTINEL || getFormationSubStageLabel(stage) !== null);
 }
 
 /**
  * Short display label for a project's Formation sub-stage (e.g. `'Engaged'`), or `null` when
  * `stage` isn't a Formation sub-stage. Single source of truth for every Formation UI surface —
  * the dashboard badge/subtitle, the sidebar Formation card, and the project-selector tag.
+ *
+ * `Object.hasOwn` (not `stage in FORMATION_SUB_STAGE_LABELS` / a bare index) so an upstream stage
+ * string that happens to collide with an inherited `Object.prototype` member name (`toString`,
+ * `constructor`, ...) can never read a function off the prototype chain instead of `null`.
  */
 export function getFormationSubStageLabel(stage: string | undefined | null): string | null {
   if (!stage) {
@@ -83,7 +84,7 @@ export function getFormationSubStageLabel(stage: string | undefined | null): str
   if (stage === DRAFT_STAGE_SENTINEL) {
     return DRAFT_STAGE_SENTINEL;
   }
-  return FORMATION_SUB_STAGE_LABELS[stage as ProjectStage] ?? null;
+  return Object.hasOwn(FORMATION_SUB_STAGE_LABELS, stage) ? (FORMATION_SUB_STAGE_LABELS[stage as ProjectStage] ?? null) : null;
 }
 
 /**

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DRAFT_STAGE_SENTINEL, FORMATION_SUB_STAGE_LABELS } from '../constants/project-formation.constants';
 import { ProjectFunding } from '../enums/project-funding.enum';
 import { ProjectStage } from '../enums/project-stage.enum';
 import type { EnrichedPersonaProject, LensItem, Project, ProjectContext, WriterSummary } from '../interfaces';
@@ -57,6 +58,32 @@ export function computeIsFoundation(project: Project | null): boolean {
     Array.isArray(project.funding_model) &&
     project.funding_model.includes('Membership')
   );
+}
+
+/**
+ * True when `stage` is one of the 5 Formation sub-stages, or the {@link DRAFT_STAGE_SENTINEL}
+ * literal (GH-1955 — see that constant's doc comment for why "Draft" is handled at all).
+ */
+export function isFormationStage(stage: string | undefined | null): boolean {
+  if (!stage) {
+    return false;
+  }
+  return stage === DRAFT_STAGE_SENTINEL || stage in FORMATION_SUB_STAGE_LABELS;
+}
+
+/**
+ * Short display label for a project's Formation sub-stage (e.g. `'Engaged'`), or `null` when
+ * `stage` isn't a Formation sub-stage. Single source of truth for every Formation UI surface —
+ * the dashboard badge/subtitle, the sidebar Formation card, and the project-selector tag.
+ */
+export function getFormationSubStageLabel(stage: string | undefined | null): string | null {
+  if (!stage) {
+    return null;
+  }
+  if (stage === DRAFT_STAGE_SENTINEL) {
+    return DRAFT_STAGE_SENTINEL;
+  }
+  return FORMATION_SUB_STAGE_LABELS[stage as ProjectStage] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Part of the Formation Checklist epic (#1965). Adds Formation-stage UI to the project dashboard, gated behind the new `FORMATION_ENABLED_FLAG`:

- Title badge (`FORMATION · <sub-stage>`) + subtitle on the project dashboard, with a distinct amber/lock treatment and visibility caption for the Confidential sub-stage
- A new `FormationCardComponent` in the sidebar: sub-stage pill, announcement date, project slug, and a staff-only deep link into the admin tool
- A "Formation" tag in the project selector's dropdown rows
- No new backend work — everything reads fields already synced via v1→v2 (`stage`, `formation_date`, `announcement_date`)

## Scope decisions made during implementation

Several fields/behaviors the ticket asked for don't exist anywhere in the sync pipeline (verified against the live `lfx-v2-project-service` contract via `gh api`, not a local checkout). Decided with the ticket owner before implementation:

- **Formation lead/coordinator/partner/product contact/trademark status/assigning org, plus the intake block (repository, assigning org, trademark status, logo)**: Epic 1 was scoped down after this PR was first opened — the application/intake flow that would populate these moved to Epic 2 (#1962). The revised #1955 is explicit that the card renders only fields the synced record already carries, so these are out **by ticket scope**, not a workaround. An earlier revision of this PR showed `executive_director`/`program_manager`/`opportunity_owner` here as a stand-in (duplicating `ProjectStaffCardComponent` directly above it in the sidebar); those rows are now removed entirely rather than duplicated, since Epic 1 doesn't call for formation-specific contacts on this card at all. If any of the intake fields (`repository_url`, `logo_url`) turn out to be populated independently of intake, they can come back later as ordinary project fields — not as an intake block.
- **`formation_admin` permission**: doesn't exist anywhere in the `linuxfoundation` org. Staff-only gating uses `PersonaService.isLFStaff` instead (LF-staff team membership) — a materially wider audience than a hypothetical formation-specific grant, but the closest real thing available. This is now tracked as open guard question **#2148**: the FGA model defines `writer`/`auditor`/`participant`/`item_owner` on `formation`, and #1954 grants LF Staff `auditor`, not `writer` — a `writer`-based guard would hide the deep link from most of staff, so the correct relation is an open architecture decision. Marked with a `// TODO(#2148)` at the guard site in `formation-card.component.ts`; guard behavior is unchanged in this PR.
- **`FormationConfidential`** stays excluded from the shared project picker (consistent with the name implying pre-announcement secrecy); its own dashboard page still renders normally for anyone already authorized to view it. Epic 1 also excludes Confidential formations end-to-end at the grant layer (#1954), which narrows the title badge's amber/lock treatment's practical audience to lf-formation/lf-legal viewers who do have access — still a coherent visual signal for that audience.

## Found and fixed during review (not part of the original diff)

The post-commit reviewer trio caught several real issues across iteration, most notably:

- **A duplicate-active-nav-item bug**: the ticket asked for a stage-scoped "Formation" nav item, but the only route available (`/project/overview`) is the same route Dashboard already uses — `routerLinkActive` can't disambiguate two entries on one path (it ignores fragment/queryParams). **Removed the nav item** rather than ship a visibly broken sidebar; the badge + card already surface Formation status on that page. **#1955 as currently written still asks for this nav item — its bullet needs to be struck or given a distinct destination; that's an issue-text edit, not a code change this PR can make.**
- **A sidebar entity-mismatch bug**: `DashboardSidebarComponent` is shared by the project, ED, and board-member dashboards, each of which passes a *different* entity as `projectUid` — but `FormationCardComponent` read `ProjectContextService.activeProject` regardless. Fixed with an explicit `showFormationCard` opt-in input, defaulting `false`, set `true` only by `ProjectDashboardComponent` where the two are guaranteed to agree.
- **Two wrong PCC deep-link URLs, caught and corrected twice**: first a `?tab=` query param that doesn't exist anywhere in PCC's routing, then a `/setup` route that only exists on PCC's **v1** frontend (`environment.urls.pcc` resolves to v2). The link now points at the one route confirmed to resolve (`/project/:id`) — **flagging for product/PCC**: the real "edit stage" / "set up" destination(s) still need to be named.
- An `evictOnWriteAccessLoss()` regression: an earlier review-driven fix added `startWith(null)` to a shared context signal to avoid stale-project flicker, which would have caused vote/survey/mailing-list manage pages to evict a user mid-edit on every project switch. Caught, reverted, and locked in with a regression test.
- A prototype-pollution vector in the stage-label lookup (`stage in OBJECT`), a duplicate HTTP fetch, several silent `catchError`s, and a missing loading guard that briefly asserted "Not set" before data arrived.

## Open items for product/design (not blockers, documented here per review)

- **EasyCLA/Crowdfunding/Insights/public stats** have no project-scoped nav surface today to gate on Formation status — EasyCLA is a personal tab, Crowdfunding and Insights are Me-lens/global links, no "public stats" component exists anywhere. Nothing was gated; a real destination needs to exist first.
- **`PROJECT_LENS_ALLOWED_STAGES`** now includes `FormationOnHold`/`FormationDisengaged` — this is server-side and unflagged (unlike the rest of this PR's UI), so those projects become picker-visible to all users ahead of the flagged UI reaching them. Doesn't widen data access (the picker is a UX convenience over already-reachable projects), but is a rollout-sequencing call worth a second look. **Recommendation:** this can be moved behind a flag cheaply — a new `ServerFeatureFlag` entry (mirroring `WeeklyBriefSlack`/`MarketingOpsFga`) gating whether these two stages are added to the set, same pattern already used elsewhere in `server-feature-flag.helper.ts`. Not implemented in this PR; flagging for a decision.
- The staff-name tooltip (`[attr.title]` on a non-focusable `<span>`) was copied verbatim from `ProjectStaffCardComponent`'s existing pattern. Retired on `FormationCardComponent` itself as part of the Epic 1 scope trim (the contact rows it applied to are gone), but `ProjectStaffCardComponent`'s own instance is untouched — still inherited a11y debt there.
- No e2e coverage for the new empty/error states (unit coverage exists).

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] Flag on/off, all 5 Formation sub-stages + Draft sentinel, `isLFStaff` present/absent — unit tested
- [x] String-content assertion that "PCC" never appears in any rendered state
- [x] Regression test locking in no transient `canWrite` flip during a project switch
- [ ] Manual verification against a real Formation-stage project (none confirmed available in the accessible test tenant as of this PR — may need stubbed data)

Refs #1955. Depends on nothing; #1958 reads the same `FORMATION_ENABLED_FLAG` constant added here.
