### PR TITLE
perf(server): log cold-start phase timings

### DIFF
--- a/apps/lfx-one/otel.mjs
+++ b/apps/lfx-one/otel.mjs
@@ -256,3 +256,8 @@ if (!otlpEndpoint) {
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
 }
+
+// Cold-start boot marker (see #1378) — fires on both the OTEL-enabled and
+// OTEL-disabled paths above, since --import completes before server.mjs loads
+// and this is otherwise the only place the otel import cost is observable.
+otelLog.info('[otel] import complete', { elapsed_ms: Math.round(performance.now()) });

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -94,12 +94,14 @@ initializeServerConsoleOverride();
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
 
-// Cold-start phase marks (see #1378) — performance.now() is monotonic and
-// zeroed at process start, so each mark is elapsed-ms since the process spawned.
-const engineStartMs = performance.now();
-
 const angularApp = new AngularNodeAppEngine();
 const app = express();
+
+// Cold-start phase marks (see #1378) — performance.now() is monotonic and
+// zeroed at process start, so each mark is elapsed-ms since the process spawned.
+// Captured after engine/app construction so engine_ms reflects that work, not
+// just the module-graph evaluation that precedes it.
+const engineStartMs = performance.now();
 
 // Trust first proxy so req.ip resolves from X-Forwarded-For.
 app.set('trust proxy', 1);
@@ -382,9 +384,6 @@ app.get('/crowdfunding/callback', authRateLimiter, (req, res) => crowdfundingCal
 
 const crowdfundingAuthService = new CrowdfundingAuthService();
 
-// Cold-start phase mark (see #1378) — router mounting + middleware complete.
-const routesReadyMs = performance.now();
-
 app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
   const ssrStartTime = Date.now();
   const auth: AuthContext = {
@@ -578,6 +577,10 @@ app.use((error: Error, req: Request, res: Response, next: NextFunction) => {
 
   apiErrorHandler(error, req, res, next);
 });
+
+// Cold-start phase mark (see #1378) — router mounting + middleware complete,
+// including the SSR catch-all and global error handler above.
+const routesReadyMs = performance.now();
 
 let httpServer: HttpServer | undefined;
 

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -370,9 +370,6 @@ app.use('/api/mktg-agents', mktgAgentsRouter);
 app.use('/public/api/*', apiErrorHandler);
 app.use('/api/*', apiErrorHandler);
 
-// Cold-start phase mark (see #1378) — router mounting + middleware complete.
-const routesReadyMs = performance.now();
-
 // Profile auth callback registered in Auth0 Profile Client.
 const profileCallbackController = new ProfileController();
 app.get('/passwordless/callback', authRateLimiter, (req, res) => profileCallbackController.handleProfileAuthCallback(req, res));
@@ -384,6 +381,9 @@ const crowdfundingCallbackController = new CrowdfundingController();
 app.get('/crowdfunding/callback', authRateLimiter, (req, res) => crowdfundingCallbackController.handleCrowdfundingAuthCallback(req, res));
 
 const crowdfundingAuthService = new CrowdfundingAuthService();
+
+// Cold-start phase mark (see #1378) — router mounting + middleware complete.
+const routesReadyMs = performance.now();
 
 app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
   const ssrStartTime = Date.now();

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -94,6 +94,10 @@ initializeServerConsoleOverride();
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
 
+// Cold-start phase marks (see #1378) — performance.now() is monotonic and
+// zeroed at process start, so each mark is elapsed-ms since the process spawned.
+const engineStartMs = performance.now();
+
 const angularApp = new AngularNodeAppEngine();
 const app = express();
 
@@ -365,6 +369,9 @@ app.use('/api/mktg-agents', mktgAgentsRouter);
 
 app.use('/public/api/*', apiErrorHandler);
 app.use('/api/*', apiErrorHandler);
+
+// Cold-start phase mark (see #1378) — router mounting + middleware complete.
+const routesReadyMs = performance.now();
 
 // Profile auth callback registered in Auth0 Profile Client.
 const profileCallbackController = new ProfileController();
@@ -695,11 +702,15 @@ async function gracefulShutdown(signal: string): Promise<void> {
 export function startServer() {
   const port = process.env['PORT'] || 4000;
   httpServer = app.listen(port, () => {
-    logger.debug(undefined, 'server_startup', 'Node Express server started', {
+    logger.info(undefined, 'server_startup', 'Node Express server started', {
       port,
       url: `http://localhost:${port}`,
       node_env: process.env['NODE_ENV'] || 'development',
       pm2: process.env['PM2'] === 'true',
+      // Cold-start phase breakdown (see #1378) — ms elapsed since process start.
+      engine_ms: Math.round(engineStartMs),
+      routes_ms: Math.round(routesReadyMs),
+      boot_ms: Math.round(performance.now()),
     });
   });
 }


### PR DESCRIPTION
## Summary

- The SSR pod's ~4 min cold start (#1378) is currently unmeasured: the only boot log line was `logger.debug`, and no environment sets `LOG_LEVEL`, so it's silently suppressed at the default `info` level everywhere. This promotes it to `logger.info` and adds three `performance.now()` phase marks (`engine_ms`, `routes_ms`, `boot_ms`) plus an `otel.mjs` import-complete marker, splitting the pre-listen window into engine construction / router mounting / otel import cost.
- Second commit fixes the `routesReadyMs` mark placement so it's taken after all router mounts (three OAuth callback routes were previously excluded), keeping the phase boundary accurate.
- This is Phase 1 of the profiling plan for #1378 — instrumentation only, no behavior change. Phase 2 (measurement in `dev`) follows once this reaches that environment.

## Notes for reviewers

- `apps/lfx-one/src/server/server.ts` is a protected/core-infrastructure file (server bootstrap) per `.claude/hooks/guard-protected-files.sh`. The change is additive only — one log-level promotion and three `performance.now()` marks folded into the existing startup log call — no control-flow or route-handling changes. Flagging per repo convention for explicit code-owner review.

## Test plan

- [x] `yarn check-types`, `yarn lint`, `yarn build` all pass
- [x] Ran the built server locally and confirmed both new log lines appear: `[otel] import complete` with `elapsed_ms`, and `server_startup` INFO with `engine_ms`/`routes_ms`/`boot_ms`
- [x] Post-commit reviewer trio (general / self-serve-convention / learnings) run per commit and on the full-branch diff — clean, no Critical/Important findings
- [x] `/lfx-self-serve-pr-readiness` — READY WITH CHANGES (protected-file SHOULD_FIX addressed above)

Issue: #1378