### PR TITLE
fix(cla): block the already-signed identity, not the CLA group (GH-1914)

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
@@ -63,16 +63,43 @@ SPDX-License-Identifier: MIT
             </div>
           }
           @for (option of options(); track option.claGroupId; let index = $index) {
+            @let alreadySigned = alreadySignedTooltip(option);
             <div class="border-b border-slate-100 last:border-b-0">
               <div
                 role="option"
                 [id]="'cla-group-option-' + option.claGroupId"
                 [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
-                class="cursor-pointer px-4 py-2.5 text-left hover:bg-slate-50"
+                [attr.aria-disabled]="alreadySigned ? true : null"
+                [attr.aria-describedby]="alreadySigned ? 'cla-group-already-signed-' + option.claGroupId : null"
+                [pTooltip]="alreadySigned"
+                tooltipPosition="top"
+                class="px-4 py-2.5 text-left"
+                [class.cursor-pointer]="!alreadySigned"
+                [class.hover:bg-slate-50]="!alreadySigned"
+                [class.cursor-not-allowed]="!!alreadySigned"
+                [class.opacity-60]="!!alreadySigned"
                 [class.bg-slate-50]="highlightedIndex() === index"
                 [attr.data-testid]="'cla-group-select-' + option.claGroupId"
                 (click)="onSelect(option)">
-                <span class="block truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
+                <span class="flex items-center gap-2">
+                  <span class="block min-w-0 truncate text-sm font-medium" [class.text-slate-900]="!alreadySigned" [class.text-slate-400]="!!alreadySigned">{{
+                    option.primaryName
+                  }}</span>
+                  @if (alreadySigned) {
+                    <span
+                      class="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-500"
+                      [attr.data-testid]="'cla-group-select-already-signed-' + option.claGroupId">
+                      {{ alreadySignedLabel }}
+                    </span>
+                    <!--
+                      Which agreement they already hold lives only in a hover tooltip, which assistive
+                      tech never reaches. Carried here as an `aria-describedby` target rather than an
+                      `aria-label`, so the option still announces its project name first and the reason
+                      after it, instead of replacing the name with the reason.
+                    -->
+                    <span class="sr-only" [id]="'cla-group-already-signed-' + option.claGroupId">{{ alreadySigned }}</span>
+                  }
+                </span>
                 @if (option.secondaryName; as secondary) {
                   <span class="block truncate text-xs text-slate-500">{{ secondary }}</span>
                 }

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
@@ -81,15 +81,17 @@ SPDX-License-Identifier: MIT
                   <span class="block min-w-0 truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
                   @if (alreadySigned) {
                     <span
-                      class="min-w-0 truncate rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-500"
+                      class="max-w-48 shrink-0 truncate rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-500"
                       [attr.data-testid]="'cla-group-select-already-signed-' + option.claGroupId">
                       {{ alreadySigned.chip }}
                     </span>
                     <!--
-                      Which agreement they already hold, and that another identity can still sign it,
-                      lives only in a hover tooltip, which assistive tech never reaches. Carried here as
-                      an `aria-describedby` target rather than an `aria-label`, so the option still
-                      announces its project name first and the note after it.
+                      Which agreement they already hold — and, where the route has one to offer,
+                      that another identity can still sign it — lives only in a hover tooltip, which
+                      assistive tech never reaches. Carried here as an `aria-describedby` target
+                      rather than an `aria-label`, so the option still announces its project name
+                      first and the note after it. The chip is capped rather than shrinkable: it
+                      names the identity, so a long project name must not truncate it away.
                     -->
                     <span class="sr-only" [id]="'cla-group-already-signed-' + option.claGroupId">{{ alreadySigned.tooltip }}</span>
                   }

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
@@ -81,7 +81,7 @@ SPDX-License-Identifier: MIT
                   <span class="block min-w-0 truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
                   @if (alreadySigned) {
                     <span
-                      class="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-500"
+                      class="min-w-0 truncate rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-500"
                       [attr.data-testid]="'cla-group-select-already-signed-' + option.claGroupId">
                       {{ alreadySigned.chip }}
                     </span>

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
@@ -62,42 +62,36 @@ SPDX-License-Identifier: MIT
               Searching…
             </div>
           }
+          @let alreadySignedNotes = alreadySignedByGroupId();
           @for (option of options(); track option.claGroupId; let index = $index) {
-            @let alreadySigned = alreadySignedTooltip(option);
+            @let alreadySigned = alreadySignedNotes.get(option.claGroupId);
             <div class="border-b border-slate-100 last:border-b-0">
               <div
                 role="option"
                 [id]="'cla-group-option-' + option.claGroupId"
                 [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
-                [attr.aria-disabled]="alreadySigned ? true : null"
                 [attr.aria-describedby]="alreadySigned ? 'cla-group-already-signed-' + option.claGroupId : null"
-                [pTooltip]="alreadySigned"
+                [pTooltip]="alreadySigned?.tooltip"
                 tooltipPosition="top"
-                class="px-4 py-2.5 text-left"
-                [class.cursor-pointer]="!alreadySigned"
-                [class.hover:bg-slate-50]="!alreadySigned"
-                [class.cursor-not-allowed]="!!alreadySigned"
-                [class.opacity-60]="!!alreadySigned"
+                class="cursor-pointer px-4 py-2.5 text-left hover:bg-slate-50"
                 [class.bg-slate-50]="highlightedIndex() === index"
                 [attr.data-testid]="'cla-group-select-' + option.claGroupId"
                 (click)="onSelect(option)">
                 <span class="flex items-center gap-2">
-                  <span class="block min-w-0 truncate text-sm font-medium" [class.text-slate-900]="!alreadySigned" [class.text-slate-400]="!!alreadySigned">{{
-                    option.primaryName
-                  }}</span>
+                  <span class="block min-w-0 truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
                   @if (alreadySigned) {
                     <span
                       class="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-500"
                       [attr.data-testid]="'cla-group-select-already-signed-' + option.claGroupId">
-                      {{ alreadySignedLabel }}
+                      {{ alreadySigned.chip }}
                     </span>
                     <!--
-                      Which agreement they already hold lives only in a hover tooltip, which assistive
-                      tech never reaches. Carried here as an `aria-describedby` target rather than an
-                      `aria-label`, so the option still announces its project name first and the reason
-                      after it, instead of replacing the name with the reason.
+                      Which agreement they already hold, and that another identity can still sign it,
+                      lives only in a hover tooltip, which assistive tech never reaches. Carried here as
+                      an `aria-describedby` target rather than an `aria-label`, so the option still
+                      announces its project name first and the note after it.
                     -->
-                    <span class="sr-only" [id]="'cla-group-already-signed-' + option.claGroupId">{{ alreadySigned }}</span>
+                    <span class="sr-only" [id]="'cla-group-already-signed-' + option.claGroupId">{{ alreadySigned.tooltip }}</span>
                   }
                 </span>
                 @if (option.secondaryName; as secondary) {

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
@@ -85,15 +85,6 @@ SPDX-License-Identifier: MIT
                       [attr.data-testid]="'cla-group-select-already-signed-' + option.claGroupId">
                       {{ alreadySigned.chip }}
                     </span>
-                    <!--
-                      Which agreement they already hold — and, where the route has one to offer,
-                      that another identity can still sign it — lives only in a hover tooltip, which
-                      assistive tech never reaches. Carried here as an `aria-describedby` target
-                      rather than an `aria-label`, so the option still announces its project name
-                      first and the note after it. The chip is capped rather than shrinkable: it
-                      names the identity, so a long project name must not truncate it away.
-                    -->
-                    <span class="sr-only" [id]="'cla-group-already-signed-' + option.claGroupId">{{ alreadySigned.tooltip }}</span>
                   }
                 </span>
                 @if (option.secondaryName; as secondary) {
@@ -124,6 +115,21 @@ SPDX-License-Identifier: MIT
                   </span>
                 }
               </div>
+
+              @if (alreadySigned) {
+                <!--
+                  Which agreement they already hold — and, where the route has one to offer, that
+                  another identity can still sign it — lives only in a hover tooltip, which assistive
+                  tech never reaches. It is carried as an `aria-describedby` target so the option
+                  still announces its project name first and the note after it, rather than as an
+                  `aria-label` that would replace the name.
+
+                  It sits outside the option rather than inside it: an option's accessible name is
+                  built from its contents, so a hidden child would put this same sentence in the
+                  name as well as the description and a screen reader would read it twice.
+                -->
+                <span class="sr-only" [id]="'cla-group-already-signed-' + option.claGroupId">{{ alreadySigned.tooltip }}</span>
+              }
 
               @if (option.orgViews.length > 1) {
                 <button

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
@@ -458,6 +458,12 @@ describe('ClaGroupSelectComponent', () => {
       expect(fixture.nativeElement.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
         'You already have an ICLA for this CLA group. Signed as jellis (GitHub). If you have another identity linked, you can still sign with it.'
       );
+
+      // And it has to live outside the option. An option's accessible name is built from its
+      // contents, so a hidden child would put the same sentence in the name as well as the
+      // description, and a screen reader would read the whole thing twice.
+      expect(row.nativeElement.querySelector(`#${describedBy}`)).toBeNull();
+      expect(row.nativeElement.textContent).not.toContain('You already have an ICLA');
     });
 
     it('still lets them select it, because another of their identities may be able to sign', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
@@ -469,5 +469,16 @@ describe('ClaGroupSelectComponent', () => {
       (fixture.componentInstance as any).onSelect(VENUS_VIEW);
       expect((fixture.componentInstance as any).selected()).toEqual(VENUS_VIEW);
     });
+
+    it('offers no other identity on a GitLab-only group, which no identity can sign', async () => {
+      // The tooltip has to read the group's own sources to know this, so exercise it through the
+      // component rather than the helper: a GitLab-only group is blocked by its route, and
+      // suggesting they link another identity would send them nowhere.
+      getClaGroupOptions.mockReturnValue(of(envelope([{ ...VENUS, organizations: [{ name: 'Venus', source: 'gitlab' }] }])));
+      await type('venus');
+
+      const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
+      expect(row.injector.get(Tooltip, null)?.content).toBe('You already have an ICLA for this CLA group. Signed as jellis (GitHub).');
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
@@ -400,7 +400,7 @@ describe('ClaGroupSelectComponent', () => {
   });
 
   describe('already signed (#1914)', () => {
-    const covering: MyClaAgreement = {
+    const alreadyHeld: MyClaAgreement = {
       id: 's1',
       kind: 'ICLA',
       claGroupName: 'Venus ICLA',
@@ -423,7 +423,7 @@ describe('ClaGroupSelectComponent', () => {
           provideRouter([]),
           provideNoopAnimations(),
           { provide: DynamicDialogRef, useValue: { close } },
-          { provide: DynamicDialogConfig, useValue: { data: { agreements: [covering] } } },
+          { provide: DynamicDialogConfig, useValue: { data: { agreements: [alreadyHeld] } } },
           { provide: MyClasService, useValue: { getClaGroupOptions } },
         ],
       });
@@ -433,20 +433,21 @@ describe('ClaGroupSelectComponent', () => {
       await fixture.whenStable();
     });
 
-    it('grays out a group the contributor already holds a CLA for, with a tooltip that says so', async () => {
+    it('tags a group the contributor already holds a CLA for with the identity that signed it', async () => {
       await type('venus');
 
       const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
-      expect(row.nativeElement.getAttribute('aria-disabled')).toBe('true');
-      expect(state('already-signed-cg-1')?.textContent?.trim()).toBe(ALREADY_SIGNED_CLA_LABEL);
-      expect(row.injector.get(Tooltip, null)?.content).toBe('You already have an ICLA for this CLA group. Signed as jellis (GitHub).');
+      expect(state('already-signed-cg-1')?.textContent?.trim()).toBe(`${ALREADY_SIGNED_CLA_LABEL} as jellis (GitHub)`);
+      expect(row.injector.get(Tooltip, null)?.content).toBe(
+        'You already have an ICLA for this CLA group. Signed as jellis (GitHub). You can still sign it with a different identity.'
+      );
     });
 
-    it('announces the reason alongside the project name rather than in place of it', async () => {
+    it('announces the note alongside the project name rather than in place of it', async () => {
       await type('venus');
 
       // An aria-label here would win over the visible text, leaving a screen reader to read
-      // every grayed row as the same sentence with no way to tell the projects apart.
+      // every tagged row as the same sentence with no way to tell the projects apart.
       const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
       expect(row.nativeElement.getAttribute('aria-label')).toBeNull();
       expect(row.nativeElement.textContent).toContain(VENUS_VIEW.primaryName);
@@ -454,19 +455,18 @@ describe('ClaGroupSelectComponent', () => {
       const describedBy = row.nativeElement.getAttribute('aria-describedby');
       expect(describedBy).toBe('cla-group-already-signed-cg-1');
       expect(fixture.nativeElement.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
-        'You already have an ICLA for this CLA group. Signed as jellis (GitHub).'
+        'You already have an ICLA for this CLA group. Signed as jellis (GitHub). You can still sign it with a different identity.'
       );
     });
 
-    it('does not select a grayed-out row on click or Enter', async () => {
+    it('still lets them select it, because another of their identities may be able to sign', async () => {
       await type('venus');
 
-      (fixture.componentInstance as any).onSelect(VENUS_VIEW);
-      expect((fixture.componentInstance as any).selected()).toBeNull();
+      const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
+      expect(row.nativeElement.getAttribute('aria-disabled')).toBeNull();
 
-      (fixture.componentInstance as any).highlightedIndex.set(0);
-      (fixture.componentInstance as any).onKeydown(new KeyboardEvent('keydown', { key: 'Enter' }));
-      expect((fixture.componentInstance as any).selected()).toBeNull();
+      (fixture.componentInstance as any).onSelect(VENUS_VIEW);
+      expect((fixture.componentInstance as any).selected()).toEqual(VENUS_VIEW);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import type { ClaGroupOption, ClaGroupSearchResponse } from '@lfx-one/shared/interfaces';
+import { ALREADY_SIGNED_CLA_LABEL } from '@lfx-one/shared/constants';
+import type { ClaGroupOption, ClaGroupSearchResponse, MyClaAgreement } from '@lfx-one/shared/interfaces';
 import { toClaGroupOptionView } from '@lfx-one/shared/utils';
 import { MyClasService } from '@services/my-clas.service';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Tooltip } from 'primeng/tooltip';
 import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -394,5 +397,76 @@ describe('ClaGroupSelectComponent', () => {
     fixture.detectChanges();
 
     expect((fixture.componentInstance as any).options()).toEqual([toClaGroupOptionView(MARS)]);
+  });
+
+  describe('already signed (#1914)', () => {
+    const covering: MyClaAgreement = {
+      id: 's1',
+      kind: 'ICLA',
+      claGroupName: 'Venus ICLA',
+      claGroupId: 'cg-1',
+      signedOn: '2022-01-01',
+      status: 'valid',
+      pdfAvailable: true,
+      signedVia: 'github',
+      signedAs: 'jellis',
+    };
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      getClaGroupOptions = vi.fn(() => of(envelope([VENUS])));
+      close = vi.fn();
+
+      TestBed.configureTestingModule({
+        imports: [ClaGroupSelectComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          { provide: DynamicDialogRef, useValue: { close } },
+          { provide: DynamicDialogConfig, useValue: { data: { agreements: [covering] } } },
+          { provide: MyClasService, useValue: { getClaGroupOptions } },
+        ],
+      });
+
+      fixture = TestBed.createComponent(ClaGroupSelectComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('grays out a group the contributor already holds a CLA for, with a tooltip that says so', async () => {
+      await type('venus');
+
+      const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
+      expect(row.nativeElement.getAttribute('aria-disabled')).toBe('true');
+      expect(state('already-signed-cg-1')?.textContent?.trim()).toBe(ALREADY_SIGNED_CLA_LABEL);
+      expect(row.injector.get(Tooltip, null)?.content).toBe('You already have an ICLA for this CLA group. Signed as jellis (GitHub).');
+    });
+
+    it('announces the reason alongside the project name rather than in place of it', async () => {
+      await type('venus');
+
+      // An aria-label here would win over the visible text, leaving a screen reader to read
+      // every grayed row as the same sentence with no way to tell the projects apart.
+      const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
+      expect(row.nativeElement.getAttribute('aria-label')).toBeNull();
+      expect(row.nativeElement.textContent).toContain(VENUS_VIEW.primaryName);
+
+      const describedBy = row.nativeElement.getAttribute('aria-describedby');
+      expect(describedBy).toBe('cla-group-already-signed-cg-1');
+      expect(fixture.nativeElement.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
+        'You already have an ICLA for this CLA group. Signed as jellis (GitHub).'
+      );
+    });
+
+    it('does not select a grayed-out row on click or Enter', async () => {
+      await type('venus');
+
+      (fixture.componentInstance as any).onSelect(VENUS_VIEW);
+      expect((fixture.componentInstance as any).selected()).toBeNull();
+
+      (fixture.componentInstance as any).highlightedIndex.set(0);
+      (fixture.componentInstance as any).onKeydown(new KeyboardEvent('keydown', { key: 'Enter' }));
+      expect((fixture.componentInstance as any).selected()).toBeNull();
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.spec.ts
@@ -65,6 +65,7 @@ describe('ClaGroupSelectComponent', () => {
         provideRouter([]),
         provideNoopAnimations(),
         { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: { agreements: [] } } },
         { provide: MyClasService, useValue: { getClaGroupOptions } },
       ],
     });
@@ -439,7 +440,7 @@ describe('ClaGroupSelectComponent', () => {
       const row = fixture.debugElement.query(By.css('[data-testid="cla-group-select-cg-1"]'));
       expect(state('already-signed-cg-1')?.textContent?.trim()).toBe(`${ALREADY_SIGNED_CLA_LABEL} as jellis (GitHub)`);
       expect(row.injector.get(Tooltip, null)?.content).toBe(
-        'You already have an ICLA for this CLA group. Signed as jellis (GitHub). You can still sign it with a different identity.'
+        'You already have an ICLA for this CLA group. Signed as jellis (GitHub). If you have another identity linked, you can still sign with it.'
       );
     });
 
@@ -455,7 +456,7 @@ describe('ClaGroupSelectComponent', () => {
       const describedBy = row.nativeElement.getAttribute('aria-describedby');
       expect(describedBy).toBe('cla-group-already-signed-cg-1');
       expect(fixture.nativeElement.querySelector(`#${describedBy}`)?.textContent?.trim()).toBe(
-        'You already have an ICLA for this CLA group. Signed as jellis (GitHub). You can still sign it with a different identity.'
+        'You already have an ICLA for this CLA group. Signed as jellis (GitHub). If you have another identity linked, you can still sign with it.'
       );
     });
 

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
-import type { ClaGroupOptionView, ClaGroupSearchResponse, ClaGroupSelectDialogData, MyClaAgreement } from '@lfx-one/shared/interfaces';
+import type { AlreadySignedNote, ClaGroupOptionView, ClaGroupSearchResponse, ClaGroupSelectDialogData, MyClaAgreement } from '@lfx-one/shared/interfaces';
 import { alreadySignedAgreementForGroup, alreadySignedChipLabel, alreadySignedGroupTooltip, toClaGroupOptionView } from '@lfx-one/shared/utils';
 import { MyClasService } from '@services/my-clas.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -14,14 +14,6 @@ import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
-
-/** What a search result the contributor already holds a CLA for is annotated with. */
-interface AlreadySignedNote {
-  /** Inline tag, naming the identity that signed it. */
-  chip: string;
-  /** Fuller sentence: which kind, whose employer on an ECLA, and that another identity can sign. */
-  tooltip: string;
-}
 
 /**
  * "Sign a CLA" picker, opened via DialogService (#1251), following the approved M2 prototype:
@@ -49,13 +41,10 @@ interface AlreadySignedNote {
 export class ClaGroupSelectComponent {
   private readonly ref = inject(DynamicDialogRef);
   private readonly myClasService = inject(MyClasService);
-  private readonly config = inject<DynamicDialogConfig<ClaGroupSelectDialogData>>(DynamicDialogConfig, { optional: true });
+  private readonly config = inject<DynamicDialogConfig<ClaGroupSelectDialogData>>(DynamicDialogConfig);
 
-  /**
-   * The CLAs tab's loaded list. Optional so a test that never opens this through DialogService
-   * still constructs; no list means nothing is tagged.
-   */
-  private readonly agreements: readonly MyClaAgreement[] = this.config?.data?.agreements ?? [];
+  /** The CLAs tab's loaded list — this dialog never fetches it. */
+  private readonly agreements: readonly MyClaAgreement[] = this.config.data?.agreements ?? [];
 
   protected readonly searchForm = new FormGroup({
     query: new FormControl(''),

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
@@ -4,9 +4,9 @@
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { ALREADY_SIGNED_CLA_LABEL, CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import { CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
 import type { ClaGroupOptionView, ClaGroupSearchResponse, ClaGroupSelectDialogData, MyClaAgreement } from '@lfx-one/shared/interfaces';
-import { alreadySignedClaTooltip, coveringAgreementForGroup, toClaGroupOptionView } from '@lfx-one/shared/utils';
+import { alreadySignedAgreementForGroup, alreadySignedChipLabel, alreadySignedGroupTooltip, toClaGroupOptionView } from '@lfx-one/shared/utils';
 import { MyClasService } from '@services/my-clas.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
@@ -14,6 +14,14 @@ import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+
+/** What a search result the contributor already holds a CLA for is annotated with. */
+interface AlreadySignedNote {
+  /** Inline tag, naming the identity that signed it. */
+  chip: string;
+  /** Fuller sentence: which kind, whose employer on an ECLA, and that another identity can sign. */
+  tooltip: string;
+}
 
 /**
  * "Sign a CLA" picker, opened via DialogService (#1251), following the approved M2 prototype:
@@ -27,8 +35,10 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
  * resolves the hand-off URL. Searching happens here and upstream rather than by filtering a
  * fetched list, so #1250 can put the real four-source search behind the same route untouched.
  *
- * A group the contributor already holds a CLA for stays in the list, grayed out, with a
- * tooltip that says so (#1914). Hiding it would look like the project does not exist.
+ * A group the contributor already holds a CLA for is tagged with the identity that signed it,
+ * and stays selectable (#1914). It has to: one contributor can hold several identities, and an
+ * ICLA signed under one of them says nothing about whether another can still sign. The refusal
+ * therefore belongs to the identity step, which grays out the identity already on an agreement.
  */
 @Component({
   selector: 'lfx-cla-group-select',
@@ -41,12 +51,9 @@ export class ClaGroupSelectComponent {
   private readonly myClasService = inject(MyClasService);
   private readonly config = inject<DynamicDialogConfig<ClaGroupSelectDialogData>>(DynamicDialogConfig, { optional: true });
 
-  /** Chip on a grayed-out row. The tooltip sentence is computed per option. */
-  protected readonly alreadySignedLabel = ALREADY_SIGNED_CLA_LABEL;
-
   /**
    * The CLAs tab's loaded list. Optional so a test that never opens this through DialogService
-   * still constructs; no list means nothing is grayed out.
+   * still constructs; no list means nothing is tagged.
    */
   private readonly agreements: readonly MyClaAgreement[] = this.config?.data?.agreements ?? [];
 
@@ -73,6 +80,13 @@ export class ClaGroupSelectComponent {
    * going" from "that term matched nothing".
    */
   protected readonly queryBand: Signal<'empty' | 'short' | 'searchable'> = this.initQueryBand();
+
+  /**
+   * Tag and tooltip per CLA group the contributor already holds, keyed by group id (#1914).
+   * Informational only — every row stays selectable, because another of their identities may
+   * still be able to sign it. The identity step is what refuses.
+   */
+  protected readonly alreadySignedByGroupId: Signal<Map<string, AlreadySignedNote>> = this.initAlreadySignedByGroupId();
 
   private readonly search$ = new Subject<string>();
 
@@ -177,7 +191,7 @@ export class ClaGroupSelectComponent {
         break;
       case 'Enter': {
         const highlighted = options[this.highlightedIndex()];
-        if (!highlighted || this.alreadySignedTooltip(highlighted)) return;
+        if (!highlighted) return;
         event.preventDefault();
         this.onSelect(highlighted);
         break;
@@ -201,18 +215,7 @@ export class ClaGroupSelectComponent {
     this.pushSearch(this.searchForm.controls.query.value ?? '');
   }
 
-  /**
-   * Tooltip on a result the contributor already holds a CLA for. Undefined means the
-   * row is selectable. Kept as a method rather than precomputed onto the view model so
-   * a search-result update cannot drop the coverage the parent already loaded.
-   */
-  protected alreadySignedTooltip(option: ClaGroupOptionView): string | undefined {
-    const covering = coveringAgreementForGroup(this.agreements, option.claGroupId);
-    return covering ? alreadySignedClaTooltip(covering) : undefined;
-  }
-
   protected onSelect(option: ClaGroupOptionView): void {
-    if (this.alreadySignedTooltip(option)) return;
     this.selected.set(option);
     this.suppressNextEmit = true;
     const display = option.secondaryName ? `${option.primaryName} — ${option.secondaryName}` : option.primaryName;
@@ -241,6 +244,19 @@ export class ClaGroupSelectComponent {
     this.options.set([]);
     this.truncated.set(false);
     this.highlightedIndex.set(-1);
+  }
+
+  private initAlreadySignedByGroupId(): Signal<Map<string, AlreadySignedNote>> {
+    return computed(() => {
+      const notes = new Map<string, AlreadySignedNote>();
+      for (const option of this.options()) {
+        const held = alreadySignedAgreementForGroup(this.agreements, option.claGroupId);
+        if (held) {
+          notes.set(option.claGroupId, { chip: alreadySignedChipLabel(held), tooltip: alreadySignedGroupTooltip(held) });
+        }
+      }
+      return notes;
+    });
   }
 
   private initQueryBand(): Signal<'empty' | 'short' | 'searchable'> {

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
 import type { AlreadySignedNote, ClaGroupOptionView, ClaGroupSearchResponse, ClaGroupSelectDialogData, MyClaAgreement } from '@lfx-one/shared/interfaces';
-import { alreadySignedAgreementForGroup, alreadySignedChipLabel, alreadySignedGroupTooltip, toClaGroupOptionView } from '@lfx-one/shared/utils';
+import { alreadySignedAgreementForGroup, alreadySignedChipLabel, alreadySignedGroupTooltip, claSignRoute, toClaGroupOptionView } from '@lfx-one/shared/utils';
 import { MyClasService } from '@services/my-clas.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
@@ -241,7 +241,10 @@ export class ClaGroupSelectComponent {
       for (const option of this.options()) {
         const held = alreadySignedAgreementForGroup(this.agreements, option.claGroupId);
         if (held) {
-          notes.set(option.claGroupId, { chip: alreadySignedChipLabel(held), tooltip: alreadySignedGroupTooltip(held) });
+          notes.set(option.claGroupId, {
+            chip: alreadySignedChipLabel(held),
+            tooltip: alreadySignedGroupTooltip(held, claSignRoute(option.organizations)),
+          });
         }
       }
       return notes;

--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.ts
@@ -4,11 +4,12 @@
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
-import type { ClaGroupOptionView, ClaGroupSearchResponse } from '@lfx-one/shared/interfaces';
-import { toClaGroupOptionView } from '@lfx-one/shared/utils';
+import { ALREADY_SIGNED_CLA_LABEL, CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import type { ClaGroupOptionView, ClaGroupSearchResponse, ClaGroupSelectDialogData, MyClaAgreement } from '@lfx-one/shared/interfaces';
+import { alreadySignedClaTooltip, coveringAgreementForGroup, toClaGroupOptionView } from '@lfx-one/shared/utils';
 import { MyClasService } from '@services/my-clas.service';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
@@ -25,16 +26,29 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
  * Closes with the chosen `ClaGroupOption`, or `null` if the contributor backs out; the caller
  * resolves the hand-off URL. Searching happens here and upstream rather than by filtering a
  * fetched list, so #1250 can put the real four-source search behind the same route untouched.
+ *
+ * A group the contributor already holds a CLA for stays in the list, grayed out, with a
+ * tooltip that says so (#1914). Hiding it would look like the project does not exist.
  */
 @Component({
   selector: 'lfx-cla-group-select',
-  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent, TooltipModule],
   templateUrl: './cla-group-select.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ClaGroupSelectComponent {
   private readonly ref = inject(DynamicDialogRef);
   private readonly myClasService = inject(MyClasService);
+  private readonly config = inject<DynamicDialogConfig<ClaGroupSelectDialogData>>(DynamicDialogConfig, { optional: true });
+
+  /** Chip on a grayed-out row. The tooltip sentence is computed per option. */
+  protected readonly alreadySignedLabel = ALREADY_SIGNED_CLA_LABEL;
+
+  /**
+   * The CLAs tab's loaded list. Optional so a test that never opens this through DialogService
+   * still constructs; no list means nothing is grayed out.
+   */
+  private readonly agreements: readonly MyClaAgreement[] = this.config?.data?.agreements ?? [];
 
   protected readonly searchForm = new FormGroup({
     query: new FormControl(''),
@@ -163,7 +177,7 @@ export class ClaGroupSelectComponent {
         break;
       case 'Enter': {
         const highlighted = options[this.highlightedIndex()];
-        if (!highlighted) return;
+        if (!highlighted || this.alreadySignedTooltip(highlighted)) return;
         event.preventDefault();
         this.onSelect(highlighted);
         break;
@@ -187,7 +201,18 @@ export class ClaGroupSelectComponent {
     this.pushSearch(this.searchForm.controls.query.value ?? '');
   }
 
+  /**
+   * Tooltip on a result the contributor already holds a CLA for. Undefined means the
+   * row is selectable. Kept as a method rather than precomputed onto the view model so
+   * a search-result update cannot drop the coverage the parent already loaded.
+   */
+  protected alreadySignedTooltip(option: ClaGroupOptionView): string | undefined {
+    const covering = coveringAgreementForGroup(this.agreements, option.claGroupId);
+    return covering ? alreadySignedClaTooltip(covering) : undefined;
+  }
+
   protected onSelect(option: ClaGroupOptionView): void {
+    if (this.alreadySignedTooltip(option)) return;
     this.selected.set(option);
     this.suppressNextEmit = true;
     const display = option.secondaryName ? `${option.primaryName} — ${option.secondaryName}` : option.primaryName;

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 
     <!--
     Page-level, not per-row: signing a new CLA has no row to act on yet. Rendered whenever the M2
-    overlay is on, then disabled while impersonating rather than withheld.
+    overlay is on, then disabled rather than withheld — see `signDisabled` for when and why.
     -->
     @if (myClasM2Enabled()) {
       <lfx-button
@@ -20,8 +20,8 @@ SPDX-License-Identifier: MIT
         icon="fa-light fa-file-signature"
         size="small"
         [loading]="starting()"
-        [disabled]="impersonating()"
-        [ariaLabel]="impersonating() ? 'This action is unavailable while impersonating another user' : undefined"
+        [disabled]="signDisabled()"
+        [ariaLabel]="signDisabledReason()"
         data-testid="sign-cla-action"
         (onClick)="openSignDialog()" />
     }

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -34,7 +34,7 @@ import { MyClasService } from '@services/my-clas.service';
 import { UserService } from '@services/user.service';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
-import { EMPTY, Observable, of, Subject, throwError } from 'rxjs';
+import { EMPTY, NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ClaGroupSelectComponent } from './cla-group-select.component';
@@ -566,6 +566,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       viewerUsername?: string | null;
       /** Loaded My CLAs list handed to the group picker (#1914). */
       agreements?: MyClaAgreement[];
+      /** Leaves the My CLAs request unresolved, so the loading state is assertable (#1914). */
+      pending?: boolean;
     } = {}
   ): Promise<ComponentFixture<ProfileClasComponent>> {
     location = { href: HOME, origin: ORIGIN };
@@ -632,7 +634,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
         {
           provide: MyClasService,
           useValue: {
-            getMyClas: vi.fn(() => of(options.agreements ? { ...EMPTY_CLAS, agreements: options.agreements } : EMPTY_CLAS)),
+            getMyClas: vi.fn(() => (options.pending ? NEVER : of(options.agreements ? { ...EMPTY_CLAS, agreements: options.agreements } : EMPTY_CLAS))),
             getPdfUrl: vi.fn(),
             getClaGroupOptions: vi.fn(() => of({ ...SEARCH_RESULTS, results: [selectedGroup] })),
             getGithubAccounts,
@@ -747,8 +749,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     expect(fixture.nativeElement.querySelector('p-dialog')).toBeNull();
   });
 
-  it('hands the loaded agreements to the picker so it can gray out already-signed groups', async () => {
-    const covering: MyClaAgreement = {
+  it('hands the loaded agreements to the picker so it can tag already-signed groups', async () => {
+    const alreadyHeld: MyClaAgreement = {
       id: 's1',
       kind: 'ICLA',
       claGroupName: 'Venus',
@@ -757,31 +759,50 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       status: 'valid',
       pdfAvailable: true,
     };
-    const fixture = await setup({ agreements: [covering], dismissGroup: 'hold' });
+    const fixture = await setup({ agreements: [alreadyHeld], dismissGroup: 'hold' });
 
     await sign(fixture);
 
     const groupOpen = openedWith.find((entry) => entry.component === ClaGroupSelectComponent);
-    expect(groupOpen?.config.data).toEqual({ agreements: [covering] });
+    expect(groupOpen?.config.data).toEqual({ agreements: [alreadyHeld] });
   });
 
-  it('does not start a hand-off when the picker closes with an already-signed group', async () => {
-    const covering: MyClaAgreement = {
+  it('carries what they already hold for the chosen group into the identity step (#1914)', async () => {
+    const alreadyHeld: MyClaAgreement = {
       id: 's1',
       kind: 'ICLA',
       claGroupName: 'Venus',
-      claGroupId: 'cg-1',
+      claGroupId: CLA_GROUP.claGroupId,
       signedOn: '2022-01-01',
       status: 'valid',
       pdfAvailable: true,
+      signedVia: 'github',
+      signedAs: 'jellis',
     };
-    const fixture = await setup({ agreements: [covering] });
+    const otherGroup: MyClaAgreement = { ...alreadyHeld, id: 's2', claGroupId: 'cg-other' };
+    const fixture = await setup({ agreements: [alreadyHeld, otherGroup] });
 
     await sign(fixture);
 
-    expect(getGithubAccounts).not.toHaveBeenCalled();
-    expect(prepareSign).not.toHaveBeenCalled();
-    expect(location.href).toBe(HOME);
+    // The group they picked, not their whole list: the step grays out identities, and an
+    // agreement on a different CLA group says nothing about this one.
+    expect(identityStepData()?.claGroupAgreements).toEqual([alreadyHeld]);
+  });
+
+  it('leaves the identity step nothing to gray out when the group is new to them', async () => {
+    const fixture = await setup({ agreements: [] });
+
+    await sign(fixture);
+
+    expect(identityStepData()?.claGroupAgreements).toBeUndefined();
+  });
+
+  it('does not open the picker until the CLA list has loaded', async () => {
+    const fixture = await setup({ pending: true });
+
+    await sign(fixture);
+
+    expect(open).not.toHaveBeenCalled();
   });
 
   it('does nothing when the contributor backs out of the project picker', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -16,6 +16,7 @@ import type {
   ClaGroupOption,
   ClaGroupOrg,
   ClaGroupSearchResponse,
+  ClaGroupSelectDialogData,
   ClaManagerList,
   GithubAccountOptions,
   MyClaAgreement,
@@ -548,7 +549,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
   /** Records dialog opens in order, so "which dialog, and was it opened at all" is assertable. */
   let opened: unknown[];
   /** Records what each dialog was opened with, so the identity step's inputs are assertable. */
-  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData } }[];
+  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData } }[];
 
   async function setup(
     options: {
@@ -563,6 +564,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       /** Linked organizations on the selected group — the sole input to the routing decision. */
       organizations?: ClaGroupOrg[];
       viewerUsername?: string | null;
+      /** Loaded My CLAs list handed to the group picker (#1914). */
+      agreements?: MyClaAgreement[];
     } = {}
   ): Promise<ComponentFixture<ProfileClasComponent>> {
     location = { href: HOME, origin: ORIGIN };
@@ -577,7 +580,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
 
     const selectedGroup: ClaGroupOption = { ...CLA_GROUP, organizations: options.organizations ?? [] };
 
-    open = vi.fn((component: unknown, config?: { header?: string; data?: SignIdentityDialogData }) => {
+    open = vi.fn((component: unknown, config?: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData }) => {
       opened.push(component);
       openedWith.push({ component, config: config ?? {} });
       if (component === SignIdentitySelectComponent) {
@@ -629,7 +632,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
         {
           provide: MyClasService,
           useValue: {
-            getMyClas: vi.fn(() => of(EMPTY_CLAS)),
+            getMyClas: vi.fn(() => of(options.agreements ? { ...EMPTY_CLAS, agreements: options.agreements } : EMPTY_CLAS)),
             getPdfUrl: vi.fn(),
             getClaGroupOptions: vi.fn(() => of({ ...SEARCH_RESULTS, results: [selectedGroup] })),
             getGithubAccounts,
@@ -742,6 +745,43 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     expect(open).toHaveBeenCalled();
     expect(opened[0]).toBe(ClaGroupSelectComponent);
     expect(fixture.nativeElement.querySelector('p-dialog')).toBeNull();
+  });
+
+  it('hands the loaded agreements to the picker so it can gray out already-signed groups', async () => {
+    const covering: MyClaAgreement = {
+      id: 's1',
+      kind: 'ICLA',
+      claGroupName: 'Venus',
+      claGroupId: 'cg-1',
+      signedOn: '2022-01-01',
+      status: 'valid',
+      pdfAvailable: true,
+    };
+    const fixture = await setup({ agreements: [covering], dismissGroup: 'hold' });
+
+    await sign(fixture);
+
+    const groupOpen = openedWith.find((entry) => entry.component === ClaGroupSelectComponent);
+    expect(groupOpen?.config.data).toEqual({ agreements: [covering] });
+  });
+
+  it('does not start a hand-off when the picker closes with an already-signed group', async () => {
+    const covering: MyClaAgreement = {
+      id: 's1',
+      kind: 'ICLA',
+      claGroupName: 'Venus',
+      claGroupId: 'cg-1',
+      signedOn: '2022-01-01',
+      status: 'valid',
+      pdfAvailable: true,
+    };
+    const fixture = await setup({ agreements: [covering] });
+
+    await sign(fixture);
+
+    expect(getGithubAccounts).not.toHaveBeenCalled();
+    expect(prepareSign).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
   });
 
   it('does nothing when the contributor backs out of the project picker', async () => {
@@ -1100,7 +1140,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
 
   /** What the identity step was actually served on the last open. */
   function identityStepData(): SignIdentityDialogData | undefined {
-    return openedWith.filter((entry) => entry.component === SignIdentitySelectComponent).at(-1)?.config.data;
+    const data = openedWith.filter((entry) => entry.component === SignIdentitySelectComponent).at(-1)?.config.data;
+    return data && 'variant' in data ? data : undefined;
   }
 
   it('keeps a group with no linked organization on the GitHub path', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -716,7 +716,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     // control on the profile. The server is still the guard.
     expect(query(fixture, 'sign-cla-action')).not.toBeNull();
     expect(signButton(fixture)?.disabled).toBe(true);
-    expect(signButton(fixture)?.getAttribute('aria-label')).toBe('This action is unavailable while impersonating another user');
+    expect(signButton(fixture)?.getAttribute('aria-label')).toBe('Sign CLA — unavailable while impersonating another user');
   });
 
   it('opens no picker when Sign CLA is reached while impersonating', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -568,6 +568,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       agreements?: MyClaAgreement[];
       /** Leaves the My CLAs request unresolved, so the loading state is assertable (#1914). */
       pending?: boolean;
+      /** Fails the My CLAs request, so the load-failure state is assertable (#1914). */
+      failed?: boolean;
     } = {}
   ): Promise<ComponentFixture<ProfileClasComponent>> {
     location = { href: HOME, origin: ORIGIN };
@@ -634,7 +636,11 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
         {
           provide: MyClasService,
           useValue: {
-            getMyClas: vi.fn(() => (options.pending ? NEVER : of(options.agreements ? { ...EMPTY_CLAS, agreements: options.agreements } : EMPTY_CLAS))),
+            getMyClas: vi.fn(() => {
+              if (options.pending) return NEVER;
+              if (options.failed) return throwError(() => new Error('my CLAs unavailable'));
+              return of(options.agreements ? { ...EMPTY_CLAS, agreements: options.agreements } : EMPTY_CLAS);
+            }),
             getPdfUrl: vi.fn(),
             getClaGroupOptions: vi.fn(() => of({ ...SEARCH_RESULTS, results: [selectedGroup] })),
             getGithubAccounts,
@@ -799,6 +805,16 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
 
   it('does not open the picker until the CLA list has loaded', async () => {
     const fixture = await setup({ pending: true });
+
+    await sign(fixture);
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('does not open the picker when the CLA list failed to load', async () => {
+    // A failed load and having signed nothing both present as an empty list, so opening here
+    // would tag no group and gray out no identity — the duplicate signing this change prevents.
+    const fixture = await setup({ failed: true });
 
     await sign(fixture);
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -148,10 +148,15 @@ export class ProfileClasComponent {
    */
   protected readonly signDisabled = computed(() => this.impersonating() || this.loading() || this.error());
 
+  /**
+   * Reads as the button's accessible name while it is disabled, so it has to name the action
+   * before the reason — an aria-label replaces the label rather than adding to it, and a reason
+   * on its own would leave a screen reader with no idea which action is unavailable.
+   */
   protected readonly signDisabledReason = computed<string | undefined>(() => {
-    if (this.impersonating()) return 'This action is unavailable while impersonating another user';
-    if (this.loading()) return 'Available once your CLAs have loaded';
-    if (this.error()) return 'Available once your CLAs load — select Retry to reload them';
+    if (this.impersonating()) return 'Sign CLA — unavailable while impersonating another user';
+    if (this.loading()) return 'Sign CLA — available once your CLAs have loaded';
+    if (this.error()) return 'Sign CLA — available once your CLAs load; select Retry to reload them';
     return undefined;
   });
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -140,16 +140,18 @@ export class ProfileClasComponent {
   // --- Sign CLA hand-off (#1251) -------------------------------------------
 
   /**
-   * Also disabled while the list is still loading (#1914). Both dialogs read the loaded
-   * agreements — the picker to tag a group they already signed, the identity step to gray out
-   * the identity that signed it — and an empty list is indistinguishable from having signed
-   * nothing, so a click landing first would offer a signature they already hold.
+   * Also disabled until the list has loaded, and while it has failed to load (#1914). Both dialogs
+   * read the loaded agreements — the picker to tag a group they already signed, the identity step
+   * to gray out the identity that signed it — and in both states the list is empty, which is
+   * indistinguishable from having signed nothing. Offering the flow then would walk them into the
+   * duplicate signing this change exists to prevent.
    */
-  protected readonly signDisabled = computed(() => this.impersonating() || this.loading());
+  protected readonly signDisabled = computed(() => this.impersonating() || this.loading() || this.error());
 
   protected readonly signDisabledReason = computed<string | undefined>(() => {
     if (this.impersonating()) return 'This action is unavailable while impersonating another user';
     if (this.loading()) return 'Available once your CLAs have loaded';
+    if (this.error()) return 'Available once your CLAs load — select Retry to reload them';
     return undefined;
   });
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -20,10 +20,10 @@ import type {
   SignIdentityVariant,
 } from '@lfx-one/shared/interfaces';
 import {
+  alreadySignedAgreementsForGroup,
   claSignRoute,
   claStatusLabel,
   claStatusSeverity,
-  coveringAgreementForGroup,
   downloadFromUrl,
   gerritSignUrl,
   isMyClasEmpty,
@@ -139,6 +139,20 @@ export class ProfileClasComponent {
 
   // --- Sign CLA hand-off (#1251) -------------------------------------------
 
+  /**
+   * Also disabled while the list is still loading (#1914). Both dialogs read the loaded
+   * agreements — the picker to tag a group they already signed, the identity step to gray out
+   * the identity that signed it — and an empty list is indistinguishable from having signed
+   * nothing, so a click landing first would offer a signature they already hold.
+   */
+  protected readonly signDisabled = computed(() => this.impersonating() || this.loading());
+
+  protected readonly signDisabledReason = computed<string | undefined>(() => {
+    if (this.impersonating()) return 'This action is unavailable while impersonating another user';
+    if (this.loading()) return 'Available once your CLAs have loaded';
+    return undefined;
+  });
+
   protected retry(): void {
     this.refresh$.next();
   }
@@ -166,7 +180,7 @@ export class ProfileClasComponent {
     // `impersonating()` is re-checked here and not only on the button: the button is now rendered
     // rather than withheld, so a keyboard or programmatic activation can reach this method, and
     // opening the picker would walk the administrator to a prepare the server refuses.
-    if (!this.myClasM2Enabled() || this.impersonating() || this.starting() || this.signDialogOpen()) return;
+    if (!this.myClasM2Enabled() || this.signDisabled() || this.starting() || this.signDialogOpen()) return;
     this.signDialogOpen.set(true);
 
     const dialogRef = this.dialogService.open(ClaGroupSelectComponent, {
@@ -181,12 +195,6 @@ export class ProfileClasComponent {
     this.whenDialogSettles<ClaGroupOption>(dialogRef, (option) => {
       this.signDialogOpen.set(false);
       if (!option) {
-        this.starting.set(false);
-        return;
-      }
-      // The picker refuses a click on an already-signed row. This is the same check
-      // in case a close value arrives another way — a second ceremony must not start.
-      if (coveringAgreementForGroup(this.agreements(), option.claGroupId)) {
         this.starting.set(false);
         return;
       }
@@ -327,7 +335,17 @@ export class ProfileClasComponent {
     this.starting.set(false);
     this.signDialogOpen.set(true);
 
-    const data: SignIdentityDialogData = { variant: effectiveVariant, accounts, ...(gerritUsername ? { gerritUsername } : {}) };
+    // What they already hold for *this* group, so the step can gray out the identity that signed
+    // it. Passed as agreements rather than a precomputed verdict because only the step knows
+    // which identities it ended up offering.
+    const claGroupAgreements = alreadySignedAgreementsForGroup(this.agreements(), option.claGroupId);
+
+    const data: SignIdentityDialogData = {
+      variant: effectiveVariant,
+      accounts,
+      ...(gerritUsername ? { gerritUsername } : {}),
+      ...(claGroupAgreements.length > 0 ? { claGroupAgreements } : {}),
+    };
 
     const dialogRef = this.dialogService.open(SignIdentitySelectComponent, {
       header: SIGN_IDENTITY_COPY[effectiveVariant].header,

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -19,7 +19,16 @@ import type {
   SignIdentitySelectResult,
   SignIdentityVariant,
 } from '@lfx-one/shared/interfaces';
-import { claSignRoute, claStatusLabel, claStatusSeverity, downloadFromUrl, gerritSignUrl, isMyClasEmpty, signedAsLine } from '@lfx-one/shared/utils';
+import {
+  claSignRoute,
+  claStatusLabel,
+  claStatusSeverity,
+  coveringAgreementForGroup,
+  downloadFromUrl,
+  gerritSignUrl,
+  isMyClasEmpty,
+  signedAsLine,
+} from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { ToastModule } from 'primeng/toast';
@@ -166,11 +175,18 @@ export class ProfileClasComponent {
       modal: true,
       closable: true,
       dismissableMask: true,
+      data: { agreements: this.agreements() },
     }) as DynamicDialogRef;
 
     this.whenDialogSettles<ClaGroupOption>(dialogRef, (option) => {
       this.signDialogOpen.set(false);
       if (!option) {
+        this.starting.set(false);
+        return;
+      }
+      // The picker refuses a click on an already-signed row. This is the same check
+      // in case a close value arrives another way — a second ceremony must not start.
+      if (coveringAgreementForGroup(this.agreements(), option.claGroupId)) {
         this.starting.set(false);
         return;
       }

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.html
@@ -8,17 +8,35 @@ SPDX-License-Identifier: MIT
 
   @if (hasIdentities()) {
     <div role="listbox" aria-label="Identities you can sign with" class="flex flex-col gap-2">
+      <!--
+        An identity that already signed this CLA group is grayed out with the reason. The tooltip
+        sits on a wrapper rather than the card, so that a card the contributor cannot click is
+        still something they can hover to find out why.
+      -->
       @for (account of accounts(); track account.githubId) {
-        <lfx-selectable-card
-          [form]="selectForm"
-          control="identity"
-          [value]="account.githubId"
-          [label]="account.label"
-          [testId]="'sign-identity-select-github-' + account.githubId" />
+        <div [pTooltip]="account.alreadySignedTooltip" tooltipPosition="top">
+          <lfx-selectable-card
+            [form]="selectForm"
+            control="identity"
+            [value]="account.githubId"
+            [label]="account.label"
+            [disabled]="!!account.alreadySignedTooltip"
+            [assistiveNote]="account.alreadySignedTooltip ?? ''"
+            [testId]="'sign-identity-select-github-' + account.githubId" />
+        </div>
       }
 
       @if (gerritLabel(); as label) {
-        <lfx-selectable-card [form]="selectForm" control="identity" [value]="gerritValue" [label]="label" testId="sign-identity-select-gerrit" />
+        <div [pTooltip]="gerritAlreadySignedTooltip()" tooltipPosition="top">
+          <lfx-selectable-card
+            [form]="selectForm"
+            control="identity"
+            [value]="gerritValue"
+            [label]="label"
+            [disabled]="!!gerritAlreadySignedTooltip()"
+            [assistiveNote]="gerritAlreadySignedTooltip() ?? ''"
+            testId="sign-identity-select-gerrit" />
+        </div>
       }
     </div>
 

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.html
@@ -9,34 +9,29 @@ SPDX-License-Identifier: MIT
   @if (hasIdentities()) {
     <div role="listbox" aria-label="Identities you can sign with" class="flex flex-col gap-2">
       <!--
-        An identity that already signed this CLA group is grayed out with the reason. The tooltip
-        sits on a wrapper rather than the card, so that a card the contributor cannot click is
-        still something they can hover to find out why.
+        An identity that already signed this CLA group is grayed out with the reason. The card owns
+        the reason so it reaches everyone: hover, keyboard focus, and screen readers alike.
       -->
       @for (account of accounts(); track account.githubId) {
-        <div [pTooltip]="account.alreadySignedTooltip" tooltipPosition="top">
-          <lfx-selectable-card
-            [form]="selectForm"
-            control="identity"
-            [value]="account.githubId"
-            [label]="account.label"
-            [disabled]="!!account.alreadySignedTooltip"
-            [assistiveNote]="account.alreadySignedTooltip ?? ''"
-            [testId]="'sign-identity-select-github-' + account.githubId" />
-        </div>
+        <lfx-selectable-card
+          [form]="selectForm"
+          control="identity"
+          [value]="account.githubId"
+          [label]="account.label"
+          [disabled]="!!account.alreadySignedTooltip"
+          [disabledReason]="account.alreadySignedTooltip ?? ''"
+          [testId]="'sign-identity-select-github-' + account.githubId" />
       }
 
       @if (gerritLabel(); as label) {
-        <div [pTooltip]="gerritAlreadySignedTooltip()" tooltipPosition="top">
-          <lfx-selectable-card
-            [form]="selectForm"
-            control="identity"
-            [value]="gerritValue"
-            [label]="label"
-            [disabled]="!!gerritAlreadySignedTooltip()"
-            [assistiveNote]="gerritAlreadySignedTooltip() ?? ''"
-            testId="sign-identity-select-gerrit" />
-        </div>
+        <lfx-selectable-card
+          [form]="selectForm"
+          control="identity"
+          [value]="gerritValue"
+          [label]="label"
+          [disabled]="!!gerritAlreadySignedTooltip()"
+          [disabledReason]="gerritAlreadySignedTooltip() ?? ''"
+          testId="sign-identity-select-gerrit" />
       }
     </div>
 

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -302,11 +302,20 @@ describe('SignIdentitySelectComponent', () => {
       await setup({ claGroupAgreements: signedAs('octocat') });
 
       const card = fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]'));
-      expect(card.parent?.injector.get(Tooltip, null)?.content).toBe(REASON);
-      // A tooltip is hover-only, so the reason is repeated where a screen reader will reach it —
-      // after the handle, so which account is refused stays clear.
+      expect(card.injector.get(Tooltip, null)?.content).toBe(REASON);
+      // The reason is also repeated where a screen reader will reach it — after the handle, so
+      // which account is refused stays clear.
       expect(card.nativeElement.textContent).toContain('octocat');
       expect(card.nativeElement.textContent).toContain(REASON);
+    });
+
+    it('keeps the grayed card reachable, so the reason is not hover-only', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      // Removing it from the tab order would leave a keyboard-only contributor with no way to
+      // ask why the account is unavailable — the tooltip also answers to focus, not just hover.
+      expect(query('sign-identity-select-github-12345')?.getAttribute('tabindex')).toBe('0');
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.tooltipEvent).toBe('both');
     });
 
     it('refuses to submit it even if the card is reached another way', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -322,7 +322,7 @@ describe('SignIdentitySelectComponent', () => {
     it.each([
       ['Enter', 'Enter'],
       ['Space', ' '],
-    ])('refuses a %s keypress on the grayed card', async (_label, key) => {
+    ])('refuses the %s key on the grayed card', async (_label, key) => {
       await setup({ claGroupAgreements: signedAs('octocat') });
 
       // Keeping the card focusable put Enter/Space on a live path: the only thing that stops it
@@ -340,6 +340,20 @@ describe('SignIdentitySelectComponent', () => {
 
       expect(identity.value).toBe(before);
       expect(close).not.toHaveBeenCalled();
+    });
+
+    it('still selects a card that has not signed, from the keyboard', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      // The mirror of the refusal above. Without it, deleting the card's (keydown) binding would
+      // leave that test green — nothing else here proves a dispatched key reaches the handler.
+      fixture.debugElement
+        .query(By.css('[data-testid="sign-identity-select-github-67890"]'))
+        .nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect((fixture.componentInstance as any).selectForm.controls.identity.value).toBe('67890');
     });
 
     it('refuses to submit it even if the card is reached another way', async () => {
@@ -378,6 +392,16 @@ describe('SignIdentitySelectComponent', () => {
 
       expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('false');
       expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('tells them to choose another identity only when one is left to choose', async () => {
+      // A Gerrit-only step offers exactly one card. Once it is grayed there is nothing else to
+      // pick, so prescribing a way out would name the one thing they cannot do.
+      await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit') });
+
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-gerrit"]')).injector.get(Tooltip, null)?.content).toBe(
+        'You already have an ICLA for this CLA group signed with this account.'
+      );
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -321,7 +321,12 @@ describe('SignIdentitySelectComponent', () => {
     it('refuses to submit it even if the card is reached another way', async () => {
       await setup({ claGroupAgreements: signedAs('octocat') });
 
-      await choose('sign-identity-select-github-12345');
+      // Clicking a grayed card is refused by the card itself, which leaves the control unwritten
+      // and never reaches the guard this test is named for. Writing the control directly is the
+      // "another way" — it is what a refactor that drops the guard would silently allow.
+      (fixture.componentInstance as any).selectForm.controls.identity.setValue('12345');
+      fixture.detectChanges();
+      await fixture.whenStable();
       (fixture.componentInstance as any).onContinue();
 
       expect(close).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -284,7 +284,9 @@ describe('SignIdentitySelectComponent', () => {
 
   describe('already signed', () => {
     function signedAs(signedAs: string, signedVia: 'github' | 'gerrit' = 'github'): MyClaAgreement[] {
-      return [{ id: 's1', kind: 'ICLA', claGroupName: 'Venus', claGroupId: 'cg-1', signedOn: '2022-01-01', status: 'valid', pdfAvailable: true, signedVia, signedAs }];
+      return [
+        { id: 's1', kind: 'ICLA', claGroupName: 'Venus', claGroupId: 'cg-1', signedOn: '2022-01-01', status: 'valid', pdfAvailable: true, signedVia, signedAs },
+      ];
     }
 
     const REASON = 'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.';

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -314,8 +314,32 @@ describe('SignIdentitySelectComponent', () => {
 
       // Removing it from the tab order would leave a keyboard-only contributor with no way to
       // ask why the account is unavailable — the tooltip also answers to focus, not just hover.
-      expect(query('sign-identity-select-github-12345')?.getAttribute('tabindex')).toBe('0');
-      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.tooltipEvent).toBe('both');
+      const card = fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]'));
+      expect(card.nativeElement.getAttribute('tabindex')).toBe('0');
+      expect(card.injector.get(Tooltip, null)?.tooltipEvent).toBe('both');
+    });
+
+    it.each([
+      ['Enter', 'Enter'],
+      ['Space', ' '],
+    ])('refuses a %s keypress on the grayed card', async (_label, key) => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      // Keeping the card focusable put Enter/Space on a live path: the only thing that stops it
+      // selecting the account is the card's own disabled guard, so assert the key leaves the
+      // control exactly as it was rather than trusting that guard to stay.
+      const identity = (fixture.componentInstance as any).selectForm.controls.identity;
+      const before = identity.value;
+
+      fixture.debugElement
+        .query(By.css('[data-testid="sign-identity-select-github-12345"]'))
+        .nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      (fixture.componentInstance as any).onContinue();
+
+      expect(identity.value).toBe(before);
+      expect(close).not.toHaveBeenCalled();
     });
 
     it('refuses to submit it even if the card is reached another way', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -298,6 +298,15 @@ describe('SignIdentitySelectComponent', () => {
       expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
     });
 
+    it('grays the account the producer recorded by number rather than handle', async () => {
+      // Agreements carry one identity string, which is the account number when no handle was
+      // recorded. Matching only the handle would leave the account that signed selectable.
+      await setup({ claGroupAgreements: signedAs('12345') });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
+      expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
     it('says why, in the tooltip and to assistive tech', async () => {
       await setup({ claGroupAgreements: signedAs('octocat') });
 

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -307,6 +307,22 @@ describe('SignIdentitySelectComponent', () => {
       expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
     });
 
+    it('reads a numeric recorded identity as a handle when a card on the step carries it', async () => {
+      // Login `12345` is a real account whose number is something else entirely. The component
+      // has to feed every handle on offer into the matcher so a recorded `12345` greys the
+      // numerically-named card alone, not an unrelated account whose id happens to be `12345`.
+      await setup({
+        accounts: [
+          { githubId: '18281050', githubUsername: '12345' },
+          { githubId: '12345', githubUsername: 'jellis' },
+        ],
+        claGroupAgreements: signedAs('12345'),
+      });
+
+      expect(query('sign-identity-select-github-18281050')?.getAttribute('aria-disabled')).toBe('true');
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
     it('says why, in the tooltip and to assistive tech', async () => {
       await setup({ claGroupAgreements: signedAs('octocat') });
 
@@ -340,15 +356,18 @@ describe('SignIdentitySelectComponent', () => {
       const identity = (fixture.componentInstance as any).selectForm.controls.identity;
       const before = identity.value;
 
-      fixture.debugElement
-        .query(By.css('[data-testid="sign-identity-select-github-12345"]'))
-        .nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).nativeElement.dispatchEvent(event);
       fixture.detectChanges();
       await fixture.whenStable();
       (fixture.componentInstance as any).onContinue();
 
       expect(identity.value).toBe(before);
       expect(close).not.toHaveBeenCalled();
+
+      // Refusing the key is not the same as ignoring it. The card is deliberately still
+      // focusable, so an unconsumed Space would scroll the dialog away instead of doing nothing.
+      expect(event.defaultPrevented).toBe(true);
     });
 
     it('still selects a card that has not signed, from the keyboard', async () => {
@@ -409,6 +428,17 @@ describe('SignIdentitySelectComponent', () => {
       await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit') });
 
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-gerrit"]')).injector.get(Tooltip, null)?.content).toBe(
+        'You already have an ICLA for this CLA group signed with this account.'
+      );
+    });
+
+    it('does not tell a single linked GitHub account to choose another identity', async () => {
+      // The most common dead-end this change set out to remove: one account, already signed,
+      // nothing else on the step. The false branch of `anotherSelectable` has to be wired through
+      // initAccounts, not only through the Gerrit call site.
+      await setup({ accounts: [OCTOCAT], claGroupAgreements: signedAs('octocat') });
+
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(
         'You already have an ICLA for this CLA group signed with this account.'
       );
     });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import type { GithubAccountOption, SignIdentityDialogData } from '@lfx-one/shared/interfaces';
+import type { GithubAccountOption, MyClaAgreement, SignIdentityDialogData } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Tooltip } from 'primeng/tooltip';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SignIdentitySelectComponent } from './sign-identity-select.component';
@@ -276,5 +278,66 @@ describe('SignIdentitySelectComponent', () => {
     (fixture.componentInstance as any).onContinue();
 
     expect(close).not.toHaveBeenCalled();
+  });
+
+  // --- Identities that already signed this CLA group (#1914) -----------------
+
+  describe('already signed', () => {
+    function signedAs(signedAs: string, signedVia: 'github' | 'gerrit' = 'github'): MyClaAgreement[] {
+      return [{ id: 's1', kind: 'ICLA', claGroupName: 'Venus', claGroupId: 'cg-1', signedOn: '2022-01-01', status: 'valid', pdfAvailable: true, signedVia, signedAs }];
+    }
+
+    const REASON = 'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.';
+
+    it('grays out the account that already signed, and only that account', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
+      expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('says why, in the tooltip and to assistive tech', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      const card = fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]'));
+      expect(card.parent?.injector.get(Tooltip, null)?.content).toBe(REASON);
+      // A tooltip is hover-only, so the reason is repeated where a screen reader will reach it —
+      // after the handle, so which account is refused stays clear.
+      expect(card.nativeElement.textContent).toContain('octocat');
+      expect(card.nativeElement.textContent).toContain(REASON);
+    });
+
+    it('refuses to submit it even if the card is reached another way', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      await choose('sign-identity-select-github-12345');
+      (fixture.componentInstance as any).onContinue();
+
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    it('still lets them sign with their other account', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat') });
+
+      await choose('sign-identity-select-github-67890');
+      (fixture.componentInstance as any).onContinue();
+
+      expect(close).toHaveBeenCalledWith({ kind: 'github', githubId: '67890' });
+    });
+
+    it('grays out the Gerrit card when the group was signed under the LF identity', async () => {
+      await setup({ variant: 'github-or-gerrit', gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit') });
+
+      expect(query('sign-identity-select-gerrit')?.getAttribute('aria-disabled')).toBe('true');
+      // A Gerrit signature says nothing about their GitHub accounts.
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('leaves every card selectable when the agreement is on another CLA group', async () => {
+      await setup({ claGroupAgreements: [] });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('false');
+      expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -8,7 +8,6 @@ import { GERRIT_IDENTITY_VALUE, SIGN_IDENTITY_COPY, SIGN_IDENTITY_PLATFORM_LABEL
 import type { GithubAccountChoice, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
 import { alreadySignedAgreementForIdentity, alreadySignedIdentityTooltip } from '@lfx-one/shared/utils';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { TooltipModule } from 'primeng/tooltip';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
@@ -76,7 +75,7 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
  */
 @Component({
   selector: 'lfx-sign-identity-select',
-  imports: [ReactiveFormsModule, ButtonComponent, SelectableCardComponent, TooltipModule],
+  imports: [ReactiveFormsModule, ButtonComponent, SelectableCardComponent],
   templateUrl: './sign-identity-select.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -176,7 +176,7 @@ export class SignIdentitySelectComponent {
 
     const byGithubId = new Map<string, MyClaAgreement>();
     for (const account of accounts) {
-      const held = account.githubUsername ? alreadySignedAgreementForIdentity(agreements, { platform: 'github', username: account.githubUsername }) : undefined;
+      const held = alreadySignedAgreementForIdentity(agreements, { platform: 'github', username: account.githubUsername, githubId: account.githubId });
       if (held) byGithubId.set(account.githubId, held);
     }
 

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { GERRIT_IDENTITY_VALUE, SIGN_IDENTITY_COPY, SIGN_IDENTITY_PLATFORM_LABELS } from '@lfx-one/shared/constants';
-import type { GithubAccountChoice, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
+import type { GithubAccountChoice, MyClaAgreement, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
 import { alreadySignedAgreementForIdentity, alreadySignedIdentityTooltip } from '@lfx-one/shared/utils';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -108,6 +108,14 @@ export class SignIdentitySelectComponent {
    * suffix they read as duplicates. The number fallback is exempt: it already names the
    * platform, and suffixing it would say GitHub twice.
    */
+  /**
+   * Which of the offered identities already hold a CLA for this group, resolved in one pass
+   * before any copy is written. The refusal message names another identity only when one is
+   * genuinely selectable, so how many are left has to be known before the tooltips exist — and
+   * resolving it once keeps the two cards' verdicts from coming from separate evaluations.
+   */
+  private readonly alreadySigned = this.resolveAlreadySigned();
+
   protected readonly accounts = signal<GithubAccountChoice[]>(this.initAccounts());
 
   /** The contributor's LF username as their Gerrit identity, or null when Gerrit is not on offer. */
@@ -156,16 +164,36 @@ export class SignIdentitySelectComponent {
     return this.accounts().some((account) => account.githubId === identityValue && !!account.alreadySignedTooltip);
   }
 
-  private initAccounts(): GithubAccountChoice[] {
+  /**
+   * Resolves the already-signed verdict for every identity the step offers, plus whether any
+   * offered identity is still selectable. A Gerrit card counts as offered on the same test
+   * `initGerritLabel` uses, so the two cannot disagree about whether it is on the step at all.
+   */
+  private resolveAlreadySigned(): { byGithubId: Map<string, MyClaAgreement>; gerrit: MyClaAgreement | undefined; anotherSelectable: boolean } {
     const agreements = this.config.data?.claGroupAgreements ?? [];
+    const accounts = this.config.data?.accounts ?? [];
+    const gerritOffered = !!this.config.data?.gerritUsername?.trim();
 
-    return (this.config.data?.accounts ?? []).map((account) => {
+    const byGithubId = new Map<string, MyClaAgreement>();
+    for (const account of accounts) {
       const held = account.githubUsername ? alreadySignedAgreementForIdentity(agreements, { platform: 'github', username: account.githubUsername }) : undefined;
+      if (held) byGithubId.set(account.githubId, held);
+    }
+
+    const gerrit = gerritOffered ? alreadySignedAgreementForIdentity(agreements, { platform: 'gerrit' }) : undefined;
+    const selectable = accounts.filter((account) => !byGithubId.has(account.githubId)).length + (gerritOffered && !gerrit ? 1 : 0);
+
+    return { byGithubId, gerrit, anotherSelectable: selectable > 0 };
+  }
+
+  private initAccounts(): GithubAccountChoice[] {
+    return (this.config.data?.accounts ?? []).map((account) => {
+      const held = this.alreadySigned.byGithubId.get(account.githubId);
 
       return {
         ...account,
         label: account.githubUsername ? this.withPlatform(account.githubUsername, SIGN_IDENTITY_PLATFORM_LABELS.github) : `GitHub account ${account.githubId}`,
-        ...(held ? { alreadySignedTooltip: alreadySignedIdentityTooltip(held) } : {}),
+        ...(held ? { alreadySignedTooltip: alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable) } : {}),
       };
     });
   }
@@ -189,8 +217,8 @@ export class SignIdentitySelectComponent {
   private initGerritAlreadySignedTooltip(): string | undefined {
     if (!this.gerritLabel()) return undefined;
 
-    const held = alreadySignedAgreementForIdentity(this.config.data?.claGroupAgreements ?? [], { platform: 'gerrit' });
-    return held ? alreadySignedIdentityTooltip(held) : undefined;
+    const held = this.alreadySigned.gerrit;
+    return held ? alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable) : undefined;
   }
 
   /** Suffixes the platform on a mixed list only; a single-source list needs no disambiguation. */

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -174,13 +174,18 @@ export class SignIdentitySelectComponent {
     const accounts = this.config.data?.accounts ?? [];
     const gerritOffered = !!this.config.data?.gerritUsername?.trim();
 
+    // Every handle on the step, so the matcher can tell a recorded account number from a handle
+    // that happens to be all digits.
+    const offeredHandles = accounts.map((account) => account.githubUsername);
+
     const byGithubId = new Map<string, MyClaAgreement>();
     for (const account of accounts) {
-      const held = alreadySignedAgreementForIdentity(agreements, { platform: 'github', username: account.githubUsername, githubId: account.githubId });
+      const identity = { platform: 'github', username: account.githubUsername, githubId: account.githubId } as const;
+      const held = alreadySignedAgreementForIdentity(agreements, identity, offeredHandles);
       if (held) byGithubId.set(account.githubId, held);
     }
 
-    const gerrit = gerritOffered ? alreadySignedAgreementForIdentity(agreements, { platform: 'gerrit' }) : undefined;
+    const gerrit = gerritOffered ? alreadySignedAgreementForIdentity(agreements, { platform: 'gerrit' }, offeredHandles) : undefined;
     const selectable = accounts.filter((account) => !byGithubId.has(account.githubId)).length + (gerritOffered && !gerrit ? 1 : 0);
 
     return { byGithubId, gerrit, anotherSelectable: selectable > 0 };

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -6,7 +6,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { GERRIT_IDENTITY_VALUE, SIGN_IDENTITY_COPY, SIGN_IDENTITY_PLATFORM_LABELS } from '@lfx-one/shared/constants';
 import type { GithubAccountChoice, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
+import { alreadySignedAgreementForIdentity, alreadySignedIdentityTooltip } from '@lfx-one/shared/utils';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
@@ -57,13 +59,24 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
  * 32rem dialog. The action still takes that component's own outlined treatment, so the two
  * agree on everything but size.
  *
+ * ## Identities that have already signed
+ *
+ * An identity already on an agreement for this CLA group is grayed out with the reason (#1914).
+ * This is the step that refuses, rather than the CLA-group picker before it: a contributor with
+ * two linked accounts who signed under one of them can still sign under the other, so refusing
+ * the whole group would deny a signature they are entitled to give. The group is only tagged.
+ *
+ * Refusing here is a courtesy, not a guarantee — EasyCLA reuses an existing signature rather
+ * than duplicating it, so what this prevents is a contributor being walked through a ceremony
+ * whose outcome they already have.
+ *
  * Closes with the chosen identity, with `linkAccounts` if they asked to link one, or `null` if
  * they backed out. A GitHub choice carries the account number alone, because the parent already
  * holds the list and resolves the rest from it rather than taking a handle from here.
  */
 @Component({
   selector: 'lfx-sign-identity-select',
-  imports: [ReactiveFormsModule, ButtonComponent, SelectableCardComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, SelectableCardComponent, TooltipModule],
   templateUrl: './sign-identity-select.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -96,15 +109,16 @@ export class SignIdentitySelectComponent {
    * suffix they read as duplicates. The number fallback is exempt: it already names the
    * platform, and suffixing it would say GitHub twice.
    */
-  protected readonly accounts = signal<GithubAccountChoice[]>(
-    (this.config.data?.accounts ?? []).map((account) => ({
-      ...account,
-      label: account.githubUsername ? this.withPlatform(account.githubUsername, SIGN_IDENTITY_PLATFORM_LABELS.github) : `GitHub account ${account.githubId}`,
-    }))
-  );
+  protected readonly accounts = signal<GithubAccountChoice[]>(this.initAccounts());
 
   /** The contributor's LF username as their Gerrit identity, or null when Gerrit is not on offer. */
   protected readonly gerritLabel = signal<string | null>(this.initGerritLabel());
+
+  /**
+   * Why the Gerrit card cannot sign, when the contributor already signed this group under their
+   * LF identity (#1914). Undefined ⇒ selectable.
+   */
+  protected readonly gerritAlreadySignedTooltip = signal<string | undefined>(this.initGerritAlreadySignedTooltip());
 
   protected readonly selectedId = signal<string | null>(null);
   protected readonly hasIdentities: Signal<boolean> = computed(() => this.accounts().length > 0 || this.gerritLabel() !== null);
@@ -115,7 +129,7 @@ export class SignIdentitySelectComponent {
 
   protected onContinue(): void {
     const selected = this.selectedId();
-    if (!selected) return;
+    if (!selected || this.isAlreadySigned(selected)) return;
 
     if (selected === GERRIT_IDENTITY_VALUE) {
       this.ref.close({ kind: 'gerrit' } satisfies SignIdentitySelectResult);
@@ -137,6 +151,26 @@ export class SignIdentitySelectComponent {
     this.ref.close({ linkAccounts: true } satisfies SignIdentitySelectResult);
   }
 
+  /** Whether the chosen card is one the contributor has already signed this group with. */
+  private isAlreadySigned(identityValue: string): boolean {
+    if (identityValue === GERRIT_IDENTITY_VALUE) return !!this.gerritAlreadySignedTooltip();
+    return this.accounts().some((account) => account.githubId === identityValue && !!account.alreadySignedTooltip);
+  }
+
+  private initAccounts(): GithubAccountChoice[] {
+    const agreements = this.config.data?.claGroupAgreements ?? [];
+
+    return (this.config.data?.accounts ?? []).map((account) => {
+      const held = account.githubUsername ? alreadySignedAgreementForIdentity(agreements, { platform: 'github', username: account.githubUsername }) : undefined;
+
+      return {
+        ...account,
+        label: account.githubUsername ? this.withPlatform(account.githubUsername, SIGN_IDENTITY_PLATFORM_LABELS.github) : `GitHub account ${account.githubId}`,
+        ...(held ? { alreadySignedTooltip: alreadySignedIdentityTooltip(held) } : {}),
+      };
+    });
+  }
+
   /**
    * The Gerrit card's label, and the only place a value that did not come from the server is
    * turned into something the contributor can pick. Read the class doc above before treating
@@ -146,6 +180,14 @@ export class SignIdentitySelectComponent {
     const username = this.config.data?.gerritUsername?.trim();
     if (!username) return null;
     return this.withPlatform(username, SIGN_IDENTITY_PLATFORM_LABELS.gerrit);
+  }
+
+  /** Only meaningful when a Gerrit card is on offer at all. */
+  private initGerritAlreadySignedTooltip(): string | undefined {
+    if (!this.initGerritLabel()) return undefined;
+
+    const held = alreadySignedAgreementForIdentity(this.config.data?.claGroupAgreements ?? [], { platform: 'gerrit' });
+    return held ? alreadySignedIdentityTooltip(held) : undefined;
   }
 
   /** Suffixes the platform on a mixed list only; a single-source list needs no disambiguation. */

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -181,9 +181,13 @@ export class SignIdentitySelectComponent {
     return this.withPlatform(username, SIGN_IDENTITY_PLATFORM_LABELS.gerrit);
   }
 
-  /** Only meaningful when a Gerrit card is on offer at all. */
+  /**
+   * Only meaningful when a Gerrit card is on offer at all — read off the `gerritLabel` signal,
+   * declared above this one, so the card's visibility and its already-signed verdict cannot
+   * come from two independent evaluations of the same question.
+   */
   private initGerritAlreadySignedTooltip(): string | undefined {
-    if (!this.initGerritLabel()) return undefined;
+    if (!this.gerritLabel()) return undefined;
 
     const held = alreadySignedAgreementForIdentity(this.config.data?.claGroupAgreements ?? [], { platform: 'gerrit' });
     return held ? alreadySignedIdentityTooltip(held) : undefined;

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -98,6 +98,14 @@ export class SignIdentitySelectComponent {
   protected readonly copy = SIGN_IDENTITY_COPY[this.config.data?.variant ?? 'github'];
 
   /**
+   * Which of the offered identities already hold a CLA for this group, resolved in one pass
+   * before any copy is written. The refusal message names another identity only when one is
+   * genuinely selectable, so how many are left has to be known before the tooltips exist — and
+   * resolving it once keeps the two cards' verdicts from coming from separate evaluations.
+   */
+  private readonly alreadySigned = this.resolveAlreadySigned();
+
+  /**
    * The handle can be blank: the server maps a missing `profileData.nickname` to `''` rather
    * than guessing one. Labelling that option with the account number keeps the two accounts
    * distinguishable. The blank handle itself is left alone — what gets recorded is not this
@@ -108,14 +116,6 @@ export class SignIdentitySelectComponent {
    * suffix they read as duplicates. The number fallback is exempt: it already names the
    * platform, and suffixing it would say GitHub twice.
    */
-  /**
-   * Which of the offered identities already hold a CLA for this group, resolved in one pass
-   * before any copy is written. The refusal message names another identity only when one is
-   * genuinely selectable, so how many are left has to be known before the tooltips exist — and
-   * resolving it once keeps the two cards' verdicts from coming from separate evaluations.
-   */
-  private readonly alreadySigned = this.resolveAlreadySigned();
-
   protected readonly accounts = signal<GithubAccountChoice[]>(this.initAccounts());
 
   /** The contributor's LF username as their Gerrit identity, or null when Gerrit is not on offer. */

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.html
@@ -14,7 +14,10 @@
   }"
   [class]="styleClass()"
   [attr.data-testid]="testId()"
-  [attr.tabindex]="isDisabled() ? -1 : 0"
+  [pTooltip]="disabledReason()"
+  tooltipPosition="top"
+  tooltipEvent="both"
+  tabindex="0"
   [attr.role]="'option'"
   [attr.aria-selected]="isSelected()"
   [attr.aria-disabled]="isDisabled()"
@@ -23,8 +26,8 @@
   <!-- Label -->
   <span class="text-base text-slate-700 font-semibold">{{ label() }}</span>
 
-  @if (assistiveNote()) {
-    <span class="sr-only">{{ assistiveNote() }}</span>
+  @if (disabledReason()) {
+    <span class="sr-only">{{ disabledReason() }}</span>
   }
 
   <!-- Selection indicator (checkmark) -->

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.html
@@ -23,6 +23,10 @@
   <!-- Label -->
   <span class="text-base text-slate-700 font-semibold">{{ label() }}</span>
 
+  @if (assistiveNote()) {
+    <span class="sr-only">{{ assistiveNote() }}</span>
+  }
+
   <!-- Selection indicator (checkmark) -->
   @if (isSelected()) {
     <i class="fa-solid fa-circle-check text-blue-500 text-lg"></i>

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
@@ -58,10 +58,13 @@ export class SelectableCardComponent {
   }
 
   protected onKeydown(event: KeyboardEvent): void {
-    if (!this.isDisabled() && (event.key === 'Enter' || event.key === ' ')) {
-      event.preventDefault();
-      this.onCardClick();
-    }
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+
+    // Consumed even when the card is disabled. A disabled card stays focusable so its reason can
+    // be read, and leaving Space to the browser there would scroll the page out from under the
+    // reader instead of doing nothing.
+    event.preventDefault();
+    if (!this.isDisabled()) this.onCardClick();
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
@@ -5,11 +5,12 @@ import { NgClass } from '@angular/common';
 import { Component, computed, input, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { TooltipModule } from 'primeng/tooltip';
 import { of, startWith, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-selectable-card',
-  imports: [NgClass, ReactiveFormsModule],
+  imports: [NgClass, ReactiveFormsModule, TooltipModule],
   templateUrl: './selectable-card.component.html',
 })
 export class SelectableCardComponent {
@@ -22,11 +23,13 @@ export class SelectableCardComponent {
   /** Disables this card alone, leaving the rest of the group selectable. */
   public readonly disabled = input<boolean>(false);
   /**
-   * Why this card is disabled, for assistive tech. Rendered inside the card and visually hidden,
-   * so it is announced after the label rather than instead of it, and a reason that only exists
-   * in a hover tooltip is not lost to anyone who cannot hover.
+   * Why this card is disabled. Rendered twice from the one input so no contributor has to hover
+   * to learn it: visually hidden inside the card, so it is announced after the label rather than
+   * instead of it, and as a tooltip on hover *or* keyboard focus. A disabled card stays in the tab
+   * order and says so with `aria-disabled`, rather than being removed from it — a card taken out
+   * of the tab order is one a keyboard-only contributor can never ask about.
    */
-  public readonly assistiveNote = input<string>('');
+  public readonly disabledReason = input<string>('');
   public readonly styleClass = input<string>('');
   public readonly testId = input<string>('');
 

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
@@ -19,6 +19,14 @@ export class SelectableCardComponent {
   public readonly value = input<string>();
   public readonly label = input.required<string>();
   public readonly toggle = input<boolean>(false);
+  /** Disables this card alone, leaving the rest of the group selectable. */
+  public readonly disabled = input<boolean>(false);
+  /**
+   * Why this card is disabled, for assistive tech. Rendered inside the card and visually hidden,
+   * so it is announced after the label rather than instead of it, and a reason that only exists
+   * in a hover tooltip is not lost to anyone who cannot hover.
+   */
+  public readonly assistiveNote = input<string>('');
   public readonly styleClass = input<string>('');
   public readonly testId = input<string>('');
 
@@ -85,6 +93,8 @@ export class SelectableCardComponent {
 
   private initIsDisabled(): Signal<boolean> {
     return computed(() => {
+      if (this.disabled()) return true;
+
       const formGroup = this.form();
       const controlName = this.control();
       return formGroup.get(controlName)?.disabled ?? false;

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-08-31
+last_updated: 2026-09-01
 intercom_collection: Account
 ---
 
@@ -75,6 +75,10 @@ The CLAs tab matches agreements to your LF username, verified emails, and linked
 ## Can I sign a CLA from the CLAs tab?
 
 You can start there. Select **Sign CLA**, search for the project, CLA group, or repository you need to sign for, and choose which linked GitHub account to sign under. Self Serve then hands you off to the EasyCLA Contributor Console, which presents and records the agreement — the signing itself does not happen in Self Serve. See [How do I sign a new CLA?](../my-clas/#how-do-i-sign-a-new-cla).
+
+## Why is a project greyed out when I search for a CLA to sign?
+
+In the **Sign a CLA** dialog, a result is greyed out and labelled **Already signed** when you already hold a CLA for it, and you cannot start a second signing for it. Results are matched per CLA group, not per project, so a project with more than one CLA group only greys out the group you signed. An **Invalidated** CLA does not grey a result out — that agreement no longer covers you, so you can sign again. A **Needs attention** or **Revoked** ECLA (Employee CLA) does grey it out, because signing again would not restore your coverage. See [Why is a project greyed out when I search?](../my-clas/#why-is-a-project-greyed-out-when-i-search).
 
 ## What do the CLA status labels mean?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -76,9 +76,9 @@ The CLAs tab matches agreements to your LF username, verified emails, and linked
 
 You can start there. Select **Sign CLA**, search for the project, CLA group, or repository you need to sign for, and choose which linked GitHub account to sign under. Self Serve then hands you off to the EasyCLA Contributor Console, which presents and records the agreement — the signing itself does not happen in Self Serve. See [How do I sign a new CLA?](../my-clas/#how-do-i-sign-a-new-cla).
 
-## Why is a project greyed out when I search for a CLA to sign?
+## Why does a search result say "Already signed as" when I search for a CLA to sign?
 
-In the **Sign a CLA** dialog, a result is greyed out and labelled **Already signed** when you already hold a CLA for it, and you cannot start a second signing for it. Results are matched per CLA group, not per project, so a project with more than one CLA group only greys out the group you signed. An **Invalidated** CLA does not grey a result out — that agreement no longer covers you, so you can sign again. A **Needs attention** or **Revoked** ECLA (Employee CLA) does grey it out, because signing again would not restore your coverage. See [Why is a project greyed out when I search?](../my-clas/#why-is-a-project-greyed-out-when-i-search).
+In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. The result stays selectable: holding a CLA under one identity does not stop you signing under another, so it is the identity step that greys out the account already covered. Results are matched per CLA group, not per project, so a project with more than one CLA group only tags the group you signed. An **Invalidated** CLA greys out nothing — that agreement no longer covers you, so you can sign again with the same identity. See [Why does a search result say "Already signed as"?](../my-clas/#why-does-a-search-result-say-already-signed-as).
 
 ## What do the CLA status labels mean?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -78,7 +78,7 @@ You can start there. Select **Sign CLA**, search for the project, CLA group, or 
 
 ## Why does a search result say "Already signed as" when I search for a CLA to sign?
 
-In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. The result stays selectable: holding a CLA under one identity does not stop you signing under another, so it is the identity step that greys out the account already covered. Results are matched per CLA group, not per project, so a project with more than one CLA group only tags the group you signed. An **Invalidated** CLA greys out nothing — that agreement no longer covers you, so you can sign again with the same identity. See [Why does a search result say "Already signed as"?](../my-clas/#why-does-a-search-result-say-already-signed-as).
+In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. The result stays selectable: holding a CLA under one identity does not stop you signing under another, so it is the identity step that greys out the account already covered — and only when that account is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Results are matched per CLA group, not per project, so a project with more than one CLA group only tags the group you signed. An **Invalidated** CLA greys out nothing — that agreement no longer covers you, so you can sign again with the same identity. See [Why does a search result say "Already signed as"?](../my-clas/#why-does-a-search-result-say-already-signed-as).
 
 ## What do the CLA status labels mean?
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -127,12 +127,14 @@ Results are matched per **CLA group**, not per project. A project with more than
 
 Which statuses grey out an identity in the next step:
 
-| Status on your existing CLA | Identity greyed out? | What to do instead                                                                                                                         |
-| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Valid**                   | Yes                  | Nothing — that identity is already covered                                                                                                 |
-| **Needs attention** (ECLA)  | Yes                  | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
-| **Revoked** (ECLA)          | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
-| **Invalidated**             | No                   | That agreement no longer covers you, so you can sign again with the same identity                                                          |
+| Status on your existing CLA      | Identity greyed out? | What to do instead                                                                                                                         |
+| -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Valid**                        | Yes                  | Nothing — that identity is already covered                                                                                                 |
+| **Needs attention** (ECLA)       | Yes                  | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
+| **Revoked** (ECLA)               | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
+| **Superseded**                   | Yes                  | A newer version of the agreement has replaced this one, so signing again under that identity changes nothing                               |
+| **—** (no status recorded, ECLA) | Yes                  | The status could not be read, so the identity stays greyed out rather than offer you a signature that may do nothing                       |
+| **Invalidated**                  | No                   | That agreement no longer covers you, so you can sign again with the same identity                                                          |
 
 ## How do I ask my CLA manager to approve or remove my ECLA?
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -117,20 +117,22 @@ You start signing from the CLAs tab and finish in the EasyCLA Contributor Consol
 
 If the search returns more matches than it can display, narrow the term — the dialog tells you when results were truncated.
 
-### Why is a project greyed out when I search?
+### Why does a search result say "Already signed as"?
 
-In the **Sign a CLA** dialog, a result is greyed out and labelled **Already signed** when you already hold a CLA for it. You cannot start a second signing for it. Hover the result to see which agreement you hold — an ICLA (Individual CLA) or an ECLA (Employee CLA) — and, when EasyCLA recorded it, the account it was signed under.
+In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. Hover the result to see which agreement you hold — an ICLA (Individual CLA) or an ECLA (Employee CLA).
 
-Results are matched per **CLA group**, not per project. A project that has more than one CLA group only greys out the group you signed; its other groups stay selectable.
+The result stays selectable, because holding a CLA under one identity does not stop you signing under another. If you have two GitHub accounts linked to your profile and signed with one of them, you can still sign with the other. Continue past the result and the identity step shows you which of your identities is already covered: it is greyed out, and the rest stay available.
 
-Which statuses grey a result out:
+Results are matched per **CLA group**, not per project. A project with more than one CLA group only tags the group you signed.
 
-| Status on your existing CLA | Greyed out? | What to do instead                                                                                                                         |
-| --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Valid**                   | Yes         | Nothing — you are already covered                                                                                                          |
-| **Needs attention** (ECLA)  | Yes         | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
-| **Revoked** (ECLA)          | Yes         | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
-| **Invalidated**             | No          | That agreement no longer covers you, so you can sign again                                                                                 |
+Which statuses grey out an identity in the next step:
+
+| Status on your existing CLA | Identity greyed out? | What to do instead                                                                                                                        |
+| --------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Valid**                   | Yes                  | Nothing — that identity is already covered                                                                                                |
+| **Needs attention** (ECLA)  | Yes                  | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
+| **Revoked** (ECLA)          | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                               |
+| **Invalidated**             | No                   | That agreement no longer covers you, so you can sign again with the same identity                                                          |
 
 ## How do I ask my CLA manager to approve or remove my ECLA?
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -121,18 +121,19 @@ If the search returns more matches than it can display, narrow the term — the 
 
 In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. Hover the result to see which agreement you hold — an ICLA (Individual CLA) or an ECLA (Employee CLA).
 
-The result stays selectable, because holding a CLA under one identity does not stop you signing under another. If you have two GitHub accounts linked to your profile and signed with one of them, you can still sign with the other. Continue past the result and the identity step shows you which of your identities is already covered: it is greyed out, and the rest stay available.
+The result stays selectable, because holding a CLA under one identity does not stop you signing under another. If you have two GitHub accounts linked to your profile and signed with one of them, you can still sign with the other.
+
+The tag names an account only when EasyCLA recorded one. Continue past the result and the identity step greys out the identity that signed — but only when the account on the agreement is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Where no account was recorded, or the CLA was signed through GitLab, the result is still tagged and every identity stays selectable.
 
 Results are matched per **CLA group**, not per project. A project with more than one CLA group only tags the group you signed.
 
-Which statuses grey out an identity in the next step:
+Which statuses grey out an identity in the next step, once the account on the agreement is one you have linked:
 
 | Status on your existing CLA      | Identity greyed out? | What to do instead                                                                                                                         |
 | -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Valid**                        | Yes                  | Nothing — that identity is already covered                                                                                                 |
 | **Needs attention** (ECLA)       | Yes                  | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
 | **Revoked** (ECLA)               | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
-| **Superseded**                   | Yes                  | A newer version of the agreement has replaced this one, so signing again under that identity changes nothing                               |
 | **—** (no status recorded, ECLA) | Yes                  | The status could not be read, so the identity stays greyed out rather than offer you a signature that may do nothing                       |
 | **Invalidated**                  | No                   | That agreement no longer covers you, so you can sign again with the same identity                                                          |
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -127,7 +127,7 @@ The tag names an account only when EasyCLA recorded one. Continue past the resul
 
 Results are matched per **CLA group**, not per project. A project with more than one CLA group only tags the group you signed.
 
-Which statuses grey out an identity in the next step, once the account on the agreement is one you have linked:
+Every status your CLAs can show, and whether it greys out an identity in the next step, once the account on the agreement is one you have linked:
 
 | Status on your existing CLA      | Identity greyed out? | What to do instead                                                                                                                         |
 | -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -127,11 +127,11 @@ Results are matched per **CLA group**, not per project. A project with more than
 
 Which statuses grey out an identity in the next step:
 
-| Status on your existing CLA | Identity greyed out? | What to do instead                                                                                                                        |
-| --------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Valid**                   | Yes                  | Nothing — that identity is already covered                                                                                                |
+| Status on your existing CLA | Identity greyed out? | What to do instead                                                                                                                         |
+| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Valid**                   | Yes                  | Nothing — that identity is already covered                                                                                                 |
 | **Needs attention** (ECLA)  | Yes                  | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
-| **Revoked** (ECLA)          | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                               |
+| **Revoked** (ECLA)          | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
 | **Invalidated**             | No                   | That agreement no longer covers you, so you can sign again with the same identity                                                          |
 
 ## How do I ask my CLA manager to approve or remove my ECLA?

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -127,7 +127,7 @@ The tag names an account only when EasyCLA recorded one. Continue past the resul
 
 Results are matched per **CLA group**, not per project. A project with more than one CLA group only tags the group you signed.
 
-How each status on an existing CLA affects the identity step, once the account on the agreement is one you have linked:
+How each status on an existing CLA affects the identity step, once that agreement matches an identity offered in the step:
 
 | Status on your existing CLA      | Identity greyed out? | What to do instead                                                                                                                         |
 | -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -4,7 +4,7 @@ description: View your signed Individual and Employee CLAs in LFX Self Serve, st
 audience: [all]
 product_area: Account
 tags: [account, cla, easycla, icla, ecla, ccla, identities, signing]
-last_updated: 2026-08-31
+last_updated: 2026-09-01
 intercom_collection: Account
 ---
 
@@ -116,6 +116,21 @@ You start signing from the CLAs tab and finish in the EasyCLA Contributor Consol
 6. Self Serve hands you off to the EasyCLA Contributor Console, which presents and records the agreement. When you finish there, you are returned to the CLAs tab.
 
 If the search returns more matches than it can display, narrow the term — the dialog tells you when results were truncated.
+
+### Why is a project greyed out when I search?
+
+In the **Sign a CLA** dialog, a result is greyed out and labelled **Already signed** when you already hold a CLA for it. You cannot start a second signing for it. Hover the result to see which agreement you hold — an ICLA (Individual CLA) or an ECLA (Employee CLA) — and, when EasyCLA recorded it, the account it was signed under.
+
+Results are matched per **CLA group**, not per project. A project that has more than one CLA group only greys out the group you signed; its other groups stay selectable.
+
+Which statuses grey a result out:
+
+| Status on your existing CLA | Greyed out? | What to do instead                                                                                                                         |
+| --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Valid**                   | Yes         | Nothing — you are already covered                                                                                                          |
+| **Needs attention** (ECLA)  | Yes         | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
+| **Revoked** (ECLA)          | Yes         | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
+| **Invalidated**             | No          | That agreement no longer covers you, so you can sign again                                                                                 |
 
 ## How do I ask my CLA manager to approve or remove my ECLA?
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -123,11 +123,11 @@ In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Al
 
 The result stays selectable, because holding a CLA under one identity does not stop you signing under another. If you have two GitHub accounts linked to your profile and signed with one of them, you can still sign with the other.
 
-The tag names an account only when EasyCLA recorded one. Continue past the result and the identity step greys out the identity that signed — but only when the account on the agreement is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Where no account was recorded, or the CLA was signed through GitLab, the result is still tagged and every identity stays selectable.
+The tag names an account only when EasyCLA recorded one. Continue past the result and the identity step greys out the identity that signed — but only when the account on the agreement is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Where no account was recorded on a CLA signed through GitHub, or the CLA was signed through GitLab, the result is still tagged and every identity stays selectable. A CLA signed through Gerrit greys out your LF identity whether or not an account was recorded.
 
 Results are matched per **CLA group**, not per project. A project with more than one CLA group only tags the group you signed.
 
-Every status your CLAs can show, and whether it greys out an identity in the next step, once the account on the agreement is one you have linked:
+How each status on an existing CLA affects the identity step, once the account on the agreement is one you have linked:
 
 | Status on your existing CLA      | Identity greyed out? | What to do instead                                                                                                                         |
 | -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -110,6 +110,13 @@ export const GITLAB_UNSUPPORTED_MESSAGE = 'Signing CLA using GitLab is not suppo
  */
 export const GITLAB_UNSUPPORTED_HEADER = 'GitLab CLA signing';
 
+/**
+ * Chip on a Sign a CLA search result the contributor already holds a CLA for (#1914).
+ * The tooltip on that row carries the sentence that says which agreement; this is only
+ * the short label that makes the grayed-out state readable without hovering.
+ */
+export const ALREADY_SIGNED_CLA_LABEL = 'Already signed';
+
 /** Hover tooltips on a right-edge kebab open off-screen; keep the CCLA reason in the item. */
 export const ECLA_COVERED_DOWNLOAD_LABEL = 'Download PDF<br><span class="mt-0.5 block text-xs font-normal">Covered by Corporate CLA (CCLA)</span>';
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -219,12 +219,21 @@ export interface ClaGroupSelectDialogData {
 export interface AlreadySignedNote {
   /** Inline tag, naming the identity that signed it. */
   chip: string;
-  /** Fuller sentence: which kind, whose employer on an ECLA, and that another identity may sign. */
+  /**
+   * Fuller sentence: which kind, and whose employer on an ECLA. It closes by offering another
+   * identity only on a route that has one to offer — never on a GitLab-only or Gerrit-only group.
+   */
   tooltip: string;
 }
 
-/** Which identity a card in the sign-identity step offers. */
-export type SignIdentityRef = { platform: 'github'; username: string } | { platform: 'gerrit' };
+/**
+ * Which identity a card in the sign-identity step offers.
+ *
+ * A GitHub card carries both keys because the producer records whichever it had: it derives the
+ * signed identity as the handle when there is one and the account number when there is not, so a
+ * card that compared only the handle would miss every agreement recorded against the number.
+ */
+export type SignIdentityRef = { platform: 'github'; username?: string; githubId: string } | { platform: 'gerrit' };
 
 /** Picker row: a search result with display fields precomputed so the template calls nothing. */
 export interface ClaGroupOptionView extends ClaGroupOption {

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -263,10 +263,11 @@ export interface GithubAccountOption {
   /** Immutable GitHub account number. Handles get renamed and reclaimed; this does not. */
   githubId: string;
   /**
-   * Display handle. Never matched on to decide identity or to address the hand-off — that is
-   * `githubId`'s job. It is compared against the handle recorded on an existing agreement, but
-   * only to decide whether to gray a card: renames and reclaims make it unreliable, and a wrong
-   * result there can only gray a card that should not have been, or miss one that should.
+   * Display handle, and never an identity key on its own. It has two consumers beyond display:
+   * it rides alongside `githubId` on prepare-sign, where the producer resolves the pair against
+   * each other, and it is compared against the handle an existing agreement recorded so the
+   * identity step can gray the account that already signed. Renames and reclaims make it
+   * unreliable for both, which is why `githubId` is what actually addresses the account.
    */
   githubUsername: string;
   avatarUrl?: string;

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -207,13 +207,24 @@ export interface ClaGroupSearchResponse {
 }
 
 /**
- * What the Sign a CLA group picker is given so it can gray out groups the contributor
- * already holds (#1914). The list is the one already loaded on the CLAs tab — the picker
- * does not fetch it again.
+ * What the Sign a CLA group picker is given so it can tag groups the contributor already
+ * holds (#1914). The list is the one already loaded on the CLAs tab — the picker does not
+ * fetch it again.
  */
 export interface ClaGroupSelectDialogData {
   agreements: MyClaAgreement[];
 }
+
+/** What a tagged picker row shows: the inline tag, and the sentence behind it. */
+export interface AlreadySignedNote {
+  /** Inline tag, naming the identity that signed it. */
+  chip: string;
+  /** Fuller sentence: which kind, whose employer on an ECLA, and that another identity may sign. */
+  tooltip: string;
+}
+
+/** Which identity a card in the sign-identity step offers. */
+export type SignIdentityRef = { platform: 'github'; username: string } | { platform: 'gerrit' };
 
 /** Picker row: a search result with display fields precomputed so the template calls nothing. */
 export interface ClaGroupOptionView extends ClaGroupOption {

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -251,6 +251,11 @@ export interface GithubAccountOption {
 export interface GithubAccountChoice extends GithubAccountOption {
   /** `githubUsername`, or a numbered fallback when the handle is blank. */
   label: string;
+  /**
+   * Why this account cannot sign the chosen CLA group, when it already has (#1914). Present
+   * ⇒ the card is grayed out and carries this as its tooltip.
+   */
+  alreadySignedTooltip?: string;
 }
 
 /**
@@ -282,6 +287,13 @@ export interface SignIdentityDialogData {
    * never submitted — see the step's own class doc before changing it.
    */
   gerritUsername?: string;
+  /**
+   * What the contributor already holds for the CLA group they picked, so the step can gray out
+   * the identity that signed it (#1914). This is where the already-signed block lives: one
+   * contributor can hold several identities, so the group itself stays selectable and only the
+   * identity already on an agreement is refused.
+   */
+  claGroupAgreements?: MyClaAgreement[];
 }
 
 /**

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -253,7 +253,12 @@ export interface ClaGroupOrgView {
 export interface GithubAccountOption {
   /** Immutable GitHub account number. Handles get renamed and reclaimed; this does not. */
   githubId: string;
-  /** Display handle. Never matched on. */
+  /**
+   * Display handle. Never matched on to decide identity or to address the hand-off — that is
+   * `githubId`'s job. It is compared against the handle recorded on an existing agreement, but
+   * only to decide whether to gray a card: renames and reclaims make it unreliable, and a wrong
+   * result there can only gray a card that should not have been, or miss one that should.
+   */
   githubUsername: string;
   avatarUrl?: string;
 }

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -206,6 +206,15 @@ export interface ClaGroupSearchResponse {
   results: ClaGroupOption[];
 }
 
+/**
+ * What the Sign a CLA group picker is given so it can gray out groups the contributor
+ * already holds (#1914). The list is the one already loaded on the CLAs tab — the picker
+ * does not fetch it again.
+ */
+export interface ClaGroupSelectDialogData {
+  agreements: MyClaAgreement[];
+}
+
 /** Picker row: a search result with display fields precomputed so the template calls nothing. */
 export interface ClaGroupOptionView extends ClaGroupOption {
   primaryName: string;

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -286,22 +286,25 @@ describe('alreadySignedAgreementForIdentity', () => {
     agreement({ id: 's2', claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: 'jellis-lf' }),
   ];
 
+  /** The handles the step is offering, which is how a recorded number is told from a handle. */
+  const offered = ['jellis', 'jellis-work'];
+
   it('matches a GitHub handle regardless of case', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' })?.id).toBe('s1');
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered)?.id).toBe('s1');
   });
 
   it('leaves the contributor a second GitHub account to sign with', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work', githubId: '67890' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work', githubId: '67890' }, offered)).toBeUndefined();
   });
 
   it('matches the Gerrit identity on the platform alone', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' })?.id).toBe('s2');
-    expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered)?.id).toBe('s2');
+    expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' }, offered)).toBeUndefined();
   });
 
   it('never blocks a GitHub card on an agreement with no recorded identity', () => {
     const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'github', signedAs: '   ' })];
-    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis', githubId: '12345' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis', githubId: '12345' }, offered)).toBeUndefined();
   });
 
   it('still blocks the Gerrit card on an agreement with no recorded identity', () => {
@@ -309,7 +312,7 @@ describe('alreadySignedAgreementForIdentity', () => {
     // accounts, so it matches none, while only one Gerrit card is ever offered and it is the
     // contributor's own LF identity — so the platform alone identifies it.
     const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: undefined })];
-    expect(alreadySignedAgreementForIdentity(blank, { platform: 'gerrit' })?.claGroupId).toBe('cg-1');
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'gerrit' }, offered)?.claGroupId).toBe('cg-1');
   });
 
   it('matches the account number when that is what the producer recorded', () => {
@@ -318,13 +321,25 @@ describe('alreadySignedAgreementForIdentity', () => {
     // that signed selectable, which is the redundant signature this is meant to prevent.
     const byNumber = [agreement({ id: 's3', claGroupId: 'cg-1', signedVia: 'github', signedAs: '12345' })];
 
-    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: '', githubId: '12345' })?.id).toBe('s3');
-    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: 'jellis', githubId: '67890' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: '', githubId: '12345' }, ['', 'jellis'])?.id).toBe('s3');
+    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: 'jellis', githubId: '67890' }, ['', 'jellis'])).toBeUndefined();
+  });
+
+  it('reads a numeric identity as a handle when a card on the step carries it', () => {
+    // Handles can be all digits: `12345` is a real login, and its account number is something
+    // else entirely. So one string can be one card's handle and another card's number, and the
+    // handle has to win — otherwise signing as the numerically-named account would gray an
+    // unrelated one, which on a single-account step leaves nothing to pick.
+    const collides = [agreement({ id: 's4', claGroupId: 'cg-1', signedVia: 'github', signedAs: '12345' })];
+    const bothOffered = ['12345', 'jellis'];
+
+    expect(alreadySignedAgreementForIdentity(collides, { platform: 'github', username: '12345', githubId: '18281050' }, bothOffered)?.id).toBe('s4');
+    expect(alreadySignedAgreementForIdentity(collides, { platform: 'github', username: 'jellis', githubId: '12345' }, bothOffered)).toBeUndefined();
   });
 
   it('does not block on an invalidated agreement', () => {
     const invalidated = [agreement({ claGroupId: 'cg-1', status: 'invalidated', signedVia: 'github', signedAs: 'jellis' })];
-    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis', githubId: '12345' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis', githubId: '12345' }, offered)).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -240,20 +240,28 @@ describe('alreadySignedChipLabel', () => {
 
 describe('alreadySignedGroupTooltip', () => {
   it('names the ICLA, the identity it was signed as, and that another identity may still sign', () => {
-    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }))).toBe(
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }), 'github')).toBe(
       'You already have an ICLA for this CLA group. Signed as jellis (GitHub). If you have another identity linked, you can still sign with it.'
     );
   });
 
   it('names the employer when an ECLA has no signed-as identity', () => {
-    expect(alreadySignedGroupTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }))).toBe(
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }), 'github')).toBe(
       'You already have an ECLA for this CLA group, covered by Acme. If you have another identity linked, you can still sign with it.'
     );
   });
 
   it('falls back to the kind alone when there is nothing else to name', () => {
-    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA' }))).toBe(
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA' }), 'github')).toBe(
       'You already have an ICLA for this CLA group. If you have another identity linked, you can still sign with it.'
+    );
+  });
+
+  it('promises no other identity on a GitLab-only group, which no identity can sign', () => {
+    // The block there is the route, not the account: Self Serve cannot sign a GitLab-only group
+    // at all, so offering "link another identity" as the way out would be a dead end.
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'gitlab', signedAs: 'jellis' }), 'gitlab-unsupported')).toBe(
+      'You already have an ICLA for this CLA group. Signed as jellis (GitLab).'
     );
   });
 });

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -3,10 +3,16 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { ALREADY_SIGNED_CLA_LABEL } from '../constants/cla.constants';
 import { PROFILE_TABS } from '../constants/profile.constants';
 import { ClaGroupOrg, ClaGroupOrgSource, ClaSignedVia, ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/cla.interface';
 import {
-  alreadySignedClaTooltip,
+  alreadySignedAgreementForGroup,
+  alreadySignedAgreementForIdentity,
+  alreadySignedAgreementsForGroup,
+  alreadySignedChipLabel,
+  alreadySignedGroupTooltip,
+  alreadySignedIdentityTooltip,
   buildProfileTabs,
   claGroupPrimaryName,
   claGroupSecondaryName,
@@ -14,7 +20,6 @@ import {
   claSignRoute,
   claStatusLabel,
   claStatusSeverity,
-  coveringAgreementForGroup,
   gerritSignUrl,
   isMyClasEmpty,
   shouldShowGithubCta,
@@ -186,44 +191,108 @@ describe('claGroupPrimaryName / claGroupSecondaryName', () => {
   });
 });
 
-describe('coveringAgreementForGroup', () => {
+describe('alreadySignedAgreementForGroup', () => {
   it('returns the first in-force agreement for that CLA group', () => {
-    const covering = agreement({ claGroupId: 'cg-1', kind: 'ICLA', status: 'valid' });
-    expect(coveringAgreementForGroup([covering, agreement({ id: 's2', claGroupId: 'cg-2' })], 'cg-1')).toBe(covering);
+    const held = agreement({ claGroupId: 'cg-1', kind: 'ICLA', status: 'valid' });
+    expect(alreadySignedAgreementForGroup([held, agreement({ id: 's2', claGroupId: 'cg-2' })], 'cg-1')).toBe(held);
   });
 
   it('does not treat an invalidated agreement as already signed', () => {
-    expect(coveringAgreementForGroup([agreement({ claGroupId: 'cg-1', status: 'invalidated' })], 'cg-1')).toBeUndefined();
+    expect(alreadySignedAgreementForGroup([agreement({ claGroupId: 'cg-1', status: 'invalidated' })], 'cg-1')).toBeUndefined();
   });
 
   it('treats needs-attention, revoked, unknown, and superseded as already signed', () => {
     const statuses: ClaStatus[] = ['needs_attention', 'revoked', 'unknown', 'superseded'];
     for (const status of statuses) {
-      expect(coveringAgreementForGroup([agreement({ claGroupId: 'cg-1', status })], 'cg-1')?.status).toBe(status);
+      expect(alreadySignedAgreementForGroup([agreement({ claGroupId: 'cg-1', status })], 'cg-1')?.status).toBe(status);
     }
   });
 
   it('ignores a blank group id and a row with no group id', () => {
-    expect(coveringAgreementForGroup([agreement({ claGroupId: 'cg-1' })], '   ')).toBeUndefined();
-    expect(coveringAgreementForGroup([agreement({})], 'cg-1')).toBeUndefined();
+    expect(alreadySignedAgreementForGroup([agreement({ claGroupId: 'cg-1' })], '   ')).toBeUndefined();
+    expect(alreadySignedAgreementForGroup([agreement({})], 'cg-1')).toBeUndefined();
   });
 });
 
-describe('alreadySignedClaTooltip', () => {
-  it('names the ICLA and the identity it was signed as', () => {
-    expect(alreadySignedClaTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }))).toBe(
-      'You already have an ICLA for this CLA group. Signed as jellis (GitHub).'
+describe('alreadySignedAgreementsForGroup', () => {
+  it('returns every in-force agreement for the group, so each identity can be checked', () => {
+    const mine = agreement({ id: 's1', claGroupId: 'cg-1', signedVia: 'github', signedAs: 'jellis' });
+    const other = agreement({ id: 's2', claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: 'jellis-lf' });
+
+    expect(alreadySignedAgreementsForGroup([mine, other, agreement({ id: 's3', claGroupId: 'cg-2' })], 'cg-1')).toEqual([mine, other]);
+  });
+
+  it('drops invalidated rows and returns nothing for a blank group id', () => {
+    expect(alreadySignedAgreementsForGroup([agreement({ claGroupId: 'cg-1', status: 'invalidated' })], 'cg-1')).toEqual([]);
+    expect(alreadySignedAgreementsForGroup([agreement({ claGroupId: 'cg-1' })], '  ')).toEqual([]);
+  });
+});
+
+describe('alreadySignedChipLabel', () => {
+  it('names the identity that signed it', () => {
+    expect(alreadySignedChipLabel(agreement({ signedVia: 'github', signedAs: 'jellis' }))).toBe('Already signed as jellis (GitHub)');
+  });
+
+  it('falls back to the bare label when no identity was recorded', () => {
+    expect(alreadySignedChipLabel(agreement({}))).toBe(ALREADY_SIGNED_CLA_LABEL);
+  });
+});
+
+describe('alreadySignedGroupTooltip', () => {
+  it('names the ICLA, the identity it was signed as, and that another identity can still sign', () => {
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }))).toBe(
+      'You already have an ICLA for this CLA group. Signed as jellis (GitHub). You can still sign it with a different identity.'
     );
   });
 
   it('names the employer when an ECLA has no signed-as identity', () => {
-    expect(alreadySignedClaTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }))).toBe(
-      'You already have an ECLA for this CLA group, covered by Acme.'
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }))).toBe(
+      'You already have an ECLA for this CLA group, covered by Acme. You can still sign it with a different identity.'
     );
   });
 
   it('falls back to the kind alone when there is nothing else to name', () => {
-    expect(alreadySignedClaTooltip(agreement({ kind: 'ICLA' }))).toBe('You already have an ICLA for this CLA group.');
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA' }))).toBe(
+      'You already have an ICLA for this CLA group. You can still sign it with a different identity.'
+    );
+  });
+});
+
+describe('alreadySignedAgreementForIdentity', () => {
+  const held = [
+    agreement({ id: 's1', claGroupId: 'cg-1', signedVia: 'github', signedAs: 'Jellis' }),
+    agreement({ id: 's2', claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: 'jellis-lf' }),
+  ];
+
+  it('matches a GitHub handle regardless of case', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis' })?.id).toBe('s1');
+  });
+
+  it('leaves the contributor a second GitHub account to sign with', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work' })).toBeUndefined();
+  });
+
+  it('matches the Gerrit identity on the platform alone', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' })?.id).toBe('s2');
+    expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' })).toBeUndefined();
+  });
+
+  it('never blocks a card on an agreement with no recorded identity', () => {
+    const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'github', signedAs: '   ' })];
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis' })).toBeUndefined();
+  });
+
+  it('does not block on an invalidated agreement', () => {
+    const invalidated = [agreement({ claGroupId: 'cg-1', status: 'invalidated', signedVia: 'github', signedAs: 'jellis' })];
+    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis' })).toBeUndefined();
+  });
+});
+
+describe('alreadySignedIdentityTooltip', () => {
+  it('says which kind this account already holds and to pick another', () => {
+    expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }))).toBe(
+      'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.'
+    );
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -264,6 +264,20 @@ describe('alreadySignedGroupTooltip', () => {
       'You already have an ICLA for this CLA group. Signed as jellis (GitLab).'
     );
   });
+
+  it('promises no other identity on a Gerrit-only group, which offers exactly one card', () => {
+    // The next step offers only the contributor's own LF identity there, so no GitHub account
+    // they link can sign this group — naming one as the way out would be a dead end.
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'gerrit', signedAs: 'jellis-lf' }), 'gerrit')).toBe(
+      'You already have an ICLA for this CLA group. Signed as jellis-lf (Gerrit).'
+    );
+  });
+
+  it('keeps the sentence where more than one identity is on offer', () => {
+    expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }), 'github-or-gerrit')).toBe(
+      'You already have an ICLA for this CLA group. Signed as jellis (GitHub). If you have another identity linked, you can still sign with it.'
+    );
+  });
 });
 
 describe('alreadySignedAgreementForIdentity', () => {
@@ -306,9 +320,13 @@ describe('alreadySignedAgreementForIdentity', () => {
 
 describe('alreadySignedIdentityTooltip', () => {
   it('says which kind this account already holds and to pick another', () => {
-    expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }))).toBe(
+    expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), true)).toBe(
       'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.'
     );
+  });
+
+  it('states the position without prescribing a way out when nothing else is selectable', () => {
+    expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), false)).toBe('You already have an ICLA for this CLA group signed with this account.');
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -287,11 +287,11 @@ describe('alreadySignedAgreementForIdentity', () => {
   ];
 
   it('matches a GitHub handle regardless of case', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis' })?.id).toBe('s1');
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' })?.id).toBe('s1');
   });
 
   it('leaves the contributor a second GitHub account to sign with', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work', githubId: '67890' })).toBeUndefined();
   });
 
   it('matches the Gerrit identity on the platform alone', () => {
@@ -301,7 +301,7 @@ describe('alreadySignedAgreementForIdentity', () => {
 
   it('never blocks a GitHub card on an agreement with no recorded identity', () => {
     const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'github', signedAs: '   ' })];
-    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis', githubId: '12345' })).toBeUndefined();
   });
 
   it('still blocks the Gerrit card on an agreement with no recorded identity', () => {
@@ -312,9 +312,19 @@ describe('alreadySignedAgreementForIdentity', () => {
     expect(alreadySignedAgreementForIdentity(blank, { platform: 'gerrit' })?.claGroupId).toBe('cg-1');
   });
 
+  it('matches the account number when that is what the producer recorded', () => {
+    // The producer derives one identity string per agreement — the handle when it had one, the
+    // account number when it did not. Comparing only the handle would leave the very account
+    // that signed selectable, which is the redundant signature this is meant to prevent.
+    const byNumber = [agreement({ id: 's3', claGroupId: 'cg-1', signedVia: 'github', signedAs: '12345' })];
+
+    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: '', githubId: '12345' })?.id).toBe('s3');
+    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: 'jellis', githubId: '67890' })).toBeUndefined();
+  });
+
   it('does not block on an invalidated agreement', () => {
     const invalidated = [agreement({ claGroupId: 'cg-1', status: 'invalidated', signedVia: 'github', signedAs: 'jellis' })];
-    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis' })).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis', githubId: '12345' })).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -192,7 +192,7 @@ describe('claGroupPrimaryName / claGroupSecondaryName', () => {
 });
 
 describe('alreadySignedAgreementForGroup', () => {
-  it('returns the first in-force agreement for that CLA group', () => {
+  it('returns the first already-signed agreement for that CLA group', () => {
     const held = agreement({ claGroupId: 'cg-1', kind: 'ICLA', status: 'valid' });
     expect(alreadySignedAgreementForGroup([held, agreement({ id: 's2', claGroupId: 'cg-2' })], 'cg-1')).toBe(held);
   });
@@ -215,7 +215,7 @@ describe('alreadySignedAgreementForGroup', () => {
 });
 
 describe('alreadySignedAgreementsForGroup', () => {
-  it('returns every in-force agreement for the group, so each identity can be checked', () => {
+  it('returns every already-signed agreement for the group, so each identity can be checked', () => {
     const mine = agreement({ id: 's1', claGroupId: 'cg-1', signedVia: 'github', signedAs: 'jellis' });
     const other = agreement({ id: 's2', claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: 'jellis-lf' });
 
@@ -239,21 +239,21 @@ describe('alreadySignedChipLabel', () => {
 });
 
 describe('alreadySignedGroupTooltip', () => {
-  it('names the ICLA, the identity it was signed as, and that another identity can still sign', () => {
+  it('names the ICLA, the identity it was signed as, and that another identity may still sign', () => {
     expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }))).toBe(
-      'You already have an ICLA for this CLA group. Signed as jellis (GitHub). You can still sign it with a different identity.'
+      'You already have an ICLA for this CLA group. Signed as jellis (GitHub). If you have another identity linked, you can still sign with it.'
     );
   });
 
   it('names the employer when an ECLA has no signed-as identity', () => {
     expect(alreadySignedGroupTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }))).toBe(
-      'You already have an ECLA for this CLA group, covered by Acme. You can still sign it with a different identity.'
+      'You already have an ECLA for this CLA group, covered by Acme. If you have another identity linked, you can still sign with it.'
     );
   });
 
   it('falls back to the kind alone when there is nothing else to name', () => {
     expect(alreadySignedGroupTooltip(agreement({ kind: 'ICLA' }))).toBe(
-      'You already have an ICLA for this CLA group. You can still sign it with a different identity.'
+      'You already have an ICLA for this CLA group. If you have another identity linked, you can still sign with it.'
     );
   });
 });
@@ -277,9 +277,17 @@ describe('alreadySignedAgreementForIdentity', () => {
     expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' })).toBeUndefined();
   });
 
-  it('never blocks a card on an agreement with no recorded identity', () => {
+  it('never blocks a GitHub card on an agreement with no recorded identity', () => {
     const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'github', signedAs: '   ' })];
     expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis' })).toBeUndefined();
+  });
+
+  it('still blocks the Gerrit card on an agreement with no recorded identity', () => {
+    // The asymmetry is deliberate, not an oversight: a GitHub blank could match any of several
+    // accounts, so it matches none, while only one Gerrit card is ever offered and it is the
+    // contributor's own LF identity — so the platform alone identifies it.
+    const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: undefined })];
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'gerrit' })?.claGroupId).toBe('cg-1');
   });
 
   it('does not block on an invalidated agreement', () => {

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { PROFILE_TABS } from '../constants/profile.constants';
 import { ClaGroupOrg, ClaGroupOrgSource, ClaSignedVia, ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/cla.interface';
 import {
+  alreadySignedClaTooltip,
   buildProfileTabs,
   claGroupPrimaryName,
   claGroupSecondaryName,
@@ -13,6 +14,7 @@ import {
   claSignRoute,
   claStatusLabel,
   claStatusSeverity,
+  coveringAgreementForGroup,
   gerritSignUrl,
   isMyClasEmpty,
   shouldShowGithubCta,
@@ -181,6 +183,47 @@ describe('claGroupPrimaryName / claGroupSecondaryName', () => {
   it('falls back to the unnamed literal only when the producer resolved neither name', () => {
     expect(claGroupPrimaryName({})).toBe('Unnamed CLA group');
     expect(claGroupSecondaryName({})).toBeNull();
+  });
+});
+
+describe('coveringAgreementForGroup', () => {
+  it('returns the first in-force agreement for that CLA group', () => {
+    const covering = agreement({ claGroupId: 'cg-1', kind: 'ICLA', status: 'valid' });
+    expect(coveringAgreementForGroup([covering, agreement({ id: 's2', claGroupId: 'cg-2' })], 'cg-1')).toBe(covering);
+  });
+
+  it('does not treat an invalidated agreement as already signed', () => {
+    expect(coveringAgreementForGroup([agreement({ claGroupId: 'cg-1', status: 'invalidated' })], 'cg-1')).toBeUndefined();
+  });
+
+  it('treats needs-attention, revoked, unknown, and superseded as already signed', () => {
+    const statuses: ClaStatus[] = ['needs_attention', 'revoked', 'unknown', 'superseded'];
+    for (const status of statuses) {
+      expect(coveringAgreementForGroup([agreement({ claGroupId: 'cg-1', status })], 'cg-1')?.status).toBe(status);
+    }
+  });
+
+  it('ignores a blank group id and a row with no group id', () => {
+    expect(coveringAgreementForGroup([agreement({ claGroupId: 'cg-1' })], '   ')).toBeUndefined();
+    expect(coveringAgreementForGroup([agreement({})], 'cg-1')).toBeUndefined();
+  });
+});
+
+describe('alreadySignedClaTooltip', () => {
+  it('names the ICLA and the identity it was signed as', () => {
+    expect(alreadySignedClaTooltip(agreement({ kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }))).toBe(
+      'You already have an ICLA for this CLA group. Signed as jellis (GitHub).'
+    );
+  });
+
+  it('names the employer when an ECLA has no signed-as identity', () => {
+    expect(alreadySignedClaTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }))).toBe(
+      'You already have an ECLA for this CLA group, covered by Acme.'
+    );
+  });
+
+  it('falls back to the kind alone when there is nothing else to name', () => {
+    expect(alreadySignedClaTooltip(agreement({ kind: 'ICLA' }))).toBe('You already have an ICLA for this CLA group.');
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -224,6 +224,45 @@ export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, return
   return `${base}/${GERRIT_CONSOLE_ROUTE_PREFIX}/${encodeURIComponent(groupId)}/${GERRIT_CONSOLE_CONTRACT_TYPE}?redirect=${redirect}`;
 }
 
+/**
+ * Statuses that mean signing again cannot produce a new agreement for this group (#1914).
+ *
+ * `invalidated` is excluded: that signature no longer covers contributions, so the
+ * contributor may need to sign again. `unknown` is included — we cannot tell they are
+ * uncovered, and walking them through a ceremony that produces nothing is worse.
+ */
+const ALREADY_SIGNED_CLA_STATUSES: ReadonlySet<ClaStatus> = new Set(['valid', 'needs_attention', 'revoked', 'unknown', 'superseded']);
+
+/**
+ * The in-force agreement that already covers this CLA group, if any. First match wins;
+ * the My CLAs list is already newest-first.
+ *
+ * Grain is the group, not the identity. The picker has not asked which identity they
+ * will sign as yet, and the product call is to gray the group out rather than let them
+ * continue into a second ceremony.
+ */
+export function coveringAgreementForGroup(agreements: readonly MyClaAgreement[], claGroupId: string): MyClaAgreement | undefined {
+  const id = claGroupId.trim();
+  if (!id) return undefined;
+  return agreements.find((agreement) => agreement.claGroupId === id && ALREADY_SIGNED_CLA_STATUSES.has(agreement.status));
+}
+
+/**
+ * Tooltip on a grayed-out Sign a CLA result (#1914). Names the kind they already hold
+ * and, when EasyCLA recorded it, the identity it was signed as.
+ */
+export function alreadySignedClaTooltip(agreement: MyClaAgreement): string {
+  const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
+  const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
+  if (signed) {
+    return `You already have ${kind} for this CLA group. ${signed}.`;
+  }
+  if (agreement.kind === 'ECLA' && agreement.companyName?.trim()) {
+    return `You already have ${kind} for this CLA group, covered by ${agreement.companyName.trim()}.`;
+  }
+  return `You already have ${kind} for this CLA group.`;
+}
+
 /** Maps a producer search result to the picker view model. */
 export function toClaGroupOptionView(option: ClaGroupOption, expanded = false): ClaGroupOptionView {
   return {

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -280,18 +280,22 @@ export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
  * Tooltip on a tagged Sign a CLA result (#1914). Names the kind they already hold, the employer
  * covering an ECLA, and — since the row is still selectable — that another identity may sign it.
  *
- * The closing sentence is conditional on purpose. All this has to work from is the agreements
- * list, which says nothing about how many identities are linked, so it cannot promise a second
- * one exists: a contributor with a single account would be told another identity can sign and
- * then reach a step offering only the card that already signed.
+ * The closing sentence is conditional on purpose. The agreements list says nothing about how
+ * many identities are linked, so it cannot promise a second one exists: a contributor with a
+ * single account would be told another identity can sign and then reach a step offering only
+ * the card that already signed.
+ *
+ * It is dropped altogether on a GitLab-only group, where the block is the route rather than the
+ * identity — Self Serve cannot sign one at all, so no identity they link would help.
  */
-export function alreadySignedGroupTooltip(agreement: MyClaAgreement): string {
+export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaSignRoute): string {
   const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
   const company = agreement.kind === 'ECLA' ? agreement.companyName?.trim() : undefined;
   const held = company ? `You already have ${kind} for this CLA group, covered by ${company}.` : `You already have ${kind} for this CLA group.`;
   const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
+  const another = route === 'gitlab-unsupported' ? '' : ' If you have another identity linked, you can still sign with it.';
 
-  return `${signed ? `${held} ${signed}.` : held} If you have another identity linked, you can still sign with it.`;
+  return `${signed ? `${held} ${signed}.` : held}${another}`;
 }
 
 /**

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -17,7 +17,7 @@ import {
 import { PROFILE_TABS } from '../constants/profile.constants';
 import { BadgeSeverity, TagSeverity } from '../interfaces/components.interface';
 import { ProfileTab } from '../interfaces';
-import {
+import type {
   ClaGroupOption,
   ClaGroupOptionView,
   ClaGroupOrg,
@@ -26,6 +26,7 @@ import {
   ClaStatus,
   MyClaAgreement,
   MyClasIdentitySummary,
+  SignIdentityRef,
 } from '../interfaces/cla.interface';
 
 /**
@@ -277,7 +278,12 @@ export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
 
 /**
  * Tooltip on a tagged Sign a CLA result (#1914). Names the kind they already hold, the employer
- * covering an ECLA, and — since the row is still selectable — that another identity can sign it.
+ * covering an ECLA, and — since the row is still selectable — that another identity may sign it.
+ *
+ * The closing sentence is conditional on purpose. All this has to work from is the agreements
+ * list, which says nothing about how many identities are linked, so it cannot promise a second
+ * one exists: a contributor with a single account would be told another identity can sign and
+ * then reach a step offering only the card that already signed.
  */
 export function alreadySignedGroupTooltip(agreement: MyClaAgreement): string {
   const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
@@ -285,11 +291,8 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement): string {
   const held = company ? `You already have ${kind} for this CLA group, covered by ${company}.` : `You already have ${kind} for this CLA group.`;
   const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
 
-  return `${signed ? `${held} ${signed}.` : held} You can still sign it with a different identity.`;
+  return `${signed ? `${held} ${signed}.` : held} If you have another identity linked, you can still sign with it.`;
 }
-
-/** Which identity a card in the sign-identity step offers. */
-export type SignIdentityRef = { platform: 'github'; username: string } | { platform: 'gerrit' };
 
 /**
  * The agreement this one identity already signed for the group, if any — the check that
@@ -300,9 +303,13 @@ export type SignIdentityRef = { platform: 'github'; username: string } | { platf
  * decides whether to gray a card, while the hand-off still submits `githubId`, and EasyCLA
  * re-derives the attested set from the caller's own token regardless of what is sent.
  *
- * An agreement with no recorded identity therefore matches nothing and blocks no card. Naming
- * a card as already-signed on the strength of a blank is the worse error: it would strand a
- * contributor whose only account is the one it grayed out.
+ * **On the GitHub branch only**, an agreement with no recorded identity matches nothing and
+ * blocks no card. Naming a card as already-signed on the strength of a blank is the worse error:
+ * it would strand a contributor whose only account is the one it grayed out.
+ *
+ * The Gerrit branch cannot make that trade, because it has nothing to compare. Only one Gerrit
+ * card is ever offered and it is the contributor's own LF identity, so the platform alone
+ * identifies it — which does mean a Gerrit agreement with a blank handle still blocks that card.
  */
 export function alreadySignedAgreementForIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef): MyClaAgreement | undefined {
   return agreements.find((agreement) => {

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -304,10 +304,12 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  * The agreement this one identity already signed for the group, if any — the check that
  * actually blocks (#1914).
  *
- * Matching is on the recorded **handle**, not the GitHub account number, because the My CLAs
- * list carries no account number to compare. That is acceptable here and nowhere else: this
- * decides whether to gray a card, while the hand-off still submits `githubId`, and EasyCLA
- * re-derives the attested set from the caller's own token regardless of what is sent.
+ * The producer records one identity string per agreement, derived as the GitHub handle when it
+ * had one and the account number when it did not. So the GitHub branch compares against both
+ * keys the card carries. The number is an exact, stable match; the handle is best-effort, since
+ * handles get renamed and reclaimed. Both are acceptable here and nowhere else: this decides
+ * whether to gray a card, while the hand-off still submits `githubId`, and EasyCLA re-derives
+ * the attested set from the caller's own token regardless of what is sent.
  *
  * **On the GitHub branch only**, an agreement with no recorded identity matches nothing and
  * blocks no card. Naming a card as already-signed on the strength of a blank is the worse error:
@@ -324,7 +326,10 @@ export function alreadySignedAgreementForIdentity(agreements: readonly MyClaAgre
     if (agreement.signedVia !== 'github') return false;
 
     const signedAs = agreement.signedAs?.trim().toLowerCase();
-    return !!signedAs && signedAs === identity.username.trim().toLowerCase();
+    if (!signedAs) return false;
+
+    const username = identity.username?.trim().toLowerCase();
+    return signedAs === identity.githubId.trim().toLowerCase() || (!!username && signedAs === username);
   });
 }
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -6,6 +6,7 @@
 // an Angular component-test harness.
 
 import {
+  ALREADY_SIGNED_CLA_LABEL,
   CLA_GROUP_MATCH_TYPE_LABELS,
   CLA_GROUP_ORG_SOURCE_ICONS,
   CLA_GROUP_ORG_SOURCE_LABELS,
@@ -127,15 +128,20 @@ export function claStatusSeverity(status: ClaStatus): TagSeverity {
 export function signedAsLine(signedVia: ClaSignedVia | undefined, signedAs: string | undefined): string | undefined {
   const identity = signedAs?.trim();
   if (!identity) return undefined;
+  return `Signed as ${identityWithPlatform(signedVia, identity)}`;
+}
+
+/** `<identity> (GitHub)`, or the bare identity when the platform is absent or unrecognised. */
+function identityWithPlatform(signedVia: ClaSignedVia | undefined, identity: string): string {
   switch (signedVia) {
     case 'github':
-      return `Signed as ${identity} (GitHub)`;
+      return `${identity} (GitHub)`;
     case 'gitlab':
-      return `Signed as ${identity} (GitLab)`;
+      return `${identity} (GitLab)`;
     case 'gerrit':
-      return `Signed as ${identity} (Gerrit)`;
+      return `${identity} (Gerrit)`;
     default:
-      return `Signed as ${identity}`;
+      return identity;
   }
 }
 
@@ -225,7 +231,7 @@ export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, return
 }
 
 /**
- * Statuses that mean signing again cannot produce a new agreement for this group (#1914).
+ * Statuses that mean signing again with the same identity cannot produce a new agreement (#1914).
  *
  * `invalidated` is excluded: that signature no longer covers contributions, so the
  * contributor may need to sign again. `unknown` is included — we cannot tell they are
@@ -234,33 +240,85 @@ export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, return
 const ALREADY_SIGNED_CLA_STATUSES: ReadonlySet<ClaStatus> = new Set(['valid', 'needs_attention', 'revoked', 'unknown', 'superseded']);
 
 /**
- * The in-force agreement that already covers this CLA group, if any. First match wins;
+ * The agreement that makes this CLA group already-signed, if any. First match wins;
  * the My CLAs list is already newest-first.
  *
- * Grain is the group, not the identity. The picker has not asked which identity they
- * will sign as yet, and the product call is to gray the group out rather than let them
- * continue into a second ceremony.
+ * Already-signed is not the same as covered: `needs_attention` and `revoked` do not cover
+ * contributions, but signing again cannot restore them either.
+ *
+ * Group grain is for the **tag** on a search result, not for blocking. One contributor can
+ * hold several identities and sign the same group again under a different one, so the group
+ * stays selectable and it is the identity picker that blocks — see
+ * `alreadySignedAgreementForIdentity`.
  */
-export function coveringAgreementForGroup(agreements: readonly MyClaAgreement[], claGroupId: string): MyClaAgreement | undefined {
+export function alreadySignedAgreementForGroup(agreements: readonly MyClaAgreement[], claGroupId: string): MyClaAgreement | undefined {
   const id = claGroupId.trim();
   if (!id) return undefined;
   return agreements.find((agreement) => agreement.claGroupId === id && ALREADY_SIGNED_CLA_STATUSES.has(agreement.status));
 }
 
+/** Every agreement already held for this CLA group, across identities. */
+export function alreadySignedAgreementsForGroup(agreements: readonly MyClaAgreement[], claGroupId: string): MyClaAgreement[] {
+  const id = claGroupId.trim();
+  if (!id) return [];
+  return agreements.filter((agreement) => agreement.claGroupId === id && ALREADY_SIGNED_CLA_STATUSES.has(agreement.status));
+}
+
 /**
- * Tooltip on a grayed-out Sign a CLA result (#1914). Names the kind they already hold
- * and, when EasyCLA recorded it, the identity it was signed as.
+ * Tag on a Sign a CLA search result the contributor already holds a CLA for (#1914). Names the
+ * identity, because that is what tells them which of their accounts is already covered and
+ * therefore which one the next step will gray out.
  */
-export function alreadySignedClaTooltip(agreement: MyClaAgreement): string {
+export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
+  const identity = agreement.signedAs?.trim();
+  if (!identity) return ALREADY_SIGNED_CLA_LABEL;
+  return `${ALREADY_SIGNED_CLA_LABEL} as ${identityWithPlatform(agreement.signedVia, identity)}`;
+}
+
+/**
+ * Tooltip on a tagged Sign a CLA result (#1914). Names the kind they already hold, the employer
+ * covering an ECLA, and — since the row is still selectable — that another identity can sign it.
+ */
+export function alreadySignedGroupTooltip(agreement: MyClaAgreement): string {
   const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
+  const company = agreement.kind === 'ECLA' ? agreement.companyName?.trim() : undefined;
+  const held = company ? `You already have ${kind} for this CLA group, covered by ${company}.` : `You already have ${kind} for this CLA group.`;
   const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
-  if (signed) {
-    return `You already have ${kind} for this CLA group. ${signed}.`;
-  }
-  if (agreement.kind === 'ECLA' && agreement.companyName?.trim()) {
-    return `You already have ${kind} for this CLA group, covered by ${agreement.companyName.trim()}.`;
-  }
-  return `You already have ${kind} for this CLA group.`;
+
+  return `${signed ? `${held} ${signed}.` : held} You can still sign it with a different identity.`;
+}
+
+/** Which identity a card in the sign-identity step offers. */
+export type SignIdentityRef = { platform: 'github'; username: string } | { platform: 'gerrit' };
+
+/**
+ * The agreement this one identity already signed for the group, if any — the check that
+ * actually blocks (#1914).
+ *
+ * Matching is on the recorded **handle**, not the GitHub account number, because the My CLAs
+ * list carries no account number to compare. That is acceptable here and nowhere else: this
+ * decides whether to gray a card, while the hand-off still submits `githubId`, and EasyCLA
+ * re-derives the attested set from the caller's own token regardless of what is sent.
+ *
+ * An agreement with no recorded identity therefore matches nothing and blocks no card. Naming
+ * a card as already-signed on the strength of a blank is the worse error: it would strand a
+ * contributor whose only account is the one it grayed out.
+ */
+export function alreadySignedAgreementForIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef): MyClaAgreement | undefined {
+  return agreements.find((agreement) => {
+    if (!ALREADY_SIGNED_CLA_STATUSES.has(agreement.status)) return false;
+    if (identity.platform === 'gerrit') return agreement.signedVia === 'gerrit';
+    if (agreement.signedVia !== 'github') return false;
+
+    const signedAs = agreement.signedAs?.trim().toLowerCase();
+    return !!signedAs && signedAs === identity.username.trim().toLowerCase();
+  });
+}
+
+/** Tooltip on a grayed-out identity card: this account is the one already on the agreement. */
+export function alreadySignedIdentityTooltip(agreement: MyClaAgreement): string {
+  const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
+  return `You already have ${kind} for this CLA group signed with this account. Choose another identity to sign again.`;
 }
 
 /** Maps a producer search result to the picker view model. */

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -311,6 +311,13 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  * whether to gray a card, while the hand-off still submits `githubId`, and EasyCLA re-derives
  * the attested set from the caller's own token regardless of what is sent.
  *
+ * Nothing in the recorded string says which of the two it is, and GitHub handles can be all
+ * digits — login `12345` is a real account, whose number is something else entirely. So a
+ * number is only read as a number once no handle on offer claims that same string; where one
+ * does, the string is that contributor's handle and grays their card alone. Without this a
+ * contributor who had signed as a numerically-named account could find a wholly unrelated
+ * account of theirs grayed, which on a single-account step would leave them nothing to pick.
+ *
  * **On the GitHub branch only**, an agreement with no recorded identity matches nothing and
  * blocks no card. Naming a card as already-signed on the strength of a blank is the worse error:
  * it would strand a contributor whose only account is the one it grayed out.
@@ -319,7 +326,13 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  * card is ever offered and it is the contributor's own LF identity, so the platform alone
  * identifies it — which does mean a Gerrit agreement with a blank handle still blocks that card.
  */
-export function alreadySignedAgreementForIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef): MyClaAgreement | undefined {
+export function alreadySignedAgreementForIdentity(
+  agreements: readonly MyClaAgreement[],
+  identity: SignIdentityRef,
+  offeredHandles: readonly string[]
+): MyClaAgreement | undefined {
+  const handles = new Set(offeredHandles.map((handle) => handle.trim().toLowerCase()).filter(Boolean));
+
   return agreements.find((agreement) => {
     if (!ALREADY_SIGNED_CLA_STATUSES.has(agreement.status)) return false;
     if (identity.platform === 'gerrit') return agreement.signedVia === 'gerrit';
@@ -329,7 +342,9 @@ export function alreadySignedAgreementForIdentity(agreements: readonly MyClaAgre
     if (!signedAs) return false;
 
     const username = identity.username?.trim().toLowerCase();
-    return signedAs === identity.githubId.trim().toLowerCase() || (!!username && signedAs === username);
+    if (username && signedAs === username) return true;
+
+    return !handles.has(signedAs) && signedAs === identity.githubId.trim().toLowerCase();
   });
 }
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -280,20 +280,22 @@ export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
  * Tooltip on a tagged Sign a CLA result (#1914). Names the kind they already hold, the employer
  * covering an ECLA, and — since the row is still selectable — that another identity may sign it.
  *
- * The closing sentence is conditional on purpose. The agreements list says nothing about how
- * many identities are linked, so it cannot promise a second one exists: a contributor with a
- * single account would be told another identity can sign and then reach a step offering only
- * the card that already signed.
+ * The closing sentence is dropped on any route that cannot offer a second identity, because
+ * there it names an escape that does not exist: `gerrit` offers exactly one card, the
+ * contributor's own LF identity, and `gitlab-unsupported` offers none at all — Self Serve cannot
+ * sign a GitLab-only group, so the block is the route rather than the account.
  *
- * It is dropped altogether on a GitLab-only group, where the block is the route rather than the
- * identity — Self Serve cannot sign one at all, so no identity they link would help.
+ * Where it is kept it stays conditional, because the agreements list says nothing about how many
+ * identities are linked or whether they too have signed. A route that offers several identities
+ * is the most this can honestly claim; the identity step is what knows which ones are refused.
  */
 export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaSignRoute): string {
   const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
   const company = agreement.kind === 'ECLA' ? agreement.companyName?.trim() : undefined;
   const held = company ? `You already have ${kind} for this CLA group, covered by ${company}.` : `You already have ${kind} for this CLA group.`;
   const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
-  const another = route === 'gitlab-unsupported' ? '' : ' If you have another identity linked, you can still sign with it.';
+  const offersOneIdentityAtMost = route === 'gerrit' || route === 'gitlab-unsupported';
+  const another = offersOneIdentityAtMost ? '' : ' If you have another identity linked, you can still sign with it.';
 
   return `${signed ? `${held} ${signed}.` : held}${another}`;
 }
@@ -326,10 +328,19 @@ export function alreadySignedAgreementForIdentity(agreements: readonly MyClaAgre
   });
 }
 
-/** Tooltip on a grayed-out identity card: this account is the one already on the agreement. */
-export function alreadySignedIdentityTooltip(agreement: MyClaAgreement): string {
+/**
+ * Tooltip on a grayed-out identity card: this account is the one already on the agreement.
+ *
+ * Points at another identity only when the step actually offers one that has not signed. A
+ * Gerrit-only step offers a single card, so once that card is grayed there is nothing left to
+ * choose, and "choose another identity" would be the one instruction the contributor cannot
+ * follow. Stating the position without prescribing a way out is the honest form there.
+ */
+export function alreadySignedIdentityTooltip(agreement: MyClaAgreement, anotherSelectable: boolean): string {
   const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
-  return `You already have ${kind} for this CLA group signed with this account. Choose another identity to sign again.`;
+  const held = `You already have ${kind} for this CLA group signed with this account.`;
+
+  return anotherSelectable ? `${held} Choose another identity to sign again.` : held;
 }
 
 /** Maps a producer search result to the picker view model. */


### PR DESCRIPTION
Closes #1914

## What was wrong

The **Sign a CLA** picker had no knowledge of the agreements the contributor already holds, so a group they had already signed stayed selectable all the way through to a live **SIGN CLA** button in the EasyCLA Contributor Console. EasyCLA reuses the existing signature, so the ceremony produced nothing — the contributor was walked through a signing that had no effect and told they had signed something they had not.

## What changed

An earlier revision of this PR greyed out the whole CLA group. Review raised that this is too coarse: a contributor can have more than one identity linked, and an ICLA signed under one of them says nothing about whether another can still sign. Greying the group denied a signature they were entitled to give.

So the two levels are now split, and the CLAs tab's already-loaded agreements feed both.

**In the CLA-group picker** — informational only, nothing is blocked:

- A result the contributor already holds a CLA for is tagged **Already signed as `<identity>`**.
- Hovering it names the agreement, the employer covering an ECLA, and that another identity may still be able to sign — for example *You already have an ICLA for this CLA group. Signed as `<username>` (GitHub). If you have another identity linked, you can still sign with it.* The wording is conditional on purpose: the picker holds only the agreements, never the count of linked identities, and a Gerrit-only group can have exactly one.
- That closing sentence is derived from the group's own sign route and dropped on any route that cannot offer a second identity: a GitLab-only group, which Self Serve cannot sign at all, and a Gerrit-only group, which offers exactly one card. On both the block is the route rather than the account, so pointing the contributor at another identity would send them nowhere.
- The row stays selectable, so they can continue and choose a different identity.

**In the identity step** — this is where the refusal happens:

- The identity already on an agreement for that group is greyed out, with *You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.*
- That closing instruction appears only when another identity is genuinely selectable. A Gerrit-only step offers exactly one card, so once it is greyed there is nothing else to choose and the message states the position without prescribing a way out.
- Their other identities stay selectable, and submitting a greyed one is refused even if the card is reached another way — by click, by keyboard, or by writing the control directly.

## What a reviewer should look at

**Identity matching compares both keys the card carries.** `MyClaAgreement` carries a single `signedAs` string, and the producer derives it as the GitHub handle when it had one and the account number when it did not. Matching only the handle would therefore miss every agreement recorded against the number and leave the account that signed still selectable — the redundant signature this change exists to prevent. Nothing in the recorded value says which of the two it is, and GitHub handles can be all digits — `12345` is a real login whose account number is something else — so a numeric value is read as an account number only once no handle on offer claims that same string; where one does, it is that contributor's handle and greys their card alone. The account number is otherwise an exact, stable match. The handle is best-effort, because handles get renamed and reclaimed, so both failure modes are worth naming: a **rename** means the card is not greyed and the contributor can re-sign, which is exactly today's behaviour and no worse; a **reclaim** could grey a card for someone who never signed. Both are tolerable only because this decides presentation. The hand-off still addresses the account by `githubId`, and EasyCLA re-derives the attested set from the caller's own token, so a wrong match here can only produce a refusal downstream — never an incorrect association. On the GitHub side an agreement with **no** recorded identity greys out nothing, rather than stranding a contributor whose only account it would have refused.

**The group tag is deliberately wider than the identity grey-out.** A group is tagged whenever any already-signed agreement matches it; an identity is greyed only when the agreement matches an identity the step actually offers — a linked GitHub account, by handle or by account number, or their LF identity via Gerrit. A GitLab agreement tags the group and greys nothing, as does a GitHub agreement with no recorded identity. A Gerrit agreement is the exception: it greys the single LF identity card whether or not a handle was recorded, because only one Gerrit card is ever offered and the platform alone identifies it. Both Help Center articles say this rather than promising a grey-out that will not always arrive.

**Invalidated agreements grey out nothing**, because that signature no longer covers contributions and a new one may be needed — with the same identity. **Needs attention** and **Revoked** do grey the identity out: signing again would not restore coverage, and the remedy is **Request approval** (or, for Revoked, nothing available in Self Serve).

**`Sign CLA` is disabled until the list has loaded, and stays disabled if it failed.** Both dialogs read those agreements, and an empty list is indistinguishable from having signed nothing whether it is not-yet-loaded or failed. A failed fetch resolves to `loaded: true` with no data, so guarding on loading alone would have re-opened this very bug on the error path; the disabled reason points at the retry.

**The shared selectable card gains two inputs.** `disabled` disables one card while the rest of the group stays selectable — it previously derived disabled state from the whole form control. `disabledReason` carries the reason once and renders it twice: as a tooltip on the card, triggered by hover *or* focus, and as visually hidden text inside it. A greyed card therefore announces *why* after its label instead of hiding the reason behind a pointer, and it keeps `tabindex="0"` while disabled so a keyboard user can still reach it. The card is used only by this step today.

## Docs

`docs/user/account/my-clas/index.md` gains a *Why does a search result say "Already signed as"?* section explaining the tag, that the result stays selectable, which identities the next step can grey out — including that a Gerrit-signed CLA greys the LF identity whether or not an account was recorded — and how each status on an existing CLA affects that step; `docs/user/account/faq/index.md` gains the matching short answer.

`superseded` is intentionally absent from that table. It is a reserved status nothing produces today, so it stays in the blocking set — the guard is then already correct whenever it starts arriving — without documenting a state no contributor can encounter.

## Verification

| Gate | Result |
|---|---|
| `yarn lint:check` | clean (one pre-existing warning in an unrelated spec) |
| `yarn check-types` | clean |
| `yarn test` | 5307 passed — 1583 app, 2409 server, 1315 shared package |
| `yarn build` | success |
| `yarn format:check` | clean |
| `docs:check` | manifest, search index, sitemap, coverage, idempotence OK |
