### PR TITLE
feat(votes): add allow abstain option and abstention results (GH-1470)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
@@ -141,6 +141,7 @@
               appendTo="body"
               [form]="form()"
               control="allow_abstain"
+              inputId="allow-abstain"
               [options]="allowAbstainOptions"
               optionLabel="label"
               optionValue="value"

--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
@@ -135,7 +135,18 @@
 
           <!-- Allow Abstain -->
           <div class="flex flex-col gap-1">
-            <lfx-checkbox [form]="form()" control="allow_abstain" label="Allow Abstain" data-testid="vote-allow-abstain-checkbox"></lfx-checkbox>
+            <label for="allow-abstain" class="text-sm font-medium text-gray-700"> Allow Abstain </label>
+            <lfx-select
+              styleClass="w-full"
+              appendTo="body"
+              [form]="form()"
+              control="allow_abstain"
+              [options]="allowAbstainOptions"
+              optionLabel="label"
+              optionValue="value"
+              placeholder="Select allow abstain"
+              data-testid="vote-allow-abstain-select">
+            </lfx-select>
             <p class="text-xs text-gray-400">Allow voters to abstain from voting instead of selecting an option.</p>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html
@@ -132,6 +132,12 @@
               Select a date after today when this {{ voteLabel.singular | lowercase }} will close and no longer accept responses.
             </p>
           </div>
+
+          <!-- Allow Abstain -->
+          <div class="flex flex-col gap-1">
+            <lfx-checkbox [form]="form()" control="allow_abstain" label="Allow Abstain" data-testid="vote-allow-abstain-checkbox"></lfx-checkbox>
+            <p class="text-xs text-gray-400">Allow voters to abstain from voting instead of selecting an option.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.ts
@@ -6,6 +6,7 @@ import { Component, input, Signal } from '@angular/core';
 import { Committee } from '@lfx-one/shared/interfaces';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CalendarComponent } from '@components/calendar/calendar.component';
+import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { CommitteeSelectorComponent } from '@components/committee-selector/committee-selector.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
@@ -14,7 +15,16 @@ import { COMMITTEE_LABEL, VOTE_ELIGIBLE_PARTICIPANTS, VOTE_LABEL } from '@lfx-on
 
 @Component({
   selector: 'lfx-vote-basics',
-  imports: [ReactiveFormsModule, InputTextComponent, TextareaComponent, SelectComponent, CalendarComponent, CommitteeSelectorComponent, LowerCasePipe],
+  imports: [
+    ReactiveFormsModule,
+    InputTextComponent,
+    TextareaComponent,
+    SelectComponent,
+    CalendarComponent,
+    CheckboxComponent,
+    CommitteeSelectorComponent,
+    LowerCasePipe,
+  ],
   templateUrl: './vote-basics.component.html',
 })
 export class VoteBasicsComponent {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.ts
@@ -6,25 +6,15 @@ import { Component, input, Signal } from '@angular/core';
 import { Committee } from '@lfx-one/shared/interfaces';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CalendarComponent } from '@components/calendar/calendar.component';
