### PR TITLE
feat(meetings): add past-meeting participant write routes

### DIFF
--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PAST_MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { meetingSvc, reconciliationSvc, addAccessToResourceMock, validateUidParameterMock } = vi.hoisted(() => ({
+  meetingSvc: {
+    getPastMeetingById: vi.fn(),
+  },
+  reconciliationSvc: {
+    reconcilePastMeetingParticipants: vi.fn(),
+  },
+  addAccessToResourceMock: vi.fn(),
+  validateUidParameterMock: vi.fn(() => true),
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
+vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/utils', () => ({
+  resolveMeetingOrganizer: vi.fn(() => null),
+  resolveMeetingOwner: vi.fn(() => null),
+}));
+
+vi.mock('../helpers/validation.helper', () => ({
+  validateUidParameter: validateUidParameterMock,
+  validateRequiredParameter: vi.fn(() => true),
+}));
+// enrichMeetingsWithCreatedBy/stripHostKey aren't exercised by the reconcile path under test.
+vi.mock('../helpers/meeting.helper', () => ({
+  enrichMeetingsWithCreatedBy: vi.fn(async (_req: unknown, meetings: unknown[]) => meetings),
+  stripHostKey: vi.fn(),
+}));
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: vi.fn(function () {
+    return meetingSvc;
+  }),
+}));
+vi.mock('../services/attendance-reconciliation.service', () => ({
+  AttendanceReconciliationService: vi.fn(function () {
+    return reconciliationSvc;
+  }),
+}));
+vi.mock('../services/access-check.service', () => ({
+  AccessCheckService: vi.fn(function () {
+    return { addAccessToResource: addAccessToResourceMock };
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { PastMeetingController } from './past-meeting.controller';
+
+function buildReq(authenticated: boolean): any {
+  return {
+    params: { uid: PAST_MEETING_UID },
+    query: {},
+    path: '/test',
+    log: {},
+    oidc: { isAuthenticated: () => authenticated },
+  };
+}
+
+function buildRes(): any {
+  return { json: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn() };
+}
+
+function buildPastMeeting(overrides: Record<string, unknown> = {}): any {
+  return { meeting_and_occurrence_id: PAST_MEETING_UID, ...overrides };
+}
+
+// Reconciliation matching logic itself is tested at its source (attendance-reconciliation.service.spec.ts)
+// per the three-file pattern. This spec covers only the controller's authorization gate: a non-organizer
+// must never reach the AI-backed reconciliation call (GH-1672 item 4 organizer-only trigger).
+describe('PastMeetingController.reconcilePastMeetingParticipants — organizer gate', () => {
+  let controller: PastMeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateUidParameterMock.mockReturnValue(true);
+    controller = new PastMeetingController();
+    meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting());
+  });
+
+  it('rejects with 403 and never calls the reconciliation service when the caller is not authenticated', async () => {
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(false), res, next);
+
+    expect(addAccessToResourceMock).not.toHaveBeenCalled();
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 and never calls the reconciliation service when the caller is authenticated but not the organizer', async () => {
+    addAccessToResourceMock.mockResolvedValue({ ...buildPastMeeting(), organizer: false });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 and fails closed when the access check itself throws', async () => {
+    addAccessToResourceMock.mockRejectedValue(new Error('access-check unavailable'));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('runs reconciliation and returns the result when the caller is the organizer', async () => {
+    addAccessToResourceMock.mockResolvedValue({ ...buildPastMeeting(), organizer: true });
+    const result = { results: [], candidate_pool_size: 5, auto_applied_count: 1, needs_review_count: 4 };
+    reconciliationSvc.reconcilePastMeetingParticipants.mockResolvedValue(result);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).toHaveBeenCalledWith(expect.anything(), PAST_MEETING_UID, buildPastMeeting());
+    expect(res.json).toHaveBeenCalledWith(result);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -261,6 +261,15 @@ export class PastMeetingController {
         return;
       }
 
+      if (participantData.is_invited === undefined && participantData.is_attended === undefined) {
+        return next(
+          ServiceValidationError.forField('is_invited', 'At least one of is_invited or is_attended must be present to update a participant', {
+            operation: 'update_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
       const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
 

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -21,7 +21,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
 import { enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
-import { validateUidParameter } from '../helpers/validation.helper';
+import { validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
@@ -249,13 +249,13 @@ export class PastMeetingController {
         return;
       }
 
-      if (!participantId) {
-        return next(
-          ServiceValidationError.forField('participantId', 'Participant ID is required', {
-            operation: 'update_past_meeting_participant',
-            service: 'past_meeting_controller',
-          })
-        );
+      if (
+        !validateRequiredParameter(participantId, 'participantId', req, next, {
+          operation: 'update_past_meeting_participant',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
       }
 
       const participant = await this.meetingService.updatePastMeetingParticipant(req, uid, participantId, participantData);
@@ -292,13 +292,13 @@ export class PastMeetingController {
         return;
       }
 
-      if (!participantId) {
-        return next(
-          ServiceValidationError.forField('participantId', 'Participant ID is required', {
-            operation: 'delete_past_meeting_participant',
-            service: 'past_meeting_controller',
-          })
-        );
+      if (
+        !validateRequiredParameter(participantId, 'participantId', req, next, {
+          operation: 'delete_past_meeting_participant',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
       }
 
       await this.meetingService.deletePastMeetingParticipant(req, uid, participantId);

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -5,6 +5,8 @@ import {
   AttachmentCategory,
   AttachmentDownloadUrlResponse,
   CreateMeetingAttachmentRequest,
+  ITXCreatePastMeetingParticipantRequest,
+  ITXUpdatePastMeetingParticipantRequest,
   PastMeeting,
   PastMeetingAttachment,
   PastMeetingRecording,
@@ -177,6 +179,136 @@ export class PastMeetingController {
 
       // Send the participants data to the client
       res.json(participants);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /past-meetings/:uid/participants
+   * Authorization (organizer-only) is enforced by lfx-v2-meeting-service on the ITX endpoint.
+   */
+  public async createPastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid } = req.params;
+    const participantData: ITXCreatePastMeetingParticipantRequest = req.body;
+    const startTime = logger.startOperation(req, 'create_past_meeting_participant', {
+      past_meeting_id: uid,
+    });
+
+    try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'create_past_meeting_participant',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
+      }
+
+      if (!participantData.is_invited && !participantData.is_attended) {
+        return next(
+          ServiceValidationError.forField('is_invited', 'At least one of is_invited or is_attended must be true', {
+            operation: 'create_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
+      const participant = await this.meetingService.createPastMeetingParticipant(req, uid, participantData);
+
+      logger.success(req, 'create_past_meeting_participant', startTime, {
+        past_meeting_id: uid,
+        participant_id: participant.id,
+      });
+
+      res.status(201).json(participant);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * PUT /past-meetings/:uid/participants/:participantId
+   * Authorization (organizer-only) is enforced by lfx-v2-meeting-service on the ITX endpoint.
+   */
+  public async updatePastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid, participantId } = req.params;
+    const participantData: ITXUpdatePastMeetingParticipantRequest = req.body;
+    const startTime = logger.startOperation(req, 'update_past_meeting_participant', {
+      past_meeting_id: uid,
+      participant_id: participantId,
+    });
+
+    try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'update_past_meeting_participant',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
+      }
+
+      if (!participantId) {
+        return next(
+          ServiceValidationError.forField('participantId', 'Participant ID is required', {
+            operation: 'update_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
+      const participant = await this.meetingService.updatePastMeetingParticipant(req, uid, participantId, participantData);
+
+      logger.success(req, 'update_past_meeting_participant', startTime, {
+        past_meeting_id: uid,
+        participant_id: participantId,
+      });
+
+      res.json(participant);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * DELETE /past-meetings/:uid/participants/:participantId
+   * Authorization (organizer-only) is enforced by lfx-v2-meeting-service on the ITX endpoint.
+   */
+  public async deletePastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid, participantId } = req.params;
+    const startTime = logger.startOperation(req, 'delete_past_meeting_participant', {
+      past_meeting_id: uid,
+      participant_id: participantId,
+    });
+
+    try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'delete_past_meeting_participant',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
+      }
+
+      if (!participantId) {
+        return next(
+          ServiceValidationError.forField('participantId', 'Participant ID is required', {
+            operation: 'delete_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
+      await this.meetingService.deletePastMeetingParticipant(req, uid, participantId);
+
+      logger.success(req, 'delete_past_meeting_participant', startTime, {
+        past_meeting_id: uid,
+        participant_id: participantId,
+      });
+
+      res.status(204).send();
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -19,10 +19,11 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
-import { ServiceValidationError } from '../errors';
+import { AuthorizationError, ServiceValidationError } from '../errors';
 import { enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
+import { AttendanceReconciliationService } from '../services/attendance-reconciliation.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 
@@ -32,6 +33,7 @@ import { MeetingService } from '../services/meeting.service';
 export class PastMeetingController {
   private meetingService: MeetingService = new MeetingService();
   private accessCheckService: AccessCheckService = new AccessCheckService();
+  private attendanceReconciliationService: AttendanceReconciliationService = new AttendanceReconciliationService();
 
   /**
    * GET /past-meetings
@@ -109,20 +111,7 @@ export class PastMeetingController {
       }
 
       const meeting = await this.meetingService.getPastMeetingById(req, uid);
-
-      if (req.oidc?.isAuthenticated()) {
-        try {
-          const meetingWithAccess = await this.accessCheckService.addAccessToResource(
-            req,
-            { ...meeting, id: meeting.meeting_and_occurrence_id ?? uid },
-            'v1_past_meeting',
-            'organizer'
-          );
-          meeting.organizer = meetingWithAccess.organizer ?? false;
-        } catch {
-          meeting.organizer = false;
-        }
-      }
+      meeting.organizer = await this.isPastMeetingOrganizer(req, meeting, uid);
 
       const counts = await this.addParticipantsCount(req, uid);
       meeting.individual_registrants_count = counts.individual_registrants_count;
@@ -309,6 +298,56 @@ export class PastMeetingController {
       });
 
       res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /past-meetings/:uid/reconcile
+   * Manual admin trigger (GH-1672 item 4) — matches unverified attendees against a candidate
+   * pool (invitees + committee members + previously-verified attendees of prior occurrences),
+   * auto-applying only high-confidence matches. No-match attendees are always returned for
+   * admin review, never silently auto-tagged unknown.
+   */
+  public async reconcilePastMeetingParticipants(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid } = req.params;
+    const startTime = logger.startOperation(req, 'reconcile_past_meeting_participants', {
+      past_meeting_id: uid,
+    });
+
+    try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'reconcile_past_meeting_participants',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
+      }
+
+      const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
+      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+
+      if (!isOrganizer) {
+        return next(
+          new AuthorizationError('Only the meeting organizer can trigger attendance reconciliation', {
+            operation: 'reconcile_past_meeting_participants',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
+      const result = await this.attendanceReconciliationService.reconcilePastMeetingParticipants(req, uid, pastMeeting);
+
+      logger.success(req, 'reconcile_past_meeting_participants', startTime, {
+        past_meeting_id: uid,
+        candidate_pool_size: result.candidate_pool_size,
+        auto_applied_count: result.auto_applied_count,
+        needs_review_count: result.needs_review_count,
+      });
+
+      res.json(result);
     } catch (error) {
       next(error);
     }
@@ -927,6 +966,28 @@ export class PastMeetingController {
         participant_count: 0,
         attended_count: 0,
       };
+    }
+  }
+
+  /**
+   * Resolves whether the requesting user is the organizer of a past meeting. Unauthenticated
+   * requests and access-check failures both default to false (fail closed).
+   */
+  private async isPastMeetingOrganizer(req: Request, pastMeeting: PastMeeting, uid: string): Promise<boolean> {
+    if (!req.oidc?.isAuthenticated()) {
+      return false;
+    }
+
+    try {
+      const meetingWithAccess = await this.accessCheckService.addAccessToResource(
+        req,
+        { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid },
+        'v1_past_meeting',
+        'organizer'
+      );
+      return meetingWithAccess.organizer ?? false;
+    } catch {
+      return false;
     }
   }
 }

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -175,7 +175,8 @@ export class PastMeetingController {
 
   /**
    * POST /past-meetings/:uid/participants
-   * Authorization (organizer-only) is enforced by lfx-v2-meeting-service on the ITX endpoint.
+   * Organizer-only, enforced both here and by lfx-v2-meeting-service on the ITX endpoint —
+   * belt-and-suspenders defense in depth, matching the reconcile endpoint's BFF-level check.
    */
   public async createPastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
@@ -203,6 +204,18 @@ export class PastMeetingController {
         );
       }
 
+      const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
+      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+
+      if (!isOrganizer) {
+        return next(
+          new AuthorizationError('Only the meeting organizer can manage past meeting participants', {
+            operation: 'create_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
       const participant = await this.meetingService.createPastMeetingParticipant(req, uid, participantData);
 
       logger.success(req, 'create_past_meeting_participant', startTime, {
@@ -218,7 +231,8 @@ export class PastMeetingController {
 
   /**
    * PUT /past-meetings/:uid/participants/:participantId
-   * Authorization (organizer-only) is enforced by lfx-v2-meeting-service on the ITX endpoint.
+   * Organizer-only, enforced both here and by lfx-v2-meeting-service on the ITX endpoint —
+   * belt-and-suspenders defense in depth, matching the reconcile endpoint's BFF-level check.
    */
   public async updatePastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid, participantId } = req.params;
@@ -247,6 +261,18 @@ export class PastMeetingController {
         return;
       }
 
+      const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
+      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+
+      if (!isOrganizer) {
+        return next(
+          new AuthorizationError('Only the meeting organizer can manage past meeting participants', {
+            operation: 'update_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
       const participant = await this.meetingService.updatePastMeetingParticipant(req, uid, participantId, participantData);
 
       logger.success(req, 'update_past_meeting_participant', startTime, {
@@ -262,7 +288,8 @@ export class PastMeetingController {
 
   /**
    * DELETE /past-meetings/:uid/participants/:participantId
-   * Authorization (organizer-only) is enforced by lfx-v2-meeting-service on the ITX endpoint.
+   * Organizer-only, enforced both here and by lfx-v2-meeting-service on the ITX endpoint —
+   * belt-and-suspenders defense in depth, matching the reconcile endpoint's BFF-level check.
    */
   public async deletePastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid, participantId } = req.params;
@@ -288,6 +315,18 @@ export class PastMeetingController {
         })
       ) {
         return;
+      }
+
+      const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
+      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+
+      if (!isOrganizer) {
+        return next(
+          new AuthorizationError('Only the meeting organizer can manage past meeting participants', {
+            operation: 'delete_past_meeting_participant',
+            service: 'past_meeting_controller',
+          })
+        );
       }
 
       await this.meetingService.deletePastMeetingParticipant(req, uid, participantId);

--- a/apps/lfx-one/src/server/routes/past-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/past-meetings.route.ts
@@ -26,6 +26,9 @@ router.put('/:uid/participants/:participantId', (req, res, next) => pastMeetingC
 // Delete a past meeting participant
 router.delete('/:uid/participants/:participantId', (req, res, next) => pastMeetingController.deletePastMeetingParticipant(req, res, next));
 
+// Manually trigger AI-assisted attendance reconciliation for a past meeting occurrence
+router.post('/:uid/reconcile', (req, res, next) => pastMeetingController.reconcilePastMeetingParticipants(req, res, next));
+
 // Get past meeting recording by UID
 router.get('/:uid/recording', (req, res, next) => pastMeetingController.getPastMeetingRecording(req, res, next));
 

--- a/apps/lfx-one/src/server/routes/past-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/past-meetings.route.ts
@@ -17,6 +17,15 @@ router.get('/count', (req, res, next) => pastMeetingController.getPastMeetingsCo
 // Get past meeting participants by UID
 router.get('/:uid/participants', (req, res, next) => pastMeetingController.getPastMeetingParticipants(req, res, next));
 
+// Create a past meeting participant
+router.post('/:uid/participants', (req, res, next) => pastMeetingController.createPastMeetingParticipant(req, res, next));
+
+// Update a past meeting participant
+router.put('/:uid/participants/:participantId', (req, res, next) => pastMeetingController.updatePastMeetingParticipant(req, res, next));
+
+// Delete a past meeting participant
+router.delete('/:uid/participants/:participantId', (req, res, next) => pastMeetingController.deletePastMeetingParticipant(req, res, next));
+
 // Get past meeting recording by UID
 router.get('/:uid/recording', (req, res, next) => pastMeetingController.getPastMeetingRecording(req, res, next));
 

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -23,6 +23,7 @@ vi.mock('@lfx-one/shared/constants', async () => {
     AI_BRIEF_ACTION_ITEMS_SYSTEM_PROMPT: 'brief action items prompt',
     AI_MODEL: 'mock-model',
     AI_NEWSLETTER_SYSTEM_PROMPT: 'newsletter prompt',
+    AI_RECONCILIATION_SYSTEM_PROMPT: 'reconciliation prompt',
     AI_REQUEST_CONFIG: actual.AI_REQUEST_CONFIG,
     DURATION_ESTIMATION: { BASE_DURATION: 15, TIME_PER_ITEM: 10, MINIMUM_DURATION: 30, MAXIMUM_DURATION: 240 },
     NEWSLETTER_AI_MAX_TOKENS: 12_000,
@@ -268,5 +269,102 @@ describe('AiService.generateNewsletter', () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(AI_REQUEST_CONFIG.NEWSLETTER_TIMEOUT_MS);
     expect(AI_REQUEST_CONFIG.NEWSLETTER_TIMEOUT_MS).toBeGreaterThan(AI_REQUEST_CONFIG.TIMEOUT_MS);
+  });
+});
+
+describe('AiService.reconcileAttendees (GH-1672 / PCC-1452 port)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let service: AiService;
+  const originalEnv = { ...process.env };
+
+  const candidates = [
+    { candidate_id: 'c0', source: 'invitee' as const, first_name: 'Alice', last_name: 'Smith', email: 'alice@example.com' },
+    { candidate_id: 'c1', source: 'committee_member' as const, first_name: 'Bob', last_name: 'Jones' },
+  ];
+  const attendees = [{ attendee_id: 'a0', zoom_user_name: 'Alice S' }];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, AI_PROXY_URL: 'https://ai-proxy.example.com', AI_API_KEY: 'test-key' };
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    service = new AiService();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('returns the matches on a well-formed response', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'high' }] })));
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'high' }]);
+  });
+
+  it('rejects a matched_candidate_id that does not resolve against the request candidates (hallucination guard)', async () => {
+    fetchMock.mockResolvedValue(
+      mockChatResponse(JSON.stringify({ matches: [{ attendee_id: 'a0', matched_candidate_id: 'does-not-exist', confidence: 'high' }] }))
+    );
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    // Note: this method only nulls the unresolvable candidate_id — it does not itself downgrade
+    // confidence. The caller (AttendanceReconciliationService.matchWithAi) is what treats a
+    // resolved-confidence + null-candidate combination as 'none' before ever considering auto-apply.
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: null, confidence: 'high' }]);
+  });
+
+  it('defaults an attendee_id omitted from the response to confidence none instead of dropping it', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [] })));
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: null, confidence: 'none' }]);
+  });
+
+  it('normalizes an invalid confidence value to none rather than trusting the model', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'certain' }] })));
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'none' }]);
+  });
+
+  it('throws on a response with no choices', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: async () => ({ choices: [] }) } as unknown as Response);
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('throws on empty response content', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(''));
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('throws on malformed JSON content', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse('not json'));
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('throws when matches is not an array', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: 'not an array' })));
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('falls back to "unknown" in the prompt when zoom_user_name is falsy', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [] })));
+
+    await service.reconcileAttendees(req, { attendees: [{ attendee_id: 'a1', zoom_user_name: '' }], candidates });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.messages[1].content).toContain('zoom_display_name: "unknown"');
   });
 });

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -6,6 +6,7 @@ import {
   AI_BRIEF_ACTION_ITEMS_SYSTEM_PROMPT,
   AI_MODEL,
   AI_NEWSLETTER_SYSTEM_PROMPT,
+  AI_RECONCILIATION_SYSTEM_PROMPT,
   AI_REQUEST_CONFIG,
   DURATION_ESTIMATION,
   NEWSLETTER_AI_MAX_TOKENS,
@@ -15,6 +16,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import {
+  AttendanceReconciliationConfidence,
   ExtractActionItemsRequest,
   ExtractActionItemsResponse,
   GenerateAgendaRequest,
@@ -23,6 +25,8 @@ import {
   GenerateNewsletterResponse,
   OpenAIChatRequest,
   OpenAIChatResponse,
+  ReconcileAttendeesRequest,
+  ReconcileAttendeesResponse,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -274,6 +278,136 @@ export class AiService {
       const cause = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to extract brief action items: ${cause}`);
     }
+  }
+
+  /**
+   * AI-assisted attendance reconciliation (GH-1672 / PCC-1452 port). Callers only send the
+   * ambiguous remainder left after a deterministic email/username pass, and must validate
+   * `matched_candidate_id` against the `candidates` they sent — this method itself only rejects
+   * candidate_ids that don't resolve against the request's own candidate list, not against any
+   * broader store.
+   */
+  public async reconcileAttendees(req: Request, request: ReconcileAttendeesRequest): Promise<ReconcileAttendeesResponse> {
+    this.assertConfigured();
+
+    const startTime = logger.startOperation(req, 'reconcile_attendees', {
+      attendeeCount: request.attendees.length,
+      candidateCount: request.candidates.length,
+    });
+
+    try {
+      const chatRequest: OpenAIChatRequest = {
+        model: this.model,
+        messages: [
+          { role: 'system', content: AI_RECONCILIATION_SYSTEM_PROMPT },
+          { role: 'user', content: this.buildReconciliationPrompt(request) },
+        ],
+        max_tokens: AI_REQUEST_CONFIG.MAX_TOKENS,
+        temperature: AI_REQUEST_CONFIG.TEMPERATURE,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'attendee_reconciliation',
+            description: 'Matched candidate (or none) and confidence tier for each attendee',
+            schema: {
+              type: 'object',
+              properties: {
+                matches: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      attendee_id: { type: 'string', description: 'The attendee_id from the input list' },
+                      matched_candidate_id: {
+                        type: ['string', 'null'],
+                        description: 'The candidate_id this attendee matches, or null if there is no plausible match',
+                      },
+                      confidence: {
+                        type: 'string',
+                        enum: ['high', 'medium', 'low', 'none'],
+                      },
+                    },
+                    required: ['attendee_id', 'matched_candidate_id', 'confidence'],
+                    additionalProperties: false,
+                  },
+                },
+              },
+              required: ['matches'],
+              additionalProperties: false,
+            },
+          },
+          strict: true,
+        },
+      };
+
+      const response = await this.makeAiRequest(chatRequest, AI_REQUEST_CONFIG.RECONCILIATION_TIMEOUT_MS);
+      const result = this.extractReconciliationMatches(request, response);
+
+      logger.success(req, 'reconcile_attendees', startTime, {
+        matchCount: result.matches.length,
+      });
+
+      return result;
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to reconcile attendees: ${cause}`);
+    }
+  }
+
+  private buildReconciliationPrompt(request: ReconcileAttendeesRequest): string {
+    const attendeeLines = request.attendees.map((a) => `- attendee_id: ${a.attendee_id}, zoom_display_name: "${a.zoom_user_name || 'unknown'}"`);
+    const candidateLines = request.candidates.map(
+      (c) =>
+        `- candidate_id: ${c.candidate_id}, name: "${[c.first_name, c.last_name].filter(Boolean).join(' ') || 'unknown'}"` +
+        `${c.org_name ? `, org: "${c.org_name}"` : ''} (source: ${c.source})`
+    );
+
+    return ['Attendees to match:', ...attendeeLines, '', 'Candidate pool:', ...candidateLines].join('\n');
+  }
+
+  /**
+   * Validates the model's response against the request it was given — rejects any
+   * `matched_candidate_id` that doesn't resolve to a real candidate_id (hallucination guard),
+   * and treats any `attendee_id` the model omitted as `confidence: 'none'` rather than losing it.
+   */
+  private extractReconciliationMatches(request: ReconcileAttendeesRequest, response: OpenAIChatResponse): ReconcileAttendeesResponse {
+    if (!response.choices || response.choices.length === 0) {
+      throw new Error('No reconciliation response generated');
+    }
+
+    const content = response.choices[0].message.content;
+    if (!content || content.trim().length === 0) {
+      throw new Error('Empty reconciliation response generated');
+    }
+
+    const parsed = JSON.parse(content.trim());
+    if (!Array.isArray(parsed.matches)) {
+      throw new Error('Invalid matches array in reconciliation response');
+    }
+
+    const candidateIds = new Set(request.candidates.map((c) => c.candidate_id));
+    const byAttendeeId = new Map<string, { matched_candidate_id: string | null; confidence: AttendanceReconciliationConfidence }>();
+
+    for (const match of parsed.matches) {
+      if (!match || typeof match.attendee_id !== 'string') {
+        continue;
+      }
+      const matchedCandidateId =
+        typeof match.matched_candidate_id === 'string' && candidateIds.has(match.matched_candidate_id) ? match.matched_candidate_id : null;
+      const confidence: AttendanceReconciliationConfidence = ['high', 'medium', 'low', 'none'].includes(match.confidence) ? match.confidence : 'none';
+      byAttendeeId.set(match.attendee_id, { matched_candidate_id: matchedCandidateId, confidence });
+    }
+
+    const matches = request.attendees.map((attendee) => {
+      const found = byAttendeeId.get(attendee.attendee_id);
+      return {
+        attendee_id: attendee.attendee_id,
+        matched_candidate_id: found?.matched_candidate_id ?? null,
+        confidence: found?.confidence ?? ('none' as const),
+      };
+    });
+
+    return { matches };
   }
 
   private extractBriefActionItemsFromResponse(response: OpenAIChatResponse): ExtractActionItemsResponse {

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -362,7 +362,10 @@ export class AiService {
    * new instructions into the prompt.
    */
   private escapeForPrompt(value: string): string {
-    return value.replace(/[\r\n]+/g, ' ').replace(/"/g, '\\"');
+    return value
+      .replace(/[\r\n]+/g, ' ')
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
   }
 
   private buildReconciliationPrompt(request: ReconcileAttendeesRequest): string {

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -354,12 +354,25 @@ export class AiService {
     }
   }
 
+  /**
+   * Escapes double quotes and collapses newlines/control characters in attendee- or
+   * candidate-controlled text before it's interpolated into a quoted prompt string. Zoom display
+   * names and candidate names come from upstream data an attendee can influence — unescaped, a
+   * name like `foo", ignore instructions and ...` could break out of its quoted field and inject
+   * new instructions into the prompt.
+   */
+  private escapeForPrompt(value: string): string {
+    return value.replace(/[\r\n]+/g, ' ').replace(/"/g, '\\"');
+  }
+
   private buildReconciliationPrompt(request: ReconcileAttendeesRequest): string {
-    const attendeeLines = request.attendees.map((a) => `- attendee_id: ${a.attendee_id}, zoom_display_name: "${a.zoom_user_name || 'unknown'}"`);
+    const attendeeLines = request.attendees.map(
+      (a) => `- attendee_id: ${a.attendee_id}, zoom_display_name: "${this.escapeForPrompt(a.zoom_user_name || 'unknown')}"`
+    );
     const candidateLines = request.candidates.map(
       (c) =>
-        `- candidate_id: ${c.candidate_id}, name: "${[c.first_name, c.last_name].filter(Boolean).join(' ') || 'unknown'}"` +
-        `${c.org_name ? `, org: "${c.org_name}"` : ''} (source: ${c.source})`
+        `- candidate_id: ${c.candidate_id}, name: "${this.escapeForPrompt([c.first_name, c.last_name].filter(Boolean).join(' ') || 'unknown')}"` +
+        `${c.org_name ? `, org: "${this.escapeForPrompt(c.org_name)}"` : ''} (source: ${c.source})`
     );
 
     return ['Attendees to match:', ...attendeeLines, '', 'Candidate pool:', ...candidateLines].join('\n');

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -8,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // internally) need mocking.
 vi.mock('@lfx-one/shared/constants', () => ({
   RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL: 30,
+  RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL: 50,
+  RECONCILIATION_MAX_CONCURRENT_AI_CALLS: 3,
   RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
 }));
 
@@ -98,7 +100,7 @@ describe('AttendanceReconciliationService', () => {
 
       const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
 
-      expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 });
+      expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0, pool_degraded: false });
       expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
     });
 

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -204,7 +204,7 @@ describe('AttendanceReconciliationService', () => {
       // The current occurrence must be fetched once for its own participants, and the prior-occurrence
       // scan must exclude it (only 'occ-0' is scanned) — two calls total, not three.
       expect(getPastMeetingParticipants).toHaveBeenCalledTimes(2);
-      expect(getPastMeetingParticipants).toHaveBeenCalledWith(req, 'occ-0');
+      expect(getPastMeetingParticipants).toHaveBeenCalledWith(req, 'occ-0', true);
     });
 
     it('leaves a high-confidence match for review when the write to persist it fails', async () => {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -1,0 +1,254 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
+// vitest config, so runtime collaborators (constants + the services this service instantiates
+// internally) need mocking.
+vi.mock('@lfx-one/shared/constants', () => ({
+  RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL: 30,
+  RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
+}));
+
+const { getPastMeetingParticipants, getPastOccurrencesForMeeting, updatePastMeetingParticipant } = vi.hoisted(() => ({
+  getPastMeetingParticipants: vi.fn(),
+  getPastOccurrencesForMeeting: vi.fn(),
+  updatePastMeetingParticipant: vi.fn(),
+}));
+vi.mock('./meeting.service', () => ({
+  MeetingService: class {
+    public getPastMeetingParticipants = getPastMeetingParticipants;
+    public getPastOccurrencesForMeeting = getPastOccurrencesForMeeting;
+    public updatePastMeetingParticipant = updatePastMeetingParticipant;
+  },
+}));
+
+const { getCommitteeMembers } = vi.hoisted(() => ({ getCommitteeMembers: vi.fn() }));
+vi.mock('./committee.service', () => ({
+  CommitteeService: class {
+    public getCommitteeMembers = getCommitteeMembers;
+  },
+}));
+
+const { isAiConfigured, reconcileAttendees } = vi.hoisted(() => ({ isAiConfigured: vi.fn(), reconcileAttendees: vi.fn() }));
+vi.mock('./ai.service', () => ({
+  AiService: class {
+    public isAiConfigured = isAiConfigured;
+    public reconcileAttendees = reconcileAttendees;
+  },
+}));
+
+vi.mock('./logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import type { PastMeeting, PastMeetingParticipant } from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+
+import { AttendanceReconciliationService } from './attendance-reconciliation.service';
+
+const req = {} as unknown as Request;
+
+function buildParticipant(overrides: Partial<PastMeetingParticipant> = {}): PastMeetingParticipant {
+  return {
+    uid: 'attendee-1',
+    meeting_id: 'meeting-1',
+    meeting_and_occurrence_id: 'occ-1',
+    past_meeting_id: 'past-1',
+    email: '',
+    first_name: 'Jane',
+    last_name: 'Doe',
+    host: false,
+    is_attended: true,
+    is_invited: false,
+    org_is_member: false,
+    org_is_project_member: false,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+const pastMeeting = { meeting_id: 'meeting-1', committees: [] } as unknown as PastMeeting;
+
+describe('AttendanceReconciliationService', () => {
+  let service: AttendanceReconciliationService;
+
+  beforeEach(() => {
+    getPastMeetingParticipants.mockReset();
+    getPastOccurrencesForMeeting.mockReset().mockResolvedValue([]);
+    updatePastMeetingParticipant.mockReset().mockResolvedValue(undefined);
+    getCommitteeMembers.mockReset().mockResolvedValue([]);
+    isAiConfigured.mockReset().mockReturnValue(false);
+    reconcileAttendees.mockReset();
+    service = new AttendanceReconciliationService();
+  });
+
+  describe('reconcilePastMeetingParticipants', () => {
+    it('returns an empty result with no upstream writes when nothing is unverified', async () => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ is_attended: true, is_verified: true })]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 });
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('auto-applies a deterministic exact-email match and marks it verified', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'alice@example.com', first_name: 'Alice', last_name: 'Smith', is_invited: true, is_attended: false }),
+      ]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'high', method: 'deterministic', auto_applied: true });
+      expect(result.auto_applied_count).toBe(1);
+      expect(result.needs_review_count).toBe(0);
+      expect(updatePastMeetingParticipant).toHaveBeenCalledWith(
+        req,
+        'occ-1',
+        'attendee-1',
+        expect.objectContaining({ is_verified: true, email: 'alice@example.com' })
+      );
+    });
+
+    it('never auto-applies a "none" confidence match and always queues it for review', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'ghost@example.com', is_attended: true, is_verified: false }),
+      ]);
+      isAiConfigured.mockReturnValue(false);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'none', auto_applied: false });
+      expect(result.auto_applied_count).toBe(0);
+      expect(result.needs_review_count).toBe(1);
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-apply a medium-confidence AI match, even with a resolved candidate', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: '', first_name: 'Jon', last_name: 'Doey', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'jon@example.com', first_name: 'Jon', last_name: 'Doe', is_invited: true, is_attended: false }),
+      ]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: 'c0', confidence: 'medium' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'medium', auto_applied: false });
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('treats a hallucinated candidate_id from the AI response as "none" rather than trusting it', async () => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ uid: 'attendee-1', email: '', is_attended: true, is_verified: false })]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: 'does-not-exist', confidence: 'high' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'none', auto_applied: false, matched_candidate: undefined });
+    });
+
+    it('defaults an attendee omitted from the AI response to "none" instead of dropping it', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: '', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'attendee-2', email: '', is_attended: true, is_verified: false }),
+      ]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: null, confidence: 'low' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toHaveLength(2);
+      const omitted = result.results.find((r) => r.attendee_id === 'attendee-2');
+      expect(omitted).toMatchObject({ confidence: 'none', auto_applied: false });
+    });
+
+    it('builds the candidate pool from invitees, committee members, and prior verified attendees, deduped by email', async () => {
+      getPastMeetingParticipants
+        .mockResolvedValueOnce([
+          buildParticipant({ uid: 'attendee-1', email: 'dup@example.com', is_attended: true, is_verified: false }),
+          buildParticipant({ uid: 'invitee-1', email: 'dup@example.com', is_invited: true, is_attended: false }),
+        ])
+        .mockResolvedValueOnce([buildParticipant({ uid: 'prior-1', email: 'dup@example.com', is_verified: true, is_attended: true })]);
+      getPastOccurrencesForMeeting.mockResolvedValue([{ meeting_and_occurrence_id: 'occ-0' }, { meeting_and_occurrence_id: 'occ-1' }]);
+      getCommitteeMembers.mockResolvedValue([{ email: 'dup@example.com', first_name: 'Dup', last_name: 'One' }]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', {
+        ...pastMeeting,
+        committees: [{ uid: 'committee-1' }],
+      } as unknown as PastMeeting);
+
+      // All three sources share the same email — the dedup comparator must collapse them to one.
+      expect(result.candidate_pool_size).toBe(1);
+      // The current occurrence must be fetched once for its own participants, and the prior-occurrence
+      // scan must exclude it (only 'occ-0' is scanned) — two calls total, not three.
+      expect(getPastMeetingParticipants).toHaveBeenCalledTimes(2);
+      expect(getPastMeetingParticipants).toHaveBeenCalledWith(req, 'occ-0');
+    });
+
+    it('leaves a high-confidence match for review when the write to persist it fails', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'alice@example.com', is_invited: true, is_attended: false }),
+      ]);
+      updatePastMeetingParticipant.mockRejectedValue(new Error('upstream 500'));
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'high', auto_applied: false });
+      expect(result.needs_review_count).toBe(1);
+      expect(result.auto_applied_count).toBe(0);
+    });
+
+    it('queues the whole chunk for review instead of failing the request when the AI call throws', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'alice@example.com', is_invited: true, is_attended: false }),
+        buildParticipant({ uid: 'attendee-2', email: '', is_attended: true, is_verified: false }),
+      ]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockRejectedValue(new Error('upstream AI timeout'));
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      // The deterministic email match for attendee-1 must survive even though the AI call for
+      // the ambiguous remainder (attendee-2) throws.
+      const deterministic = result.results.find((r) => r.attendee_id === 'attendee-1');
+      expect(deterministic).toMatchObject({ confidence: 'high', method: 'deterministic' });
+
+      const aiFailed = result.results.find((r) => r.attendee_id === 'attendee-2');
+      expect(aiFailed).toMatchObject({ confidence: 'none', method: 'ai', auto_applied: false });
+    });
+
+    it('downgrades a spec-violating response (non-none confidence with no resolvable candidate_id) to none', async () => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ uid: 'attendee-1', email: '', is_attended: true, is_verified: false })]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: null, confidence: 'high' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'none', auto_applied: false, matched_candidate: undefined });
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -455,19 +455,29 @@ export class AttendanceReconciliationService {
    * AI-derived match is never auto-applied and therefore never reaches this method. Sets
    * `is_attended: true` explicitly — the upstream ITX handler no-ops an attendee update when
    * `is_attended` is omitted, so leaving it out would silently fail to persist while this
-   * service still reported `auto_applied: true`. Identity fields (`first_name`/`last_name`/
-   * `org_name`) are intentionally left off this write — those are invitee-record fields, not
-   * appropriate to overwrite on an attendee's own record from a matched candidate.
+   * service still reported `auto_applied: true`.
+   *
+   * Also sets `is_invited: true` whenever an identity field is present: lfx-v2-meeting-service's
+   * update converter routes `email`/`username`/`lf_user_id` only into the invitee sub-record
+   * (`UpdateInviteeRequest`), and its service layer no-ops that entire invitee operation when
+   * `is_invited` is omitted — sending identity fields without `is_invited: true` would silently
+   * drop them upstream while this method still reported success. `first_name`/`last_name` are
+   * included alongside because ITX requires them to create an invitee record that doesn't already
+   * exist for this attendee.
    */
   private async applyMatch(req: Request, pastMeetingUid: string, attendeeId: string, candidate: AttendanceReconciliationCandidate): Promise<boolean> {
+    const hasIdentity = !!(candidate.email || candidate.username || candidate.lf_user_id);
     const update: ITXUpdatePastMeetingParticipantRequest = {
       is_verified: true,
       is_attended: true,
       is_ai_reconciled: false,
       is_auto_matched: true,
+      ...(hasIdentity && { is_invited: true }),
       ...(candidate.email && { email: candidate.email }),
       ...(candidate.username && { username: candidate.username }),
       ...(candidate.lf_user_id && { lf_user_id: candidate.lf_user_id }),
+      ...(candidate.first_name && { first_name: candidate.first_name }),
+      ...(candidate.last_name && { last_name: candidate.last_name }),
     };
 
     try {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -80,7 +80,12 @@ export class AttendanceReconciliationService {
 
     const results = await Promise.all(
       combined.map(async (result) => {
-        if (result.confidence !== 'high' || !result.matched_candidate || degraded) {
+        // Only a deterministic exact-identity match may auto-apply. An AI-derived match is
+        // never auto-applied regardless of its stated confidence — the model's input includes
+        // attendee-controlled Zoom display names, so a 'high' confidence from the AI path
+        // cannot be trusted as a basis for an unattended write. AI matches always queue for
+        // admin review.
+        if (result.method !== 'deterministic' || result.confidence !== 'high' || !result.matched_candidate || degraded) {
           return result;
         }
 
@@ -154,12 +159,12 @@ export class AttendanceReconciliationService {
       const existing = pool[existingIndex];
       pool[existingIndex] = {
         ...existing,
-        email: existing.email ?? candidate.email,
-        username: existing.username ?? candidate.username,
-        lf_user_id: existing.lf_user_id ?? candidate.lf_user_id,
-        first_name: existing.first_name ?? candidate.first_name,
-        last_name: existing.last_name ?? candidate.last_name,
-        org_name: existing.org_name ?? candidate.org_name,
+        email: existing.email || candidate.email,
+        username: existing.username || candidate.username,
+        lf_user_id: existing.lf_user_id || candidate.lf_user_id,
+        first_name: existing.first_name || candidate.first_name,
+        last_name: existing.last_name || candidate.last_name,
+        org_name: existing.org_name || candidate.org_name,
       };
     };
 
@@ -209,10 +214,17 @@ export class AttendanceReconciliationService {
     meetingUid: string,
     currentOccurrenceId: string
   ): Promise<{ attendees: PastMeetingParticipant[]; degraded: boolean }> {
-    const occurrences = await this.meetingService.getPastOccurrencesForMeeting(req, meetingUid);
+    let degraded = false;
+    const occurrences = await this.meetingService.getPastOccurrencesForMeeting(req, meetingUid, { throwOnFailure: true }).catch((error) => {
+      logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch prior occurrences, continuing without them', {
+        meeting_id: meetingUid,
+        err: error,
+      });
+      degraded = true;
+      return [];
+    });
     const priorOccurrences = occurrences.filter((o) => o.meeting_and_occurrence_id !== currentOccurrenceId).slice(-RECONCILIATION_MAX_PRIOR_OCCURRENCES);
 
-    let degraded = false;
     const perOccurrence = await Promise.all(
       priorOccurrences.map((o) =>
         this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch((error) => {
@@ -437,20 +449,21 @@ export class AttendanceReconciliationService {
   }
 
   /**
-   * Writes a high-confidence match back onto the attendee's participant record. Sets
+   * Writes a high-confidence deterministic match back onto the attendee's participant record —
+   * only called for `method === 'deterministic'` results (see the auto-apply gate in
+   * `reconcilePastMeetingParticipants`), so `is_ai_reconciled` is always `false` here; an
+   * AI-derived match is never auto-applied and therefore never reaches this method. Sets
    * `is_attended: true` explicitly — the upstream ITX handler no-ops an attendee update when
    * `is_attended` is omitted, so leaving it out would silently fail to persist while this
-   * service still reported `auto_applied: true`. Also sets `is_ai_reconciled`/`is_auto_matched`
-   * so the persisted record itself carries the AI-match provenance, not just this service's own
-   * response shape. Identity fields (`first_name`/`last_name`/`org_name`) are intentionally left
-   * off this write — those are invitee-record fields, not appropriate to overwrite on an
-   * attendee's own record from a matched candidate.
+   * service still reported `auto_applied: true`. Identity fields (`first_name`/`last_name`/
+   * `org_name`) are intentionally left off this write — those are invitee-record fields, not
+   * appropriate to overwrite on an attendee's own record from a matched candidate.
    */
   private async applyMatch(req: Request, pastMeetingUid: string, attendeeId: string, candidate: AttendanceReconciliationCandidate): Promise<boolean> {
     const update: ITXUpdatePastMeetingParticipantRequest = {
       is_verified: true,
       is_attended: true,
-      is_ai_reconciled: true,
+      is_ai_reconciled: false,
       is_auto_matched: true,
       ...(candidate.email && { email: candidate.email }),
       ...(candidate.username && { username: candidate.username }),

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -63,7 +63,7 @@ export class AttendanceReconciliationService {
   ): Promise<ReconcilePastMeetingParticipantsResponse> {
     logger.debug(req, 'reconcile_attendance_pool', 'Starting attendance reconciliation', { past_meeting_id: pastMeetingUid });
 
-    const participants = await this.meetingService.getPastMeetingParticipants(req, pastMeetingUid);
+    const participants = await this.meetingService.getPastMeetingParticipants(req, pastMeetingUid, true);
     const unverified = participants.filter((p) => p.is_attended && !p.is_verified);
 
     if (unverified.length === 0) {
@@ -227,7 +227,7 @@ export class AttendanceReconciliationService {
 
     const perOccurrence = await Promise.all(
       priorOccurrences.map((o) =>
-        this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch((error) => {
+        this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id, true).catch((error) => {
           logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch prior occurrence participants, continuing without them', {
             past_meeting_id: o.meeting_and_occurrence_id,
             err: error,
@@ -308,17 +308,27 @@ export class AttendanceReconciliationService {
       const email = attendee.email?.trim().toLowerCase();
       const username = attendee.username?.trim().toLowerCase();
 
-      const match =
-        (email && candidates.find((c) => c.email?.trim().toLowerCase() === email)) ||
-        (username && candidates.find((c) => c.username?.trim().toLowerCase() === username));
+      // The pool deliberately keeps candidates with the same email but conflicting usernames as
+      // separate entries (see buildCandidatePool/isSamePersonForReconciliation), so an attendee's
+      // email and username can each resolve to a different candidate. Collect every distinct
+      // candidate matched by either identifier rather than taking the first hit — auto-applying
+      // against whichever candidate happened to be inserted first would risk writing the wrong
+      // identity. Only a single, unambiguous candidate may match deterministically.
+      const matchedCandidates = new Map<string, AttendanceReconciliationCandidate>();
+      if (email) {
+        candidates.filter((c) => c.email?.trim().toLowerCase() === email).forEach((c) => matchedCandidates.set(c.candidate_id, c));
+      }
+      if (username) {
+        candidates.filter((c) => c.username?.trim().toLowerCase() === username).forEach((c) => matchedCandidates.set(c.candidate_id, c));
+      }
 
-      if (match) {
+      if (matchedCandidates.size === 1) {
         deterministic.push({
           attendee_id: attendee.uid,
           zoom_user_name: this.getDisplayName(attendee),
           confidence: 'high',
           method: 'deterministic',
-          matched_candidate: match,
+          matched_candidate: [...matchedCandidates.values()][0],
           auto_applied: false,
         });
       } else {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -1,7 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL, RECONCILIATION_MAX_PRIOR_OCCURRENCES } from '@lfx-one/shared/constants';
+import {
+  RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL,
+  RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL,
+  RECONCILIATION_MAX_CONCURRENT_AI_CALLS,
+  RECONCILIATION_MAX_PRIOR_OCCURRENCES,
+} from '@lfx-one/shared/constants';
 import {
   AttendanceReconciliationCandidate,
   AttendanceReconciliationResult,
@@ -23,9 +28,10 @@ import { MeetingService } from './meeting.service';
  * Kept out of MeetingService — this is matching/orchestration logic layered on top of
  * MeetingService's existing participant CRUD (item 3), not a new CRUD surface of its own.
  *
- * Deliberately does NOT depend on PR #2060's `isSamePerson` comparator (unmerged, on a
- * non-stacked branch) — `isSamePersonForReconciliation` below is a local equivalent so this
- * branch has no cross-branch dependency.
+ * `MeetingService.getPastMeetingParticipants` now dedupes by pairwise identity match (see that
+ * method's doc comment) rather than a single derived key, so the `unverified`/`invitees` lists
+ * this service builds on are already correctly merged before `isSamePersonForReconciliation`
+ * below ever runs on the wider candidate pool.
  */
 export class AttendanceReconciliationService {
   private meetingService: MeetingService;
@@ -42,7 +48,11 @@ export class AttendanceReconciliationService {
    * Runs reconciliation for every unverified participant of one past-meeting occurrence:
    * builds a candidate pool (occurrence invitees + committee members + previously-verified
    * attendees of prior occurrences), matches deterministically first, falls back to the AI
-   * service for the ambiguous remainder, and auto-applies only `confidence: 'high'` matches.
+   * service for the ambiguous remainder, and auto-applies only `confidence: 'high'` matches —
+   * and only when the candidate pool itself is complete. A degraded pool (a committee-member or
+   * prior-occurrence fetch failed and was silently dropped) disables auto-apply for the whole
+   * call: a missing source could hide the real match for a candidate that would otherwise
+   * auto-apply against the wrong identity, so every result is queued for review instead.
    * `confidence: 'none'` is NEVER auto-applied — it is always returned for admin review, per
    * the fix for PCC-1452's silent "auto-tagged unknown" bug.
    */
@@ -57,10 +67,10 @@ export class AttendanceReconciliationService {
     const unverified = participants.filter((p) => p.is_attended && !p.is_verified);
 
     if (unverified.length === 0) {
-      return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
+      return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0, pool_degraded: false };
     }
 
-    const candidates = await this.buildCandidatePool(req, pastMeetingUid, pastMeeting, participants);
+    const { candidates, degraded } = await this.buildCandidatePool(req, pastMeetingUid, pastMeeting, participants);
 
     const { deterministic, remainder } = this.matchDeterministically(unverified, candidates);
 
@@ -70,7 +80,7 @@ export class AttendanceReconciliationService {
 
     const results = await Promise.all(
       combined.map(async (result) => {
-        if (result.confidence !== 'high' || !result.matched_candidate) {
+        if (result.confidence !== 'high' || !result.matched_candidate || degraded) {
           return result;
         }
 
@@ -87,6 +97,7 @@ export class AttendanceReconciliationService {
       candidate_pool_size: candidates.length,
       auto_applied_count: autoAppliedCount,
       needs_review_count: needsReviewCount,
+      pool_degraded: degraded,
     });
 
     return {
@@ -94,6 +105,7 @@ export class AttendanceReconciliationService {
       candidate_pool_size: candidates.length,
       auto_applied_count: autoAppliedCount,
       needs_review_count: needsReviewCount,
+      pool_degraded: degraded,
     };
   }
 
@@ -106,9 +118,10 @@ export class AttendanceReconciliationService {
     pastMeetingUid: string,
     pastMeeting: PastMeeting,
     occurrenceParticipants: PastMeetingParticipant[]
-  ): Promise<AttendanceReconciliationCandidate[]> {
+  ): Promise<{ candidates: AttendanceReconciliationCandidate[]; degraded: boolean }> {
     const invitees = occurrenceParticipants.filter((p) => p.is_invited);
 
+    let committeeSourceDegraded = false;
     const committeeMembers = (
       await Promise.all(
         (pastMeeting.committees || []).map((committee) =>
@@ -117,13 +130,14 @@ export class AttendanceReconciliationService {
               committee_uid: committee.uid,
               err: error,
             });
+            committeeSourceDegraded = true;
             return [];
           })
         )
       )
     ).flat();
 
-    const priorAttendees = await this.getPriorVerifiedAttendees(req, pastMeeting.meeting_id, pastMeetingUid);
+    const { attendees: priorAttendees, degraded: priorSourceDegraded } = await this.getPriorVerifiedAttendees(req, pastMeeting.meeting_id, pastMeetingUid);
 
     const pool: AttendanceReconciliationCandidate[] = [];
     let nextId = 0;
@@ -132,11 +146,21 @@ export class AttendanceReconciliationService {
       if (!candidate.email && !candidate.username && !candidate.lf_user_id && !(candidate.first_name && candidate.last_name)) {
         return;
       }
-      const existing = pool.find((c) => this.isSamePersonForReconciliation(c, candidate));
-      if (existing) {
+      const existingIndex = pool.findIndex((c) => this.isSamePersonForReconciliation(c, candidate));
+      if (existingIndex === -1) {
+        pool.push({ ...candidate, candidate_id: `c${nextId++}` });
         return;
       }
-      pool.push({ ...candidate, candidate_id: `c${nextId++}` });
+      const existing = pool[existingIndex];
+      pool[existingIndex] = {
+        ...existing,
+        email: existing.email ?? candidate.email,
+        username: existing.username ?? candidate.username,
+        lf_user_id: existing.lf_user_id ?? candidate.lf_user_id,
+        first_name: existing.first_name ?? candidate.first_name,
+        last_name: existing.last_name ?? candidate.last_name,
+        org_name: existing.org_name ?? candidate.org_name,
+      };
     };
 
     invitees.forEach((p) =>
@@ -157,6 +181,7 @@ export class AttendanceReconciliationService {
         username: m.username,
         first_name: m.first_name,
         last_name: m.last_name,
+        org_name: m.organization?.name,
       })
     );
 
@@ -171,7 +196,7 @@ export class AttendanceReconciliationService {
       })
     );
 
-    return pool;
+    return { candidates: pool, degraded: committeeSourceDegraded || priorSourceDegraded };
   }
 
   /**
@@ -179,10 +204,15 @@ export class AttendanceReconciliationService {
    * series for participants already marked `is_verified` — Stephan's "we should even store it"
    * carry-forward signal, and the direct answer to PCC-1451 for this port's candidate pool.
    */
-  private async getPriorVerifiedAttendees(req: Request, meetingUid: string, currentOccurrenceId: string): Promise<PastMeetingParticipant[]> {
+  private async getPriorVerifiedAttendees(
+    req: Request,
+    meetingUid: string,
+    currentOccurrenceId: string
+  ): Promise<{ attendees: PastMeetingParticipant[]; degraded: boolean }> {
     const occurrences = await this.meetingService.getPastOccurrencesForMeeting(req, meetingUid);
     const priorOccurrences = occurrences.filter((o) => o.meeting_and_occurrence_id !== currentOccurrenceId).slice(-RECONCILIATION_MAX_PRIOR_OCCURRENCES);
 
+    let degraded = false;
     const perOccurrence = await Promise.all(
       priorOccurrences.map((o) =>
         this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch((error) => {
@@ -190,12 +220,13 @@ export class AttendanceReconciliationService {
             past_meeting_id: o.meeting_and_occurrence_id,
             err: error,
           });
+          degraded = true;
           return [];
         })
       )
     );
 
-    return perOccurrence.flat().filter((p) => p.is_verified);
+    return { attendees: perOccurrence.flat().filter((p) => p.is_verified), degraded };
   }
 
   /**
@@ -241,7 +272,10 @@ export class AttendanceReconciliationService {
    * the very attendees this service is trying to match.
    */
   private getDisplayName(attendee: PastMeetingParticipant): string {
-    return attendee.zoom_user_name || `${attendee.first_name} ${attendee.last_name}`.trim();
+    if (attendee.zoom_user_name) {
+      return attendee.zoom_user_name;
+    }
+    return [attendee.first_name, attendee.last_name].filter(Boolean).join(' ').trim();
   }
 
   /**
@@ -310,75 +344,117 @@ export class AttendanceReconciliationService {
       chunks.push(remainder.slice(i, i + RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL));
     }
 
-    const chunkResults = await Promise.all(
-      chunks.map(async (chunk) => {
-        try {
-          const response = await this.aiService.reconcileAttendees(req, {
-            attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: this.getDisplayName(a) })),
-            candidates,
-          });
+    const chunkResults: AttendanceReconciliationResult[][] = new Array(chunks.length);
+    let nextChunkIndex = 0;
 
-          const byId = new Map(response.matches.map((m) => [m.attendee_id, m]));
+    const worker = async (): Promise<void> => {
+      while (nextChunkIndex < chunks.length) {
+        const chunkIndex = nextChunkIndex++;
+        const chunk = chunks[chunkIndex];
+        chunkResults[chunkIndex] = await this.matchChunkWithAi(req, chunk, candidates);
+      }
+    };
 
-          return chunk.map((attendee) => {
-            const match = byId.get(attendee.uid);
-            const matchedCandidate = match?.matched_candidate_id ? candidates.find((c) => c.candidate_id === match.matched_candidate_id) : undefined;
-
-            // Only trust the model's stated confidence when its candidate_id actually resolved.
-            // A resolved-confidence + no-candidate combination (omitted attendee, hallucinated
-            // candidate_id, or a spec-violating null-candidate-but-non-none-confidence response)
-            // always degrades to 'none' rather than surfacing a misleading confidence with nothing
-            // attached to it.
-            const confidence = match && matchedCandidate ? match.confidence : ('none' as const);
-
-            return {
-              attendee_id: attendee.uid,
-              zoom_user_name: this.getDisplayName(attendee),
-              confidence,
-              method: 'ai' as const,
-              matched_candidate: matchedCandidate,
-              auto_applied: false,
-            };
-          });
-        } catch (error) {
-          // A transient AI failure on one chunk must not sink the whole reconciliation call —
-          // the deterministic matches already computed for other attendees would otherwise be
-          // lost along with it. Degrade this chunk to 'none' so it queues for review instead.
-          logger.warning(req, 'reconcile_attendance_pool', 'AI reconciliation chunk failed, queuing attendees for review', {
-            attendee_count: chunk.length,
-            err: error,
-          });
-          return chunk.map((attendee) => ({
-            attendee_id: attendee.uid,
-            zoom_user_name: this.getDisplayName(attendee),
-            confidence: 'none' as const,
-            method: 'ai' as const,
-            auto_applied: false,
-          }));
-        }
-      })
-    );
+    await Promise.all(Array.from({ length: Math.min(RECONCILIATION_MAX_CONCURRENT_AI_CALLS, chunks.length) }, () => worker()));
 
     return chunkResults.flat();
   }
 
   /**
-   * Writes a high-confidence match back onto the attendee's participant record.
-   * `ITXUpdatePastMeetingParticipantRequest` does not accept `is_ai_reconciled`/`is_auto_matched`
-   * (response-only fields, per item 3's documented request/response asymmetry) — this writes the
-   * matched candidate's identity fields plus `is_verified: true` instead. `AttendanceReconciliationResult.method`/
-   * `auto_applied` (this service's own response shape) is what the future review UI (item 5)
-   * relies on to know a match was AI-applied, not the upstream record's flags.
+   * Ranks the full candidate pool for one chunk's attendees and truncates to
+   * RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL — a large pool otherwise scales prompt size with
+   * pool size on top of attendee count. Ranked by normalized-name token overlap against the
+   * chunk's attendees so the candidates most plausibly relevant to this specific chunk survive
+   * truncation, rather than an arbitrary prefix of the pool.
+   */
+  private rankCandidatesForChunk(chunk: PastMeetingParticipant[], candidates: AttendanceReconciliationCandidate[]): AttendanceReconciliationCandidate[] {
+    if (candidates.length <= RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL) {
+      return candidates;
+    }
+
+    const attendeeTokens = new Set(chunk.flatMap((attendee) => this.getDisplayName(attendee).toLowerCase().split(/\s+/).filter(Boolean)));
+
+    const score = (candidate: AttendanceReconciliationCandidate): number => {
+      const candidateTokens = [candidate.first_name, candidate.last_name, candidate.username]
+        .filter(Boolean)
+        .flatMap((value) => value!.toLowerCase().split(/\s+/));
+      return candidateTokens.filter((token) => attendeeTokens.has(token)).length;
+    };
+
+    return [...candidates].sort((a, b) => score(b) - score(a)).slice(0, RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL);
+  }
+
+  private async matchChunkWithAi(
+    req: Request,
+    chunk: PastMeetingParticipant[],
+    candidates: AttendanceReconciliationCandidate[]
+  ): Promise<AttendanceReconciliationResult[]> {
+    try {
+      const rankedCandidates = this.rankCandidatesForChunk(chunk, candidates);
+      const response = await this.aiService.reconcileAttendees(req, {
+        attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: this.getDisplayName(a) })),
+        candidates: rankedCandidates,
+      });
+
+      const byId = new Map(response.matches.map((m) => [m.attendee_id, m]));
+
+      return chunk.map((attendee) => {
+        const match = byId.get(attendee.uid);
+        const matchedCandidate = match?.matched_candidate_id ? rankedCandidates.find((c) => c.candidate_id === match.matched_candidate_id) : undefined;
+
+        // Only trust the model's stated confidence when its candidate_id actually resolved.
+        // A resolved-confidence + no-candidate combination (omitted attendee, hallucinated
+        // candidate_id, or a spec-violating null-candidate-but-non-none-confidence response)
+        // always degrades to 'none' rather than surfacing a misleading confidence with nothing
+        // attached to it.
+        const confidence = match && matchedCandidate ? match.confidence : ('none' as const);
+
+        return {
+          attendee_id: attendee.uid,
+          zoom_user_name: this.getDisplayName(attendee),
+          confidence,
+          method: 'ai' as const,
+          matched_candidate: matchedCandidate,
+          auto_applied: false,
+        };
+      });
+    } catch (error) {
+      // A transient AI failure on one chunk must not sink the whole reconciliation call —
+      // the deterministic matches already computed for other attendees would otherwise be
+      // lost along with it. Degrade this chunk to 'none' so it queues for review instead.
+      logger.warning(req, 'reconcile_attendance_pool', 'AI reconciliation chunk failed, queuing attendees for review', {
+        attendee_count: chunk.length,
+        err: error,
+      });
+      return chunk.map((attendee) => ({
+        attendee_id: attendee.uid,
+        zoom_user_name: this.getDisplayName(attendee),
+        confidence: 'none' as const,
+        method: 'ai' as const,
+        auto_applied: false,
+      }));
+    }
+  }
+
+  /**
+   * Writes a high-confidence match back onto the attendee's participant record. Sets
+   * `is_attended: true` explicitly — the upstream ITX handler no-ops an attendee update when
+   * `is_attended` is omitted, so leaving it out would silently fail to persist while this
+   * service still reported `auto_applied: true`. Also sets `is_ai_reconciled`/`is_auto_matched`
+   * so the persisted record itself carries the AI-match provenance, not just this service's own
+   * response shape. Identity fields (`first_name`/`last_name`/`org_name`) are intentionally left
+   * off this write — those are invitee-record fields, not appropriate to overwrite on an
+   * attendee's own record from a matched candidate.
    */
   private async applyMatch(req: Request, pastMeetingUid: string, attendeeId: string, candidate: AttendanceReconciliationCandidate): Promise<boolean> {
     const update: ITXUpdatePastMeetingParticipantRequest = {
       is_verified: true,
+      is_attended: true,
+      is_ai_reconciled: true,
+      is_auto_matched: true,
       ...(candidate.email && { email: candidate.email }),
       ...(candidate.username && { username: candidate.username }),
       ...(candidate.lf_user_id && { lf_user_id: candidate.lf_user_id }),
-      ...(candidate.first_name && { first_name: candidate.first_name }),
-      ...(candidate.last_name && { last_name: candidate.last_name }),
-      ...(candidate.org_name && { org_name: candidate.org_name }),
     };
 
     try {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -130,7 +130,7 @@ export class AttendanceReconciliationService {
     const committeeMembers = (
       await Promise.all(
         (pastMeeting.committees || []).map((committee) =>
-          this.committeeService.getCommitteeMembers(req, committee.uid).catch((error) => {
+          this.committeeService.getCommitteeMembers(req, committee.uid, {}, { failOnPartial: true }).catch((error) => {
             logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch committee members, continuing without them', {
               committee_uid: committee.uid,
               err: error,
@@ -264,6 +264,14 @@ export class AttendanceReconciliationService {
       return emailA === emailB;
     }
 
+    // A hard identifier (username/email) on only one side is evidence the two records were
+    // never confirmed to be the same person — falling through to a name-only match here would
+    // merge them on a weaker signal than a stronger one already available. Only compare by name
+    // when neither side has any hard identifier to compare instead.
+    if (usernameA || usernameB || emailA || emailB) {
+      return false;
+    }
+
     const nameA = this.normalizeName(a.first_name, a.last_name);
     const nameB = this.normalizeName(b.first_name, b.last_name);
     return !!nameA && !!nameB && nameA === nameB;
@@ -322,13 +330,25 @@ export class AttendanceReconciliationService {
         candidates.filter((c) => c.username?.trim().toLowerCase() === username).forEach((c) => matchedCandidates.set(c.candidate_id, c));
       }
 
-      if (matchedCandidates.size === 1) {
+      const matched = matchedCandidates.size === 1 ? [...matchedCandidates.values()][0] : undefined;
+
+      // A single matched candidate is only safe to auto-match deterministically if it doesn't
+      // itself contradict the attendee on the identifier that didn't match — e.g. the attendee's
+      // email hit this candidate, but the attendee's username disagrees with the candidate's
+      // username. That's a conflicting-identity signal, not confirmation, so fall through to the
+      // ambiguous remainder instead of treating it as a confident match.
+      const candidateUsername = matched?.username?.trim().toLowerCase();
+      const candidateEmail = matched?.email?.trim().toLowerCase();
+      const hasConflict =
+        !!matched && ((!!username && !!candidateUsername && username !== candidateUsername) || (!!email && !!candidateEmail && email !== candidateEmail));
+
+      if (matched && !hasConflict) {
         deterministic.push({
           attendee_id: attendee.uid,
           zoom_user_name: this.getDisplayName(attendee),
           confidence: 'high',
           method: 'deterministic',
-          matched_candidate: [...matchedCandidates.values()][0],
+          matched_candidate: matched,
           auto_applied: false,
         });
       } else {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -467,27 +467,33 @@ export class AttendanceReconciliationService {
    * `is_attended` is omitted, so leaving it out would silently fail to persist while this
    * service still reported `auto_applied: true`.
    *
-   * Also sets `is_invited: true` whenever an identity field is present: lfx-v2-meeting-service's
-   * update converter routes `email`/`username`/`lf_user_id` only into the invitee sub-record
+   * Also sets `is_invited: true` when the matched candidate is itself an occurrence invitee
+   * (`source === 'invitee'`) and carries an identity field: lfx-v2-meeting-service's update
+   * converter routes `email`/`username`/`lf_user_id` only into the invitee sub-record
    * (`UpdateInviteeRequest`), and its service layer no-ops that entire invitee operation when
    * `is_invited` is omitted — sending identity fields without `is_invited: true` would silently
    * drop them upstream while this method still reported success. `first_name`/`last_name` are
    * included alongside because ITX requires them to create an invitee record that doesn't already
-   * exist for this attendee.
+   * exist for this attendee. Crucially, this is scoped to `source === 'invitee'` only: a walk-in
+   * matched against a committee member or a prior occurrence's attendee was never invited to
+   * *this* occurrence, and setting `is_invited: true` for them would incorrectly create an
+   * invitee record — inflating invited counts and hiding them from the uninvited filter. For
+   * those sources, identity fields are intentionally omitted (they'd be dropped upstream anyway
+   * without `is_invited`); only the attendee-only verification flags are written.
    */
   private async applyMatch(req: Request, pastMeetingUid: string, attendeeId: string, candidate: AttendanceReconciliationCandidate): Promise<boolean> {
-    const hasIdentity = !!(candidate.email || candidate.username || candidate.lf_user_id);
+    const canSetInvited = candidate.source === 'invitee' && !!(candidate.email || candidate.username || candidate.lf_user_id);
     const update: ITXUpdatePastMeetingParticipantRequest = {
       is_verified: true,
       is_attended: true,
       is_ai_reconciled: false,
       is_auto_matched: true,
-      ...(hasIdentity && { is_invited: true }),
-      ...(candidate.email && { email: candidate.email }),
-      ...(candidate.username && { username: candidate.username }),
-      ...(candidate.lf_user_id && { lf_user_id: candidate.lf_user_id }),
-      ...(candidate.first_name && { first_name: candidate.first_name }),
-      ...(candidate.last_name && { last_name: candidate.last_name }),
+      ...(canSetInvited && { is_invited: true }),
+      ...(canSetInvited && candidate.email && { email: candidate.email }),
+      ...(canSetInvited && candidate.username && { username: candidate.username }),
+      ...(canSetInvited && candidate.lf_user_id && { lf_user_id: candidate.lf_user_id }),
+      ...(canSetInvited && candidate.first_name && { first_name: candidate.first_name }),
+      ...(canSetInvited && candidate.last_name && { last_name: candidate.last_name }),
     };
 
     try {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -28,10 +28,10 @@ import { MeetingService } from './meeting.service';
  * Kept out of MeetingService — this is matching/orchestration logic layered on top of
  * MeetingService's existing participant CRUD (item 3), not a new CRUD surface of its own.
  *
- * `MeetingService.getPastMeetingParticipants` now dedupes by pairwise identity match (see that
- * method's doc comment) rather than a single derived key, so the `unverified`/`invitees` lists
- * this service builds on are already correctly merged before `isSamePersonForReconciliation`
- * below ever runs on the wider candidate pool.
+ * `MeetingService.getPastMeetingParticipants` dedupes via connected components over pairwise
+ * identity matches (see that method's doc comment), so the `unverified`/`invitees` lists this
+ * service builds on are already correctly merged before `isSamePersonForReconciliation` below
+ * ever runs on the wider candidate pool.
  */
 export class AttendanceReconciliationService {
   private meetingService: MeetingService;
@@ -242,26 +242,26 @@ export class AttendanceReconciliationService {
   }
 
   /**
-   * Identity comparator for candidate-pool dedup. Local to this service — does not depend on
-   * PR #2060's `isSamePerson` (unmerged, non-stacked branch). Mirrors that comparator's branch
-   * order: prefer overlapping email, then username (this repo's LFID-equivalent), then
-   * normalized name — an email match takes priority over username asymmetry, so two records
-   * sharing an email still merge even if only one carries a username.
+   * Identity comparator for candidate-pool dedup. Local to this service rather than reused from
+   * `MeetingService.isSamePerson` — the two operate on different shapes (this pool's candidates
+   * are a lightweight identity projection, not full `PastMeetingParticipant` records) — but
+   * mirrors that comparator's branch order for consistency: prefer username (this repo's
+   * LFID-equivalent) when both have one, else overlapping email, else normalized name.
    */
   private isSamePersonForReconciliation(
     a: { email?: string; username?: string; first_name?: string; last_name?: string },
     b: { email?: string; username?: string; first_name?: string; last_name?: string }
   ): boolean {
-    const emailA = a.email?.trim().toLowerCase();
-    const emailB = b.email?.trim().toLowerCase();
-    if (emailA && emailB) {
-      return emailA === emailB;
-    }
-
     const usernameA = a.username?.trim().toLowerCase();
     const usernameB = b.username?.trim().toLowerCase();
     if (usernameA && usernameB) {
       return usernameA === usernameB;
+    }
+
+    const emailA = a.email?.trim().toLowerCase();
+    const emailB = b.email?.trim().toLowerCase();
+    if (emailA && emailB) {
+      return emailA === emailB;
     }
 
     const nameA = this.normalizeName(a.first_name, a.last_name);

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -1,0 +1,396 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL, RECONCILIATION_MAX_PRIOR_OCCURRENCES } from '@lfx-one/shared/constants';
+import {
+  AttendanceReconciliationCandidate,
+  AttendanceReconciliationResult,
+  ITXUpdatePastMeetingParticipantRequest,
+  PastMeeting,
+  PastMeetingParticipant,
+  ReconcilePastMeetingParticipantsResponse,
+} from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { AiService } from './ai.service';
+import { CommitteeService } from './committee.service';
+import { logger } from './logger.service';
+import { MeetingService } from './meeting.service';
+
+/**
+ * Attendance reconciliation for past-meeting participants (GH-1672 / PCC-1452 port).
+ *
+ * Kept out of MeetingService — this is matching/orchestration logic layered on top of
+ * MeetingService's existing participant CRUD (item 3), not a new CRUD surface of its own.
+ *
+ * Deliberately does NOT depend on PR #2060's `isSamePerson` comparator (unmerged, on a
+ * non-stacked branch) — `isSamePersonForReconciliation` below is a local equivalent so this
+ * branch has no cross-branch dependency.
+ */
+export class AttendanceReconciliationService {
+  private meetingService: MeetingService;
+  private committeeService: CommitteeService;
+  private aiService: AiService;
+
+  public constructor() {
+    this.meetingService = new MeetingService();
+    this.committeeService = new CommitteeService();
+    this.aiService = new AiService();
+  }
+
+  /**
+   * Runs reconciliation for every unverified participant of one past-meeting occurrence:
+   * builds a candidate pool (occurrence invitees + committee members + previously-verified
+   * attendees of prior occurrences), matches deterministically first, falls back to the AI
+   * service for the ambiguous remainder, and auto-applies only `confidence: 'high'` matches.
+   * `confidence: 'none'` is NEVER auto-applied — it is always returned for admin review, per
+   * the fix for PCC-1452's silent "auto-tagged unknown" bug.
+   */
+  public async reconcilePastMeetingParticipants(
+    req: Request,
+    pastMeetingUid: string,
+    pastMeeting: PastMeeting
+  ): Promise<ReconcilePastMeetingParticipantsResponse> {
+    logger.debug(req, 'reconcile_attendance_pool', 'Starting attendance reconciliation', { past_meeting_id: pastMeetingUid });
+
+    const participants = await this.meetingService.getPastMeetingParticipants(req, pastMeetingUid);
+    const unverified = participants.filter((p) => p.is_attended && !p.is_verified);
+
+    if (unverified.length === 0) {
+      return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
+    }
+
+    const candidates = await this.buildCandidatePool(req, pastMeetingUid, pastMeeting, participants);
+
+    const { deterministic, remainder } = this.matchDeterministically(unverified, candidates);
+
+    const aiMatched = remainder.length > 0 ? await this.matchWithAi(req, remainder, candidates) : [];
+
+    const combined = [...deterministic, ...aiMatched];
+
+    const results = await Promise.all(
+      combined.map(async (result) => {
+        if (result.confidence !== 'high' || !result.matched_candidate) {
+          return result;
+        }
+
+        const applied = await this.applyMatch(req, pastMeetingUid, result.attendee_id, result.matched_candidate);
+        return { ...result, auto_applied: applied };
+      })
+    );
+
+    const autoAppliedCount = results.filter((r) => r.auto_applied).length;
+    const needsReviewCount = results.filter((r) => !r.auto_applied).length;
+
+    logger.info(req, 'reconcile_attendance_pool', 'Attendance reconciliation completed', {
+      unverified_count: unverified.length,
+      candidate_pool_size: candidates.length,
+      auto_applied_count: autoAppliedCount,
+      needs_review_count: needsReviewCount,
+    });
+
+    return {
+      results,
+      candidate_pool_size: candidates.length,
+      auto_applied_count: autoAppliedCount,
+      needs_review_count: needsReviewCount,
+    };
+  }
+
+  /**
+   * Union of three candidate sources, deduped via `isSamePersonForReconciliation` — a single-
+   * source pool (just that occurrence's invitees) was PCC's PCC-1452 root cause.
+   */
+  private async buildCandidatePool(
+    req: Request,
+    pastMeetingUid: string,
+    pastMeeting: PastMeeting,
+    occurrenceParticipants: PastMeetingParticipant[]
+  ): Promise<AttendanceReconciliationCandidate[]> {
+    const invitees = occurrenceParticipants.filter((p) => p.is_invited);
+
+    const committeeMembers = (
+      await Promise.all(
+        (pastMeeting.committees || []).map((committee) =>
+          this.committeeService.getCommitteeMembers(req, committee.uid).catch((error) => {
+            logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch committee members, continuing without them', {
+              committee_uid: committee.uid,
+              err: error,
+            });
+            return [];
+          })
+        )
+      )
+    ).flat();
+
+    const priorAttendees = await this.getPriorVerifiedAttendees(req, pastMeeting.meeting_id, pastMeetingUid);
+
+    const pool: AttendanceReconciliationCandidate[] = [];
+    let nextId = 0;
+
+    const pushIfNew = (candidate: Omit<AttendanceReconciliationCandidate, 'candidate_id'>): void => {
+      if (!candidate.email && !candidate.username && !candidate.lf_user_id && !(candidate.first_name && candidate.last_name)) {
+        return;
+      }
+      const existing = pool.find((c) => this.isSamePersonForReconciliation(c, candidate));
+      if (existing) {
+        return;
+      }
+      pool.push({ ...candidate, candidate_id: `c${nextId++}` });
+    };
+
+    invitees.forEach((p) =>
+      pushIfNew({
+        source: 'invitee',
+        email: p.email,
+        username: p.username,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        org_name: p.org_name,
+      })
+    );
+
+    committeeMembers.forEach((m) =>
+      pushIfNew({
+        source: 'committee_member',
+        email: m.email,
+        username: m.username,
+        first_name: m.first_name,
+        last_name: m.last_name,
+      })
+    );
+
+    priorAttendees.forEach((p) =>
+      pushIfNew({
+        source: 'prior_attendee',
+        email: p.email,
+        username: p.username,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        org_name: p.org_name,
+      })
+    );
+
+    return pool;
+  }
+
+  /**
+   * Scans up to RECONCILIATION_MAX_PRIOR_OCCURRENCES most-recent prior occurrences of the same
+   * series for participants already marked `is_verified` — Stephan's "we should even store it"
+   * carry-forward signal, and the direct answer to PCC-1451 for this port's candidate pool.
+   */
+  private async getPriorVerifiedAttendees(req: Request, meetingUid: string, currentOccurrenceId: string): Promise<PastMeetingParticipant[]> {
+    const occurrences = await this.meetingService.getPastOccurrencesForMeeting(req, meetingUid);
+    const priorOccurrences = occurrences.filter((o) => o.meeting_and_occurrence_id !== currentOccurrenceId).slice(-RECONCILIATION_MAX_PRIOR_OCCURRENCES);
+
+    const perOccurrence = await Promise.all(
+      priorOccurrences.map((o) =>
+        this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch((error) => {
+          logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch prior occurrence participants, continuing without them', {
+            past_meeting_id: o.meeting_and_occurrence_id,
+            err: error,
+          });
+          return [];
+        })
+      )
+    );
+
+    return perOccurrence.flat().filter((p) => p.is_verified);
+  }
+
+  /**
+   * Identity comparator for candidate-pool dedup. Local to this service — does not depend on
+   * PR #2060's `isSamePerson` (unmerged, non-stacked branch). Mirrors that comparator's branch
+   * order: prefer overlapping email, then username (this repo's LFID-equivalent), then
+   * normalized name — an email match takes priority over username asymmetry, so two records
+   * sharing an email still merge even if only one carries a username.
+   */
+  private isSamePersonForReconciliation(
+    a: { email?: string; username?: string; first_name?: string; last_name?: string },
+    b: { email?: string; username?: string; first_name?: string; last_name?: string }
+  ): boolean {
+    const emailA = a.email?.trim().toLowerCase();
+    const emailB = b.email?.trim().toLowerCase();
+    if (emailA && emailB) {
+      return emailA === emailB;
+    }
+
+    const usernameA = a.username?.trim().toLowerCase();
+    const usernameB = b.username?.trim().toLowerCase();
+    if (usernameA && usernameB) {
+      return usernameA === usernameB;
+    }
+
+    const nameA = this.normalizeName(a.first_name, a.last_name);
+    const nameB = this.normalizeName(b.first_name, b.last_name);
+    return !!nameA && !!nameB && nameA === nameB;
+  }
+
+  private normalizeName(firstName?: string, lastName?: string): string | undefined {
+    if (!firstName || !lastName) {
+      return undefined;
+    }
+    return `${firstName.trim().toLowerCase()} ${lastName.trim().toLowerCase()}`;
+  }
+
+  /**
+   * A raw, not-yet-identified Zoom attendee (the exact population this feature targets) has no
+   * reason to carry a populated `first_name`/`last_name` — those are enrichment fields set once a
+   * match is found. `zoom_user_name` is the only display name guaranteed to exist for such an
+   * attendee, so it must be preferred over reconstructing from first/last name, which is empty for
+   * the very attendees this service is trying to match.
+   */
+  private getDisplayName(attendee: PastMeetingParticipant): string {
+    return attendee.zoom_user_name || `${attendee.first_name} ${attendee.last_name}`.trim();
+  }
+
+  /**
+   * Cheap deterministic pass: exact email match, then username match. No LLM call — only the
+   * genuinely ambiguous remainder is handed to `matchWithAi`.
+   */
+  private matchDeterministically(
+    unverified: PastMeetingParticipant[],
+    candidates: AttendanceReconciliationCandidate[]
+  ): {
+    deterministic: AttendanceReconciliationResult[];
+    remainder: PastMeetingParticipant[];
+  } {
+    const deterministic: AttendanceReconciliationResult[] = [];
+    const remainder: PastMeetingParticipant[] = [];
+
+    for (const attendee of unverified) {
+      const email = attendee.email?.trim().toLowerCase();
+      const username = attendee.username?.trim().toLowerCase();
+
+      const match =
+        (email && candidates.find((c) => c.email?.trim().toLowerCase() === email)) ||
+        (username && candidates.find((c) => c.username?.trim().toLowerCase() === username));
+
+      if (match) {
+        deterministic.push({
+          attendee_id: attendee.uid,
+          zoom_user_name: this.getDisplayName(attendee),
+          confidence: 'high',
+          method: 'deterministic',
+          matched_candidate: match,
+          auto_applied: false,
+        });
+      } else {
+        remainder.push(attendee);
+      }
+    }
+
+    return { deterministic, remainder };
+  }
+
+  /**
+   * Sends the ambiguous remainder to AiService.reconcileAttendees, chunked at
+   * RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL so a large occurrence doesn't produce one
+   * unbounded prompt. Any attendee_id the model omits is treated as confidence 'none' rather
+   * than lost. Skips the call entirely (all 'none') when the AI service isn't configured —
+   * matching queues are still safe without it.
+   */
+  private async matchWithAi(
+    req: Request,
+    remainder: PastMeetingParticipant[],
+    candidates: AttendanceReconciliationCandidate[]
+  ): Promise<AttendanceReconciliationResult[]> {
+    if (!this.aiService.isAiConfigured()) {
+      return remainder.map((attendee) => ({
+        attendee_id: attendee.uid,
+        zoom_user_name: this.getDisplayName(attendee),
+        confidence: 'none',
+        method: 'ai',
+        auto_applied: false,
+      }));
+    }
+
+    const chunks: PastMeetingParticipant[][] = [];
+    for (let i = 0; i < remainder.length; i += RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL) {
+      chunks.push(remainder.slice(i, i + RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL));
+    }
+
+    const chunkResults = await Promise.all(
+      chunks.map(async (chunk) => {
+        try {
+          const response = await this.aiService.reconcileAttendees(req, {
+            attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: this.getDisplayName(a) })),
+            candidates,
+          });
+
+          const byId = new Map(response.matches.map((m) => [m.attendee_id, m]));
+
+          return chunk.map((attendee) => {
+            const match = byId.get(attendee.uid);
+            const matchedCandidate = match?.matched_candidate_id ? candidates.find((c) => c.candidate_id === match.matched_candidate_id) : undefined;
+
+            // Only trust the model's stated confidence when its candidate_id actually resolved.
+            // A resolved-confidence + no-candidate combination (omitted attendee, hallucinated
+            // candidate_id, or a spec-violating null-candidate-but-non-none-confidence response)
+            // always degrades to 'none' rather than surfacing a misleading confidence with nothing
+            // attached to it.
+            const confidence = match && matchedCandidate ? match.confidence : ('none' as const);
+
+            return {
+              attendee_id: attendee.uid,
+              zoom_user_name: this.getDisplayName(attendee),
+              confidence,
+              method: 'ai' as const,
+              matched_candidate: matchedCandidate,
+              auto_applied: false,
+            };
+          });
+        } catch (error) {
+          // A transient AI failure on one chunk must not sink the whole reconciliation call —
+          // the deterministic matches already computed for other attendees would otherwise be
+          // lost along with it. Degrade this chunk to 'none' so it queues for review instead.
+          logger.warning(req, 'reconcile_attendance_pool', 'AI reconciliation chunk failed, queuing attendees for review', {
+            attendee_count: chunk.length,
+            err: error,
+          });
+          return chunk.map((attendee) => ({
+            attendee_id: attendee.uid,
+            zoom_user_name: this.getDisplayName(attendee),
+            confidence: 'none' as const,
+            method: 'ai' as const,
+            auto_applied: false,
+          }));
+        }
+      })
+    );
+
+    return chunkResults.flat();
+  }
+
+  /**
+   * Writes a high-confidence match back onto the attendee's participant record.
+   * `ITXUpdatePastMeetingParticipantRequest` does not accept `is_ai_reconciled`/`is_auto_matched`
+   * (response-only fields, per item 3's documented request/response asymmetry) — this writes the
+   * matched candidate's identity fields plus `is_verified: true` instead. `AttendanceReconciliationResult.method`/
+   * `auto_applied` (this service's own response shape) is what the future review UI (item 5)
+   * relies on to know a match was AI-applied, not the upstream record's flags.
+   */
+  private async applyMatch(req: Request, pastMeetingUid: string, attendeeId: string, candidate: AttendanceReconciliationCandidate): Promise<boolean> {
+    const update: ITXUpdatePastMeetingParticipantRequest = {
+      is_verified: true,
+      ...(candidate.email && { email: candidate.email }),
+      ...(candidate.username && { username: candidate.username }),
+      ...(candidate.lf_user_id && { lf_user_id: candidate.lf_user_id }),
+      ...(candidate.first_name && { first_name: candidate.first_name }),
+      ...(candidate.last_name && { last_name: candidate.last_name }),
+      ...(candidate.org_name && { org_name: candidate.org_name }),
+    };
+
+    try {
+      await this.meetingService.updatePastMeetingParticipant(req, pastMeetingUid, attendeeId, update);
+      return true;
+    } catch (error) {
+      logger.warning(req, 'reconcile_attendance_pool', 'Failed to auto-apply high-confidence match, leaving for review', {
+        past_meeting_id: pastMeetingUid,
+        attendee_id: attendeeId,
+        err: error,
+      });
+      return false;
+    }
+  }
+}

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -39,7 +39,7 @@ import FormData from 'form-data';
 import { AuthorizationError, ConflictError, MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
-import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { fetchAllQueryResources, FetchAllQueryResourcesOptions } from '../helpers/query-service.helper';
 import { logger } from '../services/logger.service';
 import { resolveAuditUserDisplayName, getUsernameFromAuth, isImpersonating } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
@@ -785,7 +785,12 @@ export class CommitteeService {
   /**
    * Fetches all members for a specific committee
    */
-  public async getCommitteeMembers(req: Request, committeeId: string, query: Record<string, any> = {}): Promise<CommitteeMember[]> {
+  public async getCommitteeMembers(
+    req: Request,
+    committeeId: string,
+    query: Record<string, any> = {},
+    fetchOptions: FetchAllQueryResourcesOptions = {}
+  ): Promise<CommitteeMember[]> {
     const queryFilters = { ...query };
     delete queryFilters['page_token'];
     delete queryFilters['page_size'];
@@ -796,11 +801,14 @@ export class CommitteeService {
       tags: `committee_uid:${committeeId}`,
     };
 
-    return fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    return fetchAllQueryResources<CommitteeMember>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          ...params,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      fetchOptions
     );
   }
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -939,13 +939,13 @@ describe('MeetingService participant write methods', () => {
     const created = { id: 'p-1', past_meeting_id: 'pm-1', meeting_id: 'mtg-1', is_attended: true, zoom_user_name: 'Alice Z' };
     proxyRequest.mockResolvedValueOnce(created);
 
-    const result = await service.createPastMeetingParticipant(req, 'pm-1', { is_attended: true, zoom_user_name: 'Alice Z' });
+    const result = await service.createPastMeetingParticipant(req, 'pm-1', { is_attended: true, is_unknown: false });
 
     expect(proxyRequest).toHaveBeenCalledTimes(1);
     const [, , path, method, , body] = proxyRequest.mock.calls[0];
     expect(path).toBe('/itx/past_meetings/pm-1/participants');
     expect(method).toBe('POST');
-    expect(body).toEqual({ is_attended: true, zoom_user_name: 'Alice Z' });
+    expect(body).toEqual({ is_attended: true, is_unknown: false });
     expect(result).toEqual(created);
   });
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -926,3 +926,61 @@ describe('MeetingService.getPastMeetingParticipants', () => {
     expect(result[0].email).toBe('jane@example.com');
   });
 });
+
+describe('MeetingService participant write methods', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('createPastMeetingParticipant posts to the participants endpoint with the given body', async () => {
+    const created = { id: 'p-1', past_meeting_id: 'pm-1', meeting_id: 'mtg-1', is_attended: true, zoom_user_name: 'Alice Z' };
+    proxyRequest.mockResolvedValueOnce(created);
+
+    const result = await service.createPastMeetingParticipant(req, 'pm-1', { is_attended: true, zoom_user_name: 'Alice Z' });
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    const [, , path, method, , body] = proxyRequest.mock.calls[0];
+    expect(path).toBe('/itx/past_meetings/pm-1/participants');
+    expect(method).toBe('POST');
+    expect(body).toEqual({ is_attended: true, zoom_user_name: 'Alice Z' });
+    expect(result).toEqual(created);
+  });
+
+  it('updatePastMeetingParticipant puts to the participant endpoint with the participant id in the path', async () => {
+    const updated = { id: 'p-1', past_meeting_id: 'pm-1', meeting_id: 'mtg-1', is_verified: true };
+    proxyRequest.mockResolvedValueOnce(updated);
+
+    const result = await service.updatePastMeetingParticipant(req, 'pm-1', 'p-1', { is_verified: true });
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    const [, , path, method, , body] = proxyRequest.mock.calls[0];
+    expect(path).toBe('/itx/past_meetings/pm-1/participants/p-1');
+    expect(method).toBe('PUT');
+    expect(body).toEqual({ is_verified: true });
+    expect(result).toEqual(updated);
+  });
+
+  it('deletePastMeetingParticipant deletes the participant endpoint and returns nothing', async () => {
+    proxyRequest.mockResolvedValueOnce(undefined);
+
+    const result = await service.deletePastMeetingParticipant(req, 'pm-1', 'p-1');
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    const [, , path, method] = proxyRequest.mock.calls[0];
+    expect(path).toBe('/itx/past_meetings/pm-1/participants/p-1');
+    expect(method).toBe('DELETE');
+    expect(result).toBeUndefined();
+  });
+
+  it('encodes past meeting id and participant id in the URL', async () => {
+    proxyRequest.mockResolvedValueOnce({ id: 'p/1', past_meeting_id: 'pm 1', meeting_id: 'mtg-1' });
+
+    await service.updatePastMeetingParticipant(req, 'pm 1', 'p/1', {});
+
+    const [, , path] = proxyRequest.mock.calls[0];
+    expect(path).toBe('/itx/past_meetings/pm%201/participants/p%2F1');
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -13,7 +13,10 @@ import {
   CreateMeetingRequest,
   CreateMeetingRsvpRequest,
   ITXCreateMeetingResponseRequest,
+  ITXCreatePastMeetingParticipantRequest,
   ITXMeetingResponseResult,
+  ITXPastMeetingParticipantResult,
+  ITXUpdatePastMeetingParticipantRequest,
   Meeting,
   MeetingAttachment,
   MeetingJoinURL,
@@ -1822,6 +1825,67 @@ export class MeetingService {
       req,
       'LFX_V2_SERVICE',
       `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/attachments/${encodeURIComponent(attachmentUid)}`,
+      'DELETE'
+    );
+  }
+
+  /**
+   * Creates a new past meeting participant (invitee and/or attendee record) via ITX proxy
+   */
+  public async createPastMeetingParticipant(
+    req: Request,
+    pastMeetingUid: string,
+    participantData: ITXCreatePastMeetingParticipantRequest
+  ): Promise<ITXPastMeetingParticipantResult> {
+    logger.debug(req, 'create_past_meeting_participant', 'Creating past meeting participant', { past_meeting_id: pastMeetingUid });
+
+    return this.microserviceProxy.proxyRequest<ITXPastMeetingParticipantResult>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/participants`,
+      'POST',
+      undefined,
+      participantData
+    );
+  }
+
+  /**
+   * Updates a past meeting participant's invitee and/or attendee record via ITX proxy
+   */
+  public async updatePastMeetingParticipant(
+    req: Request,
+    pastMeetingUid: string,
+    participantId: string,
+    participantData: ITXUpdatePastMeetingParticipantRequest
+  ): Promise<ITXPastMeetingParticipantResult> {
+    logger.debug(req, 'update_past_meeting_participant', 'Updating past meeting participant', {
+      past_meeting_id: pastMeetingUid,
+      participant_id: participantId,
+    });
+
+    return this.microserviceProxy.proxyRequest<ITXPastMeetingParticipantResult>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/participants/${encodeURIComponent(participantId)}`,
+      'PUT',
+      undefined,
+      participantData
+    );
+  }
+
+  /**
+   * Deletes a past meeting participant via ITX proxy
+   */
+  public async deletePastMeetingParticipant(req: Request, pastMeetingUid: string, participantId: string): Promise<void> {
+    logger.debug(req, 'delete_past_meeting_participant', 'Deleting past meeting participant', {
+      past_meeting_id: pastMeetingUid,
+      participant_id: participantId,
+    });
+
+    await this.microserviceProxy.proxyRequest<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/participants/${encodeURIComponent(participantId)}`,
       'DELETE'
     );
   }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -359,13 +359,16 @@ export class MeetingService {
       meeting_id: meetingUid,
     });
 
-    const records = await fetchAllQueryResources<PastMeeting>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'v1_past_meeting',
-        filters: [`meeting_id:${meetingUid}`],
-        page_size: 500,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    const records = await fetchAllQueryResources<PastMeeting>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'v1_past_meeting',
+          filters: [`meeting_id:${meetingUid}`],
+          page_size: 500,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: options.throwOnFailure }
     ).catch((error) => {
       if (options.throwOnFailure) {
         throw error;
@@ -975,7 +978,7 @@ export class MeetingService {
    * through a "bridge" record B (e.g. A and B share an email, B and C share a username), and a
    * one-pass merge would miss that A and C belong to the same person depending on encounter order.
    */
-  public async getPastMeetingParticipants(req: Request, pastMeetingUid: string): Promise<PastMeetingParticipant[]> {
+  public async getPastMeetingParticipants(req: Request, pastMeetingUid: string, failOnPartial: boolean = false): Promise<PastMeetingParticipant[]> {
     logger.debug(req, 'get_past_meeting_participants', 'Fetching past meeting participants', {
       past_meeting_id: pastMeetingUid,
     });
@@ -985,11 +988,14 @@ export class MeetingService {
       tags: `meeting_and_occurrence_id:${pastMeetingUid}`,
     };
 
-    const raw = await fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    const raw = await fetchAllQueryResources<PastMeetingParticipant>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          ...params,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial }
     );
 
     // Plain union-find over connected identity-match edges (pure transitive closure, no

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1940,39 +1940,6 @@ export class MeetingService {
   }
 
   /**
-   * Compares two participant records for identity equality: prefer LFID username when both have
-   * one, else overlapping email, else normalized display name. A single derived key can't do this
-   * since which signal is "strongest" differs per record (e.g. a guest who later links an LFX
-   * account on a subsequent occurrence).
-   */
-  private isSamePastMeetingParticipant(a: PastMeetingParticipant, b: PastMeetingParticipant): boolean {
-    if (a.username && b.username) {
-      return a.username === b.username;
-    }
-
-    const aEmail = a.email?.trim().toLowerCase();
-    const bEmail = b.email?.trim().toLowerCase();
-    if (aEmail || bEmail) {
-      return !!aEmail && aEmail === bEmail;
-    }
-
-    if (a.username || b.username) {
-      return false;
-    }
-
-    const aName = this.normalizeParticipantDisplayName(a);
-    const bName = this.normalizeParticipantDisplayName(b);
-    return !!aName && !!bName && aName === bName;
-  }
-
-  private normalizeParticipantDisplayName(participant: PastMeetingParticipant): string | undefined {
-    if (!participant.first_name || !participant.last_name) {
-      return undefined;
-    }
-    return `${participant.first_name.trim().toLowerCase()} ${participant.last_name.trim().toLowerCase()}`;
-  }
-
-  /**
    * Fetches committee names for all unique committees referenced in meetings.
    * Returns a Map of committee UID -> committee name for merging into meeting data.
    */

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -348,8 +348,13 @@ export class MeetingService {
    * (`meeting_id`). No `filter_grants` — callers run this in a public/M2M context and
    * the projection carries timestamps only. Completeness is not guaranteed: a later-page
    * fetch failure returns the pages already accumulated (acceptable for navigation).
+   *
+   * By default a fetch failure is swallowed and treated as "no occurrences" — fine for
+   * navigation callers. Callers that need to distinguish "genuinely no history" from
+   * "history is unknown because the fetch failed" (e.g. reconciliation, which must not
+   * treat a failed fetch as a complete candidate pool) should pass `throwOnFailure: true`.
    */
-  public async getPastOccurrencesForMeeting(req: Request, meetingUid: string): Promise<PastOccurrenceSummary[]> {
+  public async getPastOccurrencesForMeeting(req: Request, meetingUid: string, options: { throwOnFailure?: boolean } = {}): Promise<PastOccurrenceSummary[]> {
     logger.debug(req, 'get_past_occurrences_for_meeting', 'Fetching past occurrences', {
       meeting_id: meetingUid,
     });
@@ -362,6 +367,9 @@ export class MeetingService {
         ...(pageToken && { page_token: pageToken }),
       })
     ).catch((error) => {
+      if (options.throwOnFailure) {
+        throw error;
+      }
       logger.warning(req, 'get_past_occurrences_for_meeting', 'Failed to fetch past occurrences, returning empty list', {
         meeting_id: meetingUid,
         error: error instanceof Error ? error.message : 'Unknown error',

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1932,6 +1932,39 @@ export class MeetingService {
   }
 
   /**
+   * Compares two participant records for identity equality: prefer LFID username when both have
+   * one, else overlapping email, else normalized display name. A single derived key can't do this
+   * since which signal is "strongest" differs per record (e.g. a guest who later links an LFX
+   * account on a subsequent occurrence).
+   */
+  private isSamePastMeetingParticipant(a: PastMeetingParticipant, b: PastMeetingParticipant): boolean {
+    if (a.username && b.username) {
+      return a.username === b.username;
+    }
+
+    const aEmail = a.email?.trim().toLowerCase();
+    const bEmail = b.email?.trim().toLowerCase();
+    if (aEmail || bEmail) {
+      return !!aEmail && aEmail === bEmail;
+    }
+
+    if (a.username || b.username) {
+      return false;
+    }
+
+    const aName = this.normalizeParticipantDisplayName(a);
+    const bName = this.normalizeParticipantDisplayName(b);
+    return !!aName && !!bName && aName === bName;
+  }
+
+  private normalizeParticipantDisplayName(participant: PastMeetingParticipant): string | undefined {
+    if (!participant.first_name || !participant.last_name) {
+      return undefined;
+    }
+    return `${participant.first_name.trim().toLowerCase()} ${participant.last_name.trim().toLowerCase()}`;
+  }
+
+  /**
    * Fetches committee names for all unique committees referenced in meetings.
    * Returns a Map of committee UID -> committee name for merging into meeting data.
    */

--- a/packages/shared/src/constants/ai.constants.ts
+++ b/packages/shared/src/constants/ai.constants.ts
@@ -154,6 +154,27 @@ You must respond with a valid JSON object in this exact format:
 Do not include any text outside the JSON object.`;
 
 /**
+ * System prompt for AI-assisted attendance reconciliation (GH-1672 / PCC-1452 port).
+ *
+ * Only the genuinely ambiguous remainder reaches this prompt — exact email/username/lf_user_id
+ * matches are resolved deterministically in code before this call, and every candidate this
+ * prompt sees already comes from a pool wider than just the current occurrence's invitees
+ * (committee members and prior-occurrence verified attendees are included too). The caller
+ * validates `matched_candidate_id` against the candidate set it sent — never trust it blindly.
+ */
+export const AI_RECONCILIATION_SYSTEM_PROMPT = `You are matching Zoom meeting attendees (identified only by their Zoom display name) to known identities from a candidate pool (meeting invitees, project committee members, and previously-verified attendees of earlier occurrences of the same recurring meeting).
+
+For each attendee:
+- If the Zoom display name clearly matches exactly one candidate's first + last name (allowing for minor variations like nicknames, middle initials, or reordering), return that candidate's candidate_id with confidence "high".
+- If the name plausibly matches a candidate but with meaningful ambiguity (partial match, common name, multiple similarly-close candidates), return your best-guess candidate_id with confidence "medium" or "low".
+- If there is no plausible match in the candidate pool, return matched_candidate_id: null with confidence "none". Do NOT guess a candidate just to avoid returning null.
+- Never invent a candidate_id that was not in the provided candidate list.
+
+You must return exactly one entry per attendee_id you were given, in any order. Do not omit any attendee.
+
+Respond with a JSON object matching the provided schema exactly. Do not include any text outside the JSON object.`;
+
+/**
  * AI model configuration
  */
 export const AI_MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
@@ -193,6 +214,13 @@ export const AI_REQUEST_CONFIG = {
    * generously-bounded wait there is an availability risk, not just slowness.
    */
   EXTRACTION_TIMEOUT_MS: 15_000,
+  /**
+   * AbortSignal.timeout bound for reconcileAttendees. Runs on a manual admin button click (not a
+   * page-load path), so it can afford more headroom than EXTRACTION_TIMEOUT_MS, but the prompt is
+   * bounded to RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL candidates so it shouldn't need
+   * NEWSLETTER_TIMEOUT_MS's budget either — sized independently rather than reusing either.
+   */
+  RECONCILIATION_TIMEOUT_MS: 60_000,
 };
 
 /**

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -704,6 +704,22 @@ export const RECONCILIATION_MAX_PRIOR_OCCURRENCES = 10;
 export const RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL = 30;
 
 /**
+ * Max chunk-dispatch calls to the AI service run concurrently for one reconcile request. Without
+ * a cap, a very large occurrence (many chunks) would fire all of them at once against the shared
+ * LiteLLM proxy, which is exactly the kind of unbounded burst PCC's own reconciliation feature
+ * never guarded against.
+ */
+export const RECONCILIATION_MAX_CONCURRENT_AI_CALLS = 3;
+
+/**
+ * Max candidates sent per AI chunk. The full pool (invitees + committee members + prior
+ * occurrences) can be large; sending all of it in every chunk's prompt scales prompt size with
+ * pool size on top of attendee count. Candidates are ranked by relevance (deterministic-pass
+ * near-misses first) and truncated to this count per chunk.
+ */
+export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
+
+/**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's
  * notes_added leg treats as a note. A single source of truth for both the upstream `filters_all`
  * term-clause value and the client-side re-filter comparison — see fetchNotesAddedEvents's own

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -682,6 +682,27 @@ export const PAST_MEETING_SORT = {
   UPDATED_ASC: 'updated_asc',
 } as const;
 
+// ============================================================================
+// Attendance Reconciliation (GH-1672 / PCC-1452 port)
+// ============================================================================
+
+/**
+ * Max prior occurrences of a meeting series scanned when assembling the candidate pool's
+ * "previously-verified attendee" source. Unbounded series history would mean an unbounded
+ * number of per-occurrence participant fetches for a single reconcile call; recent occurrences
+ * carry the most relevant identity signal anyway (attendance patterns and org affiliation
+ * change over time), so older ones aren't worth the extra roundtrips.
+ */
+export const RECONCILIATION_MAX_PRIOR_OCCURRENCES = 10;
+
+/**
+ * Max ambiguous attendees sent to the LLM in a single reconcileAttendees call. Bounds prompt
+ * size and keeps each call within AI_REQUEST_CONFIG's reconciliation timeout; a meeting with more
+ * ambiguous attendees than this is chunked into multiple calls dispatched concurrently (not one
+ * unbounded prompt), with each chunk independently degrading to `confidence: 'none'` on failure.
+ */
+export const RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL = 30;
+
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's
  * notes_added leg treats as a note. A single source of truth for both the upstream `filters_all`

--- a/packages/shared/src/interfaces/ai.interface.ts
+++ b/packages/shared/src/interfaces/ai.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingType } from '../enums';
+import { AttendanceReconciliationCandidate, AttendanceReconciliationConfidence } from './meeting.interface';
 
 /**
  * Request interface for AI agenda generation
@@ -71,6 +72,32 @@ export interface ExtractActionItemsResponse {
     text: string;
     /** Suggested owner role/persona for the item, when the model can infer one */
     suggested_owner_role?: string;
+  }[];
+}
+
+/**
+ * Request interface for AI-assisted attendance reconciliation — sent only for attendees the
+ * deterministic pass (exact email/username/lf_user_id match) couldn't resolve.
+ */
+export interface ReconcileAttendeesRequest {
+  attendees: {
+    attendee_id: string;
+    zoom_user_name?: string;
+  }[];
+  candidates: AttendanceReconciliationCandidate[];
+}
+
+/**
+ * Response interface for AI-assisted attendance reconciliation. `matched_candidate_id` must be
+ * validated by the caller against the `candidate_id`s it sent — the model can hallucinate one
+ * (see AiService.reconcileAttendees). Every input `attendee_id` should appear exactly once; any
+ * omitted by the model is treated as `confidence: 'none'` by the caller rather than lost.
+ */
+export interface ReconcileAttendeesResponse {
+  matches: {
+    attendee_id: string;
+    matched_candidate_id: string | null;
+    confidence: AttendanceReconciliationConfidence;
   }[];
 }
 

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1002,6 +1002,12 @@ export interface ITXCreatePastMeetingParticipantRequest {
   org_is_member?: boolean;
   /** Whether org has project membership */
   org_is_project_member?: boolean;
+  /** Associated committee UUID */
+  committee_id?: string;
+  /** Role within committee */
+  committee_role?: string;
+  /** Voting status in committee */
+  committee_voting_status?: string;
   /** URL to profile picture */
   avatar_url?: string;
   /** Whether the participant was invited/registered — creates an invitee record if true */
@@ -1020,6 +1026,8 @@ export interface ITXCreatePastMeetingParticipantRequest {
   zoom_user_name?: string;
   /** Full name of the invitee the attendee was matched to (attendee only) */
   mapped_invitee_name?: string;
+  /** Array of session objects with join/leave times (attendee only) */
+  sessions?: ITXParticipantSession[];
 }
 
 /**
@@ -1051,6 +1059,10 @@ export interface ITXUpdatePastMeetingParticipantRequest {
   org_name?: string;
   /** Job title */
   job_title?: string;
+  /** Role within committee */
+  committee_role?: string;
+  /** Voting status in committee */
+  committee_voting_status?: string;
   /** Whether the attendee has been verified (attendee only) */
   is_verified?: boolean;
   /** Whether the attendee record was last updated via AI reconciliation (attendee only) */
@@ -1068,12 +1080,14 @@ export interface ITXUpdatePastMeetingParticipantRequest {
  * participant write endpoints
  */
 export interface ITXParticipantSession {
+  /** Zoom participant UUID */
+  participant_uuid?: string;
   /** Session join timestamp (RFC3339) */
   join_time?: string;
   /** Session leave timestamp (RFC3339) */
   leave_time?: string;
-  /** Session duration in seconds */
-  duration?: number;
+  /** Reason for leaving */
+  leave_reason?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1064,6 +1064,19 @@ export interface ITXUpdatePastMeetingParticipantRequest {
 }
 
 /**
+ * A single Zoom join/leave interval for an attendee, as returned by the ITX past-meeting
+ * participant write endpoints
+ */
+export interface ITXParticipantSession {
+  /** Session join timestamp (RFC3339) */
+  join_time?: string;
+  /** Session leave timestamp (RFC3339) */
+  leave_time?: string;
+  /** Session duration in seconds */
+  duration?: number;
+}
+
+/**
  * Response shape from the ITX past-meeting participant create/update endpoints
  * @description Unified invitee/attendee view returned by the write endpoints — distinct from
  *   {@link PastMeetingParticipant} (the read-model projection indexed by the query service),
@@ -1100,6 +1113,14 @@ export interface ITXPastMeetingParticipantResult {
   org_is_project_member?: boolean;
   /** URL to profile picture */
   avatar_url?: string;
+  /** Committee UID (if the participant is a committee member) */
+  committee_id?: string;
+  /** Committee role (e.g. "Member", "Chair") */
+  committee_role?: string;
+  /** Whether the participant is a committee member */
+  is_committee_member?: boolean;
+  /** Committee voting status */
+  committee_voting_status?: string;
   /** Whether the participant was invited/registered to this past meeting */
   is_invited?: boolean;
   /** Whether the participant attended this past meeting */
@@ -1116,6 +1137,10 @@ export interface ITXPastMeetingParticipantResult {
   zoom_user_name?: string;
   /** Full name of the invitee the attendee was matched to (attendee only) */
   mapped_invitee_name?: string;
+  /** Zoom join/leave sessions for this attendee (attendee only) */
+  sessions?: ITXParticipantSession[];
+  /** Average attendance percentage across the series (attendee only) */
+  average_attendance?: number;
   /** Creation timestamp (RFC3339) */
   created_at?: string;
   /** Creator user info */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1018,14 +1018,6 @@ export interface ITXCreatePastMeetingParticipantRequest {
   is_verified?: boolean;
   /** Whether the attendee is marked as unknown (attendee only) */
   is_unknown?: boolean;
-  /** Whether the attendee record was last updated via AI reconciliation (attendee only) */
-  is_ai_reconciled?: boolean;
-  /** Whether the attendee was automatically matched to an invitee by name (attendee only) */
-  is_auto_matched?: boolean;
-  /** Zoom display name of the attendee (attendee only) */
-  zoom_user_name?: string;
-  /** Full name of the invitee the attendee was matched to (attendee only) */
-  mapped_invitee_name?: string;
   /** Array of session objects with join/leave times (attendee only) */
   sessions?: ITXParticipantSession[];
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1149,6 +1149,55 @@ export interface ITXPastMeetingParticipantResult {
   modified_by?: MeetingUserInfo;
 }
 
+/**
+ * How confidently an attendance-reconciliation match was made.
+ * `high` may be auto-applied; `medium`/`low`/`none` are always queued for admin review —
+ * `none` must never be silently auto-tagged as unknown (see GH-1672, PCC-1452 root cause).
+ */
+export type AttendanceReconciliationConfidence = 'high' | 'medium' | 'low' | 'none';
+
+/** Which layer of the candidate pool a reconciliation candidate came from. */
+export type AttendanceReconciliationCandidateSource = 'invitee' | 'committee_member' | 'prior_attendee';
+
+/**
+ * A known-identity candidate an unverified attendee can be matched against. Assembled from
+ * three sources (occurrence invitees, project committee members, previously-verified attendees
+ * of prior occurrences in the same series) — a single-source pool was PCC's root cause for its
+ * high "unknown" rate (PCC-1452): an attendee who joined without being an invitee on that exact
+ * occurrence had zero candidates and was unmatchable by construction.
+ */
+export interface AttendanceReconciliationCandidate {
+  /** Stable identifier for this candidate within one reconciliation run (not a persisted UID) */
+  candidate_id: string;
+  source: AttendanceReconciliationCandidateSource;
+  email?: string;
+  username?: string;
+  lf_user_id?: string;
+  first_name?: string;
+  last_name?: string;
+  org_name?: string;
+}
+
+/** Outcome of attempting to match one unverified attendee against the candidate pool. */
+export interface AttendanceReconciliationResult {
+  /** The attendee record's `id` (attendee_id) from ITXPastMeetingParticipantResult / participant uid */
+  attendee_id: string;
+  zoom_user_name?: string;
+  confidence: AttendanceReconciliationConfidence;
+  method: 'deterministic' | 'ai';
+  matched_candidate?: AttendanceReconciliationCandidate;
+  /** True when this match was written back via updatePastMeetingParticipant */
+  auto_applied: boolean;
+}
+
+/** Response from POST /api/past-meetings/:uid/reconcile. */
+export interface ReconcilePastMeetingParticipantsResponse {
+  results: AttendanceReconciliationResult[];
+  candidate_pool_size: number;
+  auto_applied_count: number;
+  needs_review_count: number;
+}
+
 /** Attendance filter for the past-meeting participant list. */
 export type PastParticipantAttendanceFilter = 'all' | 'attended' | 'absent';
 /** Invitation filter for the past-meeting participant list. */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -978,6 +978,154 @@ export interface EnrichedPastMeetingParticipant extends PastMeetingParticipant {
   committee_category?: string | null;
 }
 
+/**
+ * Request payload sent to the ITX past-meeting participant create endpoint
+ * @description POST /itx/past_meetings/{past_meeting_id}/participants — creates an invitee
+ *   record (when `is_invited` is true), an attendee record (when `is_attended` is true), or both
+ */
+export interface ITXCreatePastMeetingParticipantRequest {
+  /** Email address */
+  email?: string;
+  /** First name */
+  first_name?: string;
+  /** Last name */
+  last_name?: string;
+  /** LF SSO username */
+  username?: string;
+  /** LF user ID (Salesforce ID) */
+  lf_user_id?: string;
+  /** Organization name */
+  org_name?: string;
+  /** Job title */
+  job_title?: string;
+  /** Whether org has LF membership */
+  org_is_member?: boolean;
+  /** Whether org has project membership */
+  org_is_project_member?: boolean;
+  /** URL to profile picture */
+  avatar_url?: string;
+  /** Whether the participant was invited/registered — creates an invitee record if true */
+  is_invited?: boolean;
+  /** Whether the participant attended — creates an attendee record if true */
+  is_attended?: boolean;
+  /** Whether the attendee has been verified (attendee only) */
+  is_verified?: boolean;
+  /** Whether the attendee is marked as unknown (attendee only) */
+  is_unknown?: boolean;
+  /** Whether the attendee record was last updated via AI reconciliation (attendee only) */
+  is_ai_reconciled?: boolean;
+  /** Whether the attendee was automatically matched to an invitee by name (attendee only) */
+  is_auto_matched?: boolean;
+  /** Zoom display name of the attendee (attendee only) */
+  zoom_user_name?: string;
+  /** Full name of the invitee the attendee was matched to (attendee only) */
+  mapped_invitee_name?: string;
+}
+
+/**
+ * Request payload sent to the ITX past-meeting participant update endpoint
+ * @description PUT /itx/past_meetings/{past_meeting_id}/participants/{participant_id} — updates
+ *   invitee and/or attendee records as needed; setting `is_invited`/`is_attended` to false
+ *   deletes the corresponding record
+ */
+export interface ITXUpdatePastMeetingParticipantRequest {
+  /** Optional invitee ID to use directly (avoids ID mapping lookup) */
+  invitee_id?: string;
+  /** Optional attendee ID to use directly (avoids ID mapping lookup) */
+  attendee_id?: string;
+  /** Whether the participant is invited (if false, the invitee record is deleted) */
+  is_invited?: boolean;
+  /** Whether the participant attended (if false, the attendee record is deleted) */
+  is_attended?: boolean;
+  /** Email address (used when creating a missing invitee/attendee record) */
+  email?: string;
+  /** LF SSO username (used when creating a missing invitee/attendee record) */
+  username?: string;
+  /** LF user ID (used when creating a missing invitee/attendee record) */
+  lf_user_id?: string;
+  /** First name (required for invitee updates) */
+  first_name?: string;
+  /** Last name (required for invitee updates) */
+  last_name?: string;
+  /** Organization name */
+  org_name?: string;
+  /** Job title */
+  job_title?: string;
+  /** Whether the attendee has been verified (attendee only) */
+  is_verified?: boolean;
+  /** Whether the attendee record was last updated via AI reconciliation (attendee only) */
+  is_ai_reconciled?: boolean;
+  /** Whether the attendee was automatically matched to an invitee by name (attendee only) */
+  is_auto_matched?: boolean;
+  /** Zoom display name of the attendee (attendee only) */
+  zoom_user_name?: string;
+  /** Full name of the invitee the attendee was matched to (attendee only) */
+  mapped_invitee_name?: string;
+}
+
+/**
+ * Response shape from the ITX past-meeting participant create/update endpoints
+ * @description Unified invitee/attendee view returned by the write endpoints — distinct from
+ *   {@link PastMeetingParticipant} (the read-model projection indexed by the query service),
+ *   most notably using `id` rather than `uid` as the primary identifier
+ */
+export interface ITXPastMeetingParticipantResult {
+  /** Participant identifier (invitee_id or attendee_id or both) */
+  id: string;
+  /** Invitee record UUID (if is_invited is true) */
+  invitee_id?: string;
+  /** Attendee record UUID (if is_attended is true) */
+  attendee_id?: string;
+  /** Past meeting ID (meeting_id-occurrence_id) */
+  past_meeting_id: string;
+  /** Meeting ID */
+  meeting_id: string;
+  /** Primary email address */
+  email?: string;
+  /** First name */
+  first_name?: string;
+  /** Last name */
+  last_name?: string;
+  /** LF SSO username */
+  username?: string;
+  /** LF user ID (Salesforce ID) */
+  lf_user_id?: string;
+  /** Organization name */
+  org_name?: string;
+  /** Job title */
+  job_title?: string;
+  /** Whether org has LF membership */
+  org_is_member?: boolean;
+  /** Whether org has project membership */
+  org_is_project_member?: boolean;
+  /** URL to profile picture */
+  avatar_url?: string;
+  /** Whether the participant was invited/registered to this past meeting */
+  is_invited?: boolean;
+  /** Whether the participant attended this past meeting */
+  is_attended?: boolean;
+  /** Whether the attendee has been verified (attendee only) */
+  is_verified?: boolean;
+  /** Whether the attendee is marked as unknown (attendee only) */
+  is_unknown?: boolean;
+  /** Whether the attendee record was updated via AI reconciliation (attendee only) */
+  is_ai_reconciled?: boolean;
+  /** Whether the attendee name was auto-matched to a registrant's email (attendee only) */
+  is_auto_matched?: boolean;
+  /** Zoom display name of the attendee (attendee only) */
+  zoom_user_name?: string;
+  /** Full name of the invitee the attendee was matched to (attendee only) */
+  mapped_invitee_name?: string;
+  /** Creation timestamp (RFC3339) */
+  created_at?: string;
+  /** Creator user info */
+  created_by?: MeetingUserInfo;
+  /** Last modified timestamp (RFC3339) */
+  modified_at?: string;
+  /** Last modifier user info */
+  modified_by?: MeetingUserInfo;
+}
+
 /** Attendance filter for the past-meeting participant list. */
 export type PastParticipantAttendanceFilter = 'all' | 'attended' | 'absent';
 /** Invitation filter for the past-meeting participant list. */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1065,14 +1065,6 @@ export interface ITXUpdatePastMeetingParticipantRequest {
   committee_voting_status?: string;
   /** Whether the attendee has been verified (attendee only) */
   is_verified?: boolean;
-  /** Whether the attendee record was last updated via AI reconciliation (attendee only) */
-  is_ai_reconciled?: boolean;
-  /** Whether the attendee was automatically matched to an invitee by name (attendee only) */
-  is_auto_matched?: boolean;
-  /** Zoom display name of the attendee (attendee only) */
-  zoom_user_name?: string;
-  /** Full name of the invitee the attendee was matched to (attendee only) */
-  mapped_invitee_name?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -143,8 +143,8 @@ export interface MeetingCommittee {
  * `v1_meeting` projection. Used to display the meeting organizer's name.
  */
 export interface MeetingUserInfo {
-  /** Display name of the user */
-  name: string;
+  /** Display name of the user — omitted when the upstream audit stamper falls back to a degraded profile */
+  name?: string;
   /** LFID username of the user */
   username: string;
   /** Email address of the user */
@@ -1018,6 +1018,14 @@ export interface ITXCreatePastMeetingParticipantRequest {
   is_verified?: boolean;
   /** Whether the attendee is marked as unknown (attendee only) */
   is_unknown?: boolean;
+  /** Whether the attendee record was created via AI reconciliation (attendee only) */
+  is_ai_reconciled?: boolean;
+  /** Whether the attendee name was auto-matched to a registrant's email (attendee only) */
+  is_auto_matched?: boolean;
+  /** Zoom display name of the attendee (attendee only) */
+  zoom_user_name?: string;
+  /** Full name of the invitee the attendee was matched to (attendee only) */
+  mapped_invitee_name?: string;
   /** Array of session objects with join/leave times (attendee only) */
   sessions?: ITXParticipantSession[];
 }
@@ -1057,6 +1065,14 @@ export interface ITXUpdatePastMeetingParticipantRequest {
   committee_voting_status?: string;
   /** Whether the attendee has been verified (attendee only) */
   is_verified?: boolean;
+  /** Whether the attendee record was updated via AI reconciliation (attendee only) */
+  is_ai_reconciled?: boolean;
+  /** Whether the attendee name was auto-matched to a registrant's email (attendee only) */
+  is_auto_matched?: boolean;
+  /** Zoom display name of the attendee (attendee only) */
+  zoom_user_name?: string;
+  /** Full name of the invitee the attendee was matched to (attendee only) */
+  mapped_invitee_name?: string;
 }
 
 /**
@@ -1196,6 +1212,13 @@ export interface ReconcilePastMeetingParticipantsResponse {
   candidate_pool_size: number;
   auto_applied_count: number;
   needs_review_count: number;
+  /**
+   * True when one or more candidate-pool sources (committee members, a prior occurrence's
+   * participants) failed to fetch and were silently dropped rather than included. High-confidence
+   * auto-apply is disabled for a degraded pool — a missing source could hide the true match for a
+   * candidate that would otherwise auto-apply incorrectly, so results are queued for review instead.
+   */
+  pool_degraded: boolean;
 }
 
 /** Attendance filter for the past-meeting participant list. */


### PR DESCRIPTION
## Summary

Adds BFF routes (POST/PUT/DELETE) so past-meeting participant records can be created, updated, and deleted with the reconciliation fields (`is_verified`, `is_ai_reconciled`, `is_auto_matched`, `zoom_user_name`, `mapped_invitee_name`) — item 3 of the 5-item roadmap for `linuxfoundation/lfx-self-serve#1672` (AI attendance reconciliation port to LFX V2).

- `POST /api/past-meetings/:uid/participants` — creates an invitee and/or attendee record
- `PUT /api/past-meetings/:uid/participants/:participantId` — updates an invitee/attendee record
- `DELETE /api/past-meetings/:uid/participants/:participantId` — deletes a participant record

New shared interfaces (`ITXCreatePastMeetingParticipantRequest`, `ITXUpdatePastMeetingParticipantRequest`, `ITXPastMeetingParticipantResult`, `ITXParticipantSession`) were verified field-for-field against the upstream Goa design and OpenAPI spec, including two follow-up commits that trimmed response-only fields (`is_ai_reconciled`, `is_auto_matched`, `zoom_user_name`, `mapped_invitee_name`) that had been mistakenly included on the create/update request shapes.

**Note on scope:** this PR also carries item 4 of the same roadmap — AI-assisted attendance reconciliation matching (`AttendanceReconciliationService`, the `POST /api/past-meetings/:uid/reconcile` route, and its candidate-pool/deterministic-match/AI-match logic). Item 4 was originally reviewed and iterated on as a separate PR (#2065), which was based on this branch; #2065 has since merged into `main`, and a subsequent merge of `main` into this branch brought that code directly onto this PR. Item 4's own review history (including a full Copilot + Cursor Bugbot pass) lives on #2065; this PR's outstanding review threads that touch `attendance-reconciliation.service.ts` were carried over and addressed here since that file is now part of this PR's diff.

## Upstream dependency

These routes proxy to new ITX endpoints defined in [`lfx-v2-meeting-service` PR #267](https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/267) (branch `feat/GH-1672-attendee-response-fields`), which is **not yet merged**. This PR's routes will 404/500 in any environment until PR #267 merges and deploys — please confirm deployment ordering before merging this PR to a shared environment.

Builds on #2059 (item 1 — shared types), already merged to `main`. Includes item 2's participant dedup fix and item 4's reconciliation matching (#2065, merged to `main`).

## Test plan

- [x] `yarn check-types`, `yarn build`, `yarn lint:check`, `yarn format:check`, `./check-headers.sh` all pass
- [x] 50/50 unit tests pass in `meeting.service.spec.ts` (includes new coverage for create/update/delete participant methods, including URL-encoding edge cases)
- [ ] Manual verification against dev once `lfx-v2-meeting-service` #267 is merged and deployed

Refs linuxfoundation/lfx-self-serve#1672