### PR TITLE
fix(sidebar): surface marketing section under project lens

### DIFF
--- a/apps/lfx-one/e2e/marketing-access.spec.ts
+++ b/apps/lfx-one/e2e/marketing-access.spec.ts
@@ -39,7 +39,7 @@
  *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (tests skip otherwise)
  */
 
-import type { LensItem, PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
+import type { LensItem, NavLens, PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
 import { FEATURE_FLAG_OVERRIDE_STORAGE_KEY, MARKETING_OPS_FGA_ENABLED_FLAG, PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
 import { expect, Page, test } from '@playwright/test';
 
@@ -56,6 +56,12 @@ const MOCK_FOUNDATION_ITEM: LensItem = {
   name: 'Test Foundation',
   logoUrl: null,
   isFoundation: true,
+};
+
+/** Project-lens flavor of the mock item — `isFoundation: false` so a hybrid persona's `applyVisibilityFilters` doesn't strip it. */
+const MOCK_PROJECT_ITEM: LensItem = {
+  ...MOCK_FOUNDATION_ITEM,
+  isFoundation: false,
 };
 
 const SIDEBAR = {
@@ -121,11 +127,11 @@ async function stubPersona(page: Page, personas: string[], options: StubPersonaO
   );
 }
 
-async function stubNavLensItems(page: Page, items: LensItem[] = [MOCK_FOUNDATION_ITEM]): Promise<void> {
+async function stubNavLensItems(page: Page, items: LensItem[] = [MOCK_FOUNDATION_ITEM], targetLens: NavLens = 'foundation'): Promise<void> {
   await page.route('**/api/nav/lens-items*', (route) => {
     const url = route.request().url();
     const requestedLens = new URL(url).searchParams.get('lens') ?? 'foundation';
-    if (requestedLens !== 'foundation') {
+    if (requestedLens !== targetLens) {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -135,7 +141,7 @@ async function stubNavLensItems(page: Page, items: LensItem[] = [MOCK_FOUNDATION
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ items, next_page_token: null, upstream_failed: false, lens: 'foundation' }),
+      body: JSON.stringify({ items, next_page_token: null, upstream_failed: false, lens: targetLens }),
     });
   });
 }
@@ -397,7 +403,7 @@ test.describe('S10: Project lens — hybrid marketing_auditor (flag ON, contribu
     // Project lens, not just Foundation lens.
     await stubPersona(page, ['contributor'], { isMarketingAuditor: true });
     await setPersonaCookie(page, ['contributor']);
-    await stubNavLensItems(page);
+    await stubNavLensItems(page, [MOCK_PROJECT_ITEM], 'project');
     await stubProjectApi(page, MOCK_FOUNDATION_SLUG, false);
     await gotoAndWaitForSidebar(page, `/project/overview?project=${MOCK_FOUNDATION_SLUG}`);
   });
@@ -409,5 +415,6 @@ test.describe('S10: Project lens — hybrid marketing_auditor (flag ON, contribu
     await expect(page.getByTestId(SIDEBAR.marketingImpact), 'persona=hybrid-marketing_auditor lens=project item=marketing-impact').toBeVisible({
       timeout: ELEMENT_TIMEOUT,
     });
+    await expect(page.getByTestId(SIDEBAR.campaigns), 'persona=hybrid-marketing_auditor lens=project item=campaigns should be hidden').toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/marketing-access.spec.ts
+++ b/apps/lfx-one/e2e/marketing-access.spec.ts
@@ -27,6 +27,7 @@
  *   S7  Flag ON  — LF Staff stays Social-Listening-only on Marketing Impact even with marketing_auditor-equivalent access already granted via canViewExecutiveDashboards
  *   S8  Flag OFF (default) — grants present on the API response are ignored; behavior is byte-identical to pre-LFXV2-2236 ED/LF-staff-only gating
  *   S9  Flag ON  — marketing_auditor + campaign_manager grants do not unlock Health Metrics (ED/LF-Staff-only, LFXV2-2237)
+ *   S10 Flag ON  — hybrid marketing_auditor (contributor + marketing grant) sees Marketing section under Project lens too, not just Foundation (LFXV2-2235)
  *
  * This suite does NOT flip the server `LFX_MARKETING_OPS_FGA_ENABLED` env var or hit protected
  * analytics/campaigns routes directly — see `require-marketing-access.middleware.spec.ts` for
@@ -380,6 +381,32 @@ test.describe('S9: Foundation lens — marketing_auditor + campaign_manager gran
     skipWhenAuthMissing(page);
 
     await expect(page, 'persona=marketing_auditor+campaign_manager should be redirected away from health-metrics').toHaveURL(/\/foundation\/overview/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+  });
+});
+
+// ─── S10: hybrid marketing_auditor also sees Marketing under Project lens ─────
+
+test.describe('S10: Project lens — hybrid marketing_auditor (flag ON, contributor + marketing grant)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubMarketingOpsFlag(page, true);
+    // A 'contributor' persona alone grants the project lens (project-scoped role); adding
+    // isMarketingAuditor also grants the foundation lens via hasMarketingGrant — together these
+    // make the user hybrid, reproducing the bug: the Marketing section must still surface from
+    // Project lens, not just Foundation lens.
+    await stubPersona(page, ['contributor'], { isMarketingAuditor: true });
+    await setPersonaCookie(page, ['contributor']);
+    await stubNavLensItems(page);
+    await stubProjectApi(page, MOCK_FOUNDATION_SLUG, false);
+    await gotoAndWaitForSidebar(page, `/project/overview?project=${MOCK_FOUNDATION_SLUG}`);
+  });
+
+  test('sees Marketing section with Marketing Impact under Project lens', async ({ page }) => {
+    await expect(page.getByTestId(SIDEBAR.marketingSection), 'persona=hybrid-marketing_auditor lens=project section=marketing').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+    await expect(page.getByTestId(SIDEBAR.marketingImpact), 'persona=hybrid-marketing_auditor lens=project item=marketing-impact').toBeVisible({
       timeout: ELEMENT_TIMEOUT,
     });
   });

--- a/apps/lfx-one/e2e/marketing-access.spec.ts
+++ b/apps/lfx-one/e2e/marketing-access.spec.ts
@@ -28,6 +28,8 @@
  *   S8  Flag OFF (default) — grants present on the API response are ignored; behavior is byte-identical to pre-LFXV2-2236 ED/LF-staff-only gating
  *   S9  Flag ON  — marketing_auditor + campaign_manager grants do not unlock Health Metrics (ED/LF-Staff-only, LFXV2-2237)
  *   S10 Flag ON  — hybrid marketing_auditor (contributor + marketing grant) sees Marketing section under Project lens too, not just Foundation (LFXV2-2235)
+ *   S11 Flag ON  — marketing_auditor confirmed on project A, client-side switch to ungranted project B
+ *                  hides the Marketing section without a full page reload (PR #2028 review finding)
  *
  * This suite does NOT flip the server `LFX_MARKETING_OPS_FGA_ENABLED` env var or hit protected
  * analytics/campaigns routes directly — see `require-marketing-access.middleware.spec.ts` for
@@ -61,6 +63,17 @@ const MOCK_FOUNDATION_ITEM: LensItem = {
 /** Project-lens flavor of the mock item — `isFoundation: false` so a hybrid persona's `applyVisibilityFilters` doesn't strip it. */
 const MOCK_PROJECT_ITEM: LensItem = {
   ...MOCK_FOUNDATION_ITEM,
+  isFoundation: false,
+};
+
+/** A second, distinct project — used by S11 to switch scope client-side away from a granted project. */
+const MOCK_PROJECT_SLUG_B = 'test-project-b';
+
+const MOCK_PROJECT_ITEM_B: LensItem = {
+  uid: 'f0000000-0000-0000-0000-000000000002',
+  slug: MOCK_PROJECT_SLUG_B,
+  name: 'Test Project B',
+  logoUrl: null,
   isFoundation: false,
 };
 
@@ -125,6 +138,34 @@ async function stubPersona(page: Page, personas: string[], options: StubPersonaO
       }),
     })
   );
