### PR TITLE
fix(cla): render sign date in the viewer's local timezone

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.spec.ts
@@ -15,7 +15,7 @@ function agreement(overrides: Partial<MyClaAgreement> = {}): MyClaAgreement {
     kind: 'ECLA',
     claGroupName: 'CNCF',
     projectName: 'Cloud Native Computing Foundation (CNCF)',
-    signedOn: '2022-01-01',
+    signedOn: '2022-01-01T18:40:42Z',
     status: 'valid',
     pdfAvailable: false,
     ...overrides,

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -143,7 +143,7 @@ SPDX-License-Identifier: MIT
 
             <td class="px-5 py-3.5">
               <div class="flex flex-col">
-                <span class="text-sm text-slate-600">{{ row.signedOnLabel }}</span>
+                <span class="text-sm text-slate-600" [attr.data-testid]="'agreement-signed-on-' + row.id">{{ row.signedOnLabel }}</span>
                 @if (row.signedAsLine) {
                   <span class="mt-1 text-xs text-slate-400" [attr.data-testid]="'agreement-signed-as-' + row.id">{{ row.signedAsLine }}</span>
                 }

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -143,7 +143,7 @@ SPDX-License-Identifier: MIT
 
             <td class="px-5 py-3.5">
               <div class="flex flex-col">
-                <span class="text-sm text-slate-600">{{ row.agreement.signedOn ? (row.agreement.signedOn | date: 'mediumDate' : 'UTC') : '—' }}</span>
+                <span class="text-sm text-slate-600">{{ row.signedOnLabel }}</span>
                 @if (row.signedAsLine) {
                   <span class="mt-1 text-xs text-slate-400" [attr.data-testid]="'agreement-signed-as-' + row.id">{{ row.signedAsLine }}</span>
                 }

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -48,7 +48,7 @@ describe('ProfileClasComponent', () => {
     id: 's1',
     kind: 'ICLA',
     claGroupName: 'Project One',
-    signedOn: '2022-01-01',
+    signedOn: '2022-01-01T18:40:42Z',
     status: 'valid',
     pdfAvailable: true,
     ...overrides,
@@ -426,6 +426,10 @@ describe('ProfileClasComponent', () => {
     return fixture.nativeElement.querySelector(`[data-testid="agreement-signed-as-${id}"]`);
   }
 
+  function signedOn(id: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="agreement-signed-on-${id}"]`);
+  }
+
   it('renders Signed as {identity} (GitHub) / (GitLab) / (Gerrit) under the date', async () => {
     await render([
       agreement({ id: 's-gh', signedVia: 'github', signedAs: 'jellis' }),
@@ -474,12 +478,19 @@ describe('ProfileClasComponent', () => {
     expect(signedAs('s-as-only')?.tagName.toLowerCase()).not.toBe('a');
   });
 
+  it('renders an em dash when signedOn is empty or unparseable', async () => {
+    await render([agreement({ id: 's-empty', signedOn: '' }), agreement({ id: 's-bad', signedOn: 'not-a-date' })]);
+
+    expect(signedOn('s-empty')?.textContent?.trim()).toBe('—');
+    expect(signedOn('s-bad')?.textContent?.trim()).toBe('—');
+  });
+
   it('hides Sign CLA, Status, kebab, and Signed as when my-clas-m2-enabled is off', async () => {
     await render(
       [
         agreement({
           id: 's-m1',
-          signedOn: '2022-01-01',
+          signedOn: '2022-01-01T18:40:42Z',
           signedVia: 'github',
           signedAs: 'jellis',
           pdfAvailable: true,

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe, DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal, viewChildren } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
@@ -25,6 +25,7 @@ import {
   claStatusLabel,
   claStatusSeverity,
   downloadFromUrl,
+  formatClaSignedOn,
   gerritSignUrl,
   isMyClasEmpty,
   signedAsLine,
@@ -66,18 +67,7 @@ import { SignIdentitySelectComponent } from './sign-identity-select.component';
  */
 @Component({
   selector: 'lfx-profile-clas',
-  imports: [
-    DatePipe,
-    RouterLink,
-    BadgeComponent,
-    ButtonComponent,
-    EmptyStateComponent,
-    MenuComponent,
-    MessageComponent,
-    TableComponent,
-    TagComponent,
-    ToastModule,
-  ],
+  imports: [RouterLink, BadgeComponent, ButtonComponent, EmptyStateComponent, MenuComponent, MessageComponent, TableComponent, TagComponent, ToastModule],
   providers: [MessageService, DialogService],
   templateUrl: './profile-clas.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -663,6 +653,7 @@ export class ProfileClasComponent {
             icon: this.statusIcon(agreement.status),
             note: this.statusNote(agreement),
           },
+          signedOnLabel: formatClaSignedOn(agreement.signedOn) || '—',
           signedAsLine: m2 ? signedAsLine(agreement.signedVia, agreement.signedAs) : undefined,
           menuItems,
           hasActions: menuItems.length > 0,

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -653,7 +653,7 @@ export class ProfileClasComponent {
             icon: this.statusIcon(agreement.status),
             note: this.statusNote(agreement),
           },
-          signedOnLabel: formatClaSignedOn(agreement.signedOn) || '—',
+          signedOnLabel: formatClaSignedOn(agreement.signedOn),
           signedAsLine: m2 ? signedAsLine(agreement.signedVia, agreement.signedAs) : undefined,
           menuItems,
           hasActions: menuItems.length > 0,

--- a/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
@@ -43,7 +43,7 @@ function buildRes() {
   return { json: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn() } as any;
 }
 
-const iclaAgreement = { id: 'sig-icla', kind: 'ICLA', projectName: 'p', signedOn: '2022-01-01', status: 'valid', pdfAvailable: true };
+const iclaAgreement = { id: 'sig-icla', kind: 'ICLA', projectName: 'p', signedOn: '2022-01-01T18:40:42Z', status: 'valid', pdfAvailable: true };
 const resolvedIdentity = { lfUsername: 'alice', emails: [], githubIds: [], githubUsernames: [], githubLinked: false };
 
 beforeEach(() => {

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -65,7 +65,7 @@ function icla(overrides: Partial<EasyClaMyCla> = {}): EasyClaMyCla {
     status: 'valid',
     pdfAvailable: true,
     claGroupID: 'cg-1',
-    signedOn: '2022-01-01',
+    signedOn: '2022-01-01T18:40:42Z',
     ...overrides,
   };
 }
@@ -80,7 +80,7 @@ function ecla(overrides: Partial<EasyClaMyCla> = {}): EasyClaMyCla {
     status: 'valid',
     companyName: 'Acme',
     claGroupID: 'cg-2',
-    signedOn: '2022-02-02',
+    signedOn: '2022-02-02T18:40:42Z',
     ...overrides,
   };
 }

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -86,7 +86,8 @@ export interface MyClaAgreement {
   companyName?: string;
   /**
    * RFC3339 instant the agreement was signed. A bare `YYYY-MM-DD` is accepted
-   * and rendered as that UTC calendar day.
+   * and rendered as that UTC calendar day. Empty string when the producer sent
+   * no date (`cla.service` normalizes the absent field).
    */
   signedOn: string;
   /**
@@ -486,7 +487,11 @@ export interface ClaRow {
   id: string;
   agreement: MyClaAgreement;
   status: ClaRowStatus;
-  /** Date-only Sign Date in the viewer's local timezone; `'—'` when empty or unparseable. */
+  /**
+   * Sign Date: an instant renders in the viewer's local timezone, a bare
+   * `YYYY-MM-DD` as that UTC calendar day; `'—'` when empty, unparseable, or
+   * an impossible calendar date.
+   */
   signedOnLabel: string;
   /** Second line under the signed date; absent when the producer sent no identity. */
   signedAsLine?: string;

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -483,6 +483,8 @@ export interface ClaRow {
   id: string;
   agreement: MyClaAgreement;
   status: ClaRowStatus;
+  /** Date-only Sign Date in the viewer's local timezone; `'—'` when empty or unparseable. */
+  signedOnLabel: string;
   /** Second line under the signed date; absent when the producer sent no identity. */
   signedAsLine?: string;
   menuItems: ClaRowMenuItem[];

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -84,7 +84,10 @@ export interface MyClaAgreement {
   claManager?: boolean;
   /** Employer company name — present for ECLA only. */
   companyName?: string;
-  /** ISO date the agreement was signed. */
+  /**
+   * RFC3339 instant the agreement was signed. A bare `YYYY-MM-DD` is accepted
+   * and rendered as that UTC calendar day.
+   */
   signedOn: string;
   /**
    * Platform this agreement was signed via, when the producer sent one.

--- a/packages/shared/src/utils/cla-manager-actions.utils.spec.ts
+++ b/packages/shared/src/utils/cla-manager-actions.utils.spec.ts
@@ -11,7 +11,7 @@ function agreement(overrides: Partial<MyClaAgreement> = {}): MyClaAgreement {
     id: 's1',
     kind: 'ECLA',
     claGroupName: 'CNCF',
-    signedOn: '2022-01-01',
+    signedOn: '2022-01-01T18:40:42Z',
     status: 'valid',
     pdfAvailable: false,
     ...overrides,

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -30,7 +30,7 @@ import {
 } from './cla-view.utils';
 
 function agreement(overrides: Partial<MyClaAgreement> = {}): MyClaAgreement {
-  return { id: 's1', kind: 'ICLA', claGroupName: 'P', signedOn: '2022-01-01', status: 'valid', pdfAvailable: true, ...overrides };
+  return { id: 's1', kind: 'ICLA', claGroupName: 'P', signedOn: '2022-01-01T18:40:42Z', status: 'valid', pdfAvailable: true, ...overrides };
 }
 
 function identity(overrides: Partial<MyClasIdentitySummary> = {}): MyClasIdentitySummary {
@@ -172,10 +172,34 @@ describe('formatClaSignedOn', () => {
     expect(formatClaSignedOn('2026-05-08T23:24:50.232159+00:00', 'UTC')).toBe('May 8, 2026');
   });
 
-  it('returns empty for missing, blank, or unparseable values so the cell can show an em dash', () => {
-    expect(formatClaSignedOn('')).toBe('');
-    expect(formatClaSignedOn('   ')).toBe('');
-    expect(formatClaSignedOn('not-a-date')).toBe('');
+  it('pins a bare YYYY-MM-DD to UTC so a negative-offset host does not shift the calendar day', () => {
+    expect(formatClaSignedOn('2022-01-01')).toBe('Jan 1, 2022');
+    expect(formatClaSignedOn('2022-01-01', 'America/Los_Angeles')).toBe('Jan 1, 2022');
+  });
+
+  it('omits timeZone on the production no-argument path so a UTC re-pin fails this test', () => {
+    const seen: (Intl.DateTimeFormatOptions | undefined)[] = [];
+    const original = Date.prototype.toLocaleDateString;
+    // eslint-disable-next-line no-extend-native
+    Date.prototype.toLocaleDateString = function (locales?: unknown, options?: Intl.DateTimeFormatOptions): string {
+      seen.push(options);
+      return original.call(this, locales as string, options);
+    };
+    try {
+      formatClaSignedOn(afternoonPacific);
+    } finally {
+      // eslint-disable-next-line no-extend-native
+      Date.prototype.toLocaleDateString = original;
+    }
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((o) => o?.timeZone === undefined)).toBe(true);
+  });
+
+  it('returns an em dash for missing, blank, or unparseable values', () => {
+    expect(formatClaSignedOn('')).toBe('—');
+    expect(formatClaSignedOn('   ')).toBe('—');
+    expect(formatClaSignedOn('not-a-date')).toBe('—');
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -193,13 +193,19 @@ describe('formatClaSignedOn', () => {
     }
 
     expect(seen.length).toBeGreaterThan(0);
-    expect(seen.every((o) => o?.timeZone === undefined)).toBe(true);
+    expect(seen.at(-1)?.timeZone).toBeUndefined();
   });
 
   it('returns an em dash for missing, blank, or unparseable values', () => {
     expect(formatClaSignedOn('')).toBe('—');
     expect(formatClaSignedOn('   ')).toBe('—');
     expect(formatClaSignedOn('not-a-date')).toBe('—');
+  });
+
+  it('refuses impossible calendar dates rather than rolling them over', () => {
+    expect(formatClaSignedOn('2026-02-31')).toBe('—');
+    expect(formatClaSignedOn('2026-02-31T10:00:00Z')).toBe('—');
+    expect(formatClaSignedOn('0001-01-01')).toBe('—');
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -20,6 +20,7 @@ import {
   claSignRoute,
   claStatusLabel,
   claStatusSeverity,
+  formatClaSignedOn,
   gerritSignUrl,
   isMyClasEmpty,
   shouldShowGithubCta,
@@ -151,6 +152,30 @@ describe('claStatusSeverity', () => {
     expect(claStatusSeverity('invalidated')).toBe('danger');
     expect(claStatusSeverity('unknown')).toBe('secondary');
     expect(claStatusSeverity('superseded')).toBe('warn');
+  });
+});
+
+describe('formatClaSignedOn', () => {
+  // The three shapes from #2032. UTC pin vs local is a no-op on the first two; the third
+  // is the reported off-by-one (Pacific afternoon → next UTC calendar day).
+  const afternoonPacific = '2026-09-01T17:30:00-07:00';
+
+  it('renders a Pacific-afternoon timestamp as Sep 1 locally and Sep 2 in UTC', () => {
+    expect(formatClaSignedOn(afternoonPacific, 'America/Los_Angeles')).toBe('Sep 1, 2026');
+    expect(formatClaSignedOn(afternoonPacific, 'UTC')).toBe('Sep 2, 2026');
+  });
+
+  it('keeps same-calendar-day timestamps on the same date in Pacific and UTC', () => {
+    expect(formatClaSignedOn('2026-05-01T18:40:42Z', 'America/Los_Angeles')).toBe('May 1, 2026');
+    expect(formatClaSignedOn('2026-05-01T18:40:42Z', 'UTC')).toBe('May 1, 2026');
+    expect(formatClaSignedOn('2026-05-08T23:24:50.232159+00:00', 'America/Los_Angeles')).toBe('May 8, 2026');
+    expect(formatClaSignedOn('2026-05-08T23:24:50.232159+00:00', 'UTC')).toBe('May 8, 2026');
+  });
+
+  it('returns empty for missing, blank, or unparseable values so the cell can show an em dash', () => {
+    expect(formatClaSignedOn('')).toBe('');
+    expect(formatClaSignedOn('   ')).toBe('');
+    expect(formatClaSignedOn('not-a-date')).toBe('');
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -114,6 +114,8 @@ export function claStatusSeverity(status: ClaStatus): TagSeverity {
   }
 }
 
+const CLA_SIGNED_ON_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
  * Date-only Sign Date for My CLAs (#2032).
  *
@@ -124,18 +126,26 @@ export function claStatusSeverity(status: ClaStatus): TagSeverity {
  * next UTC date. Omitting `timeZone` uses the viewer's local zone; pass an IANA
  * name in tests so CI (UTC) can still pin the Pacific case.
  *
- * Empty / unparseable → `''` so the cell can show an em dash.
+ * A bare `YYYY-MM-DD` parses as UTC midnight (ECMA-262), so it is pinned to UTC
+ * to keep that calendar day — the reverse of the instant case.
+ *
+ * Safe here only because the CLAs rows never render under SSR (`initState`
+ * returns unloaded off-browser). Do not call from a server-rendered path
+ * without passing an explicit `timeZone` (see `formatHubSpotUpdatedAt`).
+ *
+ * Empty / unparseable → `'—'` (same placeholder as `claStatusLabel('unknown')`).
  */
 export function formatClaSignedOn(iso: string, timeZone?: string): string {
   const trimmed = iso.trim();
-  if (!trimmed) return '';
+  if (!trimmed) return '—';
   const date = new Date(trimmed);
-  if (Number.isNaN(date.getTime())) return '';
+  if (Number.isNaN(date.getTime())) return '—';
+  const zone = CLA_SIGNED_ON_DATE_ONLY.test(trimmed) ? 'UTC' : timeZone;
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-    ...(timeZone ? { timeZone } : {}),
+    ...(zone ? { timeZone: zone } : {}),
   });
 }
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -115,6 +115,31 @@ export function claStatusSeverity(status: ClaStatus): TagSeverity {
 }
 
 /**
+ * Date-only Sign Date for My CLAs (#2032).
+ *
+ * Producer `signedOn` is a real RFC3339 instant, not a calendar-day stored as UTC
+ * midnight. Pinning the formatter to UTC (the DatePipe `'UTC'` argument, or
+ * `{ timeZone: 'UTC' }` on `toLocaleDateString`) shifts the calendar day for
+ * viewers in negative offsets — a Pacific afternoon signature displays as the
+ * next UTC date. Omitting `timeZone` uses the viewer's local zone; pass an IANA
+ * name in tests so CI (UTC) can still pin the Pacific case.
+ *
+ * Empty / unparseable → `''` so the cell can show an em dash.
+ */
+export function formatClaSignedOn(iso: string, timeZone?: string): string {
+  const trimmed = iso.trim();
+  if (!trimmed) return '';
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    ...(timeZone ? { timeZone } : {}),
+  });
+}
+
+/**
  * Second line under the signed date (#1573). Undefined ⇒ the Signed cell is date-only.
  *
  * Every platform the producer names takes a suffix. `gerrit` reads wider than the Gerrit

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -28,6 +28,7 @@ import type {
   MyClasIdentitySummary,
   SignIdentityRef,
 } from '../interfaces/cla.interface';
+import { formatIsoDateLabel } from './date-time.utils';
 
 /**
  * Profile subtab list, with the read-only "CLAs" tab appended (before Transactions)
@@ -133,19 +134,30 @@ const CLA_SIGNED_ON_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
  * returns unloaded off-browser). Do not call from a server-rendered path
  * without passing an explicit `timeZone` (see `formatHubSpotUpdatedAt`).
  *
- * Empty / unparseable → `'—'` (same placeholder as `claStatusLabel('unknown')`).
+ * Empty, unparseable, or an impossible calendar date (Feb 31) → `'—'`
+ * (same placeholder as `claStatusLabel('unknown')`).
  */
 export function formatClaSignedOn(iso: string, timeZone?: string): string {
   const trimmed = iso.trim();
   if (!trimmed) return '—';
+
+  if (CLA_SIGNED_ON_DATE_ONLY.test(trimmed)) {
+    const label = formatIsoDateLabel(trimmed);
+    return label === trimmed ? '—' : label;
+  }
+
+  const datePart = trimmed.slice(0, 10);
+  if (CLA_SIGNED_ON_DATE_ONLY.test(datePart) && formatIsoDateLabel(datePart) === datePart) {
+    return '—';
+  }
+
   const date = new Date(trimmed);
   if (Number.isNaN(date.getTime())) return '—';
-  const zone = CLA_SIGNED_ON_DATE_ONLY.test(trimmed) ? 'UTC' : timeZone;
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-    ...(zone ? { timeZone: zone } : {}),
+    ...(timeZone ? { timeZone } : {}),
   });
 }
 


### PR DESCRIPTION
## Summary
- My CLAs Sign Date was pinned to UTC, so a Pacific afternoon signature displayed as the next calendar day.
- Format the producer RFC3339 instant in the viewer's local timezone (date-only, same shape as `mediumDate`).
- Pin the reported Pacific vs UTC split in shared unit tests.

## Test plan
- [ ] Unit: `2026-09-01T17:30:00-07:00` → `Sep 1, 2026` in `America/Los_Angeles`, `Sep 2, 2026` in UTC
- [ ] Profile → My CLAs with the machine in a negative offset: a signature from the prior afternoon still shows that local date
- [ ] Empty `signedOn` still shows —

Closes #2032