### PR TITLE
fix(events): use full LF Open Source identity on china certificates

### DIFF
--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -11,9 +11,16 @@ const snowflakeMocks = vi.hoisted(() => ({
 
 const pdfMocks = vi.hoisted(() => ({
   images: [] as { path: string; options: Record<string, unknown> | undefined }[],
+  texts: [] as { text: string; options: Record<string, unknown> | undefined }[],
 }));
 
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
+vi.mock('@lfx-one/shared/utils', async () => {
+  const eventUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/event.utils')>(
+    '../../../../../packages/shared/src/utils/event.utils'
+  );
+  return { isBackfillEventSource: eventUtils.isBackfillEventSource };
+});
 vi.mock('./snowflake.service', () => ({
   SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },
 }));
@@ -53,7 +60,11 @@ vi.mock('pdfkit', () => {
     public lineGap(): this {
       return this;
     }
-    public text(): this {
+    public text(text: unknown, ...rest: unknown[]): this {
+      if (typeof text === 'string') {
+        const options = rest.find((arg) => typeof arg === 'object' && arg !== null) as Record<string, unknown> | undefined;
+        pdfMocks.texts.push({ text, options });
+      }
       return this;
     }
     public moveDown(): this {
@@ -122,16 +133,22 @@ function drawnSignature(): { path: string; options: Record<string, unknown> | un
   return pdfMocks.images[1];
 }
 
+/** All strings passed to doc.text() across the letter, in draw order. */
+function drawnTexts(): string[] {
+  return pdfMocks.texts.map((t) => t.text);
+}
+
 describe('CertificateService', () => {
   let service: CertificateService;
 
   beforeEach(() => {
     vi.clearAllMocks();
     pdfMocks.images = [];
+    pdfMocks.texts = [];
     service = new CertificateService();
   });
 
-  describe('LF Open Source logo override', () => {
+  describe('LF Open Source identity override', () => {
     it('applies the LF Open Source logo for a backfill event in China', async () => {
       mockRow();
 
@@ -149,7 +166,21 @@ describe('CertificateService', () => {
       expect(drawnLogo().options?.['width']).toBe(240);
     });
 
-    it('overrides a project template logo but keeps that project name and signature', async () => {
+    it('replaces the link, name, description and on-behalf line', async () => {
+      mockRow();
+
+      await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      const texts = drawnTexts();
+      expect(texts).toContain('https://lfopensource.cn/');
+      expect(texts.some((t) => t.startsWith('LF Open Source, LLC is pleased that you were able to attend'))).toBe(true);
+      expect(texts).toContain(
+        'LF Open Source, LLC is a nonprofit consortium dedicated to fostering the growth of the Linux operating system. LF Open Source, LLC promotes, protects and standardizes Linux by providing unified resources and services. It is supported by its members — the leading IT companies such as IBM, Intel, Hewlett Packard, etc.'
+      );
+      expect(texts).toContain('On behalf of LF Open Source, LLC, we are glad you were able to join us.');
+    });
+
+    it('overrides a project template logo, link, name, description and on-behalf line but keeps that project address and signature', async () => {
       // Real data: event -6, KubeCon + CloudNativeCon China 2026, owned by CNCF.
       mockRow({ PROJECT_ID: CNCF_PROJECT_ID });
 
@@ -157,6 +188,13 @@ describe('CertificateService', () => {
 
       expect(drawnLogo().path).toContain(LF_OPEN_SOURCE_LOGO);
       expect(drawnSignature().path).toContain('cncf-signature.png');
+
+      const texts = drawnTexts();
+      expect(texts).toContain('https://lfopensource.cn/');
+      expect(texts.some((t) => t.startsWith('LF Open Source, LLC is pleased that you were able to attend'))).toBe(true);
+      expect(texts.some((t) => t.includes('CNCF'))).toBe(false);
+      // CNCF's address block is untouched by the override.
+      expect(texts.some((t) => t.includes('2810 N Church St'))).toBe(true);
     });
 
     it.each([
@@ -173,7 +211,7 @@ describe('CertificateService', () => {
     });
   });
 
-  describe('events that must keep their existing logo', () => {
+  describe('events that must keep their existing identity', () => {
     it.each([
       // 84 China events come from Bevy and must not pick up the override.
       ['a bevy-sourced China event', { EVENT_SOURCE: 'bevy' }],
@@ -184,21 +222,25 @@ describe('CertificateService', () => {
       ['a Hong Kong event', { EVENT_COUNTRY: 'Hong Kong (SAR China)' }],
       ['a null source', { EVENT_SOURCE: null }],
       ['a null country', { EVENT_COUNTRY: null }],
-    ])('keeps the default logo for %s', async (_label, overrides) => {
+    ])('keeps the default logo and link for %s', async (_label, overrides) => {
       mockRow(overrides);
 
       await service.generateCertificate(req, { eventId: 'evt-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
 
       expect(drawnLogo().path).toContain(TLF_LOGO);
       expect(drawnLogo().options?.['width']).toBe(145);
+      expect(drawnTexts()).toContain('https://www.linuxfoundation.org/');
+      expect(drawnTexts().some((t) => t.startsWith('The Linux Foundation is pleased'))).toBe(true);
     });
 
-    it('keeps the CNCF logo for a non-matching CNCF event', async () => {
+    it('keeps the CNCF logo, link and name for a non-matching CNCF event', async () => {
       mockRow({ PROJECT_ID: CNCF_PROJECT_ID, EVENT_SOURCE: 'cvent', EVENT_COUNTRY: 'United States' });
 
       await service.generateCertificate(req, { eventId: 'evt-2', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
 
       expect(drawnLogo().path).toContain(CNCF_LOGO);
+      expect(drawnTexts()).toContain('https://www.cncf.io/');
+      expect(drawnTexts().some((t) => t.startsWith('Cloud Native Computing Foundation (CNCF) is pleased'))).toBe(true);
     });
   });
 

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -3,8 +3,10 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mirrors brand-kit.service.spec.ts: shared modules are mocked because the `@lfx-one/shared/*`
-// alias isn't wired into this app's vitest config. pdf.constants is aliased to its real source.
+// Mirrors brand-kit.service.spec.ts: the `@lfx-one/shared/*` alias is wired into vitest.config.ts,
+// but the `utils` barrel transitively imports Angular-dependent modules that can't load in this
+// spec's `node` environment, so it's narrowed to the one pure function this service needs.
+// pdf.constants is aliased to its real source and doesn't need mocking.
 const snowflakeMocks = vi.hoisted(() => ({
   execute: vi.fn(),
 }));
@@ -89,6 +91,8 @@ vi.mock('fs', () => {
 });
 
 import type { Request } from 'express';
+
+import { PROJECT_TEMPLATES } from '@lfx-one/shared/constants/pdf.constants';
 
 import { AuthorizationError, ResourceNotFoundError } from '../errors';
 import { CertificateService } from './certificate.service';
@@ -197,7 +201,7 @@ describe('CertificateService', () => {
       expect(texts.some((t) => t.includes('CNCF'))).toBe(false);
       // The default and CNCF templates share an identical address, so asserting on it can't tell
       // "kept CNCF's template" from "fell back to default" — signature text can, since it names its ED.
-      expect(texts).toContain('Priyanka Sharma\nExecutive Director');
+      expect(texts).toContain(PROJECT_TEMPLATES[CNCF_PROJECT_ID].signatureText);
     });
 
     it.each([

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -195,8 +195,9 @@ describe('CertificateService', () => {
       expect(texts).toContain('https://lfopensource.cn/');
       expect(texts.some((t) => t.startsWith('LF Open Source, LLC is pleased that you were able to attend'))).toBe(true);
       expect(texts.some((t) => t.includes('CNCF'))).toBe(false);
-      // CNCF's address block is untouched by the override.
-      expect(texts.some((t) => t.includes('2810 N Church St'))).toBe(true);
+      // CNCF's signature text names its own ED; the default template's is identical to CNCF's
+      // address, so asserting on the address alone wouldn't distinguish "kept" from "fell back".
+      expect(texts).toContain('Priyanka Sharma\nExecutive Director');
     });
 
     it.each([

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -16,11 +16,25 @@ const pdfMocks = vi.hoisted(() => ({
 
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 vi.mock('@lfx-one/shared/utils', async () => {
-  // Spread event.utils so added exports from this module are available; other util modules still need their own importActual.
   const eventUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/event.utils')>(
     '../../../../../packages/shared/src/utils/event.utils'
   );
-  return { ...eventUtils };
+  // A plain `{ isBackfillEventSource }` object would make any *other* barrel export the service
+  // under test starts using resolve to `undefined` — surfacing as an opaque "X is not a function"
+  // wherever it's called, far from this mock. The Proxy throws immediately, at the missing
+  // property, naming this file as the place to add the new export.
+  return new Proxy(
+    { isBackfillEventSource: eventUtils.isBackfillEventSource },
+    {
+      get(target, prop, receiver) {
+        // `'then'` is probed by JS's own Promise-resolution algorithm (this factory is async, and
+        // its return value gets duck-typed) — answering `undefined` here says "not a thenable"
+        // without tripping the guard below.
+        if (prop === 'then' || prop in target) return Reflect.get(target, prop, receiver);
+        throw new Error(`certificate.service.spec.ts's '@lfx-one/shared/utils' mock doesn't stub '${String(prop)}' — add it to the mock in this file.`);
+      },
+    }
+  );
 });
 vi.mock('./snowflake.service', () => ({
   SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -19,22 +19,9 @@ vi.mock('@lfx-one/shared/utils', async () => {
   const eventUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/event.utils')>(
     '../../../../../packages/shared/src/utils/event.utils'
   );
-  // A plain `{ isBackfillEventSource }` object would make any *other* barrel export the service
-  // under test starts using resolve to `undefined` — surfacing as an opaque "X is not a function"
-  // wherever it's called, far from this mock. The Proxy throws immediately, at the missing
-  // property, naming this file as the place to add the new export.
-  return new Proxy(
-    { isBackfillEventSource: eventUtils.isBackfillEventSource },
-    {
-      get(target, prop, receiver) {
-        // `'then'` is probed by JS's own Promise-resolution algorithm (this factory is async, and
-        // its return value gets duck-typed) — answering `undefined` here says "not a thenable"
-        // without tripping the guard below.
-        if (prop === 'then' || prop in target) return Reflect.get(target, prop, receiver);
-        throw new Error(`certificate.service.spec.ts's '@lfx-one/shared/utils' mock doesn't stub '${String(prop)}' — add it to the mock in this file.`);
-      },
-    }
-  );
+  // Vitest already wraps this return value in a Proxy that throws on any unstubbed export
+  // ("No 'X' export is defined on the mock"), so a future second import fails loudly on its own.
+  return { isBackfillEventSource: eventUtils.isBackfillEventSource };
 });
 vi.mock('./snowflake.service', () => ({
   SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -16,10 +16,11 @@ const pdfMocks = vi.hoisted(() => ({
 
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 vi.mock('@lfx-one/shared/utils', async () => {
+  // Spread (not hand-pick) so a future second util import fails loudly instead of resolving undefined.
   const eventUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/event.utils')>(
     '../../../../../packages/shared/src/utils/event.utils'
   );
-  return { isBackfillEventSource: eventUtils.isBackfillEventSource };
+  return { ...eventUtils };
 });
 vi.mock('./snowflake.service', () => ({
   SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },
@@ -202,6 +203,7 @@ describe('CertificateService', () => {
       ['padded lowercase country', { EVENT_COUNTRY: ' china ' }],
       ['capitalised source', { EVENT_SOURCE: 'Backfill' }],
       ['padded source', { EVENT_SOURCE: ' BACKFILL ' }],
+      ['source padded with a non-breaking space', { EVENT_SOURCE: ' backfill ' }],
     ])('applies the override despite %s', async (_label, overrides) => {
       mockRow(overrides);
 

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -182,7 +182,7 @@ describe('CertificateService', () => {
       expect(texts).toContain('On behalf of LF Open Source, LLC, we are glad you were able to join us.');
     });
 
-    it('overrides a project template logo, link, name, description and on-behalf line but keeps that project address and signature', async () => {
+    it('overrides a project template logo, link, name, description and on-behalf line but keeps that project signature', async () => {
       // Real data: event -6, KubeCon + CloudNativeCon China 2026, owned by CNCF.
       mockRow({ PROJECT_ID: CNCF_PROJECT_ID });
 
@@ -195,8 +195,8 @@ describe('CertificateService', () => {
       expect(texts).toContain('https://lfopensource.cn/');
       expect(texts.some((t) => t.startsWith('LF Open Source, LLC is pleased that you were able to attend'))).toBe(true);
       expect(texts.some((t) => t.includes('CNCF'))).toBe(false);
-      // CNCF's signature text names its own ED; the default template's is identical to CNCF's
-      // address, so asserting on the address alone wouldn't distinguish "kept" from "fell back".
+      // The default and CNCF templates share an identical address, so asserting on it can't tell
+      // "kept CNCF's template" from "fell back to default" — signature text can, since it names its ED.
       expect(texts).toContain('Priyanka Sharma\nExecutive Director');
     });
 

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -16,7 +16,7 @@ const pdfMocks = vi.hoisted(() => ({
 
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 vi.mock('@lfx-one/shared/utils', async () => {
-  // Spread (not hand-pick) so a future second util import fails loudly instead of resolving undefined.
+  // Spread event.utils so added exports from this module are available; other util modules still need their own importActual.
   const eventUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/event.utils')>(
     '../../../../../packages/shared/src/utils/event.utils'
   );
@@ -203,7 +203,7 @@ describe('CertificateService', () => {
       ['padded lowercase country', { EVENT_COUNTRY: ' china ' }],
       ['capitalised source', { EVENT_SOURCE: 'Backfill' }],
       ['padded source', { EVENT_SOURCE: ' BACKFILL ' }],
-      ['source padded with a non-breaking space', { EVENT_SOURCE: ' backfill ' }],
+      ['source padded with a non-breaking space', { EVENT_SOURCE: '\u00A0backfill\u00A0' }],
     ])('applies the override despite %s', async (_label, overrides) => {
       mockRow(overrides);
 

--- a/apps/lfx-one/src/server/services/certificate.service.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.ts
@@ -86,10 +86,10 @@ export class CertificateService {
   }
 
   /**
-   * Country trimmed and lowercased so casing drift in imported CSV data doesn't skip the
-   * override, and whole-string so 'Hong Kong (SAR China)' doesn't match. The source half
-   * defers to isBackfillEventSource() so this stays in lockstep with the rest of the backfill
-   * handling. Unmatched values keep the base template.
+   * Country trimmed/lowercased against casing drift in imported CSV data, and whole-string so
+   * 'Hong Kong (SAR China)' doesn't match.
+   * Source half defers to isBackfillEventSource() for one source of truth; its ' \t\n\r' strip
+   * is narrower than trim() (see event.utils.spec.ts). Unmatched values keep the base template.
    */
   private requiresLfOpenSourceOverride(event: CertificateEventRow): boolean {
     const country = event.EVENT_COUNTRY?.trim().toLowerCase();

--- a/apps/lfx-one/src/server/services/certificate.service.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.ts
@@ -88,13 +88,14 @@ export class CertificateService {
   /**
    * Country trimmed/lowercased against casing drift in imported CSV data, and whole-string so
    * 'Hong Kong (SAR China)' doesn't match.
-   * Source half defers to isBackfillEventSource() for one source of truth; its ' \t\n\r' strip
-   * is narrower than trim() (see event.utils.spec.ts). Unmatched values keep the base template.
+   * Source half defers to isBackfillEventSource() for one source of truth, pre-trimmed here since
+   * its ' \t\n\r' strip (kept narrow for Snowflake SQL parity, see event.utils.ts) is too narrow
+   * for this JS-only comparison. Unmatched values keep the base template.
    */
   private requiresLfOpenSourceOverride(event: CertificateEventRow): boolean {
     const country = event.EVENT_COUNTRY?.trim().toLowerCase();
 
-    return isBackfillEventSource(event.EVENT_SOURCE) && country === LF_OPEN_SOURCE_OVERRIDE_MATCH.EVENT_COUNTRY.toLowerCase();
+    return isBackfillEventSource(event.EVENT_SOURCE?.trim()) && country === LF_OPEN_SOURCE_OVERRIDE_MATCH.EVENT_COUNTRY.toLowerCase();
   }
 
   private async getEventRow(req: Request, eventId: string, userEmail: string): Promise<CertificateEventRow> {

--- a/apps/lfx-one/src/server/services/certificate.service.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.ts
@@ -16,11 +16,11 @@ import { PDFTemplateDetails, CertificateData, CertificateEventRow } from '@lfx-o
 import {
   DEFAULT_LOGO_WIDTH,
   DEFAULT_TEMPLATE,
-  LF_OPEN_SOURCE_LOGO,
-  LF_OPEN_SOURCE_LOGO_MATCH,
-  LF_OPEN_SOURCE_LOGO_WIDTH,
+  LF_OPEN_SOURCE_OVERRIDE,
+  LF_OPEN_SOURCE_OVERRIDE_MATCH,
   PROJECT_TEMPLATES,
 } from '@lfx-one/shared/constants/pdf.constants';
+import { isBackfillEventSource } from '@lfx-one/shared/utils';
 
 // In production, import.meta.url points to the server bundle (dist/lfx-one/server/server.mjs)
 // and pdf-templates are copied there by the build script.
@@ -64,13 +64,13 @@ export class CertificateService {
 
     const baseTemplate = PROJECT_TEMPLATES[eventRow.PROJECT_ID] ?? DEFAULT_TEMPLATE;
 
-    // Legal requires the LF Open Source mark for China backfill events, whichever project owns
-    // them. Logo only — name, address, body copy and signature stay with the base template.
-    const isLfOpenSourceOverride = this.requiresLfOpenSourceLogo(eventRow);
-    const template = isLfOpenSourceOverride ? { ...baseTemplate, logo: LF_OPEN_SOURCE_LOGO, logoWidth: LF_OPEN_SOURCE_LOGO_WIDTH } : baseTemplate;
+    // Legal requires the full LF Open Source identity for China backfill events, whichever
+    // project owns them. Address and signature stay with the base template.
+    const isLfOpenSourceOverride = this.requiresLfOpenSourceOverride(eventRow);
+    const template = isLfOpenSourceOverride ? { ...baseTemplate, ...LF_OPEN_SOURCE_OVERRIDE } : baseTemplate;
 
     if (isLfOpenSourceOverride) {
-      logger.debug(req, 'generate_certificate', 'Applying LF Open Source logo override', {
+      logger.debug(req, 'generate_certificate', 'Applying LF Open Source identity override', {
         event_id: data.eventId,
         event_source: eventRow.EVENT_SOURCE,
         event_country: eventRow.EVENT_COUNTRY,
@@ -86,14 +86,15 @@ export class CertificateService {
   }
 
   /**
-   * Trimmed and lowercased so casing drift in imported CSV data doesn't skip the override, and
-   * whole-string so 'Hong Kong (SAR China)' doesn't match. Unmatched values keep the base logo.
+   * Country trimmed and lowercased so casing drift in imported CSV data doesn't skip the
+   * override, and whole-string so 'Hong Kong (SAR China)' doesn't match. The source half
+   * defers to isBackfillEventSource() so this stays in lockstep with the rest of the backfill
+   * handling. Unmatched values keep the base template.
    */
-  private requiresLfOpenSourceLogo(event: CertificateEventRow): boolean {
-    const source = event.EVENT_SOURCE?.trim().toLowerCase();
+  private requiresLfOpenSourceOverride(event: CertificateEventRow): boolean {
     const country = event.EVENT_COUNTRY?.trim().toLowerCase();
 
-    return source === LF_OPEN_SOURCE_LOGO_MATCH.EVENT_SOURCE.toLowerCase() && country === LF_OPEN_SOURCE_LOGO_MATCH.EVENT_COUNTRY.toLowerCase();
+    return isBackfillEventSource(event.EVENT_SOURCE) && country === LF_OPEN_SOURCE_OVERRIDE_MATCH.EVENT_COUNTRY.toLowerCase();
   }
 
   private async getEventRow(req: Request, eventId: string, userEmail: string): Promise<CertificateEventRow> {

--- a/packages/shared/src/constants/pdf.constants.ts
+++ b/packages/shared/src/constants/pdf.constants.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { EVENT_SOURCE_BACKFILL } from './events.constants';
 import { PDFTemplateDetails } from '../interfaces/events.interface';
 
 export const DEFAULT_TEMPLATE: PDFTemplateDetails = {
@@ -37,11 +36,11 @@ export const LF_OPEN_SOURCE_OVERRIDE: Pick<PDFTemplateDetails, 'link' | 'name' |
 };
 
 /**
- * Event source + country pair that triggers the LF Open Source override. EVENT_SOURCE
- * stands in for REGISTRATION_SOURCE, which the Platinum view does not expose — see GH-1695.
+ * Country that, paired with a backfill EVENT_SOURCE (see isBackfillEventSource), triggers the
+ * LF Open Source override. EVENT_SOURCE stands in for REGISTRATION_SOURCE, which the Platinum
+ * view does not expose — see GH-1695.
  */
 export const LF_OPEN_SOURCE_OVERRIDE_MATCH = {
-  EVENT_SOURCE: EVENT_SOURCE_BACKFILL,
   EVENT_COUNTRY: 'China',
 } as const;
 

--- a/packages/shared/src/constants/pdf.constants.ts
+++ b/packages/shared/src/constants/pdf.constants.ts
@@ -20,13 +20,15 @@ export const DEFAULT_LOGO_WIDTH = 145;
 /**
  * Full LF Open Source, LLC identity mandated by legal for attendance certificates on events
  * held in China that were imported through the CSV backfill flow. Overrides the
- * project/default template's link, name, description, on-behalf line, and logo — address and
- * signature stay with the base template. See GH-1695 (logo only) and GH-2039 (full identity).
+ * project/default template's link, name, description, on-behalf line, and logo. Address and
+ * signature deliberately stay with the base template — legal scoped the mandate to the entity
+ * named and linked in the letter, not to the signing officer or mailing address. See GH-1695
+ * (logo only) and GH-2039 (full identity).
  *
  * The 13.6:1 wordmark is illegible at DEFAULT_LOGO_WIDTH (~10pt tall); 240pt matches the
  * Linux Foundation icon's visual weight and clears the address block at x=408.
  */
-export const LF_OPEN_SOURCE_OVERRIDE: Pick<PDFTemplateDetails, 'link' | 'name' | 'desc' | 'onBehalf' | 'logo' | 'logoWidth'> = {
+export const LF_OPEN_SOURCE_OVERRIDE: Required<Pick<PDFTemplateDetails, 'link' | 'name' | 'desc' | 'onBehalf' | 'logo' | 'logoWidth'>> = {
   link: 'https://lfopensource.cn/',
   name: 'LF Open Source, LLC',
   desc: 'LF Open Source, LLC is a nonprofit consortium dedicated to fostering the growth of the Linux operating system. LF Open Source, LLC promotes, protects and standardizes Linux by providing unified resources and services. It is supported by its members — the leading IT companies such as IBM, Intel, Hewlett Packard, etc.',

--- a/packages/shared/src/constants/pdf.constants.ts
+++ b/packages/shared/src/constants/pdf.constants.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { EVENT_SOURCE_BACKFILL } from './events.constants';
 import { PDFTemplateDetails } from '../interfaces/events.interface';
 
 export const DEFAULT_TEMPLATE: PDFTemplateDetails = {
@@ -14,27 +15,33 @@ export const DEFAULT_TEMPLATE: PDFTemplateDetails = {
   signatureText: `Jim Zemlin\nExecutive Director`,
 };
 
-/**
- * Logo mandated by legal for events held in China that were imported through the CSV
- * backfill flow. Overrides the project/default letterhead logo — see GH-1695.
- */
-export const LF_OPEN_SOURCE_LOGO = 'lfopensource-logo.png';
-
 /** Logo width used by the letterhead when a template doesn't specify its own. */
 export const DEFAULT_LOGO_WIDTH = 145;
 
 /**
+ * Full LF Open Source, LLC identity mandated by legal for attendance certificates on events
+ * held in China that were imported through the CSV backfill flow. Overrides the
+ * project/default template's link, name, description, on-behalf line, and logo — address and
+ * signature stay with the base template. See GH-1695 (logo only) and GH-2039 (full identity).
+ *
  * The 13.6:1 wordmark is illegible at DEFAULT_LOGO_WIDTH (~10pt tall); 240pt matches the
  * Linux Foundation icon's visual weight and clears the address block at x=408.
  */
-export const LF_OPEN_SOURCE_LOGO_WIDTH = 240;
+export const LF_OPEN_SOURCE_OVERRIDE: Pick<PDFTemplateDetails, 'link' | 'name' | 'desc' | 'onBehalf' | 'logo' | 'logoWidth'> = {
+  link: 'https://lfopensource.cn/',
+  name: 'LF Open Source, LLC',
+  desc: 'LF Open Source, LLC is a nonprofit consortium dedicated to fostering the growth of the Linux operating system. LF Open Source, LLC promotes, protects and standardizes Linux by providing unified resources and services. It is supported by its members — the leading IT companies such as IBM, Intel, Hewlett Packard, etc.',
+  onBehalf: 'On behalf of LF Open Source, LLC, we are glad you were able to join us.',
+  logo: 'lfopensource-logo.png',
+  logoWidth: 240,
+};
 
 /**
- * Event source + country pair that triggers the LF Open Source logo override. EVENT_SOURCE
+ * Event source + country pair that triggers the LF Open Source override. EVENT_SOURCE
  * stands in for REGISTRATION_SOURCE, which the Platinum view does not expose — see GH-1695.
  */
-export const LF_OPEN_SOURCE_LOGO_MATCH = {
-  EVENT_SOURCE: 'backfill',
+export const LF_OPEN_SOURCE_OVERRIDE_MATCH = {
+  EVENT_SOURCE: EVENT_SOURCE_BACKFILL,
   EVENT_COUNTRY: 'China',
 } as const;
 

--- a/packages/shared/src/constants/pdf.constants.ts
+++ b/packages/shared/src/constants/pdf.constants.ts
@@ -28,7 +28,7 @@ export const DEFAULT_LOGO_WIDTH = 145;
  * The 13.6:1 wordmark is illegible at DEFAULT_LOGO_WIDTH (~10pt tall); 240pt matches the
  * Linux Foundation icon's visual weight and clears the address block at x=408.
  */
-export const LF_OPEN_SOURCE_OVERRIDE: Required<Pick<PDFTemplateDetails, 'link' | 'name' | 'desc' | 'onBehalf' | 'logo' | 'logoWidth'>> = {
+export const LF_OPEN_SOURCE_OVERRIDE: Required<Omit<PDFTemplateDetails, 'address' | 'signature' | 'signatureText'>> = {
   link: 'https://lfopensource.cn/',
   name: 'LF Open Source, LLC',
   desc: 'LF Open Source, LLC is a nonprofit consortium dedicated to fostering the growth of the Linux operating system. LF Open Source, LLC promotes, protects and standardizes Linux by providing unified resources and services. It is supported by its members — the leading IT companies such as IBM, Intel, Hewlett Packard, etc.',

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -19,6 +19,10 @@ import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
  * Consequence: a source value padded with one of those exotic characters matches on neither side,
  * so the row falls to the `ELSE` branch and keeps the stored IS_PAST_EVENT — the pre-fix behaviour,
  * which is the safe direction to fail in.
+ *
+ * This parity requirement only binds callers mirroring isPastEventSql() against Snowflake. A
+ * JS-only caller (no SQL counterpart) may pre-trim with String.prototype.trim() before calling —
+ * see certificate.service.ts's requiresLfOpenSourceOverride() for a documented example.
  */
 export function isBackfillEventSource(source: string | null | undefined): boolean {
   return source?.replace(/^[ \t\n\r]+|[ \t\n\r]+$/g, '').toLowerCase() === EVENT_SOURCE_BACKFILL;

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -21,8 +21,7 @@ import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
  * which is the safe direction to fail in.
  *
  * This parity requirement only binds callers mirroring isPastEventSql() against Snowflake. A
- * JS-only caller (no SQL counterpart) may pre-trim with String.prototype.trim() before calling —
- * see certificate.service.ts's requiresLfOpenSourceOverride() for a documented example.
+ * JS-only caller (no SQL counterpart) may pre-trim with String.prototype.trim() before calling.
  */
 export function isBackfillEventSource(source: string | null | undefined): boolean {
   return source?.replace(/^[ \t\n\r]+|[ \t\n\r]+$/g, '').toLowerCase() === EVENT_SOURCE_BACKFILL;


### PR DESCRIPTION
## Summary

- Widens the existing China-backfill certificate override (previously logo-only, from #1695) to also override the link, entity name, description paragraph, and "on behalf of" sentence with LF Open Source, LLC content.
- Address and signature block deliberately stay with the base project/default template — legal scoped the mandate to the entity named and linked in the letter, not the signing officer or mailing address.
- Consolidates the source-match check onto the shared `isBackfillEventSource()` util for one source of truth with `isPastEventSql()`.

Fixes #2039