+}
+
+/**
+ * Slug-aware variant of {@link stubPersona} — returns different grants depending on the `?project=`
+ * query param `PersonaService.refreshEnrichedPersonas` sends per scope (persona.service.ts:198).
+ * Needed for S11: the plain `stubPersona` stub is static regardless of which slug is probed, so it
+ * can't reproduce a confirmed-on-A / denied-on-B scope switch.
+ */
+async function stubPersonaByProject(page: Page, personas: string[], grantsBySlug: Record<string, StubPersonaOptions>): Promise<void> {
+  await page.route('**/api/user/personas*', (route) => {
+    const url = route.request().url();
+    const slug = new URL(url).searchParams.get('project');
+    const { isLFStaff = false, isMarketingAuditor = false, isCampaignManager = false } = (slug && grantsBySlug[slug]) || {};
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas,
+        personaProjects: {},
+        projects: [],
+        organizations: [],
+        isRootWriter: false,
+        isLFStaff,
+        isMarketingAuditor,
+        isCampaignManager,
+      }),
+    });
+  });
 }
 
 async function stubNavLensItems(page: Page, items: LensItem[] = [MOCK_FOUNDATION_ITEM], targetLens: NavLens = 'foundation'): Promise<void> {
@@ -416,5 +457,41 @@ test.describe('S10: Project lens — hybrid marketing_auditor (flag ON, contribu
       timeout: ELEMENT_TIMEOUT,
     });
     await expect(page.getByTestId(SIDEBAR.campaigns), 'persona=hybrid-marketing_auditor lens=project item=campaigns should be hidden').toHaveCount(0);
