### PR TITLE
fix(social-listening): unify saved view and bookmark toasts (GH-2022)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/views-dropdown/views-dropdown.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/views-dropdown/views-dropdown.component.html
@@ -8,7 +8,7 @@
         class="fa-light fa-circle-info text-xs text-gray-400"
         pTooltip="Choose your filters, then save them as a preset view for quick access later. Switch between saved preset views at any time."
         tooltipPosition="right"></i>
-      SAVED FILTER VIEWS
+      SAVED VIEWS
     </h3>
   </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.spec.ts
@@ -407,19 +407,19 @@ describe('SocialListeningComponent', () => {
       expect(currentParams['q']).toBe('mesh');
     });
 
-    it('keeps a deep-linked ?search= in the URL while the debounced query catches up', async () => {
-      currentParams = { search: 'mesh' };
+    it('keeps a deep-linked ?q= in the URL while the debounced query catches up', async () => {
+      currentParams = { q: 'mesh' };
       queryParams$.next(currentParams);
       await settle();
 
       // Inside the 500ms debounce window the URL-write effect must not strip the param.
       expect(navigate).not.toHaveBeenCalled();
-      expect(currentParams['search']).toBe('mesh');
+      expect(currentParams['q']).toBe('mesh');
 
       // Once the debounce lands, the applied state re-encodes to the same URL — still no write.
       await new Promise((resolve) => setTimeout(resolve, 600));
       await settle();
-      expect(currentParams['search']).toBe('mesh');
+      expect(currentParams['q']).toBe('mesh');
       expect(navigate).not.toHaveBeenCalled();
     });
   });

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -111,9 +111,8 @@ import { ViewsDropdownComponent } from './components/views-dropdown/views-dropdo
 const EMPTY_FEED_RESPONSE: SocialListeningFeedResponse = { mentions: [], computedAt: null };
 
 /**
- * Social Listening — Foundation Lens page (ED + LF Staff), LFXV2-3016: PCC's mentions feed on the
- * 3015 endpoints — windowed pagination (100-row windows, ±2 cached), query-param sync, and reset
- * effects on scope/filter/foundation change. Saved views are deferred.
+ * Social Listening — Foundation Lens page (ED + LF Staff), LFXV2-3016: PCC's mentions feed on the 3015 endpoints —
+ * windowed pagination (100-row windows, ±2 cached), query-param sync, and reset effects on scope/filter/foundation change.
  */
 @Component({
   selector: 'lfx-social-listening',
@@ -162,7 +161,7 @@ export class SocialListeningComponent {
   public readonly selectedPlatform = signal('all');
   public readonly searchInput = signal(this.initialSearch);
 
-  // === Filter signals (wired into the predicate now; the filters panel UI lands in LFXV2-3017) ===
+  // === Filter signals (wired into the predicate and the filters panel, LFXV2-3017) ===
   public readonly selectedSentiment = signal('all');
   public readonly selectedRelevance = signal('all');
   public readonly selectedLanguage = signal('all');
@@ -407,7 +406,7 @@ export class SocialListeningComponent {
     // for owned keys at default so merge removes them. queryParamsEqual prevents write loops.
     effect(() => {
       const target = encodePredicateToQueryParams(this.currentPredicate(), this.currentScope(), this.activeViewId(), this.defaultPeriod);
-      // Don't strip a deep-linked ?search= while the debounced query is still catching up to the input.
+      // Don't strip a deep-linked ?q= while the debounced query is still catching up to the input.
       const pendingSearch = this.searchInput().trim();
       if (pendingSearch.length >= MENTION_SEARCH_MIN_CHARS && pendingSearch !== this.searchQuery()) return;
       if (queryParamsEqual(target, this.route.snapshot.queryParams)) return;

--- a/apps/lfx-one/src/app/shared/services/mention-bookmark.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/mention-bookmark.service.spec.ts
@@ -68,7 +68,7 @@ describe('MentionBookmarkService', () => {
 
     await flush();
     expect(socialListeningService.upsertPreference).toHaveBeenCalledWith(preferenceName, '["m1"]');
-    expect(messageService.add).toHaveBeenCalledWith({ severity: 'success', summary: 'Bookmarked', detail: 'Mention added to your bookmarks.' });
+    expect(messageService.add).toHaveBeenCalledWith({ severity: 'success', summary: 'Bookmark added', detail: 'Mention added to your bookmarks.' });
   });
 
   it('deletes the preference row when the last bookmark is removed', async () => {
@@ -110,7 +110,11 @@ describe('MentionBookmarkService', () => {
     await flush();
 
     expect(service.state().data.has('m1')).toBe(false);
-    expect(messageService.add).toHaveBeenCalledWith({ severity: 'error', summary: 'Could not save bookmark', detail: 'Please try again.' });
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Failed to save bookmark',
+      detail: 'Could not save the bookmark. Please try again.',
+    });
   });
 
   it('rolls back and toasts the error when the delete fails', async () => {
@@ -123,7 +127,11 @@ describe('MentionBookmarkService', () => {
     await flush();
 
     expect(service.state().data.has('m1')).toBe(true);
-    expect(messageService.add).toHaveBeenCalledWith({ severity: 'error', summary: 'Could not remove bookmark', detail: 'Please try again.' });
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Failed to remove bookmark',
+      detail: 'Could not remove the bookmark. Please try again.',
+    });
   });
 
   it('ignores toggles while the initial load is in flight', async () => {

--- a/apps/lfx-one/src/app/shared/services/mention-bookmark.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mention-bookmark.service.ts
@@ -35,13 +35,7 @@ export class MentionBookmarkService {
     serialize: (ids) => JSON.stringify([...ids]),
     // PCC parity: emptying the set deletes the row rather than persisting '[]'.
     shouldDeleteOnEmpty: (ids) => ids.size === 0,
-    onLoadError: () => {
-      this.messageService.add({
-        severity: 'error',
-        summary: 'Bookmarks unavailable',
-        detail: 'Your bookmarks could not be loaded. Refresh the page and try again.',
-      });
-    },
+    onLoadError: () => this.notifyUnavailable(),
   });
 
   public readonly state = this.store.state;
@@ -54,13 +48,7 @@ export class MentionBookmarkService {
     const { data: ids, loading, error } = this.store.state();
     // A failed load leaves an empty fallback set — writing from it would clobber the persisted bookmarks.
     if (loading || error) {
-      if (error) {
-        this.messageService.add({
-          severity: 'error',
-          summary: 'Bookmarks unavailable',
-          detail: 'Your bookmarks could not be loaded. Refresh the page and try again.',
-        });
-      }
+      if (error) this.notifyUnavailable();
       return;
     }
 
@@ -97,15 +85,23 @@ export class MentionBookmarkService {
       onSuccess: () =>
         this.messageService.add(
           adding
-            ? { severity: 'success', summary: 'Bookmarked', detail: 'Mention added to your bookmarks.' }
+            ? { severity: 'success', summary: 'Bookmark added', detail: 'Mention added to your bookmarks.' }
             : { severity: 'success', summary: 'Bookmark removed', detail: 'Mention removed from your bookmarks.' }
         ),
       onError: () =>
         this.messageService.add({
           severity: 'error',
-          summary: adding ? 'Could not save bookmark' : 'Could not remove bookmark',
-          detail: 'Please try again.',
+          summary: adding ? 'Failed to save bookmark' : 'Failed to remove bookmark',
+          detail: adding ? 'Could not save the bookmark. Please try again.' : 'Could not remove the bookmark. Please try again.',
         }),
+    });
+  }
+
+  private notifyUnavailable(): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Bookmarks unavailable',
+      detail: 'Your bookmarks could not be loaded. Refresh the page and try again.',
     });
   }
 }

--- a/apps/lfx-one/src/app/shared/services/saved-filter.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/saved-filter.service.spec.ts
@@ -102,7 +102,7 @@ describe('SavedFilterService', () => {
     expect(service.state().readOnly).toBe(true);
   });
 
-  it('surfaces a load failure as an info toast and keeps the store empty', async () => {
+  it('surfaces a load failure as an error toast and keeps the store empty', async () => {
     socialListeningService.getPreference.mockReturnValue(throwError(() => new Error('boom')));
 
     service.setContext(ctx);
@@ -111,9 +111,9 @@ describe('SavedFilterService', () => {
     expect(service.state().error).toBeTruthy();
     expect(service.state().data).toEqual([]);
     expect(messageService.add).toHaveBeenCalledWith({
-      severity: 'info',
-      summary: 'Views temporarily unavailable',
-      detail: "We couldn't load your saved views. Please try again later.",
+      severity: 'error',
+      summary: 'Saved views unavailable',
+      detail: 'Your saved views could not be loaded. Refresh the page and try again.',
     });
   });
 
@@ -174,7 +174,7 @@ describe('SavedFilterService', () => {
     expect(socialListeningService.upsertPreference).not.toHaveBeenCalled();
   });
 
-  it('rejects a save at the per-project limit with a warn toast', async () => {
+  it('rejects a save at the per-foundation limit with a warn toast', async () => {
     const atCap = Array.from({ length: MAX_SAVED_FILTERS_PER_PROJECT }, (_, i) => view({ id: `v${i}`, name: `View ${i}` }));
     socialListeningService.getPreference.mockReturnValue(of(storedDoc(atCap)));
     service.setContext(ctx);

--- a/apps/lfx-one/src/app/shared/services/saved-filter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/saved-filter.service.ts
@@ -53,13 +53,7 @@ export class SavedFilterService {
         });
       }
     },
-    onLoadError: () => {
-      this.messageService.add({
-        severity: 'info',
-        summary: 'Views temporarily unavailable',
-        detail: "We couldn't load your saved views. Please try again later.",
-      });
-    },
+    onLoadError: () => this.notifyUnavailable(),
     onContextChange: () => this.deletingViewIdsSignal.set(new Set()),
   });
 

--- a/packages/shared/src/constants/social-listening.constants.ts
+++ b/packages/shared/src/constants/social-listening.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/** Social Listening runtime constants — option lists double as server-side validation whitelists (3015). No hex colors (styling rule): Tailwind `colorClass` + `TagSeverity`. */
+/** Social Listening runtime constants — option lists double as server-side validation whitelists (LFXV2-3015). No hex colors (styling rule): Tailwind `colorClass` + `TagSeverity`. */
 
 import type { FilterPillOption } from '../interfaces/dashboard-metric.interface';
 import type {


### PR DESCRIPTION
## Summary

The Social Listening saved-views and bookmark toast copy had drifted out of sync with each other and with the implementation, and a few specs/comments were stale from earlier iterations. This PR aligns the saved-filter load-failure toast with the sibling bookmark error (severity + copy), makes the bookmark add/remove toasts parallel, fixes a vacuous deep-link test so it actually exercises the debounce guard, and sweeps stale wording ("SAVED FILTER VIEWS", legacy `?search=` references).

Resolves #2022

## Behavior changes

### Saved views load failure

| Before | After |
|---|---|
| If your saved views couldn't be loaded, a neutral info message ("Views temporarily unavailable — We couldn't load your saved views. Please try again later.") appeared, unlike every other failure message on the page. | The failure shows as a proper error ("Saved views unavailable — Your saved views could not be loaded. Refresh the page and try again."), matching the wording and severity used by the sibling bookmarks message. |

### Bookmark toasts

| Before | After |
|---|---|
| Bookmarking a mention showed "Bookmarked", and failures used short, mismatched messages ("Could not save bookmark / Could not remove bookmark — Please try again."). | Add and remove messages are parallel ("Bookmark added" / "Bookmark removed"), and failures use consistent "Failed to save bookmark" / "Failed to remove bookmark" messages with full guidance ("Could not save the bookmark. Please try again."). |

### Views dropdown heading

| Before | After |
|---|---|
| The saved-views dropdown was labeled "SAVED FILTER VIEWS". | The dropdown is labeled "SAVED VIEWS". |

## Technical changes

`apps/lfx-one/src/app/shared/services/saved-filter.service.ts` — Saved filter service
- `onLoadError` now delegates to the existing `notifyUnavailable()` (error severity, "Saved views unavailable" copy) instead of the stale inline info toast it was carrying.

`apps/lfx-one/src/app/shared/services/mention-bookmark.service.ts` — Bookmark service
- Extracted a shared private `notifyUnavailable()` used by both the store's `onLoadError` and the toggle guard when a failed load blocks a write.
- Made the add/remove toasts parallel: success summaries are now "Bookmark added" / "Bookmark removed"; failures are "Failed to save bookmark" / "Failed to remove bookmark" with per-action detail sentences.

`apps/lfx-one/src/app/modules/dashboards/social-listening/components/views-dropdown/views-dropdown.component.html` — Views dropdown
- Renamed the dropdown heading from "SAVED FILTER VIEWS" to "SAVED VIEWS".

`apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts` — Social Listening page
- Comment sweep only: the URL-write effect comment now references the owned `?q=` param (not the legacy `?search=`), the filter-signals comment reflects that the filters panel landed in LFXV2-3017, and the class doc no longer claims saved views are deferred.

`.../social-listening.component.spec.ts`, `.../saved-filter.service.spec.ts`, `.../mention-bookmark.service.spec.ts` — Tests
- Fixed the vacuous deep-link test to drive the owned `q` query param (it previously set `search`, which the component never reads) so the debounce guard is genuinely exercised.
- Updated the saved-filter load-failure spec to expect the error toast from `notifyUnavailable()` instead of the removed info toast.
- Renamed the stale "per-project limit" test title to "per-foundation" and updated bookmark toast expectations to the new copy.

`packages/shared/src/constants/social-listening.constants.ts` — Shared constants
- Comment-only: ticket reference corrected from `3015` to `LFXV2-3015`.