-import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { CommitteeSelectorComponent } from '@components/committee-selector/committee-selector.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
-import { COMMITTEE_LABEL, VOTE_ELIGIBLE_PARTICIPANTS, VOTE_LABEL } from '@lfx-one/shared/constants';
+import { COMMITTEE_LABEL, VOTE_ALLOW_ABSTAIN_OPTIONS, VOTE_ELIGIBLE_PARTICIPANTS, VOTE_LABEL } from '@lfx-one/shared/constants';
 
 @Component({
   selector: 'lfx-vote-basics',
-  imports: [
-    ReactiveFormsModule,
-    InputTextComponent,
-    TextareaComponent,
-    SelectComponent,
-    CalendarComponent,
-    CheckboxComponent,
-    CommitteeSelectorComponent,
-    LowerCasePipe,
-  ],
+  imports: [ReactiveFormsModule, InputTextComponent, TextareaComponent, SelectComponent, CalendarComponent, CommitteeSelectorComponent, LowerCasePipe],
   templateUrl: './vote-basics.component.html',
 })
 export class VoteBasicsComponent {
@@ -38,6 +28,7 @@ export class VoteBasicsComponent {
   public readonly committeeLabel = COMMITTEE_LABEL;
   public readonly voteLabel = VOTE_LABEL;
   public readonly eligibleParticipantsOptions = [...VOTE_ELIGIBLE_PARTICIPANTS];
+  public readonly allowAbstainOptions = [...VOTE_ALLOW_ABSTAIN_OPTIONS];
   public readonly minDate = (() => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -306,7 +306,7 @@
                   </div>
                 </div>
               }
-              @if (voteData.allow_abstain && !voteResultsError()) {
+              @if (showAbstain() && !voteResultsError()) {
                 <!-- Vote-level abstention row — muted and never winner-styled; choice percentages above exclude abstentions. -->
                 <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
                   <div class="flex items-center justify-between mb-2">
@@ -362,7 +362,7 @@
                   </div>
                 </div>
               }
-              @if (voteData.allow_abstain && !voteResultsError()) {
+              @if (showAbstain() && !voteResultsError()) {
                 <!-- Vote-level abstention row — muted and never winner-styled; ranked tallies above exclude abstentions. -->
                 <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
                   <div class="flex items-center justify-between mb-2">
@@ -471,8 +471,8 @@
                 <p class="text-xs text-slate-500">Response Rate</p>
                 <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
               </div>
-              @if (voteData.allow_abstain) {
-                <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown only for votes created with allow_abstain. -->
+              @if (showAbstain() && !voteResultsError()) {
+                <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown when the vote allows abstain or results report abstentions. -->
                 <div class="text-center flex-1" data-testid="vote-results-abstained-stat">
                   <p class="text-xs text-slate-500">Abstained</p>
                   <p class="font-semibold text-slate-900 text-lg">{{ participationStats().abstainedVoters }}</p>
@@ -587,7 +587,7 @@
               </div>
             }
 
-            @if (voteData.allow_abstain) {
+            @if (showAbstain() && !voteResultsError()) {
               <!-- Vote-level abstention row (not per-question) — muted and never winner-styled.
                    abstainedRate is the share of all responses cast; choice percentages above exclude abstentions. -->
               <div class="flex flex-col gap-1.5" data-testid="vote-results-option-abstain">
@@ -620,8 +620,8 @@
                   <p class="text-xs text-slate-500">Response Rate</p>
                   <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
                 </div>
-                @if (voteData.allow_abstain) {
-                  <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown only for votes created with allow_abstain. -->
+                @if (showAbstain() && !voteResultsError()) {
+                  <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown when the vote allows abstain or results report abstentions. -->
                   <div class="text-center flex-1" data-testid="vote-results-abstained-stat">
                     <p class="text-xs text-slate-500">Abstained</p>
                     <p class="font-semibold text-slate-900 text-lg">{{ participationStats().abstainedVoters }}</p>
@@ -675,8 +675,8 @@
                 <p class="text-xs text-slate-500">Response Rate</p>
                 <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
               </div>
-              @if (voteData.allow_abstain) {
-                <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown only for votes created with allow_abstain. -->
+              @if (showAbstain() && !voteResultsError()) {
+                <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown when the vote allows abstain or results report abstentions. -->
                 <div class="text-center flex-1" data-testid="vote-results-abstained-stat">
                   <p class="text-xs text-slate-500">Abstained</p>
                   <p class="font-semibold text-slate-900 text-lg">{{ participationStats().abstainedVoters }}</p>
@@ -765,7 +765,7 @@
               </div>
             }
 
-            @if (voteData.allow_abstain) {
+            @if (showAbstain() && !voteResultsError()) {
               <!-- Vote-level abstention row (not per-question) — muted and never winner-styled.
                    abstainedRate is the share of all responses cast; choice percentages above exclude abstentions. -->
               <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-option-abstain">

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -307,7 +307,7 @@
                 </div>
               }
               @if (showAbstain() && !voteResultsError()) {
-                <!-- Vote-level abstention row — muted and never winner-styled; choice percentages above exclude abstentions. -->
+                <!-- Vote-level abstention row — muted and never winner-styled; choice percentages above use all responses cast (including abstentions) as their denominator. -->
                 <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
                   <div class="flex items-center justify-between mb-2">
                     <span class="text-sm font-medium italic text-slate-500">Abstain</span>
@@ -589,7 +589,7 @@
 
             @if (showAbstain() && !voteResultsError()) {
               <!-- Vote-level abstention row (not per-question) — muted and never winner-styled.
-                   abstainedRate is the share of all responses cast; choice percentages above exclude abstentions. -->
+                   abstainedRate is the share of all responses cast; choice percentages above use the same denominator. -->
               <div class="flex flex-col gap-1.5" data-testid="vote-results-option-abstain">
                 <div class="flex items-center justify-between text-sm">
                   <span class="font-normal italic text-slate-500">Abstain</span>
@@ -767,7 +767,7 @@
 
             @if (showAbstain() && !voteResultsError()) {
               <!-- Vote-level abstention row (not per-question) — muted and never winner-styled.
-                   abstainedRate is the share of all responses cast; choice percentages above exclude abstentions. -->
+                   abstainedRate is the share of all responses cast; choice percentages above use the same denominator. -->
               <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-option-abstain">
                 <div class="flex items-center justify-between mb-2">
                   <span class="text-sm font-medium italic text-slate-500">Abstain</span>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -381,6 +381,10 @@
               <p-skeleton width="80px" height="40px"></p-skeleton>
               <p-skeleton width="80px" height="40px"></p-skeleton>
               <p-skeleton width="80px" height="40px"></p-skeleton>
+              @if (voteData.allow_abstain) {
+                <!-- 4th "Abstained" stat in the participation card — keep the skeleton count in sync to avoid a layout shift on load. -->
+                <p-skeleton width="80px" height="40px"></p-skeleton>
+              }
             </div>
             <p-skeleton width="100%" height="8px"></p-skeleton>
           </div>
@@ -388,6 +392,13 @@
           <div class="flex flex-col gap-4">
             <p-skeleton width="150px" height="24px"></p-skeleton>
             @for (i of [1, 2, 3]; track i) {
+              <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-2">
+                <p-skeleton width="60%" height="16px"></p-skeleton>
+                <p-skeleton width="100%" height="8px"></p-skeleton>
+              </div>
+            }
+            @if (voteData.allow_abstain) {
+              <!-- Muted "Abstain" row appended to the Live/Final Results option lists — reserve its space while loading. -->
               <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-2">
                 <p-skeleton width="60%" height="16px"></p-skeleton>
                 <p-skeleton width="100%" height="8px"></p-skeleton>
@@ -426,6 +437,13 @@
                 <p class="text-xs text-slate-500">Response Rate</p>
                 <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
               </div>
+              @if (voteData.allow_abstain) {
+                <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown only for votes created with allow_abstain. -->
+                <div class="text-center flex-1" data-testid="vote-results-abstained-stat">
+                  <p class="text-xs text-slate-500">Abstained</p>
+                  <p class="font-semibold text-slate-900 text-lg">{{ participationStats().abstainedVoters }}</p>
+                </div>
+              }
             </div>
             <div class="w-full bg-slate-200 rounded-full h-2 overflow-hidden">
               <div class="h-full bg-blue-500 transition-all" [style.width.%]="participationStats().participationRate"></div>
@@ -534,6 +552,23 @@
                 </div>
               </div>
             }
+
+            @if (voteData.allow_abstain) {
+              <!-- Vote-level abstention row (not per-question) — muted and never winner-styled.
+                   abstainedRate is the share of all responses cast; choice percentages above exclude abstentions. -->
+              <div class="flex flex-col gap-1.5" data-testid="vote-results-option-abstain">
+                <div class="flex items-center justify-between text-sm">
+                  <span class="font-normal italic text-slate-500">Abstain</span>
+                  <span class="font-normal text-slate-500">
+                    {{ participationStats().abstainedVoters }} {{ participationStats().abstainedVoters === 1 ? 'abstention' : 'abstentions' }} ·
+                    {{ participationStats().abstainedRate }}%
+                  </span>
+                </div>
+                <div class="h-2 bg-slate-200 rounded-full overflow-hidden">
+                  <div class="h-full rounded-full bg-slate-300 transition-all" [style.width.%]="participationStats().abstainedRate"></div>
+                </div>
+              </div>
+            }
           </div>
 
           <div class="pt-4 border-t border-slate-200 flex flex-col gap-4">
@@ -551,6 +586,13 @@
                   <p class="text-xs text-slate-500">Response Rate</p>
                   <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
                 </div>
+                @if (voteData.allow_abstain) {
+                  <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown only for votes created with allow_abstain. -->
+                  <div class="text-center flex-1" data-testid="vote-results-abstained-stat">
+                    <p class="text-xs text-slate-500">Abstained</p>
+                    <p class="font-semibold text-slate-900 text-lg">{{ participationStats().abstainedVoters }}</p>
+                  </div>
+                }
               </div>
 
               <div class="w-full bg-slate-200 rounded-full h-2 overflow-hidden">
@@ -599,6 +641,13 @@
                 <p class="text-xs text-slate-500">Response Rate</p>
                 <p class="font-semibold text-blue-600 text-lg">{{ participationStats().participationRate }}%</p>
               </div>
+              @if (voteData.allow_abstain) {
+                <!-- Abstentions count as cast responses upstream but are excluded from choice tallies; shown only for votes created with allow_abstain. -->
+                <div class="text-center flex-1" data-testid="vote-results-abstained-stat">
+                  <p class="text-xs text-slate-500">Abstained</p>
+                  <p class="font-semibold text-slate-900 text-lg">{{ participationStats().abstainedVoters }}</p>
+                </div>
+              }
             </div>
 
             <div class="w-full bg-slate-200 rounded-full h-2 overflow-hidden">
@@ -678,6 +727,25 @@
                       </div>
                     </div>
                   }
+                </div>
+              </div>
+            }
+
+            @if (voteData.allow_abstain) {
+              <!-- Vote-level abstention row (not per-question) — muted and never winner-styled.
+                   abstainedRate is the share of all responses cast; choice percentages above exclude abstentions. -->
+              <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-option-abstain">
+                <div class="flex items-center justify-between mb-2">
+                  <span class="text-sm font-medium italic text-slate-500">Abstain</span>
+                  <div class="flex items-center gap-2">
+                    <span class="text-sm font-semibold text-slate-600">
+                      {{ participationStats().abstainedVoters }} {{ participationStats().abstainedVoters === 1 ? 'abstention' : 'abstentions' }}
+                    </span>
+                    <span class="text-sm text-slate-500">({{ participationStats().abstainedRate }}%)</span>
+                  </div>
+                </div>
+                <div class="w-full bg-white rounded-full h-2 overflow-hidden">
+                  <div class="h-full bg-slate-400 transition-all" [style.width.%]="participationStats().abstainedRate"></div>
                 </div>
               </div>
             }

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -306,6 +306,23 @@
                   </div>
                 </div>
               }
+              @if (voteData.allow_abstain) {
+                <!-- Vote-level abstention row — muted and never winner-styled; choice percentages above exclude abstentions. -->
+                <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
+                  <div class="flex items-center justify-between mb-2">
+                    <span class="text-sm font-medium italic text-slate-500">Abstain</span>
+                    <div class="flex items-center gap-2">
+                      <span class="text-sm font-semibold text-slate-600">
+                        {{ participationStats().abstainedVoters }} {{ participationStats().abstainedVoters === 1 ? 'abstention' : 'abstentions' }}
+                      </span>
+                      <span class="text-sm text-slate-500">({{ participationStats().abstainedRate }}%)</span>
+                    </div>
+                  </div>
+                  <div class="w-full bg-white rounded-full h-2 overflow-hidden">
+                    <div class="h-full bg-slate-400 transition-all" [style.width.%]="participationStats().abstainedRate"></div>
+                  </div>
+                </div>
+              }
               @if (voteResultsError()) {
                 <p class="text-sm text-rose-700" data-testid="vote-results-voter-error">Couldn't load final results. Try reopening this vote.</p>
               } @else if (hasZeroVotes()) {
@@ -345,9 +362,26 @@
                   </div>
                 </div>
               }
+              @if (voteData.allow_abstain) {
+                <!-- Vote-level abstention row — muted and never winner-styled; ranked tallies above exclude abstentions. -->
+                <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
+                  <div class="flex items-center justify-between mb-2">
+                    <span class="text-sm font-medium italic text-slate-500">Abstain</span>
+                    <div class="flex items-center gap-2">
+                      <span class="text-sm font-semibold text-slate-600">
+                        {{ participationStats().abstainedVoters }} {{ participationStats().abstainedVoters === 1 ? 'abstention' : 'abstentions' }}
+                      </span>
+                      <span class="text-sm text-slate-500">({{ participationStats().abstainedRate }}%)</span>
+                    </div>
+                  </div>
+                  <div class="w-full bg-white rounded-full h-2 overflow-hidden">
+                    <div class="h-full bg-slate-400 transition-all" [style.width.%]="participationStats().abstainedRate"></div>
+                  </div>
+                </div>
+              }
               @if (voteResultsError()) {
                 <p class="text-sm text-rose-700" data-testid="vote-results-voter-error">Couldn't load final results. Try reopening this vote.</p>
-              } @else if (rankedQuestions().length === 0) {
+              } @else if (rankedQuestions().length === 0 && participationStats().abstainedVoters === 0) {
                 <p class="text-sm text-slate-500" data-testid="vote-results-voter-zero-responses">No votes were submitted.</p>
               }
             </div>
@@ -397,8 +431,8 @@
                 <p-skeleton width="100%" height="8px"></p-skeleton>
               </div>
             }
-            @if (voteData.allow_abstain) {
-              <!-- Muted "Abstain" row appended to the Live/Final Results option lists — reserve its space while loading. -->
+            @if (voteData.allow_abstain && isGenericPoll()) {
+              <!-- Muted "Abstain" row appended to the generic Live/Final Results option lists — reserve its space while loading. -->
               <div class="rounded-lg border border-slate-200 p-4 flex flex-col gap-2">
                 <p-skeleton width="60%" height="16px"></p-skeleton>
                 <p-skeleton width="100%" height="8px"></p-skeleton>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html
@@ -306,7 +306,7 @@
                   </div>
                 </div>
               }
-              @if (voteData.allow_abstain) {
+              @if (voteData.allow_abstain && !voteResultsError()) {
                 <!-- Vote-level abstention row — muted and never winner-styled; choice percentages above exclude abstentions. -->
                 <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
                   <div class="flex items-center justify-between mb-2">
@@ -362,7 +362,7 @@
                   </div>
                 </div>
               }
-              @if (voteData.allow_abstain) {
+              @if (voteData.allow_abstain && !voteResultsError()) {
                 <!-- Vote-level abstention row — muted and never winner-styled; ranked tallies above exclude abstentions. -->
                 <div class="rounded-lg border border-slate-200 bg-slate-50 p-4" data-testid="vote-results-voter-option-abstain">
                   <div class="flex items-center justify-between mb-2">

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -112,6 +112,8 @@ export class VoteResultsDrawerComponent {
   /** Creator-scope inline cast CTA gate: active vote where the viewer is also a voter awaiting response. Voter audience uses the dedicated State A panel instead. */
   protected readonly canCastVoteFromDrawer: Signal<boolean> = this.initCanCastVoteFromDrawer();
   protected readonly participationStats: Signal<VoteParticipationStats> = this.initParticipationStats();
+  /** Abstain UI follows the data, not just the flag: shows when the vote allows abstain OR results report abstentions (e.g. flag edited off mid-vote) — mirrors the hasZeroVotes short-circuit. */
+  protected readonly showAbstain: Signal<boolean> = computed(() => !!this.vote()?.allow_abstain || this.participationStats().abstainedVoters > 0);
   protected readonly isVoteClosed: Signal<boolean> = this.initIsVoteClosed();
   protected readonly questionsWithResults: Signal<VoteResultsQuestion[]> = this.initQuestionsWithResults();
   protected readonly rankedQuestions: Signal<RankedQuestionView[]> = this.initRankedQuestions();
@@ -243,7 +245,7 @@ export class VoteResultsDrawerComponent {
       return results.poll_results.map((pollResult) => {
         const choiceVotes = pollResult.generic_choice_votes || [];
 
-        // Compute total votes first for percentage calculation
+        // Per-question choice-vote sum — drives the question model's totalVotes (zero-state detection), not percentages.
         const totalVotes = choiceVotes.reduce((sum, cv) => sum + cv.vote_count, 0);
 
         // Build options with vote counts from the results API
@@ -251,7 +253,7 @@ export class VoteResultsDrawerComponent {
           choiceId: cv.choice_id,
           text: pollResult.question.choices.find((c) => c.choice_id === cv.choice_id)?.choice_text || cv.choice_id,
           voteCount: cv.vote_count,
-          percentage: this.computePercentage(cv.percentage, cv.vote_count, totalVotes),
+          percentage: this.computePercentage(cv.percentage, cv.vote_count, results.num_votes_cast || 0),
           isWinner: false,
           isTied: false,
           isLeading: false,
@@ -374,10 +376,11 @@ export class VoteResultsDrawerComponent {
     });
   }
 
-  private computePercentage(apiPercentage: number, voteCount: number, totalVotes: number): number {
+  /** Fallback base is num_votes_cast (all responses cast) so a missing upstream percentage stays on the same denominator upstream uses — not the per-question choice-vote sum. */
+  private computePercentage(apiPercentage: number, voteCount: number, totalResponses: number): number {
     if (apiPercentage > 0) return apiPercentage;
-    if (totalVotes <= 0) return 0;
-    return Math.round((voteCount / totalVotes) * 100);
+    if (totalResponses <= 0) return 0;
+    return Math.round((voteCount / totalResponses) * 100);
   }
 
   private initVotingMethodText(): Signal<string> {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -20,7 +20,13 @@ import {
   VoteResultsResponse,
 } from '@lfx-one/shared/interfaces';
 import { VOTE_COMMENT_RESULTS_PAGE_SIZE, VOTE_COMMENT_RESULTS_ROWS_PER_PAGE_OPTIONS } from '@lfx-one/shared/constants';
-import { getVoteEndedEarlyDetailTooltip, isVoteEndedEarly, sortCommentResponsesByRecency, splitIntoParagraphs } from '@lfx-one/shared/utils';
+import {
+  computeVoteParticipationStats,
+  getVoteEndedEarlyDetailTooltip,
+  isVoteEndedEarly,
+  sortCommentResponsesByRecency,
+  splitIntoParagraphs,
+} from '@lfx-one/shared/utils';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
@@ -222,18 +228,7 @@ export class VoteResultsDrawerComponent {
   }
 
   private initParticipationStats(): Signal<VoteParticipationStats> {
-    return computed(() => {
-      const results = this.voteResults();
-      if (!results) {
-        return { eligibleVoters: 0, totalResponses: 0, participationRate: 0 };
-      }
-
-      const eligibleVoters = results.num_recipients || 0;
-      const totalResponses = results.num_votes_cast || 0;
-      const participationRate = eligibleVoters > 0 ? Math.round((totalResponses / eligibleVoters) * 100) : 0;
-
-      return { eligibleVoters, totalResponses, participationRate };
-    });
+    return computed(() => computeVoteParticipationStats(this.voteResults()));
   }
 
   private initQuestionsWithResults(): Signal<VoteResultsQuestion[]> {

--- a/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.ts
@@ -471,6 +471,8 @@ export class VoteResultsDrawerComponent {
 
   private initHasZeroVotes(): Signal<boolean> {
     return computed(() => {
+      // Abstentions are cast responses upstream but excluded from choice tallies — they must not read as "no votes".
+      if (this.participationStats().abstainedVoters > 0) return false;
       const qs = this.questionsWithResults();
       if (!qs.length) return true;
       return qs.every((q) => q.totalVotes === 0);

--- a/apps/lfx-one/src/app/modules/votes/components/vote-review/vote-review.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-review/vote-review.component.html
@@ -51,6 +51,10 @@
               }
             </span>
           </div>
+          <div class="flex justify-between gap-4">
+            <span class="text-gray-500">Allow Abstain:</span>
+            <span class="text-gray-900 text-right">{{ allowAbstain() ? 'Yes' : 'No' }}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/votes/components/vote-review/vote-review.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/vote-review/vote-review.component.ts
@@ -40,6 +40,7 @@ export class VoteReviewComponent {
   public readonly eligibleParticipants: Signal<string> = this.initEligibleParticipants();
   public readonly eligibleParticipantsLabel: Signal<string> = this.initEligibleParticipantsLabel();
   public readonly closeDate: Signal<Date | null> = this.initCloseDate();
+  public readonly allowAbstain: Signal<boolean> = this.initAllowAbstain();
   public readonly questions: Signal<VoteReviewQuestion[]> = this.initQuestions();
   public readonly commentPrompts: Signal<VoteReviewCommentPrompt[]> = this.initCommentPrompts();
 
@@ -104,6 +105,13 @@ export class VoteReviewComponent {
     return computed(() => {
       this.formValue();
       return this.form().get('close_date')?.value || null;
+    });
+  }
+
+  private initAllowAbstain(): Signal<boolean> {
+    return computed(() => {
+      this.formValue();
+      return !!this.form().get('allow_abstain')?.value;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
@@ -413,6 +413,7 @@ export class VoteManageComponent {
       committee: formValue.committee,
       eligible_participants: formValue.eligible_participants,
       close_date: formValue.close_date,
+      allow_abstain: formValue.allow_abstain,
     });
 
     // Rebuild questions FormArray (Step 2)
@@ -460,6 +461,7 @@ export class VoteManageComponent {
       committee: new FormControl<CommitteeReference | null>(null, [Validators.required, validCommitteeReference()]),
       eligible_participants: new FormControl('', [Validators.required]),
       close_date: new FormControl<Date | null>(null, [Validators.required]),
+      allow_abstain: new FormControl<boolean>(false, { nonNullable: true }),
 
       // Step 2: Vote Questions (array of questions)
       questions: new FormArray([this.createQuestionFormGroup()], [Validators.minLength(1)]),

--- a/packages/shared/src/constants/poll.constants.ts
+++ b/packages/shared/src/constants/poll.constants.ts
@@ -242,6 +242,16 @@ export const VOTE_ELIGIBLE_PARTICIPANTS = [
 ] as const;
 
 /**
+ * Allow abstain options for vote creation
+ * @description Defines whether participants can abstain from voting instead of selecting an option
+ * Maps to the allow_abstain field in the Vote interface; defaults to 'No' (false)
+ */
+export const VOTE_ALLOW_ABSTAIN_OPTIONS = [
+  { label: 'Yes', value: true, description: 'Voters can abstain from voting instead of selecting an option' },
+  { label: 'No', value: false, description: 'Voters must select an option' },
+] as const;
+
+/**
  * Vote response type options
  * @description Defines how participants can respond to the vote question
  */

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -480,6 +480,10 @@ export interface VoteParticipationStats {
   totalResponses: number;
   /** Participation rate as percentage (0-100) */
   participationRate: number;
+  /** Number of voters who abstained — a subset of totalResponses (upstream counts abstentions as cast responses but excludes them from choice tallies) */
+  abstainedVoters: number;
+  /** Abstentions as a percentage of all responses cast (0-100) */
+  abstainedRate: number;
 }
 
 /**

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -399,6 +399,8 @@ export interface VoteFormValue {
   eligible_participants: string;
   /** Vote close/end date */
   close_date: Date | null;
+  /** Whether voters may abstain from voting */
+  allow_abstain: boolean;
   /** Array of question form values */
   questions: QuestionFormValue[];
   /** Array of comment-prompt form values (optional, creator authoring only) */

--- a/packages/shared/src/utils/vote.utils.spec.ts
+++ b/packages/shared/src/utils/vote.utils.spec.ts
@@ -11,8 +11,15 @@ import '@angular/compiler';
 import { describe, expect, it } from 'vitest';
 
 import { PollStatus } from '../enums';
-import type { Vote, VoteFormValue } from '../interfaces/poll.interface';
-import { buildCreateVoteRequest, buildDraftUpdateVoteRequest, buildDraftVoteRequest, buildUpdateVoteRequest, mapVoteToFormValue } from './vote.utils';
+import type { Vote, VoteFormValue, VoteResultsResponse } from '../interfaces/poll.interface';
+import {
+  buildCreateVoteRequest,
+  buildDraftUpdateVoteRequest,
+  buildDraftVoteRequest,
+  buildUpdateVoteRequest,
+  computeVoteParticipationStats,
+  mapVoteToFormValue,
+} from './vote.utils';
 
 /** Minimal VoteFormValue fixture — the request builders only read the fields set here. */
 function formValue(overrides: Partial<VoteFormValue> = {}): VoteFormValue {
@@ -77,5 +84,40 @@ describe('mapVoteToFormValue', () => {
 
   it('defaults allow_abstain to false when the vote predates the field', () => {
     expect(mapVoteToFormValue(vote()).allow_abstain).toBe(false);
+  });
+});
+
+describe('computeVoteParticipationStats', () => {
+  /** Minimal VoteResultsResponse fixture — the stats computation only reads the num_* fields. */
+  function results(overrides: Partial<VoteResultsResponse> = {}): VoteResultsResponse {
+    return {
+      poll_results: [],
+      comment_results: [],
+      num_recipients: 4,
+      num_votes_cast: 3,
+      num_abstained: 1,
+      poll_end_time: '2025-06-01T00:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('returns zeros when results have not loaded', () => {
+    expect(computeVoteParticipationStats(null)).toEqual({ eligibleVoters: 0, totalResponses: 0, participationRate: 0, abstainedVoters: 0, abstainedRate: 0 });
+  });
+
+  it('maps num_abstained to abstainedVoters', () => {
+    expect(computeVoteParticipationStats(results()).abstainedVoters).toBe(1);
+  });
+
+  it('computes abstainedRate as the rounded share of all responses cast', () => {
+    expect(computeVoteParticipationStats(results()).abstainedRate).toBe(33);
+  });
+
+  it('guards abstainedRate against zero responses', () => {
+    expect(computeVoteParticipationStats(results({ num_votes_cast: 0, num_abstained: 0 })).abstainedRate).toBe(0);
+  });
+
+  it('keeps participationRate as the share of eligible voters (abstentions count as responses)', () => {
+    expect(computeVoteParticipationStats(results()).participationRate).toBe(75);
   });
 });

--- a/packages/shared/src/utils/vote.utils.spec.ts
+++ b/packages/shared/src/utils/vote.utils.spec.ts
@@ -1,0 +1,81 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for vote.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
+
+// vote.utils.ts imports @angular/forms, whose import graph reaches Angular's partially-compiled
+// @angular/common. Under vitest that needs the JIT compiler as a fallback, so load it before
+// importing the module under test (same shim as the apps/lfx-one spec files).
+import '@angular/compiler';
+
+import { describe, expect, it } from 'vitest';
+
+import { PollStatus } from '../enums';
+import type { Vote, VoteFormValue } from '../interfaces/poll.interface';
+import { buildCreateVoteRequest, buildDraftUpdateVoteRequest, buildDraftVoteRequest, buildUpdateVoteRequest, mapVoteToFormValue } from './vote.utils';
+
+/** Minimal VoteFormValue fixture — the request builders only read the fields set here. */
+function formValue(overrides: Partial<VoteFormValue> = {}): VoteFormValue {
+  return {
+    title: 'Board election',
+    description: 'Pick the next board members',
+    committee: { uid: 'committee-uid', name: 'Board' },
+    eligible_participants: 'voting_rep',
+    close_date: new Date('2025-06-01T00:00:00Z'),
+    allow_abstain: false,
+    questions: [{ question: 'Who should join?', response_type: 'single', options: ['Alice', 'Bob'] }],
+    commentPrompts: [],
+    ...overrides,
+  };
+}
+
+// All four builders must always emit allow_abstain explicitly: ITX updatePoll rebuilds the
+// DynamoDB item via PutItem full-replace, so omitting the field would silently reset an
+// enabled flag to false on any edit.
+const voteRequestBuilders = [
+  ['buildCreateVoteRequest', buildCreateVoteRequest],
+  ['buildDraftVoteRequest', buildDraftVoteRequest],
+  ['buildUpdateVoteRequest', buildUpdateVoteRequest],
+  ['buildDraftUpdateVoteRequest', buildDraftUpdateVoteRequest],
+] as const;
+
+for (const [name, build] of voteRequestBuilders) {
+  describe(name, () => {
+    it('emits allow_abstain: true when the form enables it', () => {
+      expect(build(formValue({ allow_abstain: true }), 'project-uid').allow_abstain).toBe(true);
+    });
+
+    it('emits allow_abstain: false when the form disables it (never omits the field)', () => {
+      const request = build(formValue({ allow_abstain: false }), 'project-uid');
+
+      expect(request.allow_abstain).toBe(false);
+      expect('allow_abstain' in request).toBe(true);
+    });
+  });
+}
+
+describe('mapVoteToFormValue', () => {
+  /** Minimal Vote fixture — the mapper only reads the fields set here. */
+  function vote(overrides: Partial<Vote> = {}): Vote {
+    return {
+      uid: 'vote-uid',
+      name: 'Board election',
+      end_time: '2025-06-01T00:00:00Z',
+      status: PollStatus.DISABLED,
+      project_uid: 'project-uid',
+      ...overrides,
+    };
+  }
+
+  it('round-trips allow_abstain: true into the form value', () => {
+    expect(mapVoteToFormValue(vote({ allow_abstain: true })).allow_abstain).toBe(true);
+  });
+
+  it('maps allow_abstain: false explicitly', () => {
+    expect(mapVoteToFormValue(vote({ allow_abstain: false })).allow_abstain).toBe(false);
+  });
+
+  it('defaults allow_abstain to false when the vote predates the field', () => {
+    expect(mapVoteToFormValue(vote()).allow_abstain).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/vote.utils.ts
+++ b/packages/shared/src/utils/vote.utils.ts
@@ -22,6 +22,8 @@ import type {
   UpdateVoteRequest,
   Vote,
   VoteFormValue,
+  VoteParticipationStats,
+  VoteResultsResponse,
 } from '../interfaces/poll.interface';
 
 /**
@@ -124,6 +126,28 @@ export function mapVoteToFormValue(vote: Vote): VoteFormValue {
     questions: (vote.poll_questions?.filter((question) => !isDraftPlaceholderPollQuestion(question)) ?? []).map(mapApiQuestionToFormValue),
     commentPrompts: (vote.poll_comment_prompts ?? []).map(mapApiCommentPromptToFormValue),
   };
+}
+
+/**
+ * Computes participation stats for the results drawer from the results API payload
+ * @description Upstream (itx-service-voting) counts abstentions in `num_votes_cast` but excludes
+ * them from per-choice tallies, so `abstainedVoters` is always a subset of `totalResponses` and
+ * `abstainedRate` is their share of all responses cast (choice percentages use a different base).
+ * @param results - VoteResultsResponse from the results API, or null when not yet loaded
+ * @returns VoteParticipationStats for the participation card and abstain row
+ */
+export function computeVoteParticipationStats(results: VoteResultsResponse | null): VoteParticipationStats {
+  if (!results) {
+    return { eligibleVoters: 0, totalResponses: 0, participationRate: 0, abstainedVoters: 0, abstainedRate: 0 };
+  }
+
+  const eligibleVoters = results.num_recipients || 0;
+  const totalResponses = results.num_votes_cast || 0;
+  const abstainedVoters = results.num_abstained || 0;
+  const participationRate = eligibleVoters > 0 ? Math.round((totalResponses / eligibleVoters) * 100) : 0;
+  const abstainedRate = totalResponses > 0 ? Math.round((abstainedVoters / totalResponses) * 100) : 0;
+
+  return { eligibleVoters, totalResponses, participationRate, abstainedVoters, abstainedRate };
 }
 
 /**

--- a/packages/shared/src/utils/vote.utils.ts
+++ b/packages/shared/src/utils/vote.utils.ts
@@ -120,6 +120,7 @@ export function mapVoteToFormValue(vote: Vote): VoteFormValue {
     committee,
     eligible_participants: mapFiltersToEligibility(vote.committee_filters),
     close_date: vote.end_time ? new Date(vote.end_time) : null,
+    allow_abstain: vote.allow_abstain ?? false,
     questions: (vote.poll_questions?.filter((question) => !isDraftPlaceholderPollQuestion(question)) ?? []).map(mapApiQuestionToFormValue),
     commentPrompts: (vote.poll_comment_prompts ?? []).map(mapApiCommentPromptToFormValue),
   };
@@ -239,6 +240,7 @@ export function buildCreateVoteRequest(formValue: VoteFormValue, projectUid: str
     project_uid: projectUid,
     committee_uid: formValue.committee?.uid || '',
     committee_filters: mapEligibilityToFilters(formValue.eligible_participants),
+    allow_abstain: formValue.allow_abstain,
     poll_questions: formValue.questions.map(mapQuestionToApiFormat),
     poll_comment_prompts: mapCommentPromptsToApiFormat(formValue.commentPrompts),
   };
@@ -256,6 +258,7 @@ export function buildDraftVoteRequest(formValue: VoteFormValue, projectUid: stri
     project_uid: projectUid,
     committee_uid: formValue.committee?.uid || '',
     committee_filters: mapEligibilityToFilters(formValue.eligible_participants),
+    allow_abstain: formValue.allow_abstain,
     poll_questions,
     poll_comment_prompts: mapCommentPromptsToApiFormat(formValue.commentPrompts),
   };
@@ -275,6 +278,7 @@ export function buildUpdateVoteRequest(formValue: VoteFormValue, projectUid: str
     project_uid: projectUid,
     committee_uid: formValue.committee?.uid || '',
     committee_filters: mapEligibilityToFilters(formValue.eligible_participants),
+    allow_abstain: formValue.allow_abstain,
     poll_questions: formValue.questions.map(mapQuestionToApiFormat),
     poll_comment_prompts: mapCommentPromptsToApiFormat(formValue.commentPrompts),
   };
@@ -292,6 +296,7 @@ export function buildDraftUpdateVoteRequest(formValue: VoteFormValue, projectUid
     project_uid: projectUid,
     committee_uid: formValue.committee?.uid || '',
     committee_filters: mapEligibilityToFilters(formValue.eligible_participants),
+    allow_abstain: formValue.allow_abstain,
     poll_questions,
     poll_comment_prompts: mapCommentPromptsToApiFormat(formValue.commentPrompts),
   };

--- a/packages/shared/src/utils/vote.utils.ts
+++ b/packages/shared/src/utils/vote.utils.ts
@@ -130,9 +130,9 @@ export function mapVoteToFormValue(vote: Vote): VoteFormValue {
 
 /**
  * Computes participation stats for the results drawer from the results API payload
- * @description Upstream (itx-service-voting) counts abstentions in `num_votes_cast` but excludes
- * them from per-choice tallies, so `abstainedVoters` is always a subset of `totalResponses` and
- * `abstainedRate` is their share of all responses cast (choice percentages use a different base).
+ * @description Upstream (itx-service-voting) counts abstentions in `num_votes_cast` but excludes them from
+ * per-choice tallies, so `abstainedVoters` is a subset of `totalResponses`; `abstainedRate` is their share of all
+ * responses cast — the same `num_votes_cast` base upstream uses for per-choice percentages, so the two always agree.
  * @param results - VoteResultsResponse from the results API, or null when not yet loaded
  * @returns VoteParticipationStats for the participation card and abstain row
  */


### PR DESCRIPTION
## Summary

Adds an "Allow Abstain" setting to vote creation so organizers can let participants abstain instead of choosing an option, and surfaces abstention counts in the results drawer. The flag is threaded end-to-end — form, request builders, review step — so editing a vote never silently resets it, and results for abstain-enabled votes now show how many voters abstained alongside the usual participation stats.

Resolves #1470

## Behavior changes

### Vote creation

| Before | After |
|---|---|
| There was no way to let voters abstain — every participant had to pick an option, and nothing about abstaining appeared anywhere in the create/edit flow. | A Yes/No "Allow Abstain" select (defaulting to No) appears in the basics step of the vote form, and the chosen value is shown as a read-only row on the review step before submitting. |

### Vote results

| Before | After |
|---|---|
| The results drawer showed only eligible voters, responses, and response rate — abstentions were invisible even though the backend counts them. | For votes created with abstaining allowed, the participation card gains an "Abstained" count, and a muted italic "Abstain" row appears under the option list showing abstention count and share of all responses cast. Loading skeletons reserve space for both so nothing shifts on load. |

## Technical changes

`packages/shared/src/constants/poll.constants.ts` — Shared constants

- Adds `VOTE_ALLOW_ABSTAIN_OPTIONS` Yes/No options for the basics-step select, mapping to the `allow_abstain` field on the Vote interface

`packages/shared/src/interfaces/poll.interface.ts` — Shared types

- Adds `allow_abstain: boolean` to `VoteFormValue`
- Adds `abstainedVoters` and `abstainedRate` to `VoteParticipationStats`, documented as a subset of `totalResponses` (upstream counts abstentions as cast responses but excludes them from choice tallies)

`packages/shared/src/utils/vote.utils.ts` — Shared vote helpers

- Threads `allow_abstain` through all four vote request builders (`buildCreateVoteRequest`, `buildDraftVoteRequest`, `buildUpdateVoteRequest`, `buildDraftUpdateVoteRequest`) so ITX full-replace updates never silently reset the flag
- Maps `allow_abstain` back into the form in `mapVoteToFormValue`, defaulting to `false` for votes that predate the field
- Extracts the drawer's participation-stats computation into a shared `computeVoteParticipationStats` util, extended with `abstainedVoters` / `abstainedRate`

`packages/shared/src/utils/vote.utils.spec.ts` — Tests

- Covers the builders and mapper round-trip for `allow_abstain`, plus `computeVoteParticipationStats` edge cases (null results, zero eligible voters, abstention rates)

`apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts` — Vote form state

- Adds a non-nullable `allow_abstain` `FormControl` defaulting to `false`, and patches it when editing an existing vote

`apps/lfx-one/src/app/modules/votes/components/vote-basics/vote-basics.component.html, vote-basics.component.ts` — Basics step

- Renders the "Allow Abstain" `lfx-select` bound to the `allow_abstain` control with helper text and a `data-testid`

`apps/lfx-one/src/app/modules/votes/components/vote-review/vote-review.component.html, vote-review.component.ts` — Review step

- Adds a read-only "Allow Abstain: Yes/No" row backed by an `initAllowAbstain()` computed signal

`apps/lfx-one/src/app/modules/votes/components/vote-results-drawer/vote-results-drawer.component.html, vote-results-drawer.component.ts` — Results drawer

- Replaces the inline participation-stats computed with the shared `computeVoteParticipationStats` util
- Renders the "Abstained" stat in the participation card and the muted "Abstain" row in both live and final results, gated on `voteData.allow_abstain`
- Adds matching skeleton placeholders for the new stat and row to avoid layout shift while loading