+  });
+});
+
+// ─── S11: scope switch A (granted) → B (ungranted) hides Marketing without a full reload ──
+
+test.describe('S11: Project lens — marketing_auditor confirmed on project A, switches to ungranted project B', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubMarketingOpsFlag(page, true);
+    await stubPersonaByProject(page, ['contributor'], {
+      [MOCK_PROJECT_ITEM.slug]: { isMarketingAuditor: true },
+      [MOCK_PROJECT_SLUG_B]: {},
+    });
+    await setPersonaCookie(page, ['contributor']);
+    await stubNavLensItems(page, [MOCK_PROJECT_ITEM, MOCK_PROJECT_ITEM_B], 'project');
+    await stubProjectApi(page, MOCK_PROJECT_ITEM.slug, false);
+    await stubProjectApi(page, MOCK_PROJECT_SLUG_B, false);
+    await gotoAndWaitForSidebar(page, `/project/overview?project=${MOCK_PROJECT_ITEM.slug}`);
+  });
+
+  test('Marketing section disappears after switching to project B via the project selector', async ({ page }) => {
+    await expect(page.getByTestId(SIDEBAR.marketingSection), 'persona=marketing_auditor project=A section=marketing').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // Client-side scope switch — the project selector popover, not page.goto, so this exercises the
+    // reactive marketingPersonaSlug -> grantsByScope -> marketingSectionItem chain rather than a fresh SSR load.
+    await page.getByTestId('project-selector').click();
+    await page.getByTestId(`lens-item-${MOCK_PROJECT_SLUG_B}`).click();
+
+    await expect(page, 'switching to project B should update the URL').toHaveURL(new RegExp(`project=${MOCK_PROJECT_SLUG_B}`), {
+      timeout: ELEMENT_TIMEOUT,
+    });
+    await expect(page.getByTestId(SIDEBAR.marketingSection), 'persona=marketing_auditor project=B(no-grant) section=marketing should be hidden').toHaveCount(
+      0,
+      { timeout: ELEMENT_TIMEOUT }
+    );
   });
 });

