### PR TITLE
feat(meetings): add reconciliation fields to past-meeting participant type

### DIFF
--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -934,6 +934,16 @@ export interface PastMeetingParticipant {
   is_attended: boolean;
   /** Whether participant was invited to the meeting */
   is_invited: boolean;
+  /** Whether the attendee record has been verified (attendee only) */
+  is_verified?: boolean;
+  /** Whether the attendee record was last updated via AI reconciliation (attendee only) */
+  is_ai_reconciled?: boolean;
+  /** Whether the attendee was automatically matched to an invitee by name (attendee only) */
+  is_auto_matched?: boolean;
+  /** Zoom display name of the attendee (attendee only) */
+  zoom_user_name?: string;
+  /** Full name of the invitee the attendee was matched to (attendee only) */
+  mapped_invitee_name?: string;
   /** LF membership status */
   org_is_member: boolean;
   /** Project membership status */


### PR DESCRIPTION
## Summary
- Adds `is_verified`, `is_ai_reconciled`, `is_auto_matched`, `zoom_user_name`, and `mapped_invitee_name` (all optional) to `PastMeetingParticipant` in `packages/shared/src/interfaces/meeting.interface.ts`, so `EnrichedPastMeetingParticipant` inherits them too.
- Type-only change — no runtime behavior differs. The query-service response already passes these fields through opaquely (`getPastMeetingParticipants` in `apps/lfx-one/src/server/services/meeting.service.ts` fetches via `/query/resources` and returns the raw JSON), this just makes them type-safe for downstream consumers once the index actually carries them.

## Ticket
Part of linuxfoundation/lfx-self-serve#1672 (first of a 5-item plan: shared types → dedup fix → BFF write routes → AI matching → three-tab admin review UI). This PR covers only item 1 (shared types); the rest will land as separate PRs per this repo's diff-size convention.

## Changes
- `packages/shared/src/interfaces/meeting.interface.ts`: added the 5 reconciliation fields to `PastMeetingParticipant`.

## Related work
- Upstream field support (read + write) added in `lfx-v2-meeting-service`:
  - https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/266 (`is_verified` search-index propagation)
  - https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/267 (`AttendeeResponse`/`CreateAttendeeRequest`/`UpdateAttendeeRequest` carry `is_ai_reconciled`, `is_auto_matched`, `zoom_user_name`, `mapped_invitee_name`)
  - Both must deploy (and the search index reindex) before these fields are populated in production; this PR is safe to merge independently since the fields are optional.

## Test plan
- [x] `yarn check-types` passes
- [x] `./check-headers.sh` passes
- [x] Reviewer trio (`lfx-general-code-reviewer`, `lfx-self-serve-code-reviewer`, `lfx-self-serve-learnings-reviewer`) ran post-commit — all three returned clean, zero findings