### PR TITLE
feat(formation): seed the project formation checklist template

### DIFF
--- a/packages/shared/src/constants/formation-template.constants.spec.ts
+++ b/packages/shared/src/constants/formation-template.constants.spec.ts
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { FormationOwnerTeam, FormationTemplateSectionKey } from '../enums';
+import type { FormationTemplateItem, FormationTemplateSection, FormationTemplateSubItem } from '../interfaces';
+
+import { FORMATION_TEMPLATE } from './formation-template.constants';
+
+/**
+ * Structural validation of the seeded formation checklist template (GH-1959/GH-2163). Content
+ * (titles/owners/action types, especially the chat-workspace sub-item names) is a draft pending
+ * stakeholder review. The content fingerprint below is the primary place that pins today's draft
+ * data (and forces a conscious version bump alongside any edit to it) and the gating-id list
+ * gives that one behaviorally-significant fact (which items block Active) its own named failure;
+ * every other test asserts a structural invariant that must hold for any future content — with
+ * one exception: dropping the last item owned by a given team also fails owner-team coverage.
+ */
+describe('FORMATION_TEMPLATE', () => {
+  const allItems = (): FormationTemplateItem[] => FORMATION_TEMPLATE.sections.flatMap((section) => section.items);
+
+  // Bumping `version` alongside a content edit made after this template has shipped is a
+  // documented convention, not something a test can enforce on its own — so pin a fingerprint of
+  // every field the version contract covers. Editing a title, reordering items, or changing an
+  // owner/action/gate touches this fingerprint, forcing a conscious visit to this test (and, once
+  // shipped, the version bump) rather than passing silently. Pre-release edits stay at v1.
+  it('pins the v1 content fingerprint — bump `version` above once this needs to change post-ship', () => {
+    const subItemFingerprint = (subItem: FormationTemplateSubItem): string => [subItem.key, subItem.title, subItem.owner_team].join('|');
+    const itemFingerprint = (item: FormationTemplateItem): string =>
+      [
+        item.key,
+        item.title,
+        item.owner_team,
+        item.action,
+        item.action_link ?? '',
+        item.is_gating,
+        (item.sub_items ?? []).map(subItemFingerprint).join(','),
+      ].join('|');
+    const sectionFingerprint = (section: FormationTemplateSection): string =>
+      `${section.key}::${section.title}::[${section.items.map(itemFingerprint).join(';')}]`;
+
+    expect(FORMATION_TEMPLATE.version).toBe(1);
+    expect(FORMATION_TEMPLATE.name).toBe('Project formation');
+    expect(FORMATION_TEMPLATE.sections.map(sectionFingerprint)).toEqual([
+      'legal_and_entity::Legal and entity::[' +
+        [
+          'formation_review_packet|Formation review and packet|brand_counsel|manual||true|',
+          'preliminary_trademark_search|Preliminary trademark search|brand_counsel|manual||false|',
+          'charter_agreed|Charter agreed|formation|manual||true|',
+          'contribution_agreement|Contribution agreement (DocuSign)|formation|link||true|',
+          'indepth_trademark_search_series_llc|In-depth trademark search and Series LLC|brand_counsel|manual||true|',
+          'membership_tiers|Membership tiers|product|manual||false|',
+        ].join(';') +
+        ']',
+      'community_and_launch::Community and launch::[' +
+        [
+          'repositories_github_owner|Repositories and GitHub owner|community|provisionable||false|',
+          'domain_dns|Domain/DNS|it|manual||false|',
+          'website_logo_footer|Website/logo/footer|marketing|manual||false|',
+          'mailing_lists|Mailing lists|community|provisionable||false|',
+          'chat_workspace|Chat workspace|it|request||false|chat_workspace_create|Create workspace|it,chat_workspace_channels|Configure channels|it,chat_workspace_roles|Set up roles and permissions|it,chat_workspace_onboard_admins|Onboard admins|it',
+          'insights_access|Insights access|product_ops|request||false|',
+          'asset_transfers|Asset transfers|formation|manual||false|',
+          'tsc_kickoff|TSC and kickoff|community|provisionable||false|',
+          'member_join_page|Member join page|product|manual||false|',
+          'comms|Launch comms|marketing|manual||false|',
+          'blog_post|Launch blog post|marketing|manual||false|',
+        ].join(';') +
+        ']',
+    ]);
+  });
+
+  const allKeys = (): string[] => [...allItems().map((item) => item.key), ...allItems().flatMap((item) => item.sub_items?.map((subItem) => subItem.key) ?? [])];
+
+  it('has no duplicate keys across items and sub-items', () => {
+    const keys = allKeys();
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('gives every item and sub-item a non-empty title', () => {
+    const untitled = allItems()
+      .flatMap((item) => [item, ...(item.sub_items ?? [])])
+      .filter((item) => item.title.trim() === '');
+    expect(untitled).toEqual([]);
+  });
+
+  // Explicit counts (GH-1959 scope trim, re-verified after the GH-2163 canonical-types adoption)
+  // called out by the ticket's acceptance criteria. Already implied by the fingerprint and
+  // gating-id assertions above, but named here so a count drift fails with its own diagnostic
+  // instead of only showing up as an opaque array diff.
+  it('has exactly 17 items, 4 of them gating', () => {
+    expect(allItems().length).toBe(17);
+    expect(allItems().filter((item) => item.is_gating).length).toBe(4);
+  });
+
+  // The core acceptance criterion: gate flags only ever appear on legal/entity items. A rule
+  // for any future content, not a fact about today's rows — so it stays even as the fingerprint
+  // above changes.
+  it('never gates a community/launch item', () => {
+    const gatedLaunchItems = FORMATION_TEMPLATE.sections
+      .filter((section) => section.key === FormationTemplateSectionKey.COMMUNITY_AND_LAUNCH)
+      .flatMap((section) => section.items)
+      .filter((item) => item.is_gating);
+    expect(gatedLaunchItems).toEqual([]);
+  });
+
+  // Named separately from the fingerprint above so an unintended gate flip fails with a
+  // diagnostic naming the specific gating set the ticket specifies, not just an opaque array
+  // diff — gate correctness has a real downstream consequence (blocking the formation's
+  // transition to Active).
+  it('gates exactly the items the ticket calls out as gating', () => {
+    const gatingKeys = allItems()
+      .filter((item) => item.is_gating)
+      .map((item) => item.key);
+
+    expect(gatingKeys.sort()).toEqual(['formation_review_packet', 'charter_agreed', 'contribution_agreement', 'indepth_trademark_search_series_llc'].sort());
+  });
+
+  it('exercises every owner team the enum defines, including on sub-items', () => {
+    const usedTeams = new Set(allItems().flatMap((item) => [item.owner_team, ...(item.sub_items ?? []).map((subItem) => subItem.owner_team)]));
+
+    // Derived from the enum, not hardcoded, so a team added to FormationOwnerTeam that no
+    // item actually uses fails here instead of passing unnoticed.
+    expect([...usedTeams].sort()).toEqual(Object.values(FormationOwnerTeam).sort());
+  });
+
+  it('deep-freezes the template so a consumer cannot mutate the shared singleton', () => {
+    // Walks the whole object graph rather than naming specific fields, so it keeps covering the
+    // freeze guarantee even if FormationTemplateItem later gains another nested object or array.
+    const isDeepFrozen = (value: unknown): boolean => {
+      if (value === null || typeof value !== 'object') return true;
+      if (!Object.isFrozen(value)) return false;
+      return Object.values(value).every(isDeepFrozen);
+    };
+
+    expect(isDeepFrozen(FORMATION_TEMPLATE)).toBe(true);
+  });
+});

--- a/packages/shared/src/constants/formation-template.constants.spec.ts
+++ b/packages/shared/src/constants/formation-template.constants.spec.ts
@@ -15,7 +15,9 @@ import { FORMATION_TEMPLATE } from './formation-template.constants';
  * data (and forces a conscious version bump alongside any edit to it) and the gating-id list
  * gives that one behaviorally-significant fact (which items block Active) its own named failure;
  * every other test asserts a structural invariant that must hold for any future content — with
- * one exception: dropping the last item owned by a given team also fails owner-team coverage.
+ * two exceptions: dropping the last item owned by a given team also fails owner-team coverage,
+ * and the item/gate count test below is itself content-pinned (it hardcodes today's totals, not
+ * a structural rule).
  */
 describe('FORMATION_TEMPLATE', () => {
   const allItems = (): FormationTemplateItem[] => FORMATION_TEMPLATE.sections.flatMap((section) => section.items);
@@ -40,6 +42,7 @@ describe('FORMATION_TEMPLATE', () => {
     const sectionFingerprint = (section: FormationTemplateSection): string =>
       `${section.key}::${section.title}::[${section.items.map(itemFingerprint).join(';')}]`;
 
+    expect(FORMATION_TEMPLATE.uid).toBe('formation-template-default');
     expect(FORMATION_TEMPLATE.version).toBe(1);
     expect(FORMATION_TEMPLATE.name).toBe('Project formation');
     expect(FORMATION_TEMPLATE.sections.map(sectionFingerprint)).toEqual([
@@ -56,11 +59,11 @@ describe('FORMATION_TEMPLATE', () => {
       'community_and_launch::Community and launch::[' +
         [
           'repositories_github_owner|Repositories and GitHub owner|community|provisionable||false|',
-          'domain_dns|Domain/DNS|it|manual||false|',
+          'domain_dns|Domain/DNS|it|status_only||false|',
           'website_logo_footer|Website/logo/footer|marketing|manual||false|',
           'mailing_lists|Mailing lists|community|provisionable||false|',
-          'chat_workspace|Chat workspace|it|request||false|chat_workspace_create|Create workspace|it,chat_workspace_channels|Configure channels|it,chat_workspace_roles|Set up roles and permissions|it,chat_workspace_onboard_admins|Onboard admins|it',
-          'insights_access|Insights access|product_ops|request||false|',
+          'chat_workspace|Chat workspace|it|status_only||false|chat_workspace_create|Create workspace|it,chat_workspace_invite_admin|Invite lfitslackadmin@|it,chat_workspace_add_inventory|Add to inventory|it,chat_workspace_submit_pro_sku|Submit Pro SKU|it',
+          'insights_access|Insights access|product_ops|status_only||false|',
           'asset_transfers|Asset transfers|formation|manual||false|',
           'tsc_kickoff|TSC and kickoff|community|provisionable||false|',
           'member_join_page|Member join page|product|manual||false|',

--- a/packages/shared/src/constants/formation-template.constants.ts
+++ b/packages/shared/src/constants/formation-template.constants.ts
@@ -1,0 +1,193 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } from '../enums';
+import type { FormationTemplate } from '../interfaces';
+
+/**
+ * Recursively freezes an object graph so adding a nested object/array field later doesn't
+ * silently leave it mutable — unlike a hand-walked freeze coupled to today's exact shape.
+ * Tracks visited nodes in `seen` rather than skipping on `Object.isFrozen`, so a node that
+ * arrives already (shallow-)frozen still has its own children walked and frozen.
+ */
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (value !== null && typeof value === 'object' && !seen.has(value)) {
+    seen.add(value);
+    Object.freeze(value);
+    Object.values(value).forEach((child) => deepFreeze(child, seen));
+  }
+  return value;
+}
+
+/**
+ * The single seeded checklist template applied to every new project formation (Epic 1, #1965).
+ * No template editor exists yet (Epic 2, #1994) — this is the only template, and its content is
+ * pending stakeholder review (GH-1959). Only legal/entity items may gate the formation's
+ * transition to Active (not all of them do); community and launch items never gate. Bump
+ * `version` alongside any content edit here once this template has shipped — see
+ * `FormationTemplate.version`. Pre-release content edits (like this one) stay at v1.
+ *
+ * Shape adopted from the canonical `FormationTemplate` (GH-2163) — nested `sections[].items[]`,
+ * snake_case keys with no `legal-`/`launch-` prefix (the prefix was a local-only convention;
+ * section membership is now structural, not encoded in the key).
+ *
+ * Deep-frozen so the shared module-level singleton can't be mutated in place by one consumer
+ * and corrupt it for every other reader.
+ */
+export const FORMATION_TEMPLATE: FormationTemplate = deepFreeze({
+  uid: 'formation-template-default',
+  version: 1,
+  name: 'Project formation',
+  sections: [
+    {
+      key: FormationTemplateSectionKey.LEGAL_AND_ENTITY,
+      title: 'Legal and entity',
+      // Items below with is_gating: true gate the transition to Active.
+      items: [
+        {
+          key: 'formation_review_packet',
+          title: 'Formation review and packet',
+          owner_team: FormationOwnerTeam.BRAND_COUNSEL,
+          action: FormationActionType.MANUAL,
+          is_gating: true,
+        },
+        {
+          key: 'preliminary_trademark_search',
+          title: 'Preliminary trademark search',
+          owner_team: FormationOwnerTeam.BRAND_COUNSEL,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+        {
+          key: 'charter_agreed',
+          title: 'Charter agreed',
+          owner_team: FormationOwnerTeam.FORMATION,
+          action: FormationActionType.MANUAL,
+          is_gating: true,
+        },
+        {
+          key: 'contribution_agreement',
+          title: 'Contribution agreement (DocuSign)',
+          owner_team: FormationOwnerTeam.FORMATION,
+          action: FormationActionType.LINK,
+          is_gating: true,
+        },
+        {
+          key: 'indepth_trademark_search_series_llc',
+          title: 'In-depth trademark search and Series LLC',
+          owner_team: FormationOwnerTeam.BRAND_COUNSEL,
+          action: FormationActionType.MANUAL,
+          is_gating: true,
+        },
+        {
+          key: 'membership_tiers',
+          title: 'Membership tiers',
+          owner_team: FormationOwnerTeam.PRODUCT,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+      ],
+    },
+    {
+      key: FormationTemplateSectionKey.COMMUNITY_AND_LAUNCH,
+      title: 'Community and launch',
+      // Never gates.
+      items: [
+        {
+          key: 'repositories_github_owner',
+          title: 'Repositories and GitHub owner',
+          owner_team: FormationOwnerTeam.COMMUNITY,
+          action: FormationActionType.PROVISIONABLE,
+          is_gating: false,
+        },
+        {
+          // LFX does not register domains — someone does this work elsewhere, so the row is
+          // manual and records status rather than provisioning. It should still say where that
+          // work happens (action_link exists for exactly this), but no canonical IT/domain
+          // destination is defined anywhere in this repo, so it is left unset rather than guessed
+          // — see GH-1959 for the open question raised with the formation/IT owners.
+          key: 'domain_dns',
+          title: 'Domain/DNS',
+          owner_team: FormationOwnerTeam.IT,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+        {
+          key: 'website_logo_footer',
+          title: 'Website/logo/footer',
+          owner_team: FormationOwnerTeam.MARKETING,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+        {
+          // LFX provisions mailing lists itself — this is what `provisionable` means, not an
+          // approval workflow waiting on someone else's ticket.
+          key: 'mailing_lists',
+          title: 'Mailing lists',
+          owner_team: FormationOwnerTeam.COMMUNITY,
+          action: FormationActionType.PROVISIONABLE,
+          is_gating: false,
+        },
+        {
+          key: 'chat_workspace',
+          title: 'Chat workspace',
+          owner_team: FormationOwnerTeam.IT,
+          action: FormationActionType.REQUEST,
+          is_gating: false,
+          sub_items: [
+            { key: 'chat_workspace_create', title: 'Create workspace', owner_team: FormationOwnerTeam.IT },
+            { key: 'chat_workspace_channels', title: 'Configure channels', owner_team: FormationOwnerTeam.IT },
+            { key: 'chat_workspace_roles', title: 'Set up roles and permissions', owner_team: FormationOwnerTeam.IT },
+            { key: 'chat_workspace_onboard_admins', title: 'Onboard admins', owner_team: FormationOwnerTeam.IT },
+          ],
+        },
+        {
+          key: 'insights_access',
+          title: 'Insights access',
+          owner_team: FormationOwnerTeam.PRODUCT_OPS,
+          action: FormationActionType.REQUEST,
+          is_gating: false,
+        },
+        {
+          key: 'asset_transfers',
+          title: 'Asset transfers',
+          owner_team: FormationOwnerTeam.FORMATION,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+        {
+          key: 'tsc_kickoff',
+          title: 'TSC and kickoff',
+          owner_team: FormationOwnerTeam.COMMUNITY,
+          action: FormationActionType.PROVISIONABLE,
+          is_gating: false,
+        },
+        {
+          key: 'member_join_page',
+          title: 'Member join page',
+          owner_team: FormationOwnerTeam.PRODUCT,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+        {
+          key: 'comms',
+          title: 'Launch comms',
+          owner_team: FormationOwnerTeam.MARKETING,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+        // Kept as its own row rather than folded into "Launch comms" — the ticket calls out the
+        // launch blog post by name as an item the 31 Aug review added and said not to drop.
+        {
+          key: 'blog_post',
+          title: 'Launch blog post',
+          owner_team: FormationOwnerTeam.MARKETING,
+          action: FormationActionType.MANUAL,
+          is_gating: false,
+        },
+      ],
+    },
+  ],
+  // No row for "formation sets Active" — that's the derived Activating state (#1957) once every
+  // is_gating: true item above is Done, not a checklist row a team completes.
+} satisfies FormationTemplate);

--- a/packages/shared/src/constants/formation-template.constants.ts
+++ b/packages/shared/src/constants/formation-template.constants.ts
@@ -25,7 +25,7 @@ function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
  * pending stakeholder review (GH-1959). Only legal/entity items may gate the formation's
  * transition to Active (not all of them do); community and launch items never gate. Bump
  * `version` alongside any content edit here once this template has shipped — see
- * `FormationTemplate.version`. Pre-release content edits (like this one) stay at v1.
+ * `FormationTemplate.version`. Content edits made before the first release stay at v1.
  *
  * Shape adopted from the canonical `FormationTemplate` (GH-2163) — nested `sections[].items[]`,
  * snake_case keys with no `legal-`/`launch-` prefix (the prefix was a local-only convention;
@@ -66,6 +66,10 @@ export const FORMATION_TEMPLATE: FormationTemplate = deepFreeze({
           is_gating: true,
         },
         {
+          // Completion follows a DocuSign envelope link (action_link exists for exactly this),
+          // but no canonical DocuSign envelope/template URL is defined anywhere in this repo, so
+          // it is left unset rather than guessed — see GH-1959 for the open question raised with
+          // the formation owners, alongside the same question for domain_dns below.
           key: 'contribution_agreement',
           title: 'Contribution agreement (DocuSign)',
           owner_team: FormationOwnerTeam.FORMATION,
@@ -101,15 +105,15 @@ export const FORMATION_TEMPLATE: FormationTemplate = deepFreeze({
           is_gating: false,
         },
         {
-          // LFX does not register domains — someone does this work elsewhere, so the row is
-          // manual and records status rather than provisioning. It should still say where that
-          // work happens (action_link exists for exactly this), but no canonical IT/domain
+          // Request-shaped rows are status-only in Epic 1 — the request mechanism and SLA are
+          // deferred to #1963, so this row only records who owns it and whether it's done, with
+          // an optional link (action_link exists for exactly this). No canonical IT/domain
           // destination is defined anywhere in this repo, so it is left unset rather than guessed
           // — see GH-1959 for the open question raised with the formation/IT owners.
           key: 'domain_dns',
           title: 'Domain/DNS',
           owner_team: FormationOwnerTeam.IT,
-          action: FormationActionType.MANUAL,
+          action: FormationActionType.STATUS_ONLY,
           is_gating: false,
         },
         {
@@ -129,23 +133,27 @@ export const FORMATION_TEMPLATE: FormationTemplate = deepFreeze({
           is_gating: false,
         },
         {
+          // Request-shaped row, status-only in Epic 1 (see domain_dns above) — the four IT
+          // sub-item titles are #1963's canonical set, not this ticket's original best-effort
+          // draft.
           key: 'chat_workspace',
           title: 'Chat workspace',
           owner_team: FormationOwnerTeam.IT,
-          action: FormationActionType.REQUEST,
+          action: FormationActionType.STATUS_ONLY,
           is_gating: false,
           sub_items: [
             { key: 'chat_workspace_create', title: 'Create workspace', owner_team: FormationOwnerTeam.IT },
-            { key: 'chat_workspace_channels', title: 'Configure channels', owner_team: FormationOwnerTeam.IT },
-            { key: 'chat_workspace_roles', title: 'Set up roles and permissions', owner_team: FormationOwnerTeam.IT },
-            { key: 'chat_workspace_onboard_admins', title: 'Onboard admins', owner_team: FormationOwnerTeam.IT },
+            { key: 'chat_workspace_invite_admin', title: 'Invite lfitslackadmin@', owner_team: FormationOwnerTeam.IT },
+            { key: 'chat_workspace_add_inventory', title: 'Add to inventory', owner_team: FormationOwnerTeam.IT },
+            { key: 'chat_workspace_submit_pro_sku', title: 'Submit Pro SKU', owner_team: FormationOwnerTeam.IT },
           ],
         },
         {
+          // Request-shaped row, status-only in Epic 1 — see domain_dns above.
           key: 'insights_access',
           title: 'Insights access',
           owner_team: FormationOwnerTeam.PRODUCT_OPS,
-          action: FormationActionType.REQUEST,
+          action: FormationActionType.STATUS_ONLY,
           is_gating: false,
         },
         {

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -102,3 +102,4 @@ export * from './foundation-message.constants';
 export * from './social-listening.constants';
 export * from './id-migration.constants';
 export * from './formation.constants';
+export * from './formation-template.constants';


### PR DESCRIPTION
## Summary

Seeds the single checklist template applied automatically to every new project formation (Epic 1, #1965). No template editor exists yet (Epic 2, #1994) — this PR is content/data only.

- Shape adopted from the canonical `FormationTemplate` types landed on `main` by #2163 (merged as #2175), which reconciled this ticket's structure with #1958's: nested `sections[].items[]` (was flat `items[]`), snake_case `key` (was `id`, and dropped the `legal-`/`launch-` prefix — section membership is now structural), `owner_team`/`FormationOwnerTeam` (was `ownerTeam`/`FormationItemOwnerTeam`), `action`/`FormationActionType` (was `actionType`/`FormationItemActionType`), `is_gating` (was `gate`), `sub_items` (was `subItems`). `FormationTemplate.name` (`"Project formation"`) and each `FormationTemplateSection.title` (`"Legal and entity"`, `"Community and launch"`) are new required display strings the old flat shape never carried.
- 6 legal/entity items (4 gating, 2 non-gating per the ticket's explicit "no gate" notes) + 11 community/launch items (never gate), including the chat-workspace item's 4 IT sub-items.
- Owner teams cover exactly the 7 named in the ticket (Formation, Brand Counsel, Community, IT, Marketing, Product Ops, Product) — no PMO items, matching the ticket's explicit scope note.
- `packages/shared/src/constants/formation-template.constants.spec.ts` pins the v1 content fingerprint (now including `name`/section `title`s), a named gating-set assertion, an explicit item/gate count assertion, and structural invariants (no duplicate keys, no gate on launch items, full owner-team coverage, deep-freeze) — all re-pinned to the new nested/snake_case shape; counts stay at 17 items / 4 gating.

**2 Sep update:** #1959's body was revised after Epic 1 was cut back — project application/intake moved to Epic 2 (#1962), so the "Draft project record" and "Intake submitted" rows (both intake-created, both gating) were dropped from the template. They come back with the application flow if still wanted then. This is reflected in the current commit; the template went from 19 items/6 gating to 17 items/4 gating.

**4 Sep update — canonical types:** Rebased onto `main`'s canonical formation types (#2163/#2175, see shape note above).

**4 Sep update (correction) — `action_link` + provisioning revert:** The prior update briefly set both `domain_dns` and `mailing_lists` to `MANUAL`, reasoning that both were request-shaped approval workflows that could stall a formation's readiness on someone else's ticket. That premise was only half right:

- `domain_dns` → `MANUAL` was correct at the time; superseded on 8 Sep by `STATUS_ONLY` (see below). The underlying reasoning is unchanged: LFX cannot register domains, so the row records status for work done elsewhere.
- `mailing_lists` → `MANUAL` was a mistake, now reverted **back to `PROVISIONABLE`**. Mailing lists are not an approval workflow — LFX genuinely provisions them itself — so the diff history here reads as a correction, not churn.

The `MANUAL`/no-link gap this surfaced was tracked as #2212 (a manual row had no way to say *where* the work happens). #2212's fix — `FormationTemplateItem.action_link?: string` with the `{{project.uid}}`/`{{project.slug}}` substitution contract — was cherry-picked onto this branch to land alongside its first consumer, but #2212 was merged to `main` independently as #2213 before this branch was rebased. This branch now picks up `action_link` from `main` directly (via the `origin/main` rebase below) rather than carrying its own copy of those commits.

`domain_dns` still ships **without** an `action_link`: no canonical IT/domain-registration destination is defined anywhere in this repo (no service-desk URL, no admin-tool base reachable from `packages/shared`, no existing `{{project.*}}` substitution convention to match). Flagged the missing destination as an open question on #1959 rather than shipping a guessed URL.

**6 Sep update:** Rebased onto `main` after #2213 (the `action_link` field) merged independently. Dropped this branch's own copies of #2213's two commits (identical content, now redundant) and replayed only the `domain_dns`/`mailing_lists` correction on top — one clean commit ahead of `main`.

**8 Sep update — action types and chat-workspace sub-items (review feedback):**

Three rows changed action type, and `REQUEST` is now unused in Epic 1:

- `domain_dns` → `STATUS_ONLY` (was `MANUAL`)
- `chat_workspace` → `STATUS_ONLY` (was `REQUEST`)
- `insights_access` → `STATUS_ONLY` (was `REQUEST`)

The `REQUEST` changes follow the Epic 1 scope cut. Requests with SLA are #1963, which is Epic 2, so a `REQUEST` row in Epic 1 renders an affordance with no flow behind it. That is the same reasoning that removed the intake-created rows on 2 Sep: a row whose mechanism does not exist in this epic sits permanently untouched. `REQUEST` stays in `FormationActionType` for Epic 2 rather than being removed from the enum.

`domain_dns` moving from `MANUAL` to `STATUS_ONLY` is the more debatable one and is called out for the review: `MANUAL` implies someone acts on the row inside the product, and nobody does — there is no destination to send them to (no canonical IT/service-desk URL exists in this repo), so the row only ever records what happened elsewhere. `STATUS_ONLY` says that directly. **If the intent was that a destination is coming later and the row should keep an action affordance in the meantime, this should go back to `MANUAL`.**

The chat-workspace sub-items were replaced with IT's actual steps:

| was | now |
| --- | --- |
| Create workspace | Create workspace |
| Configure channels | Invite lfitslackadmin@ |
| Set up roles and permissions | Add to inventory |
| Onboard admins | Submit Pro SKU |

These are more accurate. They are also mechanism-specific in a way the epic's own principle discourages ("the checklist records status, not mechanism ... never how it was done"), and they name the tooling in all but the word. **Worth an explicit decision in review:** either these are IT-owned sub-steps where naming the mechanism is the point, or they should be re-generalised. They were not specified in the ticket, so either answer is a choice rather than a correction.

Note the pairing: `chat_workspace` is `STATUS_ONLY` yet carries four sub-items that IT actually performs. That is intentional — the sub-items are a record of progress on work done outside the product, not actions the product offers.

Counts are unchanged by all of the above: **17 items, 4 gating**, asserted explicitly in the spec.

## Content review — pending, non-blocking

Item titles, owners, and action types (especially the four chat-workspace IT sub-item names, which the ticket doesn't specify) are a best-effort draft. Per the ticket, this content still needs review from the formation, brand counsel, and product stakeholders named in the ticket's acceptance criteria before the template is considered final — flagging here per the ticket's acceptance criteria, not as a blocker to landing the shape.

One deliberate deviation from the ticket's literal item list, worth confirming in that review:
- `Launch blog post` is kept as its own row rather than folded into `Launch comms` (per the 31 Aug review note that it must not be dropped).

"Formation sets Active" is intentionally *not* a checklist row — it's the derived Activating state once every gating item is Done (see the trailing comment in `formation-template.constants.ts`).

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] `./check-headers.sh` passes
- [x] Spec (`formation-template.constants.spec.ts`) covers gate-flag correctness, structural invariants, explicit item/gate counts, and the v1 content fingerprint — re-pinned to the canonical nested/snake_case shape, now extended to cover `action_link`
- [x] Reviewed by the post-commit reviewer trio (general, self-serve conventions, learnings) — clean

Closes #1959

#2212 is not closed by this PR — it merged separately as #2213.