### PR TITLE
refactor(shared): add lfx-toast-message and route toasts through it (GH-1895)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -9,7 +9,7 @@
         @if (message.data?.uid) {
           <button
             type="button"
-            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+            class="toast-action"
             (click)="onUndoDecline(message.data.uid)"
             aria-label="Undo declining the invitation"
             data-testid="committee-view-invitation-undo">

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -5,33 +5,19 @@
   <!-- Invitation decline toast — carries the Undo affordance for the deferred decline. -->
   <p-toast [key]="inviteToastKey" position="top-right" styleClass="committee-view-invite-toast">
     <ng-template let-message pTemplate="message">
-      <div class="flex items-start gap-3 w-full">
-        @switch (message.severity) {
-          @case ('error') {
-            <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-          }
-          @case ('info') {
-            <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-          }
-          @default {
-            <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-          }
+      <lfx-toast-message [message]="message">
+        @if (message.data?.uid) {
+          <button
+            type="button"
+            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+            (click)="onUndoDecline(message.data.uid)"
+            aria-label="Undo declining the invitation"
+            data-testid="committee-view-invitation-undo">
+            <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
+            <span>Undo</span>
+          </button>
         }
-        <div class="flex flex-col gap-1 min-w-0 flex-1">
-          <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
-          @if (message.data?.uid) {
-            <button
-              type="button"
-              class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
-              (click)="onUndoDecline(message.data.uid)"
-              aria-label="Undo declining the invitation"
-              data-testid="committee-view-invitation-undo">
-              <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
-              <span>Undo</span>
-            </button>
-          }
-        </div>
-      </div>
+      </lfx-toast-message>
     </ng-template>
   </p-toast>
 

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -9,7 +9,7 @@
         @if (message.data?.uid) {
           <button
             type="button"
-            class="toast-action"
+            class="toast-action self-start"
             (click)="onUndoDecline(message.data.uid)"
             aria-label="Undo declining the invitation"
             data-testid="committee-view-invitation-undo">

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -14,6 +14,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { RouteLoadingComponent } from '@components/loading/route-loading.component';
+import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
 import {
   Committee,
   CommitteeInvite,
@@ -119,6 +120,7 @@ const ACCESS_RETRY_INTERVAL_MS = 400;
     CardComponent,
     TagComponent,
     RouteLoadingComponent,
+    ToastMessageComponent,
     DatePipe,
     NgClass,
     PopoverModule,

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
@@ -7,7 +7,7 @@
       @if (message.data?.uid) {
         <button
           type="button"
-          class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+          class="toast-action"
           (click)="onUndoDecline({ uid: message.data.uid, committeeUid: message.data.committeeUid })"
           aria-label="Undo declining the invitation"
           data-testid="committee-invitations-toast-undo">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
@@ -7,7 +7,7 @@
       @if (message.data?.uid) {
         <button
           type="button"
-          class="toast-action"
+          class="toast-action self-start"
           (click)="onUndoDecline({ uid: message.data.uid, committeeUid: message.data.committeeUid })"
           aria-label="Undo declining the invitation"
           data-testid="committee-invitations-toast-undo">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
@@ -3,33 +3,19 @@
 
 <p-toast [key]="toastKey" position="top-right" styleClass="committee-invitations-toast">
   <ng-template let-message pTemplate="message">
-    <div class="flex items-start gap-3 w-full">
-      @switch (message.severity) {
-        @case ('error') {
-          <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
-        @case ('info') {
-          <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
-        @default {
-          <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
+    <lfx-toast-message [message]="message">
+      @if (message.data?.uid) {
+        <button
+          type="button"
+          class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+          (click)="onUndoDecline({ uid: message.data.uid, committeeUid: message.data.committeeUid })"
+          aria-label="Undo declining the invitation"
+          data-testid="committee-invitations-toast-undo">
+          <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
+          <span>Undo</span>
+        </button>
       }
-      <div class="flex flex-col gap-1 min-w-0 flex-1">
-        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
-        @if (message.data?.uid) {
-          <button
-            type="button"
-            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
-            (click)="onUndoDecline({ uid: message.data.uid, committeeUid: message.data.committeeUid })"
-            aria-label="Undo declining the invitation"
-            data-testid="committee-invitations-toast-undo">
-            <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
-            <span>Undo</span>
-          </button>
-        }
-      </div>
-    </div>
+    </lfx-toast-message>
   </ng-template>
 </p-toast>
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -5,6 +5,7 @@ import { computed, Component, DestroyRef, inject, output, Signal } from '@angula
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
 import { PendingInvitation, PendingInvitationRowVm } from '@lfx-one/shared/interfaces';
 import { RouterLink } from '@angular/router';
 import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
@@ -31,7 +32,7 @@ const TOAST_KEY = 'committee-invitations';
  */
 @Component({
   selector: 'lfx-committee-invitations',
-  imports: [ButtonComponent, TagComponent, ToastModule, InvitationSubtextPipe, RouterLink],
+  imports: [ButtonComponent, TagComponent, ToastMessageComponent, ToastModule, InvitationSubtextPipe, RouterLink],
   templateUrl: './committee-invitations.component.html',
   styleUrl: './committee-invitations.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -27,7 +27,7 @@
       @if (message.data?.undoInviteUid) {
         <button
           type="button"
-          class="toast-action"
+          class="toast-action self-start"
           (click)="onUndoDecline()"
           aria-label="Undo declining the invitation"
           data-testid="dashboard-pending-actions-toast-undo">

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -7,7 +7,7 @@
       @if (message.data?.meetingUrl) {
         <a
           [routerLink]="message.data.meetingUrl"
-          class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1"
+          class="toast-action"
           [attr.aria-label]="message.data.meetingTitle ? 'View details for ' + message.data.meetingTitle : 'View meeting details'"
           [attr.title]="message.data.meetingTitle ? 'View details for ' + message.data.meetingTitle : null"
           data-testid="dashboard-pending-actions-toast-meeting-link">
@@ -27,7 +27,7 @@
       @if (message.data?.undoInviteUid) {
         <button
           type="button"
-          class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+          class="toast-action"
           (click)="onUndoDecline()"
           aria-label="Undo declining the invitation"
           data-testid="dashboard-pending-actions-toast-undo">

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -3,37 +3,19 @@
 
 <p-toast key="pending-actions-toast" position="top-right" styleClass="pending-actions-toast">
   <ng-template let-message pTemplate="message">
-    <div class="flex items-start gap-3 w-full">
-      @switch (message.severity) {
-        @case ('error') {
-          <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
-        @case ('warn') {
-          <i class="fa-light fa-triangle-exclamation text-amber-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
-        @case ('info') {
-          <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
-        @default {
-          <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-        }
+    <lfx-toast-message [message]="message">
+      @if (message.data?.meetingUrl) {
+        <a
+          [routerLink]="message.data.meetingUrl"
+          class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1"
+          [attr.aria-label]="message.data.meetingTitle ? 'View details for ' + message.data.meetingTitle : 'View meeting details'"
+          [attr.title]="message.data.meetingTitle ? 'View details for ' + message.data.meetingTitle : null"
+          data-testid="dashboard-pending-actions-toast-meeting-link">
+          <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
+          <span>View meeting details</span>
+        </a>
       }
-      <div class="flex flex-col gap-1 min-w-0 flex-1">
-        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
-        <span class="text-xs text-gray-600 break-words">{{ message.detail }}</span>
-        @if (message.data?.meetingUrl) {
-          <a
-            [routerLink]="message.data.meetingUrl"
-            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1"
-            [attr.aria-label]="message.data.meetingTitle ? 'View details for ' + message.data.meetingTitle : 'View meeting details'"
-            [attr.title]="message.data.meetingTitle ? 'View details for ' + message.data.meetingTitle : null"
-            data-testid="dashboard-pending-actions-toast-meeting-link">
-            <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
-            <span>View meeting details</span>
-          </a>
-        }
-      </div>
-    </div>
+    </lfx-toast-message>
   </ng-template>
 </p-toast>
 
@@ -41,23 +23,19 @@
      unrelated RSVP/vote/meeting toasts that share the 'pending-actions-toast' key. -->
 <p-toast [key]="undoToastKey" position="top-right" styleClass="pending-actions-toast">
   <ng-template let-message pTemplate="message">
-    <div class="flex items-start gap-3 w-full">
-      <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-      <div class="flex flex-col gap-1 min-w-0 flex-1">
-        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
-        @if (message.data?.undoInviteUid) {
-          <button
-            type="button"
-            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
-            (click)="onUndoDecline()"
-            aria-label="Undo declining the invitation"
-            data-testid="dashboard-pending-actions-toast-undo">
-            <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
-            <span>Undo</span>
-          </button>
-        }
-      </div>
-    </div>
+    <lfx-toast-message [message]="message">
+      @if (message.data?.undoInviteUid) {
+        <button
+          type="button"
+          class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+          (click)="onUndoDecline()"
+          aria-label="Undo declining the invitation"
+          data-testid="dashboard-pending-actions-toast-undo">
+          <i class="fa-light fa-rotate-left text-[10px]" aria-hidden="true"></i>
+          <span>Undo</span>
+        </button>
+      }
+    </lfx-toast-message>
   </ng-template>
 </p-toast>
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -9,6 +9,7 @@ import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-
 import { VoteBallotInlineComponent } from '@app/modules/votes/components/vote-ballot-inline/vote-ballot-inline.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
 import {
   PENDING_ACTION_BUTTON_ICON,
   PENDING_ACTION_EMPTY_GRACE_MS,
@@ -43,6 +44,7 @@ const INVITE_UNDO_TOAST_KEY = 'pending-actions-undo';
   imports: [
     ButtonComponent,
     TagComponent,
+    ToastMessageComponent,
     RsvpButtonGroupComponent,
     VoteBallotInlineComponent,
     PendingActionsDrawerComponent,

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -6,7 +6,9 @@
     <ng-template let-message pTemplate="message">
       <lfx-toast-message [message]="message">
         @if (message.data?.showSupport) {
-          <button type="button" lfxOpenIntercom class="toast-action" data-testid="my-events-salesforce-error-contact-support">Contact Support</button>
+          <button type="button" lfxOpenIntercom class="toast-action self-start" data-testid="my-events-salesforce-error-contact-support">
+            Contact Support
+          </button>
         }
       </lfx-toast-message>
     </ng-template>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -6,13 +6,7 @@
     <ng-template let-message pTemplate="message">
       <lfx-toast-message [message]="message">
         @if (message.data?.showSupport) {
-          <button
-            type="button"
-            lfxOpenIntercom
-            class="toast-action"
-            data-testid="my-events-salesforce-error-contact-support">
-            Contact Support
-          </button>
+          <button type="button" lfxOpenIntercom class="toast-action" data-testid="my-events-salesforce-error-contact-support">Contact Support</button>
         }
       </lfx-toast-message>
     </ng-template>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -4,32 +4,17 @@
   <!-- Salesforce-ID error toast — keyed so the custom template carrying the Contact Support action renders only for this error. -->
   <p-toast [key]="salesforceErrorToastKey" position="top-right">
     <ng-template let-message pTemplate="message">
-      <div class="flex items-start gap-3 w-full">
-        @switch (message.severity) {
-          @case ('error') {
-            <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-          }
-          @case ('info') {
-            <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-          }
-          @default {
-            <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
-          }
+      <lfx-toast-message [message]="message">
+        @if (message.data?.showSupport) {
+          <button
+            type="button"
+            lfxOpenIntercom
+            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+            data-testid="my-events-salesforce-error-contact-support">
+            Contact Support
+          </button>
         }
-        <div class="flex flex-col gap-1 min-w-0 flex-1">
-          <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
-          <span class="text-sm text-gray-600">{{ message.detail }}</span>
-          @if (message.data?.showSupport) {
-            <button
-              type="button"
-              lfxOpenIntercom
-              class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
-              data-testid="my-events-salesforce-error-contact-support">
-              Contact Support
-            </button>
-          }
-        </div>
-      </div>
+      </lfx-toast-message>
     </ng-template>
   </p-toast>
 

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -9,7 +9,7 @@
           <button
             type="button"
             lfxOpenIntercom
-            class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+            class="toast-action"
             data-testid="my-events-salesforce-error-contact-support">
             Contact Support
           </button>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -6,6 +6,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
+import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
 import { MY_EVENT_STATUS_OPTIONS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
@@ -32,6 +33,7 @@ const SALESFORCE_ERROR_TOAST_KEY = 'my-events-salesforce-error';
     EventsListComponent,
     Tooltip,
     ToastModule,
+    ToastMessageComponent,
     OpenIntercomDirective,
   ],
   templateUrl: './my-events-dashboard.component.html',

--- a/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.html
+++ b/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.html
@@ -1,0 +1,27 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex items-start gap-3 w-full">
+  @switch (message().severity) {
+    @case ('error') {
+      <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+    }
+    @case ('warn') {
+      <i class="fa-light fa-triangle-exclamation text-amber-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+    }
+    @case ('info') {
+      <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+    }
+    @default {
+      <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+    }
+  }
+  <div class="flex flex-col gap-1 min-w-0 flex-1">
+    <span class="text-sm font-semibold text-gray-900">{{ message().summary }}</span>
+    @if (message().detail) {
+      <span class="text-xs text-gray-600 break-words">{{ message().detail }}</span>
+    }
+    <!-- Action slot — consumers project their own button/anchor (Undo, Contact Support, meeting link) verbatim. -->
+    <ng-content />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.html
+++ b/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.html
@@ -19,7 +19,7 @@
   <div class="flex flex-col gap-1 min-w-0 flex-1">
     <span class="text-sm font-semibold text-gray-900">{{ message().summary }}</span>
     @if (message().detail) {
-      <span class="text-xs text-gray-600 break-words">{{ message().detail }}</span>
+      <span class="text-xs text-gray-600 break-words" data-testid="toast-message-detail">{{ message().detail }}</span>
     }
     <!-- Action slot — consumers project their own button/anchor (Undo, Contact Support, meeting link) verbatim. -->
     <ng-content />

--- a/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.scss
+++ b/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.scss
@@ -1,0 +1,8 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// :host must vanish from the box tree so the inner flex row stays a direct item
+// of PrimeNG's .p-toast-message-content — keeps the close button flush right (mirrors foundation-row.component.scss).
+:host {
+  display: contents;
+}

--- a/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.spec.ts
@@ -1,0 +1,99 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ToastMessageOptions } from 'primeng/api';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ToastMessageComponent } from './toast-message.component';
+
+// Host for the projection test — the action slot exists so consumers can project
+// their own button/anchor, so the spec proves projected content really renders.
+@Component({
+  selector: 'lfx-toast-message-test-host',
+  imports: [ToastMessageComponent],
+  template: `
+    <lfx-toast-message [message]="message">
+      <button type="button" data-testid="toast-action">Undo</button>
+    </lfx-toast-message>
+  `,
+})
+class ToastMessageTestHostComponent {
+  public readonly message: ToastMessageOptions = { severity: 'info', summary: 'Invite declined' };
+}
+
+describe('ToastMessageComponent', () => {
+  let fixture: ComponentFixture<ToastMessageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [ToastMessageComponent, ToastMessageTestHostComponent] }).compileComponents();
+  });
+
+  // Creation and setInput stay paired: a required-input fixture left pending
+  // without a value throws NG0950 when the zoneless scheduler flushes.
+  async function renderWith(message: ToastMessageOptions): Promise<void> {
+    fixture = TestBed.createComponent(ToastMessageComponent);
+    fixture.componentRef.setInput('message', message);
+    await fixture.whenStable();
+  }
+
+  function severityIcon(): Element | null {
+    return fixture.nativeElement.querySelector('i[aria-hidden="true"]');
+  }
+
+  it('renders the error icon for severity error', async () => {
+    await renderWith({ severity: 'error', summary: 'Something failed' });
+
+    expect(severityIcon()?.classList).toContain('fa-circle-xmark');
+  });
+
+  it('renders the warn icon for severity warn', async () => {
+    await renderWith({ severity: 'warn', summary: 'Heads up' });
+
+    expect(severityIcon()?.classList).toContain('fa-triangle-exclamation');
+  });
+
+  it('renders the info icon for severity info', async () => {
+    await renderWith({ severity: 'info', summary: 'Invite declined' });
+
+    expect(severityIcon()?.classList).toContain('fa-circle-info');
+  });
+
+  it('renders the success icon for any other severity', async () => {
+    await renderWith({ severity: 'success', summary: 'Saved' });
+
+    expect(severityIcon()?.classList).toContain('fa-circle-check');
+  });
+
+  it('renders the summary', async () => {
+    await renderWith({ severity: 'info', summary: 'Invite declined' });
+
+    expect(fixture.nativeElement.textContent).toContain('Invite declined');
+  });
+
+  it('hides the detail line when detail is absent', async () => {
+    await renderWith({ severity: 'info', summary: 'Invite declined' });
+
+    expect(fixture.nativeElement.querySelector('.break-words')).toBeNull();
+  });
+
+  it('shows the detail line when detail is present', async () => {
+    await renderWith({ severity: 'error', summary: 'Something failed', detail: 'Missing Salesforce ID' });
+
+    const detail = fixture.nativeElement.querySelector('.break-words');
+    expect(detail).not.toBeNull();
+    expect(detail.textContent).toContain('Missing Salesforce ID');
+  });
+
+  it('renders projected action content', async () => {
+    const hostFixture = TestBed.createComponent(ToastMessageTestHostComponent);
+    // Explicit initial pass: the host has no inputs, so nothing marks it dirty the way setInput does.
+    hostFixture.detectChanges();
+    await hostFixture.whenStable();
+
+    const action = hostFixture.nativeElement.querySelector('[data-testid="toast-action"]');
+    expect(action).not.toBeNull();
+    expect(action.textContent?.trim()).toBe('Undo');
+  });
+});

--- a/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.spec.ts
@@ -75,13 +75,13 @@ describe('ToastMessageComponent', () => {
   it('hides the detail line when detail is absent', async () => {
     await renderWith({ severity: 'info', summary: 'Invite declined' });
 
-    expect(fixture.nativeElement.querySelector('.break-words')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="toast-message-detail"]')).toBeNull();
   });
 
   it('shows the detail line when detail is present', async () => {
     await renderWith({ severity: 'error', summary: 'Something failed', detail: 'Missing Salesforce ID' });
 
-    const detail = fixture.nativeElement.querySelector('.break-words');
+    const detail = fixture.nativeElement.querySelector('[data-testid="toast-message-detail"]');
     expect(detail).not.toBeNull();
     expect(detail.textContent).toContain('Missing Salesforce ID');
   });

--- a/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.ts
+++ b/apps/lfx-one/src/app/shared/components/toast-message/toast-message.component.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import type { ToastMessageOptions } from 'primeng/api';
+
+@Component({
+  selector: 'lfx-toast-message',
+  templateUrl: './toast-message.component.html',
+  styleUrl: './toast-message.component.scss',
+})
+export class ToastMessageComponent {
+  public readonly message = input.required<ToastMessageOptions>();
+}

--- a/apps/lfx-one/src/styles.scss
+++ b/apps/lfx-one/src/styles.scss
@@ -414,3 +414,9 @@ html {
 .person-detail-drawer .p-drawer-header {
   @apply items-start;
 }
+
+// Toast action slot — consumers project their own button/anchor into <lfx-toast-message>, and projected
+// content falls outside the component's view encapsulation, so the shared class must live globally.
+.toast-action {
+  @apply mt-1 inline-flex items-center gap-1 self-start text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline;
+}

--- a/apps/lfx-one/src/styles.scss
+++ b/apps/lfx-one/src/styles.scss
@@ -418,5 +418,5 @@ html {
 // Toast action slot — consumers project their own button/anchor into <lfx-toast-message>, and projected
 // content falls outside the component's view encapsulation, so the shared class must live globally.
 .toast-action {
-  @apply mt-1 inline-flex items-center gap-1 self-start text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline;
+  @apply mt-1 inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline;
 }


### PR DESCRIPTION
## Summary

Five PrimeNG toasts across committees, dashboards, and events were each hand-rolling the same custom `pTemplate="message"` markup — a severity icon switch, summary line, optional detail line, and an action button/anchor — with small copy-paste drift between copies. This PR extracts that shared structure into a single presentational `lfx-toast-message` component and routes all five toasts through it, so the icon/severity mapping, typography, and layout now live in exactly one place while each consumer keeps only its own action slot content (Undo, Contact Support, View meeting details).

Resolves #1895

## Behavior changes

### Toast markup across committees, dashboards, and events

| Before | After |
|---|---|
| Five toasts each carried their own copy of the same custom message layout (icon, title, detail text, action), so any visual tweak to toast structure had to be made in five places and the copies had already drifted slightly | All five toasts render through one shared component; each screen only supplies its own action button or link, and the toasts look and behave exactly as they did before |

### My Events error toast detail text

| Before | After |
|---|---|
| The error toast on the My Events dashboard showed its detail line in a slightly larger text size than the equivalent detail lines in the other custom toasts | The detail line uses the same smaller text size as every other toast (a one-step-smaller, user-approved visual normalization) |

## Technical changes

`apps/lfx-one/src/app/shared/components/toast-message/` — New shared component

- Adds `lfx-toast-message`, a presentational component taking a required `ToastMessageOptions` input (PrimeNG's message type)
- Centralizes the severity → icon switch (error / warn / info / default-success), the summary line, a detail line that renders only when `detail` is present, and an `ng-content` action slot for consumer-supplied buttons/anchors
- Suppresses the host element from the box tree via `:host { display: contents }` so the inner flex row stays a direct child of PrimeNG's `.p-toast-message-content` and the close button stays flush right — mirroring the existing `foundation-row` pattern
- Adds a colocated spec covering the severity icon mapping, summary rendering, detail visibility on/off, and content projection of the action slot

`apps/lfx-one/src/app/modules/committees/committee-view/`, `apps/lfx-one/src/app/modules/committees/components/committee-invitations/` — Committee toasts

- Replaces the inline custom message template in both the committee-view invitation-decline toast and the committee-invitations toast with `lfx-toast-message`, projecting the existing Undo button (testid, aria-label, click handler unchanged)
- Imports `ToastMessageComponent` in both component classes

`apps/lfx-one/src/app/modules/dashboards/components/pending-actions/` — Dashboard toasts

- Routes both pending-actions toasts (the meeting-link toast and the invite-undo toast) through `lfx-toast-message`, projecting the "View meeting details" router link and the Undo button verbatim
- Toast keys, payloads, and `data-testid` hooks are untouched

`apps/lfx-one/src/app/modules/events/my-events-dashboard/` — My Events toast

- Routes the Salesforce-ID error toast through `lfx-toast-message`, projecting the existing Contact Support (Intercom) button
- Normalizes the detail line from `text-sm` to the shared `text-xs` style (the one intentional visual delta)
