### PR TITLE
docs(meetings): update join-page doc, add refetch test

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
@@ -233,4 +233,20 @@ describe('MeetingJoinComponent', () => {
 
     expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toEqual([]);
   });
+
+  it('preserves the roster and the optimistic pad when a refetch for the SAME meeting+occurrence fails', async () => {
+    getMyMeetingRegistrants.mockReturnValueOnce(of(buildRegistrants(10))).mockReturnValueOnce(throwError(() => new Error('roster fetch failed')));
+
+    const component = await createComponent();
+    expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(10);
+
+    component.onRegistrantsRefreshRequested(2);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    // The failed refetch belongs to the same meeting+occurrence as the last confirmed roster, so
+    // it must fall back to the existing `registrants()` snapshot rather than an empty list, and
+    // must not treat that fallback as a roster of length 0 that would zero out the pending pad.
+    expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(10);
+    expect(component.additionalRegistrantsCount()).toBe(2);
+  });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
@@ -281,10 +281,18 @@ describe('MeetingJoinComponent', () => {
         project: buildProject(),
       })
     );
-    getMyMeetingRegistrants.mockReturnValueOnce(of(buildRegistrants(10))).mockReturnValueOnce(throwError(() => new Error('roster fetch failed')));
+    // The recurring meeting's `currentOccurrence` computed settles from `null` to occurrence A in a
+    // separate reactive tick from `meeting` itself resolving, so setup can issue more than one
+    // registrant fetch before things settle. Keep every setup-phase fetch successful and queue the
+    // failure only for the deliberate occurrence switch below, so the failure lands exactly where
+    // the test means it to (a fixed once/once pairing here previously let setup silently consume
+    // both mocks, leaving the switch to fall through to the default `of([])` mock instead).
+    getMyMeetingRegistrants.mockReturnValue(of(buildRegistrants(10)));
 
     const component = await createComponent();
     expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(10);
+
+    getMyMeetingRegistrants.mockReturnValueOnce(throwError(() => new Error('roster fetch failed')));
 
     // Select the second occurrence in the series — same meeting, different `occurrence_id` —
     // so a regression that dropped the occurrence segment from `buildRegistrantsRosterKey` would

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
@@ -8,7 +8,7 @@ import { ApplicationRef, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute, convertToParamMap, ParamMap, Router } from '@angular/router';
-import { Meeting, MeetingRegistrant, PublicMeetingProject, User } from '@lfx-one/shared/interfaces';
+import { Meeting, MeetingOccurrence, MeetingRegistrant, PublicMeetingProject, User } from '@lfx-one/shared/interfaces';
 import { MeetingService } from '@services/meeting.service';
 import { PlausibleService } from '@services/plausible.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -22,7 +22,7 @@ import { MeetingJoinComponent } from './meeting-join.component';
 
 // Regression coverage for GH-1731's guest-add orchestration: the join page maintains an optimistic
 // pad of guest-add counts (onRegistrantsRefreshRequested) that reconcileOptimisticPad reconciles
