### PR TITLE
feat(dashboards): show partial Health Score label

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -185,7 +185,7 @@
                         class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
                         [style.backgroundColor]="categoryBadge[category].bg"
                         [style.color]="categoryBadge[category].text">
-                        {{ categoryLabel[category] }}
+                        {{ categoryLabelFor(project) }}
                       </span>
                     } @else {
                       <span

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -12,6 +12,7 @@ import { InsightsHandoffSectionComponent } from '@components/insights-handoff-se
 import {
   DEFAULT_FOUNDATION_HEALTH_SCORE_DISTRIBUTION,
   DEFAULT_FOUNDATION_PROJECTS_DETAIL,
+  HEALTH_SCORE_PARTIAL_SUFFIX,
   lfxColors,
   PROJECT_HEALTH_CATEGORY_BADGE,
   PROJECT_HEALTH_CATEGORY_LABEL,
@@ -29,6 +30,7 @@ import {
   computeHealthyOrBetterCount,
   computeHealthyOrBetterPct,
   computeScoredCount,
+  isPartialHealthScore,
 } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -211,6 +213,15 @@ export class ProjectHealthScoresDrawerComponent {
       return next;
     });
     this.page.set(1);
+  }
+
+  // Bare category label, plus " - Partial" when the BFF-sourced coveredCategoryCount marks a
+  // 2-of-3 score (never recomputed locally — see ProjectTableRow.healthCoveredCategoryCount).
+  protected categoryLabelFor(project: ProjectTableRow): string {
+    const category = project.healthScoreCategory;
+    if (!category) return '';
+    const label = this.categoryLabel[category];
+    return isPartialHealthScore(project.healthCoveredCategoryCount) ? `${label}${HEALTH_SCORE_PARTIAL_SUFFIX}` : label;
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -29,6 +29,7 @@ import {
   PD_VALID_TABS,
   PD_DEFAULT_TIME_RANGE,
   PD_DRAWER_QUERY_PARAM,
+  HEALTH_SCORE_PARTIAL_SUFFIX,
   PD_HEALTH_TAG,
   PD_NON_LF_MARKER,
   PD_VALID_DRAWER_CARD_KEYS,
@@ -58,7 +59,7 @@ import type {
   OrgLensProjectLeaderboardRow,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
-import { parseLocalDateString } from '@lfx-one/shared/utils';
+import { isPartialHealthScore, parseLocalDateString } from '@lfx-one/shared/utils';
 import type { MenuItem } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { InputTextModule } from 'primeng/inputtext';
@@ -210,8 +211,15 @@ export class OrgProjectDetailComponent {
   protected readonly isNonLfProject = computed(() => this.heroState().data?.isNonLfProject ?? false);
   protected readonly breadcrumbItems = computed<MenuItem[]>(() => this.initBreadcrumb());
   protected readonly healthMeta = computed(() => {
-    const health = this.hero()?.health;
-    return health ? PD_HEALTH_TAG[health] : null;
+    const hero = this.hero();
+    const health = hero?.health;
+    if (!health) {
+      return null;
+    }
+    const tag = PD_HEALTH_TAG[health];
+    // Bare-band bg/text stay unsuffixed for color lookup; only the rendered label gets " - Partial",
+    // sourced straight from the BFF's healthCoveredCategoryCount — never recomputed locally.
+    return isPartialHealthScore(hero?.healthCoveredCategoryCount ?? null) ? { ...tag, label: `${tag.label}${HEALTH_SCORE_PARTIAL_SUFFIX}` } : tag;
   });
   protected readonly firstCommitLabel = computed(() => this.formatMonthYear(this.hero()?.firstCommit ?? null));
   protected readonly softwareValueLabel = computed(() => this.formatCompactUsd(this.hero()?.softwareValueUsd ?? null));

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_ORG_PROJECTS_WORKSPACES,
   HEALTH_SCORE_BADGE,
   HEALTH_SCORE_LABELS,
+  HEALTH_SCORE_PARTIAL_SUFFIX,
   INFLUENCE_BAND_BAR_FILL_CLASS,
   INFLUENCE_BAND_BAR_FILL_CLASS_LIGHT,
   INFLUENCE_BAND_LABELS,
@@ -47,7 +48,7 @@ import type {
   OrgProjectsWorkspaceId,
   SortDirection,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl, downloadCsv, localDateStamp } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, downloadCsv, isPartialHealthScore, localDateStamp } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogModule } from 'primeng/dialog';
 import { PopoverModule } from 'primeng/popover';
@@ -595,7 +596,7 @@ export class OrgProjectsComponent {
   // Full health summary (rating + sub-scores) so keyboard/screen-reader users get the popover's content without a mouse.
   protected healthAriaLabel(project: OrgLensProject): string {
     const metrics = project.healthMetrics.map((m) => `${m.label} ${m.value}`).join(', ');
-    return `Health: ${HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)]}. ${metrics}.`;
+    return `Health: ${this.healthLabelFor(project)}. ${metrics}.`;
   }
   /** The "Add project(s)" multi-select filter box drives the debounced server-side project search. */
   protected onAddProjectsFilter(query: string): void {
@@ -794,7 +795,7 @@ export class OrgProjectsComponent {
           ecosystemBars: orgMetricsUnavailable ? [] : this.bandBars(project.ecosystemInfluence),
           technicalBandLabel: orgMetricsUnavailable ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[project.technicalInfluence],
           ecosystemBandLabel: orgMetricsUnavailable ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[project.ecosystemInfluence],
-          healthLabel: HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)],
+          healthLabel: this.healthLabelFor(project),
           healthBadge: HEALTH_SCORE_BADGE[this.normalizeHealth(project.health)],
           // Need ≥2 samples to draw a line; a shorter series renders a flat baseline placeholder instead.
           hasTrendData: project.trend.series.length > 1,
@@ -1034,6 +1035,13 @@ export class OrgProjectsComponent {
 
   private normalizeHealth(health: HealthScore): HealthScore {
     return Object.prototype.hasOwnProperty.call(HEALTH_SCORE_BADGE, health) ? health : 'unavailable';
+  }
+
+  // Bare band label, plus " - Partial" when the BFF-sourced coveredCategoryCount marks a 2-of-3 score
+  // (never recomputed locally — see OrgLensProject.healthCoveredCategoryCount).
+  private healthLabelFor(project: OrgLensProject): string {
+    const label = HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)];
+    return isPartialHealthScore(project.healthCoveredCategoryCount) ? `${label}${HEALTH_SCORE_PARTIAL_SUFFIX}` : label;
   }
 
   // Fallback rows (explicit health-only/unavailable, influence/trend "Unavailable") always sort after measured rows,

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -254,6 +254,15 @@ describe('OrgLensProjectDetailService.getHeroBlock health mapping', () => {
 
     expect(block?.hero.health).toBeNull();
   });
+
+  it('passes healthMaxScore and healthCoveredCategoryCount straight through from the warehouse', async () => {
+    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 70, HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 });
+
+    const block = await service.getHeroBlock(ORG, SLUG);
+
+    expect(block?.hero.healthCoveredCategoryCount).toBe(2);
+    expect(block?.hero.healthMaxScore).toBe(75);
+  });
 });
 
 describe('OrgLensProjectDetailService.getLeaderboardBreakdown', () => {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -46,6 +46,8 @@ interface HeroRow {
   DESCRIPTION: string | null;
   HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
+  COVERED_CATEGORY_COUNT_V2: number | null;
+  HEALTH_MAX_SCORE_V2: number | null;
   SOFTWARE_VALUE: number | null;
   FIRST_COMMIT_TS: Date | string | null;
 }
@@ -1099,6 +1101,7 @@ export class OrgLensProjectDetailService {
       `
         SELECT PROJECT_NAME, PROJECT_SLUG, PROJECT_LOGO_URL, FOUNDATION_NAME, IS_LF_PROJECT,
                DESCRIPTION, HEALTH_OVERALL_SCORE_V2, HEALTH_SCORE_CATEGORY_V2,
+               COVERED_CATEGORY_COUNT_V2, HEALTH_MAX_SCORE_V2,
                SOFTWARE_VALUE, FIRST_COMMIT_TS
         FROM ${this.projectsTable()}
         WHERE ACCOUNT_ID = ? AND PROJECT_SLUG = ?
@@ -1882,6 +1885,9 @@ export class OrgLensProjectDetailService {
       firstCommit: toIsoDate(row.FIRST_COMMIT_TS),
       softwareValueUsd: row.SOFTWARE_VALUE ?? null,
       health: this.mapHealth(row),
+      // Sourced straight from the warehouse — never recomputed, per health.mapHealth's v2-category/score precedence.
+      healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
+      healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
       foundationLabel,
     };
   }

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -56,6 +56,8 @@ function projectsRow(overrides: Record<string, unknown> = {}) {
     DBT_RUN_AT: null,
     HEALTH_OVERALL_SCORE_V2: null,
     HEALTH_SCORE_CATEGORY_V2: null,
+    COVERED_CATEGORY_COUNT_V2: null,
+    HEALTH_MAX_SCORE_V2: null,
     HEALTH_CONTRIBUTOR_PERCENTAGE: null,
     HEALTH_POPULARITY_PERCENTAGE: null,
     HEALTH_DEVELOPMENT_PERCENTAGE: null,
@@ -111,5 +113,23 @@ describe('OrgLensProjectsService health score mapping', () => {
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('unavailable');
+  });
+
+  it('passes healthMaxScore and healthCoveredCategoryCount straight through from the warehouse', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 70, HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.healthCoveredCategoryCount).toBe(2);
+    expect(response.projects[0]?.healthMaxScore).toBe(75);
+  });
+
+  it('passes through a full (3-category) score unchanged, not marked partial', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 90, COVERED_CATEGORY_COUNT_V2: 3, HEALTH_MAX_SCORE_V2: 100 }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.healthCoveredCategoryCount).toBe(3);
+    expect(response.projects[0]?.healthMaxScore).toBe(100);
   });
 });

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -408,6 +408,8 @@ export class OrgLensProjectsService {
         FOUNDATION_LOGO_URL,
         HEALTH_OVERALL_SCORE_V2,
         HEALTH_SCORE_CATEGORY_V2,
+        COVERED_CATEGORY_COUNT_V2,
+        HEALTH_MAX_SCORE_V2,
         HEALTH_CONTRIBUTOR_PERCENTAGE,
         HEALTH_POPULARITY_PERCENTAGE,
         HEALTH_DEVELOPMENT_PERCENTAGE,
@@ -456,6 +458,8 @@ export class OrgLensProjectsService {
         DBT_RUN_AT,
         HEALTH_OVERALL_SCORE_V2,
         HEALTH_SCORE_CATEGORY_V2,
+        COVERED_CATEGORY_COUNT_V2,
+        HEALTH_MAX_SCORE_V2,
         HEALTH_CONTRIBUTOR_PERCENTAGE,
         HEALTH_POPULARITY_PERCENTAGE,
         HEALTH_DEVELOPMENT_PERCENTAGE,
@@ -499,6 +503,9 @@ export class OrgLensProjectsService {
       logoUrl: row.PROJECT_LOGO_URL ?? '',
       foundation: this.mapFoundation(row),
       health: hasHealthScore ? this.mapHealthScore(row) : 'unavailable',
+      // Sourced straight from the warehouse — never recomputed, per mapHealthScore's v2-category/score precedence.
+      healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
+      healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
       // These 'silent'/'non-lf' fallbacks are only user-visible for real (activity) rows. For no-activity rows the
       // UI shows "Unavailable" and compareInfluenceAvailability sinks them past measured rows, so the fallback band
       // is never compared against a measured one — it only affects the (tied) ordering of two no-activity rows.

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1923,7 +1923,8 @@ export class ProjectService {
         d.MAINTAINERS_CURRENT_COUNT,
         d.STARS_YTD_COUNT,
         d.LAST_UPDATED_TS,
-        d.HEALTH_SCORE_CATEGORY_V2
+        d.HEALTH_SCORE_CATEGORY_V2,
+        d.COVERED_CATEGORY_COUNT_V2
       FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_TOTAL_PROJECTS_DETAIL d
       WHERE d.FOUNDATION_SLUG = ?
       ORDER BY d.PROJECT_NAME ASC
@@ -1954,6 +1955,7 @@ export class ProjectService {
         // Normalize the upstream capitalized category to our lowercase union; guard
         // against unexpected strings so the interface's promise (FoundationHealthScore | null) holds.
         healthScoreCategory: normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2),
+        healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
       }));
 
       logger.debug(undefined, 'get_foundation_projects_detail', 'Fetched project detail rows', { count: projects.length });

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -98,6 +98,12 @@ export const HEALTH_SCORE_LABELS: Record<HealthScore, string> = {
   unavailable: 'Unavailable',
 };
 
+/**
+ * Appended to a health label when the score covers only 2 of the 3 CHAOSS categories (`healthMaxScore` is
+ * 60/65/75 rather than 100), so users know the score isn't out of the usual 100.
+ */
+export const HEALTH_SCORE_PARTIAL_SUFFIX = ' - Partial';
+
 export const HEALTH_SCORE_BADGE: Record<HealthScore, { bg: string; text: string }> = {
   excellent: { bg: lfxColors.emerald[100], text: lfxColors.emerald[700] },
   healthy: { bg: lfxColors.blue[100], text: lfxColors.blue[700] },

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2256,6 +2256,8 @@ export interface FoundationProjectsDetailRow {
   LAST_UPDATED_TS: Date | string | null;
   // Joined from PROJECT_HEALTH_METRICS_LATEST (newest score per project); null when unscored.
   HEALTH_SCORE_CATEGORY_V2: string | null;
+  // Warehouse-computed count (0-3) of categories covered; 2 marks a partial score.
+  COVERED_CATEGORY_COUNT_V2: number | null;
 }
 
 /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -274,6 +274,11 @@ export interface ProjectTableRow {
   // Newest health-score category from PROJECT_HEALTH_METRICS_LATEST; null when unscored.
   healthScoreCategory: FoundationHealthScore | null;
   /**
+   * Warehouse-computed count (0-3) of categories covered for `healthScoreCategory`. `2` marks a
+   * partial score — sourced straight from `covered_category_count_v2`, never recomputed locally.
+   */
+  healthCoveredCategoryCount: number | null;
+  /**
    * Populated only by the Foundation Projects page's grouped endpoint
    * (`getFoundationProjectsDetailGrouped`) — the slug/name of the foundation or
    * sub-foundation this row's Snowflake query was fetched under, so the page can

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -66,6 +66,17 @@ export interface OrgLensProjectHero {
   softwareValueUsd: number | null;
   /** Overall health tier; null when the warehouse has no health score for the project (hero hides the badge). */
   health: OrgLensProjectHealth | null;
+  /**
+   * Warehouse-computed max score for `health` (100 when all 3 CHAOSS categories are covered; 60/65/75 when
+   * exactly one is missing; `null` when fewer than 2 are covered, matching `health: null`). Sourced straight
+   * from `health_max_score_v2` — never recompute this locally.
+   */
+  healthMaxScore: number | null;
+  /**
+   * Warehouse-computed count (0–3) of CHAOSS categories covered for `health`. `healthMaxScore < 100` (i.e. `2`)
+   * marks a partial score — sourced straight from `covered_category_count_v2`, never recomputed locally.
+   */
+  healthCoveredCategoryCount: number | null;
   foundationLabel: string;
 }
 

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -70,6 +70,17 @@ export interface OrgLensProject {
   foundation: OrgLensProjectFoundation;
   /** CHAOSS health classification. */
   health: HealthScore;
+  /**
+   * Warehouse-computed max score for `health` (100 when all 3 CHAOSS categories are covered; 60/65/75 when
+   * exactly one is missing; `null` when fewer than 2 are covered, matching `health: 'unavailable'`). Sourced
+   * straight from `health_max_score_v2` — never recompute this locally.
+   */
+  healthMaxScore: number | null;
+  /**
+   * Warehouse-computed count (0–3) of CHAOSS categories covered for `health`. `healthMaxScore < 100` (i.e. `2`)
+   * marks a partial score — sourced straight from `covered_category_count_v2`, never recomputed locally.
+   */
+  healthCoveredCategoryCount: number | null;
   /** Technical influence band. */
   technicalInfluence: InfluenceBand;
   /** Ecosystem influence band. */
@@ -258,6 +269,8 @@ export interface OrgLensProjectRow {
   DBT_RUN_AT: string | Date | null;
   HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
+  COVERED_CATEGORY_COUNT_V2: number | null;
+  HEALTH_MAX_SCORE_V2: number | null;
   HEALTH_CONTRIBUTOR_PERCENTAGE: number | null;
   HEALTH_POPULARITY_PERCENTAGE: number | null;
   HEALTH_DEVELOPMENT_PERCENTAGE: number | null;

--- a/packages/shared/src/utils/insights.utils.spec.ts
+++ b/packages/shared/src/utils/insights.utils.spec.ts
@@ -3,19 +3,19 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { classifyHealthScore, normalizeHealthScoreCategoryV2 } from './insights.utils';
+import { classifyHealthScore, isPartialHealthScore, normalizeHealthScoreCategoryV2 } from './insights.utils';
 
 describe('classifyHealthScore', () => {
   it.each([
     [100, 'excellent'],
-    [80, 'excellent'],
-    [79, 'healthy'],
-    [60, 'healthy'],
-    [59, 'fair'],
-    [40, 'fair'],
-    [39, 'concerning'],
-    [20, 'concerning'],
-    [19, 'critical'],
+    [85, 'excellent'],
+    [84, 'healthy'],
+    [70, 'healthy'],
+    [69, 'fair'],
+    [50, 'fair'],
+    [49, 'concerning'],
+    [30, 'concerning'],
+    [29, 'critical'],
     [0, 'critical'],
   ] as const)('classifies %i as %s', (score, band) => {
     expect(classifyHealthScore(score)).toBe(band);
@@ -24,6 +24,18 @@ describe('classifyHealthScore', () => {
   it('places the five bands in a strictly worsening order as the score drops', () => {
     const order = [90, 70, 50, 30, 10].map(classifyHealthScore);
     expect(order).toEqual(['excellent', 'healthy', 'fair', 'concerning', 'critical']);
+  });
+});
+
+describe('isPartialHealthScore', () => {
+  it.each([
+    [2, true],
+    [3, false],
+    [1, false],
+    [0, false],
+    [null, false],
+  ] as const)('returns %s for coveredCategoryCount %s', (coveredCategoryCount, expected) => {
+    expect(isPartialHealthScore(coveredCategoryCount)).toBe(expected);
   });
 });
 

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -55,26 +55,37 @@ export function buildLensAwareInsightsUrl(
 }
 
 /**
- * Classifies an LFX Insights project health score (0–100) into a band, matching the Insights
- * primary project Health Score component (`health-score.vue`): `>= 80` Excellent, `>= 60` Healthy,
- * `>= 40` Fair, `>= 20` Concerning, else Critical. The `unavailable` state (no score) is handled by
- * callers, so this returns only the five scored bands and is the single source both the Org Lens
- * Projects table and the project-detail hero classify through (they must never disagree).
+ * Classifies an LFX Insights project health score (0–100) into a band, matching lf-dbt's
+ * `get_health_score_category_v2` macro and the Insights primary project Health Score component
+ * (`health-score.vue`): `>= 85` Excellent, `>= 70` Healthy, `>= 50` Fair, `>= 30` Concerning, else
+ * Critical. The `unavailable` state (no score) is handled by callers, so this returns only the five
+ * scored bands and is the single source both the Org Lens Projects table and the project-detail hero
+ * classify through (they must never disagree).
  */
 export function classifyHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
-  if (score >= 80) {
+  if (score >= 85) {
     return 'excellent';
   }
-  if (score >= 60) {
+  if (score >= 70) {
     return 'healthy';
   }
-  if (score >= 40) {
+  if (score >= 50) {
     return 'fair';
   }
-  if (score >= 20) {
+  if (score >= 30) {
     return 'concerning';
   }
   return 'critical';
+}
+
+/**
+ * A health score is partial when the warehouse's `covered_category_count_v2` reports exactly 2 of the
+ * 3 CHAOSS categories covered (`health_max_score_v2` is 60/65/75 rather than 100). `< 2` categories
+ * means no score at all (`health`/`healthMaxScore` are `null`/`unavailable`), and `3` is a full score —
+ * neither is partial.
+ */
+export function isPartialHealthScore(coveredCategoryCount: number | null): boolean {
+  return coveredCategoryCount === 2;
 }
 
 const HEALTH_SCORE_CATEGORIES = new Set<Exclude<HealthScore, 'unavailable'>>(['excellent', 'healthy', 'fair', 'concerning', 'critical']);


### PR DESCRIPTION
## Summary

- Adds a "Partial" qualifier to the Health Score label shown on org project detail and org projects list pages when a project's Health Score v2 is missing exactly one category (2 of 3 categories covered).
- Sources this directly from Tinybird's `coveredCategoryCount`/`healthMaxScore` fields (crowd.dev PR #4548) rather than recomputing partiality client-side from category values.
- Bundled fix: `classifyHealthScore` thresholds updated from 80/60/40/20 to 85/70/50/30 to match the Akrites-methodology band boundaries used elsewhere in the platform — this was inconsistent with the label bands already in use and is corrected here rather than filed separately, since both changes touch the same classification function.

## Changes

| File | Change |
|---|---|
| `apps/lfx-one/src/app/modules/dashboards/pages/org-lens/org-project-detail/org-project-detail.component.ts` | Renders "- Partial" suffix on Health Score label when applicable |
| `apps/lfx-one/src/app/modules/dashboards/pages/org-lens/org-projects/org-projects.component.ts` | Same suffix logic for the projects list view |
| `apps/lfx-one/src/app/modules/dashboards/services/org-lens-project-detail.service.ts` (+ `.spec.ts`) | Passes through `coveredCategoryCount`/`healthMaxScore` from the BFF response |
| `apps/lfx-one/src/server/.../org-lens-projects.service.ts` (+ `.spec.ts`) | Server-side proxy maps upstream fields to the DTO |
| `apps/lfx-one/src/app/modules/dashboards/.../org-lens-projects.constants.ts` | Adds partial-score threshold constant |
| `apps/lfx-one/src/app/modules/dashboards/.../org-lens-project-detail.interface.ts`, `org-lens-projects.interface.ts` | Adds `coveredCategoryCount`/`healthMaxScore` fields |
| `packages/shared/src/utils/insights.utils.ts` (+ `.spec.ts`) | `isPartialHealthScore()` helper (true only when `coveredCategoryCount === 2`) and updated `classifyHealthScore` thresholds |

## JIRA

IN-1262

## Deploy order

1. crowd.dev PR #4548 (Tinybird fields) — must be deployed to prod first
2. insights PR #2145 — independent, safe to deploy any time (graceful fallback if fields are null)
3. lf-dbt PR (branch `feat/IN-1262-partial-health-score`, not yet merged) — feeds the same fields through the medallion layers to any lf-dbt-sourced consumers
4. This PR — depends on crowd.dev's Tinybird fields being live upstream; UI degrades gracefully (no "- Partial" suffix) if they're absent

## Test plan

- [x] `CI=true yarn check-types` passes
- [x] Unit tests for `isPartialHealthScore()` and `classifyHealthScore()` threshold changes
- [ ] Manual QA: partial-score project shows "- Partial" suffix and capped total on both org project detail and org projects list — **needs a live pass before merge**, including verifying behavior under the admin role, which wasn't covered in this session's QA pass
- [ ] Manual QA: full-score project (3/3 categories) shows no suffix, uncapped total

## Checklist

- [x] DCO sign-off + GPG signature on commit
- [x] `yarn check-types` clean
- [x] No new files (no license header check needed)
- [x] Security spot-check clean
- [x] JIRA key (IN-1262) present in commit body per repo convention