--- a/apps/lfx-one/e2e/marketing-access.spec.ts
+++ b/apps/lfx-one/e2e/marketing-access.spec.ts
@@ -26,6 +26,7 @@
  *   S6  Flag ON  — contributor without campaign_manager is redirected off /foundation/campaigns
  *   S7  Flag ON  — LF Staff stays Social-Listening-only on Marketing Impact even with marketing_auditor-equivalent access already granted via canViewExecutiveDashboards
  *   S8  Flag OFF (default) — grants present on the API response are ignored; behavior is byte-identical to pre-LFXV2-2236 ED/LF-staff-only gating
+ *   S9  Flag ON  — marketing_auditor + campaign_manager grants do not unlock Health Metrics (ED/LF-Staff-only, LFXV2-2237)
  *
  * This suite does NOT flip the server `LFX_MARKETING_OPS_FGA_ENABLED` env var or hit protected
  * analytics/campaigns routes directly — see `require-marketing-access.middleware.spec.ts` for
@@ -60,6 +61,7 @@ const SIDEBAR = {
   marketingSection: 'sidebar-item-marketing',
   marketingImpact: 'sidebar-marketing-impact',
   campaigns: 'sidebar-marketing-campaigns',
+  healthMetrics: 'sidebar-metrics-health-metrics',
 };
 
 const CAMPAIGNS_PAGE = 'campaigns-page';