-// against the roster refetch, and a `registrantsMeetingKey` guard that prevents a failed refetch
+// against the roster refetch, and a `registrantsRosterKey` guard that prevents a failed refetch
 // from leaking a previous meeting's roster into a newly-navigated meeting. Both were fixed during
 // PR #1748 review: a null baseline no longer gets treated as "absorbed" (dealako's ask).
 describe('MeetingJoinComponent', () => {
@@ -107,7 +107,14 @@ describe('MeetingJoinComponent', () => {
           useValue: {
             paramMap: paramMap$.asObservable(),
             queryParamMap: queryParamMap$.asObservable(),
-            snapshot: { paramMap: paramMap$.value, queryParamMap: queryParamMap$.value },
+            snapshot: {
+              get paramMap() {
+                return paramMap$.value;
+              },
+              get queryParamMap() {
+                return queryParamMap$.value;
+              },
+            },
           },
         },
         { provide: Router, useValue: { navigate: vi.fn() } },
@@ -235,7 +242,10 @@ describe('MeetingJoinComponent', () => {
   });
 
   it('preserves the roster and the optimistic pad when a refetch for the SAME meeting+occurrence fails', async () => {
-    getMyMeetingRegistrants.mockReturnValueOnce(of(buildRegistrants(10))).mockReturnValueOnce(throwError(() => new Error('roster fetch failed')));
+    getMyMeetingRegistrants
+      .mockReturnValueOnce(of(buildRegistrants(10)))
+      .mockReturnValueOnce(throwError(() => new Error('roster fetch failed')))
+      .mockReturnValueOnce(of(buildRegistrants(11)));
 
     const component = await createComponent();
     expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(10);
@@ -248,5 +258,43 @@ describe('MeetingJoinComponent', () => {
     // must not treat that fallback as a roster of length 0 that would zero out the pending pad.
     expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(10);
     expect(component.additionalRegistrantsCount()).toBe(2);
+    expect((component as unknown as { registrantsLoading: () => boolean }).registrantsLoading()).toBe(false);
+
+    // A follow-up refetch that actually observes growth is the only way to prove the pad above
+    // isn't just a leftover value the failure path left untouched — it must still be able to
+    // converge once the query-service index catches up.
+    component.onRegistrantsRefreshRequested(0);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(11);
+    expect(component.additionalRegistrantsCount()).toBe(1);
+  });
+
+  it("falls back to an empty roster instead of leaking a previous occurrence's roster when the refetch for a newly-selected occurrence fails", async () => {
+    const buildOccurrence = (occurrenceId: string, startTime: string) =>
+      ({ occurrence_id: occurrenceId, start_time: startTime, duration: 60 }) as unknown as MeetingOccurrence;
+    const OCCURRENCE_A = buildOccurrence('occurrence-a', FUTURE_START_TIME);
+    const OCCURRENCE_B = buildOccurrence('occurrence-b', '2099-01-02T00:00:00.000Z');
+    getPublicMeeting.mockReturnValue(
+      of({
+        meeting: buildMeeting({ recurrence: { type: 2, repeat_interval: 1 }, occurrences: [OCCURRENCE_A, OCCURRENCE_B] }),
+        project: buildProject(),
+      })
+    );
+    getMyMeetingRegistrants.mockReturnValueOnce(of(buildRegistrants(10))).mockReturnValueOnce(throwError(() => new Error('roster fetch failed')));
+
+    const component = await createComponent();
+    expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toHaveLength(10);
+
+    // Select the second occurrence in the series — same meeting, different `occurrence_id` —
+    // so a regression that dropped the occurrence segment from `buildRegistrantsRosterKey` would
+    // wrongly treat this as the same confirmed roster and fall back to it instead of `[]`.
+    // The meeting-fetch pipeline debounces route-param changes via a real (non-zone-tracked) RxJS
+    // timer (see the meeting-switch test above), so a real macrotask tick is required to flush it.
+    queryParamMap$.next(convertToParamMap({ occurrence: String(new Date(OCCURRENCE_B.start_time).getTime()) }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toEqual([]);
   });
 });

--- a/docs/architecture/frontend/public-meeting-join.md
+++ b/docs/architecture/frontend/public-meeting-join.md
@@ -133,15 +133,18 @@ Past meeting IDs are either a plain numeric ID (fallback after upcoming returns 
 
 Key signals and their gating:
 
-| Signal           | Type                            | Gate                                                                                           |
-| ---------------- | ------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `meeting`        | `Signal<Meeting & { project }>` | `toSignal` of `getPublicMeeting` / `getPublicPastMeeting` fallback chain                       |
-| `authenticated`  | `WritableSignal<boolean>`       | set from `UserService`                                                                         |
-| `password`       | `WritableSignal<string\|null>`  | set from URL `?password` query param                                                           |
-| `attachments`    | `Signal<MeetingAttachment[]>`   | `initializeAttachments` — only fetches when `authenticated()`                                  |
-| `materialFiles`  | `Signal<MeetingAttachment[]>`   | filtered from `attachments`                                                                    |
-| `registrants`    | `Signal<MeetingRegistrant[]>`   | `initializeRegistrants` — requires `authenticated && (organizer\|\|invited) && !isPastMeeting` |
-| `fetchedJoinUrl` | `Signal<string\|undefined>`     | `initializeFetchedJoinUrl` — triggers on guest form submission                                 |
+| Signal               | Type                            | Gate                                                                                                                                                                              |
+| -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `meeting`            | `Signal<Meeting & { project }>` | `toSignal` of `getPublicMeeting` / `getPublicPastMeeting` fallback chain                                                                                                          |
+| `authenticated`      | `WritableSignal<boolean>`       | set from `UserService`                                                                                                                                                            |
+| `password`           | `WritableSignal<string\|null>`  | set from URL `?password` query param                                                                                                                                              |
+| `attachments`        | `Signal<MeetingAttachment[]>`   | `initializeAttachments` — only fetches when `authenticated()`                                                                                                                     |
+| `materialFiles`      | `Signal<MeetingAttachment[]>`   | filtered from `attachments`                                                                                                                                                       |
+| `registrants`        | `Signal<MeetingRegistrant[]>`   | `initializeRegistrants` — requires `authenticated && (organizer\|\|invited\|\|optimisticInvited) && !isPastMeeting`; empty `[]` on any other branch                               |
+| `registrantsLoading` | `WritableSignal<boolean>`       | starts `true`; set by `initializeRegistrants` around the roster fetch, cleared via `finalize` (or immediately on the no-fetch branch) so the RSVP card doesn't hang on a skeleton |
+| `fetchedJoinUrl`     | `Signal<string\|undefined>`     | `initializeFetchedJoinUrl` — triggers on guest form submission                                                                                                                    |
+
+**Registrant counts are not read from the meeting object.** `getMeetingById` / `getPublicMeeting` no longer populate `individual_registrants_count` or `committee_members_count` — those fields are omitted from the response entirely (see [GH-1731](https://github.com/linuxfoundation/lfx-self-serve/issues/1731)). The join page derives its own counts from the `registrants` roster it fetches (`totalInvitees`, `additionalRegistrantsCount`), with `reconcileOptimisticPad` reconciling an optimistic guest-add pad against the roster length once a refetch lands. See `packages/shared/src/utils/meeting.utils.ts` for the reconciliation logic and its documented count-delta heuristic limitations.
 
 **Template structure:**
 


### PR DESCRIPTION
## Summary

Follow-up to #1748 addressing the two minor comments from dealako's approval on that PR:

- **`docs/architecture/frontend/public-meeting-join.md`**: was stale after #1748 landed — documents the current `registrants` / `registrantsLoading` signals and notes that `individual_registrants_count` / `committee_members_count` are no longer populated on `getMeetingById` / `getPublicMeeting` responses.
- **`meeting-join.component.spec.ts`**: adds a test for the same-meeting refetch-failure path in `initializeRegistrants` — asserts the roster and optimistic guest-add pad are preserved (not zeroed) when `registrantsRosterKey` matches the current meeting+occurrence.

No functional code changes.

## Test plan

- [x] `yarn test:app` (meeting-join.component.spec.ts) — 6/6 passing, including the new test
- [x] `yarn lint:check` — clean
- [x] `yarn format:check` — clean
- [x] `yarn check-types` — clean

Issue: #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXTFU9SPZCPJSkTtW3ZTdQ