### PR TITLE
fix(meetings): dedupe past-meeting participants by pairwise identity

### DIFF
--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -746,6 +746,7 @@ describe('MeetingService.getPastMeetingParticipants', () => {
     expect(result).toHaveLength(1);
     expect(result[0].is_invited).toBe(true);
     expect(result[0].is_attended).toBe(true);
+    expect(result[0].email).toBe('jane@example.com');
   });
 
   it('does not merge two records with the same email but different usernames', async () => {
@@ -867,19 +868,48 @@ describe('MeetingService.getPastMeetingParticipants', () => {
     expect(result).toHaveLength(1);
   });
 
-  it('refuses to bridge two conflicting LFID usernames through a shared-email no-username record', async () => {
+  it('isolates an ambiguous shared-email bridge record rather than guessing which of two conflicting LFID usernames it belongs to', async () => {
+    const resources = [
+      participantRecord('a', { username: 'user-a', email: 'shared@example.com', is_attended: true }),
+      participantRecord('b', { username: undefined, email: 'shared@example.com', is_attended: true, host: true }),
+      participantRecord('c', { username: 'user-b', email: 'shared@example.com' }),
+    ];
+
+    proxyRequest.mockResolvedValueOnce({ resources });
+    const forward = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    proxyRequest.mockResolvedValueOnce({ resources: [...resources].reverse() });
+    const reversed = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    for (const result of [forward, reversed]) {
+      expect(result).toHaveLength(3);
+      expect(result.map((p) => p.username).sort()).toEqual([undefined, 'user-a', 'user-b'].sort());
+
+      // The ambiguous bridge record's own attendance/host flags must not bleed into either
+      // conflicting username's group, regardless of encounter order.
+      const bridgeRecord = result.find((p) => !p.username);
+      const userA = result.find((p) => p.username === 'user-a');
+      const userB = result.find((p) => p.username === 'user-b');
+      expect(bridgeRecord?.is_attended).toBe(true);
+      expect(bridgeRecord?.host).toBe(true);
+      expect(userA?.host).toBe(false);
+      expect(userB?.is_attended).toBe(false);
+    }
+  });
+
+  it('refuses to bridge two conflicting guest emails through a shared-name no-email record', async () => {
     proxyRequest.mockResolvedValueOnce({
       resources: [
-        participantRecord('a', { username: 'user-a', email: 'shared@example.com' }),
-        participantRecord('b', { username: undefined, email: 'shared@example.com' }),
-        participantRecord('c', { username: 'user-b', email: 'shared@example.com' }),
+        participantRecord('a', { email: 'guest-one@example.com', first_name: 'Sam', last_name: 'Guest' }),
+        participantRecord('b', { email: undefined, first_name: 'Sam', last_name: 'Guest' }),
+        participantRecord('c', { email: 'guest-two@example.com', first_name: 'Sam', last_name: 'Guest' }),
       ],
     });
 
     const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
 
-    expect(result).toHaveLength(2);
-    expect(result.map((p) => p.username).sort()).toEqual(['user-a', 'user-b']);
+    expect(result).toHaveLength(3);
+    expect(result.map((p) => p.email).sort()).toEqual(['guest-one@example.com', 'guest-two@example.com', undefined].sort());
   });
 
   it('does not let a blank-string email sentinel on the preferred record discard a real email on merge', async () => {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -18,6 +18,11 @@ vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
 vi.mock('@lfx-one/shared/utils', () => ({
   buildRecurrenceNeverEndDate: vi.fn(),
   getPastMeetingTranscriptUrl: vi.fn(),
+  isUnresolvableParticipantName: vi.fn((first?: string | null, last?: string | null) => {
+    const tokens = [first, last].map((token) => (token ?? '').trim().toLowerCase());
+    const meaningful = tokens.filter((token) => token && token !== 'unknown' && token !== '[unknown]');
+    return meaningful.length === 0;
+  }),
   mapITXResponseToMeetingRsvp: vi.fn(),
   normalizeIndexedMeetingAiSummary: vi.fn((meeting) => meeting),
   normalizeIndexedMeetingInviteResponses: vi.fn((meeting) => meeting),
@@ -803,5 +808,58 @@ describe('MeetingService.getPastMeetingParticipants', () => {
     const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
 
     expect(result).toHaveLength(2);
+  });
+
+  it('does not merge two unnamed records with no email or username to fall back on', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { first_name: undefined, last_name: undefined }),
+        participantRecord('b', { first_name: undefined, last_name: undefined }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not merge two records with placeholder "[unknown]" names', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { first_name: '[unknown]', last_name: '[unknown]' }),
+        participantRecord('b', { first_name: '[unknown]', last_name: '[unknown]' }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('merges on matching name when only one side has an email', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { email: 'jane@example.com', first_name: 'Jane', last_name: 'Doe' }),
+        participantRecord('b', { first_name: 'Jane', last_name: 'Doe' }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('coalesces three records into one person via a bridging record, regardless of encounter order', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { email: 'shared@example.com', username: undefined }),
+        participantRecord('b', { email: 'other@example.com', username: 'jdoe' }),
+        participantRecord('c', { email: 'shared@example.com', username: 'jdoe' }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -695,3 +695,113 @@ describe('MeetingService.getAuthorizedRegistrantsForImport', () => {
     expect(query.page_size).toBe(51);
   });
 });
+
+describe('MeetingService.getPastMeetingParticipants', () => {
+  let service: MeetingService;
+
+  const participantRecord = (id: string, overrides: Record<string, unknown> = {}) => ({
+    id: `v1_past_meeting_participant:${id}`,
+    data: {
+      uid: id,
+      meeting_id: 'meeting-1',
+      meeting_and_occurrence_id: 'meeting-1-occ-1',
+      past_meeting_id: 'past-1',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      host: false,
+      is_attended: false,
+      is_invited: true,
+      org_is_member: false,
+      org_is_project_member: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    },
+  });
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('merges two records sharing the same LFID username, even with different emails', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { email: 'jane@example.com', username: 'jdoe', is_invited: true, is_attended: false }),
+        participantRecord('b', { email: 'jane.alt@example.com', username: 'jdoe', is_invited: false, is_attended: true }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].is_invited).toBe(true);
+    expect(result[0].is_attended).toBe(true);
+  });
+
+  it('does not merge two records with the same email but different usernames', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { email: 'shared@example.com', username: 'user-a' }),
+        participantRecord('b', { email: 'shared@example.com', username: 'user-b' }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('merges by email when neither record has a username', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [participantRecord('a', { email: 'guest@example.com' }), participantRecord('b', { email: 'GUEST@example.com' })],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('merges on matching email even when only one side has a username — email is checked before the username-asymmetry fallback', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [participantRecord('a', { email: 'guest@example.com', username: 'jdoe' }), participantRecord('b', { email: 'guest@example.com' })],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('does not merge asymmetric-username records when neither has an email to fall back on', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { username: 'jdoe', first_name: 'Jane', last_name: 'Doe' }),
+        participantRecord('b', { first_name: 'Jane', last_name: 'Doe' }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('falls back to normalized display name when neither username nor email is present', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [participantRecord('a', { first_name: 'Jane', last_name: 'Doe' }), participantRecord('b', { first_name: 'jane', last_name: 'doe' })],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('does not merge different people who share no identity signal at all', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [participantRecord('a', { first_name: 'Jane', last_name: 'Doe' }), participantRecord('b', { first_name: 'John', last_name: 'Smith' })],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(2);
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -18,6 +18,10 @@ vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
 vi.mock('@lfx-one/shared/utils', () => ({
   buildRecurrenceNeverEndDate: vi.fn(),
   getPastMeetingTranscriptUrl: vi.fn(),
+  // Intentionally a light behavioral double, not a frozen copy meant to track the real predicate:
+  // it only needs to exercise the placeholder-vs-blank branch in this file's dedup tests. The
+  // predicate's own placeholder-token coverage lives in meeting.utils.spec.ts — a future token
+  // added there won't be reflected here, but that's the authoritative test for this behavior.
   isUnresolvableParticipantName: vi.fn((first?: string | null, last?: string | null) => {
     const tokens = [first, last].map((token) => (token ?? '').trim().toLowerCase());
     const meaningful = tokens.filter((token) => token && token !== 'unknown' && token !== '[unknown]');
@@ -861,5 +865,34 @@ describe('MeetingService.getPastMeetingParticipants', () => {
     const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
 
     expect(result).toHaveLength(1);
+  });
+
+  it('refuses to bridge two conflicting LFID usernames through a shared-email no-username record', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { username: 'user-a', email: 'shared@example.com' }),
+        participantRecord('b', { username: undefined, email: 'shared@example.com' }),
+        participantRecord('c', { username: 'user-b', email: 'shared@example.com' }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.username).sort()).toEqual(['user-a', 'user-b']);
+  });
+
+  it('does not let a blank-string email sentinel on the preferred record discard a real email on merge', async () => {
+    proxyRequest.mockResolvedValueOnce({
+      resources: [
+        participantRecord('a', { email: '', first_name: 'Jane', last_name: 'Doe', is_attended: true }),
+        participantRecord('b', { email: 'jane@example.com', first_name: 'Jane', last_name: 'Doe', is_attended: false }),
+      ],
+    });
+
+    const result = await service.getPastMeetingParticipants(req, 'meeting-1-occ-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].email).toBe('jane@example.com');
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -981,8 +981,16 @@ export class MeetingService {
       })
     );
 
+    // Union-find over connected identity-match edges. `rootUsername` tracks the resolved LFID
+    // username for each component's current root, since a merge must be refused (not just
+    // skipped) once known: isSamePerson is not transitive — a no-username row can share an email
+    // with two records that carry different, conflicting usernames, and unioning through it would
+    // incorrectly merge two distinct LFX accounts into one participant.
     const parent = raw.map((_, index) => index);
+    const rootUsername = raw.map((participant) => participant.username || undefined);
     const find = (index: number): number => {
+      // Path halving: reparent every other node to its grandparent so later find() calls stay
+      // near O(1) amortized. This mutates `parent` even on a plain lookup.
       while (parent[index] !== index) {
         parent[index] = parent[parent[index]];
         index = parent[index];
@@ -992,13 +1000,24 @@ export class MeetingService {
 
     for (let i = 0; i < raw.length; i++) {
       for (let j = i + 1; j < raw.length; j++) {
-        if (this.isSamePerson(raw[i], raw[j])) {
-          const rootI = find(i);
-          const rootJ = find(j);
-          if (rootI !== rootJ) {
-            parent[rootI] = rootJ;
-          }
+        if (!this.isSamePerson(raw[i], raw[j])) {
+          continue;
         }
+
+        const rootI = find(i);
+        const rootJ = find(j);
+        if (rootI === rootJ) {
+          continue;
+        }
+
+        const usernameI = rootUsername[rootI];
+        const usernameJ = rootUsername[rootJ];
+        if (usernameI && usernameJ && usernameI !== usernameJ) {
+          continue;
+        }
+
+        parent[rootI] = rootJ;
+        rootUsername[rootJ] = usernameI ?? usernameJ;
       }
     }
 
@@ -1957,6 +1976,9 @@ export class MeetingService {
    * one — an asymmetric email (one record has it, the other doesn't) falls through to the
    * username-asymmetry guard and then the name fallback, so the common case of a partially-enriched
    * duplicate (same person, one record still missing an email) can still merge on matching names.
+   * The name-only fallback is an accepted PCC-parity tradeoff: two distinct guests who share a
+   * display name and have no email/username on any record will be merged. Callers needing a
+   * stronger guarantee should require a corroborating signal before relying on this path.
    */
   private isSamePerson(a: PastMeetingParticipant, b: PastMeetingParticipant): boolean {
     if (a.username && b.username) {
@@ -1992,6 +2014,15 @@ export class MeetingService {
     return `${first ?? ''} ${last ?? ''}`.trim().toLowerCase();
   }
 
+  /**
+   * Prefers a non-blank string value, treating whitespace-only strings the same as missing.
+   * Matches `isSamePerson`'s own email normalization — some upstream records carry `''` as an
+   * "empty" sentinel rather than omitting the field, and `??` alone would treat that as present.
+   */
+  private pickNonBlank<T extends string | undefined>(preferred: T, fallback: T): T {
+    return preferred?.trim() ? preferred : fallback;
+  }
+
   /** Folds a connected group of identity-matched participant records into one merged record. */
   private mergePastMeetingParticipantGroup(group: PastMeetingParticipant[]): PastMeetingParticipant {
     return group.reduce((merged, participant) => {
@@ -2004,11 +2035,11 @@ export class MeetingService {
         host: merged.host || participant.host,
         org_is_member: merged.org_is_member || participant.org_is_member,
         org_is_project_member: merged.org_is_project_member || participant.org_is_project_member,
-        avatar_url: preferred.avatar_url ?? other.avatar_url,
-        job_title: preferred.job_title ?? other.job_title,
-        org_name: preferred.org_name ?? other.org_name,
-        username: preferred.username ?? other.username,
-        email: preferred.email ?? other.email,
+        avatar_url: this.pickNonBlank(preferred.avatar_url, other.avatar_url),
+        job_title: this.pickNonBlank(preferred.job_title, other.job_title),
+        org_name: this.pickNonBlank(preferred.org_name, other.org_name),
+        username: this.pickNonBlank(preferred.username, other.username),
+        email: this.pickNonBlank(preferred.email, other.email),
       };
     });
   }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -41,6 +41,7 @@ import {
 import {
   buildRecurrenceNeverEndDate,
   getPastMeetingTranscriptUrl,
+  isUnresolvableParticipantName,
   mapITXResponseToMeetingRsvp,
   normalizeIndexedMeetingAiSummary,
   normalizeIndexedMeetingInviteResponses,
@@ -955,9 +956,13 @@ export class MeetingService {
 
   /**
    * Fetches past meeting participants by past meeting UID.
-   * Deduplicates by pairwise identity match — the query service can emit multiple records per
-   * person, and a single derived key (e.g. prefer email, else uid) can't correctly merge two
-   * records whose strongest available signal differs (one has a username, the other only an email).
+   * Deduplicates by pairwise identity match, grouped via connected components — the query service
+   * can emit multiple records per person, and a single derived key (e.g. prefer email, else uid)
+   * can't correctly merge two records whose strongest available signal differs (one has a username,
+   * the other only an email). Connected components (rather than a single left-to-right pass) are
+   * required because merging is not a simple equivalence check: record A may only match record C
+   * through a "bridge" record B (e.g. A and B share an email, B and C share a username), and a
+   * one-pass merge would miss that A and C belong to the same person depending on encounter order.
    */
   public async getPastMeetingParticipants(req: Request, pastMeetingUid: string): Promise<PastMeetingParticipant[]> {
     logger.debug(req, 'get_past_meeting_participants', 'Fetching past meeting participants', {
@@ -976,32 +981,39 @@ export class MeetingService {
       })
     );
 
-    const merged: PastMeetingParticipant[] = [];
-    for (const participant of raw) {
-      const existingIndex = merged.findIndex((candidate) => this.isSamePerson(candidate, participant));
-      if (existingIndex === -1) {
-        merged.push(participant);
-        continue;
+    const parent = raw.map((_, index) => index);
+    const find = (index: number): number => {
+      while (parent[index] !== index) {
+        parent[index] = parent[parent[index]];
+        index = parent[index];
       }
-      const existing = merged[existingIndex];
-      const preferred = participant.is_attended && !existing.is_attended ? participant : existing;
-      const other = preferred === participant ? existing : participant;
-      merged[existingIndex] = {
-        ...preferred,
-        is_attended: existing.is_attended || participant.is_attended,
-        is_invited: existing.is_invited || participant.is_invited,
-        host: existing.host || participant.host,
-        org_is_member: existing.org_is_member || participant.org_is_member,
-        org_is_project_member: existing.org_is_project_member || participant.org_is_project_member,
-        avatar_url: preferred.avatar_url ?? other.avatar_url,
-        job_title: preferred.job_title ?? other.job_title,
-        org_name: preferred.org_name ?? other.org_name,
-        username: preferred.username ?? other.username,
-        email: preferred.email ?? other.email,
-      };
+      return index;
+    };
+
+    for (let i = 0; i < raw.length; i++) {
+      for (let j = i + 1; j < raw.length; j++) {
+        if (this.isSamePerson(raw[i], raw[j])) {
+          const rootI = find(i);
+          const rootJ = find(j);
+          if (rootI !== rootJ) {
+            parent[rootI] = rootJ;
+          }
+        }
+      }
     }
 
-    return merged;
+    const groups = new Map<number, PastMeetingParticipant[]>();
+    raw.forEach((participant, index) => {
+      const root = find(index);
+      const group = groups.get(root);
+      if (group) {
+        group.push(participant);
+      } else {
+        groups.set(root, [participant]);
+      }
+    });
+
+    return Array.from(groups.values()).map((group) => this.mergePastMeetingParticipantGroup(group));
   }
 
   /**
@@ -1939,9 +1951,12 @@ export class MeetingService {
 
   /**
    * Compares two participant records for identity equality: prefer LFID username when both have
-   * one, else overlapping email, else normalized display name. A single derived key can't do this
-   * since which signal is "strongest" differs per record (e.g. a guest who later links an LFX
-   * account on a subsequent occurrence).
+   * one, else overlapping email when both have one, else normalized display name. A single derived
+   * key can't do this since which signal is "strongest" differs per record (e.g. a guest who later
+   * links an LFX account on a subsequent occurrence). Email is only decisive when BOTH records have
+   * one — an asymmetric email (one record has it, the other doesn't) falls through to the
+   * username-asymmetry guard and then the name fallback, so the common case of a partially-enriched
+   * duplicate (same person, one record still missing an email) can still merge on matching names.
    */
   private isSamePerson(a: PastMeetingParticipant, b: PastMeetingParticipant): boolean {
     if (a.username && b.username) {
@@ -1950,8 +1965,8 @@ export class MeetingService {
 
     const aEmail = a.email?.trim().toLowerCase();
     const bEmail = b.email?.trim().toLowerCase();
-    if (aEmail || bEmail) {
-      return !!aEmail && aEmail === bEmail;
+    if (aEmail && bEmail) {
+      return aEmail === bEmail;
     }
 
     if (a.username || b.username) {
@@ -1963,13 +1978,38 @@ export class MeetingService {
     return !!aName && aName === bName;
   }
 
-  /** Normalized display name for identity comparison. Empty when both name parts are missing, so two unnamed participants never match. */
+  /**
+   * Normalized display name for identity comparison. Empty when both name parts are missing, or
+   * when the name is an unresolvable placeholder (e.g. "unknown" / "[unknown]") that upstream emits
+   * for unidentified Zoom/dial-in rows, so two such rows never falsely merge into one person.
+   */
   private normalizeParticipantName(participant: PastMeetingParticipant): string {
-    const first = participant.first_name?.trim();
-    const last = participant.last_name?.trim();
-    if (!first && !last) {
+    if (isUnresolvableParticipantName(participant.first_name, participant.last_name)) {
       return '';
     }
+    const first = participant.first_name?.trim();
+    const last = participant.last_name?.trim();
     return `${first ?? ''} ${last ?? ''}`.trim().toLowerCase();
+  }
+
+  /** Folds a connected group of identity-matched participant records into one merged record. */
+  private mergePastMeetingParticipantGroup(group: PastMeetingParticipant[]): PastMeetingParticipant {
+    return group.reduce((merged, participant) => {
+      const preferred = participant.is_attended && !merged.is_attended ? participant : merged;
+      const other = preferred === participant ? merged : participant;
+      return {
+        ...preferred,
+        is_attended: merged.is_attended || participant.is_attended,
+        is_invited: merged.is_invited || participant.is_invited,
+        host: merged.host || participant.host,
+        org_is_member: merged.org_is_member || participant.org_is_member,
+        org_is_project_member: merged.org_is_project_member || participant.org_is_project_member,
+        avatar_url: preferred.avatar_url ?? other.avatar_url,
+        job_title: preferred.job_title ?? other.job_title,
+        org_name: preferred.org_name ?? other.org_name,
+        username: preferred.username ?? other.username,
+        email: preferred.email ?? other.email,
+      };
+    });
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -955,7 +955,9 @@ export class MeetingService {
 
   /**
    * Fetches past meeting participants by past meeting UID.
-   * Deduplicates by email — the query service can emit multiple records per person.
+   * Deduplicates by pairwise identity match — the query service can emit multiple records per
+   * person, and a single derived key (e.g. prefer email, else uid) can't correctly merge two
+   * records whose strongest available signal differs (one has a username, the other only an email).
    */
   public async getPastMeetingParticipants(req: Request, pastMeetingUid: string): Promise<PastMeetingParticipant[]> {
     logger.debug(req, 'get_past_meeting_participants', 'Fetching past meeting participants', {
@@ -974,18 +976,17 @@ export class MeetingService {
       })
     );
 
-    const seen = new Map<string, PastMeetingParticipant>();
+    const merged: PastMeetingParticipant[] = [];
     for (const participant of raw) {
-      const normalizedEmail = participant.email?.trim().toLowerCase();
-      const key = normalizedEmail || participant.uid;
-      const existing = seen.get(key);
-      if (!existing) {
-        seen.set(key, participant);
+      const existingIndex = merged.findIndex((candidate) => this.isSamePerson(candidate, participant));
+      if (existingIndex === -1) {
+        merged.push(participant);
         continue;
       }
+      const existing = merged[existingIndex];
       const preferred = participant.is_attended && !existing.is_attended ? participant : existing;
       const other = preferred === participant ? existing : participant;
-      seen.set(key, {
+      merged[existingIndex] = {
         ...preferred,
         is_attended: existing.is_attended || participant.is_attended,
         is_invited: existing.is_invited || participant.is_invited,
@@ -996,10 +997,10 @@ export class MeetingService {
         job_title: preferred.job_title ?? other.job_title,
         org_name: preferred.org_name ?? other.org_name,
         username: preferred.username ?? other.username,
-      });
+      };
     }
 
-    return [...seen.values()];
+    return merged;
   }
 
   /**
@@ -1933,5 +1934,36 @@ export class MeetingService {
       recurrence_type: recurrence.type,
     });
     return { ...recurrence, end_date_time: neverEndDate };
+  }
+
+  /**
+   * Compares two participant records for identity equality: prefer LFID username when both have
+   * one, else overlapping email, else normalized display name. A single derived key can't do this
+   * since which signal is "strongest" differs per record (e.g. a guest who later links an LFX
+   * account on a subsequent occurrence).
+   */
+  private isSamePerson(a: PastMeetingParticipant, b: PastMeetingParticipant): boolean {
+    if (a.username && b.username) {
+      return a.username === b.username;
+    }
+
+    const aEmail = a.email?.trim().toLowerCase();
+    const bEmail = b.email?.trim().toLowerCase();
+    if (aEmail || bEmail) {
+      return !!aEmail && aEmail === bEmail;
+    }
+
+    if (a.username || b.username) {
+      return false;
+    }
+
+    const aName = this.normalizeParticipantName(a);
+    const bName = this.normalizeParticipantName(b);
+    return !!aName && aName === bName;
+  }
+
+  /** Normalized display name for identity comparison. */
+  private normalizeParticipantName(participant: PastMeetingParticipant): string {
+    return `${participant.first_name} ${participant.last_name}`.trim().toLowerCase();
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -997,6 +997,7 @@ export class MeetingService {
         job_title: preferred.job_title ?? other.job_title,
         org_name: preferred.org_name ?? other.org_name,
         username: preferred.username ?? other.username,
+        email: preferred.email ?? other.email,
       };
     }
 
@@ -1962,8 +1963,13 @@ export class MeetingService {
     return !!aName && aName === bName;
   }
 
-  /** Normalized display name for identity comparison. */
+  /** Normalized display name for identity comparison. Empty when both name parts are missing, so two unnamed participants never match. */
   private normalizeParticipantName(participant: PastMeetingParticipant): string {
-    return `${participant.first_name} ${participant.last_name}`.trim().toLowerCase();
+    const first = participant.first_name?.trim();
+    const last = participant.last_name?.trim();
+    if (!first && !last) {
+      return '';
+    }
+    return `${first ?? ''} ${last ?? ''}`.trim().toLowerCase();
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -981,13 +981,12 @@ export class MeetingService {
       })
     );
 
-    // Union-find over connected identity-match edges. `rootUsername` tracks the resolved LFID
-    // username for each component's current root, since a merge must be refused (not just
-    // skipped) once known: isSamePerson is not transitive — a no-username row can share an email
-    // with two records that carry different, conflicting usernames, and unioning through it would
-    // incorrectly merge two distinct LFX accounts into one participant.
+    // Plain union-find over connected identity-match edges (pure transitive closure, no
+    // conflict veto during union). isSamePerson is not transitive — a no-username row can
+    // share an email with two records that carry different, conflicting usernames — so a
+    // component can chain together records that never agree pairwise. Conflicts are detected
+    // and split out afterward, per component, in splitConflictingComponent.
     const parent = raw.map((_, index) => index);
-    const rootUsername = raw.map((participant) => participant.username || undefined);
     const find = (index: number): number => {
       // Path halving: reparent every other node to its grandparent so later find() calls stay
       // near O(1) amortized. This mutates `parent` even on a plain lookup.
@@ -1003,36 +1002,27 @@ export class MeetingService {
         if (!this.isSamePerson(raw[i], raw[j])) {
           continue;
         }
-
         const rootI = find(i);
         const rootJ = find(j);
-        if (rootI === rootJ) {
-          continue;
+        if (rootI !== rootJ) {
+          parent[rootI] = rootJ;
         }
-
-        const usernameI = rootUsername[rootI];
-        const usernameJ = rootUsername[rootJ];
-        if (usernameI && usernameJ && usernameI !== usernameJ) {
-          continue;
-        }
-
-        parent[rootI] = rootJ;
-        rootUsername[rootJ] = usernameI ?? usernameJ;
       }
     }
 
-    const groups = new Map<number, PastMeetingParticipant[]>();
+    const components = new Map<number, PastMeetingParticipant[]>();
     raw.forEach((participant, index) => {
       const root = find(index);
-      const group = groups.get(root);
-      if (group) {
-        group.push(participant);
+      const component = components.get(root);
+      if (component) {
+        component.push(participant);
       } else {
-        groups.set(root, [participant]);
+        components.set(root, [participant]);
       }
     });
 
-    return Array.from(groups.values()).map((group) => this.mergePastMeetingParticipantGroup(group));
+    const groups = Array.from(components.values()).flatMap((component) => this.splitConflictingComponent(component));
+    return groups.map((group) => this.mergePastMeetingParticipantGroup(group));
   }
 
   /**
@@ -1980,6 +1970,50 @@ export class MeetingService {
    * display name and have no email/username on any record will be merged. Callers needing a
    * stronger guarantee should require a corroborating signal before relying on this path.
    */
+  /**
+   * Splits a connected component of identity-matched records into safe merge groups. Pure
+   * transitive closure can chain records that never agree pairwise — e.g. a no-username row
+   * shares an email with two records that carry different, conflicting usernames — and blindly
+   * attaching that bridge row to whichever side it happens to reach first would misattribute its
+   * own attendance/host data depending on scan order. Instead, once a component has 2+ distinct
+   * hard identifiers (usernames, or emails among the username-less members), it's split by that
+   * identifier and any row lacking it is isolated as its own group rather than guessed into one
+   * side — matching the reviewer-suggested resolution of leaving an ambiguous row separate.
+   */
+  private splitConflictingComponent(members: PastMeetingParticipant[]): PastMeetingParticipant[][] {
+    const usernames = new Set(members.map((m) => m.username).filter((u): u is string => !!u));
+    const usernameConflict = usernames.size > 1;
+
+    const usernameless = members.filter((m) => !m.username);
+    const usernamelessEmails = new Set(usernameless.map((m) => m.email?.trim().toLowerCase()).filter((e): e is string => !!e));
+    const emailConflict = !usernameConflict && usernamelessEmails.size > 1;
+
+    if (!usernameConflict && !emailConflict) {
+      return [members];
+    }
+
+    const groupKey = (member: PastMeetingParticipant): string | undefined =>
+      usernameConflict ? member.username || undefined : member.email?.trim().toLowerCase() || undefined;
+
+    const byKey = new Map<string, PastMeetingParticipant[]>();
+    const floaters: PastMeetingParticipant[] = [];
+    for (const member of members) {
+      const key = groupKey(member);
+      if (!key) {
+        floaters.push(member);
+        continue;
+      }
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.push(member);
+      } else {
+        byKey.set(key, [member]);
+      }
+    }
+
+    return [...Array.from(byKey.values()), ...floaters.map((floater) => [floater])];
+  }
+
   private isSamePerson(a: PastMeetingParticipant, b: PastMeetingParticipant): boolean {
     if (a.username && b.username) {
       return a.username === b.username;
@@ -2025,7 +2059,7 @@ export class MeetingService {
 
   /** Folds a connected group of identity-matched participant records into one merged record. */
   private mergePastMeetingParticipantGroup(group: PastMeetingParticipant[]): PastMeetingParticipant {
-    return group.reduce((merged, participant) => {
+    const merged = group.reduce((merged, participant) => {
       const preferred = participant.is_attended && !merged.is_attended ? participant : merged;
       const other = preferred === participant ? merged : participant;
       return {
@@ -2042,5 +2076,23 @@ export class MeetingService {
         email: this.pickNonBlank(preferred.email, other.email),
       };
     });
+
+    return { ...merged, email: this.pickMergedEmail(group) ?? merged.email };
+  }
+
+  /**
+   * Prefers the invited/account email over an ad-hoc attended-session email when a merged group
+   * carries two different, both non-blank, emails (e.g. records that match on a shared LFID
+   * username but disagree on email). `mergePastMeetingParticipantGroup`'s attended-first
+   * preference would otherwise silently discard the invited email even though downstream
+   * committee-enrichment lookups join on `participant.email` against the invited/account address,
+   * not whatever ad-hoc address Zoom captured for that session.
+   */
+  private pickMergedEmail(group: PastMeetingParticipant[]): string | undefined {
+    const invitedEmail = group.find((participant) => participant.is_invited && participant.email?.trim())?.email;
+    if (invitedEmail) {
+      return invitedEmail;
+    }
+    return group.find((participant) => participant.email?.trim())?.email;
   }
 }


### PR DESCRIPTION
## Summary

- `getPastMeetingParticipants` deduplicated past-meeting participant records from the query service using a single derived key (normalized email, else `uid`). A person who attends under a second LFX account, or whose email is missing on one record but present on another, could not be merged by any single key — since which signal is "strongest" differs per record.
- Replaces the single-key merge with a pairwise `isSamePerson` identity comparator: match on LFID `username` when both records have one, else overlapping email, else normalized display name.
- Mirrors the identity-comparison fix shipped for the same class of bug in `lfx-pcc` PR #3738 (`isSamePerson`), adapted for this repo's `PastMeetingParticipant` type, which has no `lf_user_id`/`lf_sso` field — `username` (LFID username) plays that role here.
- Follow-up commit hardens the merge (`email` is now carried forward the same way `username` already was) and guards the name-fallback against missing `first_name`/`last_name` so two unnamed participants never falsely match on `"undefined undefined"`.

## Changes

- `apps/lfx-one/src/server/services/meeting.service.ts`: replace single-key `Map`-based dedup with pairwise `isSamePerson`/`normalizeParticipantName` comparison in `getPastMeetingParticipants`.
- `apps/lfx-one/src/server/services/meeting.service.spec.ts`: add unit coverage for `getPastMeetingParticipants` — username match, email match, name-fallback match, and non-matching cases.

## Related work

Item 2 of a 5-item roadmap for `linuxfoundation/lfx-self-serve#1672` (LFX V2 port of PCC's attendance-reconciliation feature). Item 1 (shared types) is #2059, open separately — this PR intentionally does not depend on it (dropped a `zoom_user_name` name-fallback reference so this branch stays independently mergeable off `main`).

Refs: linuxfoundation/lfx-self-serve#1672

## Test plan

- [x] `yarn vitest run src/server/services/meeting.service.spec.ts -t "getPastMeetingParticipants"` — 7/7 passing
- [x] `yarn check-types`, `yarn lint:check`, `yarn format:check`, `yarn build`, `./check-headers.sh` all pass
- [x] Pre-PR reviewer trio (general + self-serve-convention + learnings) clean on both commits and on the full-branch sweep