@@ -347,6 +349,37 @@ test.describe('S8: Foundation lens — flag OFF (default) ignores marketing_audi
 
     await gotoAndWaitForSidebar(page, `/foundation/marketing-impact?project=${MOCK_FOUNDATION_SLUG}`);
     await expect(page.getByTestId('marketing-impact-social-listening-only'), 'flag=off marketing_auditor grant should not unlock full tabs').toBeVisible({
+      timeout: ELEMENT_TIMEOUT,
+    });
+  });
+});
+
+// ─── S9: marketing_auditor/campaign_manager grants do not unlock Health Metrics ──
+
+test.describe('S9: Foundation lens — marketing_auditor + campaign_manager grants do not unlock Health Metrics (flag ON)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubMarketingOpsFlag(page, true);
+    await stubPersona(page, ['contributor'], { isMarketingAuditor: true, isCampaignManager: true });
+    await setPersonaCookie(page, ['contributor']);
+    await stubNavLensItems(page);
+    await stubProjectApi(page, MOCK_FOUNDATION_SLUG, false);
+  });
+
+  test('sidebar hides Health Metrics despite marketing_auditor/campaign_manager grants', async ({ page }) => {
+    await gotoAndWaitForSidebar(page, `/foundation/overview?project=${MOCK_FOUNDATION_SLUG}`);
+    await expect(
+      page.getByTestId(SIDEBAR.healthMetrics),
+      'persona=marketing_auditor+campaign_manager item=health-metrics should be hidden (ED/LF-Staff-only)'
+    ).toHaveCount(0);
+  });
+
+  test('is redirected off /foundation/health-metrics to /foundation/overview', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.goto(`/foundation/health-metrics?project=${MOCK_FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await expect(page, 'persona=marketing_auditor+campaign_manager should be redirected away from health-metrics').toHaveURL(/\/foundation\/overview/, {
       timeout: ELEMENT_TIMEOUT,
     });
   });

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -89,7 +89,13 @@ export class SidebarNavService {
         // Documents (last of projectLensItems) and the Governance section in the project sidebar.
         const mktgOsItems = this.isMktgOsAgentsEnabled() ? [this.mktgOsAgentsNavItem] : [];
         const base = [...this.projectLensItems, ...mktgOsItems, this.projectGovernanceSection];
-        return this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
+        const withComms = this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
+        // Marketing-only FGA users who are also hybrid personas (e.g. a project role plus a
+        // marketing_auditor/campaign_manager grant) land here via getAllowedLensIds()/isHybridPersona
+        // rather than the foundation lens — they must still reach Campaign Impact/Campaigns
+        // (LFXV2-2235 review finding: hybrid marketing users lost the Marketing section in project lens).
+        const marketingSection = this.marketingSectionItem();
+        return marketingSection ? [...withComms, marketingSection] : withComms;
       }
       case 'org':
         return this.isOrgLensEnabled() ? this.visibleOrgLensItems() : this.visibleMeLensItems();
@@ -410,13 +416,24 @@ export class SidebarNavService {
       }
     }
 
-    // Marketing section visibility is independent of Metrics: while marketing-ops-fga-enabled is
-    // on, a root/project-scoped marketing_auditor grant also unlocks Campaign Impact, and a
-    // campaign_manager grant unlocks Campaigns — neither implies the other, so each item is built
-    // independently and the section itself only appears once it has at least one item. LF Staff see
-    // Campaign Impact via canViewExecutiveDashboards() the same as Metrics, but are restricted to the
-    // Social Listening tab once inside — full Marketing Impact access is ED/marketing_auditor only
-    // (LFXV2-2236 gap-analysis G4). Never widen the Metrics section itself for marketing_auditor.
+    const marketingSection = this.marketingSectionItem();
+    if (marketingSection) {
+      items.push(marketingSection);
+    }
+
+    return items;
+  });
+
+  // Marketing section visibility is independent of Metrics: while marketing-ops-fga-enabled is
+  // on, a root/project-scoped marketing_auditor grant also unlocks Campaign Impact, and a
+  // campaign_manager grant unlocks Campaigns — neither implies the other, so each item is built
+  // independently and the section itself only appears once it has at least one item. LF Staff see
+  // Campaign Impact via canViewExecutiveDashboards() the same as Metrics, but are restricted to the
+  // Social Listening tab once inside — full Marketing Impact access is ED/marketing_auditor only
+  // (LFXV2-2236 gap-analysis G4). Never widen the Metrics section itself for marketing_auditor.
+  // Extracted so both foundationLensItems and the project-lens branch of sidebarItems (hybrid
+  // marketing users) can surface the same section (LFXV2-2235 review finding).
+  private readonly marketingSectionItem = computed((): SidebarMenuItem | null => {
     this.marketingPersonaSlug();
     const marketingItems: SidebarMenuItem[] = [];
 
@@ -445,16 +462,16 @@ export class SidebarNavService {
       });
     }
 
-    if (marketingItems.length > 0) {
-      items.push({
-        label: 'Marketing',
-        isSection: true,
-        expanded: true,
-        items: marketingItems,
-      });
+    if (marketingItems.length === 0) {
+      return null;
     }
 
-    return items;
+    return {
+      label: 'Marketing',
+      isSection: true,
+      expanded: true,
+      items: marketingItems,
+    };
   });
 
   // --- Project Lens Items (base) ---

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -262,13 +262,21 @@ export class SidebarNavService {
     { initialValue: false }
   );
 
-  // Keeps isMarketingAuditor/isCampaignManager in sync with the active foundation — the root-scoped
-  // fetch alone misses a per-project grant (LFXV2-2235 review finding). Read in canSeeMarketing below
-  // to register the dependency; the refreshed value lives on PersonaService's own signals.
+  // Keeps PersonaService.grantsByScope populated for the active foundation/project — the root-scoped
+  // fetch alone misses a per-project grant (LFXV2-2235 review finding). marketingSectionItem reads
+  // this same slug to look up grantsByScope for the active scope.
   // For project-lens-only marketing users, `selectedFoundation` is never populated because
   // foundation rows that the sidebar shows under the project lens are stored in `selectedProject`
   // (sidebar.component.ts:188-200). Fall back to selectedProject so the scoped probe fires as soon
   // as they pick any context, bootstrapping their first-session foundation grant.
+  // Always re-probes on a selectedProject change — a scope switch from a confirmed project A to an
+  // unprobed project B must not leave the sidebar showing A's (possibly no-longer-relevant) grant for
+  // B (PR #2028 Copilot review finding). This used to stop probing once a grant was confirmed, to
+  // avoid a `false` result for an unrelated project clobbering the confirmed grant — but that
+  // clobber risk lived entirely in the legacy global isMarketingAuditor/isCampaignManager signals,
+  // which marketingSectionItem no longer reads as its primary source. grantsByScope resolves each
+  // relation to its own scope key (writeGrantForScope), so a denial for project B is written under
+  // B's own key and cannot overwrite project A's already-confirmed entry.
   private readonly marketingPersonaSlug: Signal<string> = toSignal(
     toObservable(
       computed(() => {
@@ -278,15 +286,6 @@ export class SidebarNavService {
         const foundationSlug = this.projectContextService.selectedFoundation()?.slug;
         if (foundationSlug) {
           return foundationSlug;
-        }
-        // Only fall back to selectedProject while no marketing grant is confirmed yet. Once
-        // isMarketingAuditor/isCampaignManager is true, a later selectedProject change with no
-        // explicit selectedFoundation must not re-probe that unrelated project slug — a `false`
-        // result there would overwrite (not merge with) the already-confirmed foundation-scoped
-        // grant (LFXV2-2235 review finding: "project slug clears marketing grant"). A genuine
-        // foundation switch still re-verifies via the selectedFoundation branch above.
-        if (this.personaService.isMarketingAuditor() || this.personaService.isCampaignManager()) {
-          return '';
         }
         return this.projectContextService.selectedProject()?.slug ?? '';
       })
@@ -439,11 +438,11 @@ export class SidebarNavService {
   // 'Projects' switcher entry already relies on (lens.service.ts switchLens/isHybridPersona), not
   // an oversight introduced here.
   private readonly marketingSectionItem = computed((): SidebarMenuItem | null => {
-    this.marketingPersonaSlug();
+    const slug = this.marketingPersonaSlug();
     const marketingItems: SidebarMenuItem[] = [];
 
     const canSeeMarketingImpact =
-      this.personaService.canViewExecutiveDashboards() || (this.isMarketingOpsFgaEnabled() && this.personaService.isMarketingAuditor());
+      this.personaService.canViewExecutiveDashboards() || (this.isMarketingOpsFgaEnabled() && this.hasMarketingGrant(slug, 'isMarketingAuditor'));
     if (canSeeMarketingImpact) {
       marketingItems.push({
         label: 'Campaign Impact',
@@ -457,7 +456,7 @@ export class SidebarNavService {
     // A campaign_manager-only user (no ED, no marketing_auditor, not LF Staff) must still see this
     // item, so it cannot be nested inside the Campaign Impact check above.
     const canSeeCampaigns =
-      this.personaService.currentPersona() === 'executive-director' || (this.isMarketingOpsFgaEnabled() && this.personaService.isCampaignManager());
+      this.personaService.currentPersona() === 'executive-director' || (this.isMarketingOpsFgaEnabled() && this.hasMarketingGrant(slug, 'isCampaignManager'));
     if (canSeeCampaigns) {
       marketingItems.push({
         label: 'Campaigns',
@@ -620,5 +619,36 @@ export class SidebarNavService {
 
   private initCanSeeNewsletters(): Signal<boolean> {
     return computed(() => this.personaService.currentPersona() === 'executive-director' || this.projectContextService.canWrite());
+  }
+
+  /**
+   * Scope-aware grant check, mirroring `marketing-impact.component.ts`'s `initHasFullMarketingAccess`
+   * and `campaigns.component.ts`'s `hasCampaignAccess`. Reads `PersonaService.grantsByScope` for
+   * `slug` first, then falls back to the ROOT (`null`) entry, before falling back to the legacy
+   * global `isMarketingAuditor`/`isCampaignManager` signal gated by `marketingGrantSlug()` — the same
+   * per-scope-first ordering those two components use, so the sidebar can't disagree with the page a
+   * click lands on (PR #2028 Copilot review finding: sidebar visibility based on stale global signal).
+   */
+  private hasMarketingGrant(slug: string, relation: 'isMarketingAuditor' | 'isCampaignManager'): boolean {
+    const grants = this.personaService.grantsByScope();
+    const scopedGrant = slug ? grants.get(slug) : undefined;
+    if (scopedGrant?.[relation]) {
+      return true;
+    }
+    const rootGrant = grants.get(null);
+    if (rootGrant?.[relation]) {
+      return true;
+    }
+    // An authoritative `false` at either scope key must win over the legacy global signal below,
+    // which can be stale `true` from a different scope's earlier probe.
+    if (scopedGrant !== undefined || rootGrant !== undefined) {
+      return false;
+    }
+    // No per-scope entry yet — fall back to the global signal with the slug gate.
+    const grantSlug = this.personaService.marketingGrantSlug();
+    if (slug && grantSlug !== null && grantSlug !== slug) {
+      return false;
+    }
+    return relation === 'isMarketingAuditor' ? this.personaService.isMarketingAuditor() : this.personaService.isCampaignManager();
   }
 }

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -432,7 +432,12 @@ export class SidebarNavService {
   // Social Listening tab once inside — full Marketing Impact access is ED/marketing_auditor only
   // (LFXV2-2236 gap-analysis G4). Never widen the Metrics section itself for marketing_auditor.
   // Extracted so both foundationLensItems and the project-lens branch of sidebarItems (hybrid
-  // marketing users) can surface the same section (LFXV2-2235 review finding).
+  // marketing users) can surface the same section (LFXV2-2235 review finding). Both items below
+  // route to /foundation/* paths tagged `lens: 'foundation'` in app.routes.ts, so a hybrid user
+  // clicking one from the project lens gets flipped into the foundation lens by
+  // MainLayoutComponent.syncLensFromRoute — the same lens-switch-on-navigate behavior the merged
+  // 'Projects' switcher entry already relies on (lens.service.ts switchLens/isHybridPersona), not
+  // an oversight introduced here.
   private readonly marketingSectionItem = computed((): SidebarMenuItem | null => {
     this.marketingPersonaSlug();
     const marketingItems: SidebarMenuItem[] = [];


### PR DESCRIPTION
## Summary
- Hybrid-persona users with a marketing_auditor/campaign_manager FGA grant plus project-level access could land in the Project lens, where the Marketing section (Campaign Impact/Campaigns) was never built — only `foundationLensItems()` constructed it.
- Extracts the section into a shared `marketingSectionItem` computed and consumes it from both the `'foundation'` and `'project'` branches of `SidebarNavService.sidebarItems`, so it shows up regardless of which lens is active.
- Adds e2e coverage: S9 confirms marketing grants don't unlock Health Metrics (LFXV2-2237 gap), S10 confirms a hybrid marketing_auditor sees the Marketing section under Project lens (the actual LFXV2-2235 fix).

## Test plan
- [x] `yarn format && yarn lint && yarn build` clean
- [x] License headers pass (`./check-headers.sh`)
- [x] Reviewer trio (general + self-serve conventions + learnings) clean on every commit
- [x] Full-branch sweep (all three reviewers vs `origin/main`) clean
- [x] `/lfx-self-serve-pr-readiness` — READY
- [x] New e2e scenarios S9/S10 added to `marketing-access.spec.ts`

LFXV2-2235
LFXV2-2237