### PR TITLE
feat(meetings): add ai-assisted attendance reconciliation matching

### DIFF
--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PAST_MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { meetingSvc, reconciliationSvc, addAccessToResourceMock, validateUidParameterMock } = vi.hoisted(() => ({
+  meetingSvc: {
+    getPastMeetingById: vi.fn(),
+  },
+  reconciliationSvc: {
+    reconcilePastMeetingParticipants: vi.fn(),
+  },
+  addAccessToResourceMock: vi.fn(),
+  validateUidParameterMock: vi.fn(() => true),
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
+vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/utils', () => ({
+  resolveMeetingOrganizer: vi.fn(() => null),
+  resolveMeetingOwner: vi.fn(() => null),
+}));
+
+vi.mock('../helpers/validation.helper', () => ({
+  validateUidParameter: validateUidParameterMock,
+  validateRequiredParameter: vi.fn(() => true),
+}));
+// enrichMeetingsWithCreatedBy/stripHostKey aren't exercised by the reconcile path under test.
+vi.mock('../helpers/meeting.helper', () => ({
+  enrichMeetingsWithCreatedBy: vi.fn(async (_req: unknown, meetings: unknown[]) => meetings),
+  stripHostKey: vi.fn(),
+}));
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: vi.fn(function () {
+    return meetingSvc;
+  }),
+}));
+vi.mock('../services/attendance-reconciliation.service', () => ({
+  AttendanceReconciliationService: vi.fn(function () {
+    return reconciliationSvc;
+  }),
+}));
+vi.mock('../services/access-check.service', () => ({
+  AccessCheckService: vi.fn(function () {
+    return { addAccessToResource: addAccessToResourceMock };
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { PastMeetingController } from './past-meeting.controller';
+
+function buildReq(authenticated: boolean): any {
+  return {
+    params: { uid: PAST_MEETING_UID },
+    query: {},
+    path: '/test',
+    log: {},
+    oidc: { isAuthenticated: () => authenticated },
+  };
+}
+
+function buildRes(): any {
+  return { json: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn() };
+}
+
+function buildPastMeeting(overrides: Record<string, unknown> = {}): any {
+  return { meeting_and_occurrence_id: PAST_MEETING_UID, ...overrides };
+}
+
+// Reconciliation matching logic itself is tested at its source (attendance-reconciliation.service.spec.ts)
+// per the three-file pattern. This spec covers only the controller's authorization gate: a non-organizer
+// must never reach the AI-backed reconciliation call (GH-1672 item 4 organizer-only trigger).
+describe('PastMeetingController.reconcilePastMeetingParticipants — organizer gate', () => {
+  let controller: PastMeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateUidParameterMock.mockReturnValue(true);
+    controller = new PastMeetingController();
+    meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting());
+  });
+
+  it('rejects with 403 and never calls the reconciliation service when the caller is not authenticated', async () => {
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(false), res, next);
+
+    expect(addAccessToResourceMock).not.toHaveBeenCalled();
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 and never calls the reconciliation service when the caller is authenticated but not the organizer', async () => {
+    addAccessToResourceMock.mockResolvedValue({ ...buildPastMeeting(), organizer: false });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 and fails closed when the access check itself throws', async () => {
+    addAccessToResourceMock.mockRejectedValue(new Error('access-check unavailable'));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('runs reconciliation and returns the result when the caller is the organizer', async () => {
+    addAccessToResourceMock.mockResolvedValue({ ...buildPastMeeting(), organizer: true });
+    const result = { results: [], candidate_pool_size: 5, auto_applied_count: 1, needs_review_count: 4 };
+    reconciliationSvc.reconcilePastMeetingParticipants.mockResolvedValue(result);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).toHaveBeenCalledWith(expect.anything(), PAST_MEETING_UID, buildPastMeeting());
+    expect(res.json).toHaveBeenCalledWith(result);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -111,20 +111,7 @@ export class PastMeetingController {
       }
 
       const meeting = await this.meetingService.getPastMeetingById(req, uid);
-
-      if (req.oidc?.isAuthenticated()) {
-        try {
-          const meetingWithAccess = await this.accessCheckService.addAccessToResource(
-            req,
-            { ...meeting, id: meeting.meeting_and_occurrence_id ?? uid },
-            'v1_past_meeting',
-            'organizer'
-          );
-          meeting.organizer = meetingWithAccess.organizer ?? false;
-        } catch {
-          meeting.organizer = false;
-        }
-      }
+      meeting.organizer = await this.isPastMeetingOrganizer(req, meeting, uid);
 
       const counts = await this.addParticipantsCount(req, uid);
       meeting.individual_registrants_count = counts.individual_registrants_count;
@@ -340,21 +327,7 @@ export class PastMeetingController {
       }
 
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
-
-      let isOrganizer = false;
-      if (req.oidc?.isAuthenticated()) {
-        try {
-          const meetingWithAccess = await this.accessCheckService.addAccessToResource(
-            req,
-            { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid },
-            'v1_past_meeting',
-            'organizer'
-          );
-          isOrganizer = meetingWithAccess.organizer ?? false;
-        } catch {
-          isOrganizer = false;
-        }
-      }
+      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
 
       if (!isOrganizer) {
         return next(
@@ -993,6 +966,28 @@ export class PastMeetingController {
         participant_count: 0,
         attended_count: 0,
       };
+    }
+  }
+
+  /**
+   * Resolves whether the requesting user is the organizer of a past meeting. Unauthenticated
+   * requests and access-check failures both default to false (fail closed).
+   */
+  private async isPastMeetingOrganizer(req: Request, pastMeeting: PastMeeting, uid: string): Promise<boolean> {
+    if (!req.oidc?.isAuthenticated()) {
+      return false;
+    }
+
+    try {
+      const meetingWithAccess = await this.accessCheckService.addAccessToResource(
+        req,
+        { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid },
+        'v1_past_meeting',
+        'organizer'
+      );
+      return meetingWithAccess.organizer ?? false;
+    } catch {
+      return false;
     }
   }
 }

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -19,7 +19,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
-import { ServiceValidationError } from '../errors';
+import { AuthorizationError, ServiceValidationError } from '../errors';
 import { enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
@@ -340,6 +340,31 @@ export class PastMeetingController {
       }
 
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
+
+      let isOrganizer = false;
+      if (req.oidc?.isAuthenticated()) {
+        try {
+          const meetingWithAccess = await this.accessCheckService.addAccessToResource(
+            req,
+            { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid },
+            'v1_past_meeting',
+            'organizer'
+          );
+          isOrganizer = meetingWithAccess.organizer ?? false;
+        } catch {
+          isOrganizer = false;
+        }
+      }
+
+      if (!isOrganizer) {
+        return next(
+          new AuthorizationError('Only the meeting organizer can trigger attendance reconciliation', {
+            operation: 'reconcile_past_meeting_participants',
+            service: 'past_meeting_controller',
+          })
+        );
+      }
+
       const result = await this.attendanceReconciliationService.reconcilePastMeetingParticipants(req, uid, pastMeeting);
 
       logger.success(req, 'reconcile_past_meeting_participants', startTime, {

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -23,6 +23,7 @@ import { ServiceValidationError } from '../errors';
 import { enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
 import { validateRequiredParameter, validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
+import { AttendanceReconciliationService } from '../services/attendance-reconciliation.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 
@@ -32,6 +33,7 @@ import { MeetingService } from '../services/meeting.service';
 export class PastMeetingController {
   private meetingService: MeetingService = new MeetingService();
   private accessCheckService: AccessCheckService = new AccessCheckService();
+  private attendanceReconciliationService: AttendanceReconciliationService = new AttendanceReconciliationService();
 
   /**
    * GET /past-meetings
@@ -309,6 +311,45 @@ export class PastMeetingController {
       });
 
       res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /past-meetings/:uid/reconcile
+   * Manual admin trigger (GH-1672 item 4) — matches unverified attendees against a candidate
+   * pool (invitees + committee members + previously-verified attendees of prior occurrences),
+   * auto-applying only high-confidence matches. No-match attendees are always returned for
+   * admin review, never silently auto-tagged unknown.
+   */
+  public async reconcilePastMeetingParticipants(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { uid } = req.params;
+    const startTime = logger.startOperation(req, 'reconcile_past_meeting_participants', {
+      past_meeting_id: uid,
+    });
+
+    try {
+      if (
+        !validateUidParameter(uid, req, next, {
+          operation: 'reconcile_past_meeting_participants',
+          service: 'past_meeting_controller',
+        })
+      ) {
+        return;
+      }
+
+      const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
+      const result = await this.attendanceReconciliationService.reconcilePastMeetingParticipants(req, uid, pastMeeting);
+
+      logger.success(req, 'reconcile_past_meeting_participants', startTime, {
+        past_meeting_id: uid,
+        candidate_pool_size: result.candidate_pool_size,
+        auto_applied_count: result.auto_applied_count,
+        needs_review_count: result.needs_review_count,
+      });
+
+      res.json(result);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/routes/past-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/past-meetings.route.ts
@@ -26,6 +26,9 @@ router.put('/:uid/participants/:participantId', (req, res, next) => pastMeetingC
 // Delete a past meeting participant
 router.delete('/:uid/participants/:participantId', (req, res, next) => pastMeetingController.deletePastMeetingParticipant(req, res, next));
 
+// Manually trigger AI-assisted attendance reconciliation for a past meeting occurrence
+router.post('/:uid/reconcile', (req, res, next) => pastMeetingController.reconcilePastMeetingParticipants(req, res, next));
+
 // Get past meeting recording by UID
 router.get('/:uid/recording', (req, res, next) => pastMeetingController.getPastMeetingRecording(req, res, next));
 

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -23,6 +23,7 @@ vi.mock('@lfx-one/shared/constants', async () => {
     AI_BRIEF_ACTION_ITEMS_SYSTEM_PROMPT: 'brief action items prompt',
     AI_MODEL: 'mock-model',
     AI_NEWSLETTER_SYSTEM_PROMPT: 'newsletter prompt',
+    AI_RECONCILIATION_SYSTEM_PROMPT: 'reconciliation prompt',
     AI_REQUEST_CONFIG: actual.AI_REQUEST_CONFIG,
     DURATION_ESTIMATION: { BASE_DURATION: 15, TIME_PER_ITEM: 10, MINIMUM_DURATION: 30, MAXIMUM_DURATION: 240 },
     NEWSLETTER_AI_MAX_TOKENS: 12_000,
@@ -268,5 +269,102 @@ describe('AiService.generateNewsletter', () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(AI_REQUEST_CONFIG.NEWSLETTER_TIMEOUT_MS);
     expect(AI_REQUEST_CONFIG.NEWSLETTER_TIMEOUT_MS).toBeGreaterThan(AI_REQUEST_CONFIG.TIMEOUT_MS);
+  });
+});
+
+describe('AiService.reconcileAttendees (GH-1672 / PCC-1452 port)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let service: AiService;
+  const originalEnv = { ...process.env };
+
+  const candidates = [
+    { candidate_id: 'c0', source: 'invitee' as const, first_name: 'Alice', last_name: 'Smith', email: 'alice@example.com' },
+    { candidate_id: 'c1', source: 'committee_member' as const, first_name: 'Bob', last_name: 'Jones' },
+  ];
+  const attendees = [{ attendee_id: 'a0', zoom_user_name: 'Alice S' }];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, AI_PROXY_URL: 'https://ai-proxy.example.com', AI_API_KEY: 'test-key' };
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    service = new AiService();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  it('returns the matches on a well-formed response', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'high' }] })));
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'high' }]);
+  });
+
+  it('rejects a matched_candidate_id that does not resolve against the request candidates (hallucination guard)', async () => {
+    fetchMock.mockResolvedValue(
+      mockChatResponse(JSON.stringify({ matches: [{ attendee_id: 'a0', matched_candidate_id: 'does-not-exist', confidence: 'high' }] }))
+    );
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    // Note: this method only nulls the unresolvable candidate_id — it does not itself downgrade
+    // confidence. The caller (AttendanceReconciliationService.matchWithAi) is what treats a
+    // resolved-confidence + null-candidate combination as 'none' before ever considering auto-apply.
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: null, confidence: 'high' }]);
+  });
+
+  it('defaults an attendee_id omitted from the response to confidence none instead of dropping it', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [] })));
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: null, confidence: 'none' }]);
+  });
+
+  it('normalizes an invalid confidence value to none rather than trusting the model', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'certain' }] })));
+
+    const result = await service.reconcileAttendees(req, { attendees, candidates });
+
+    expect(result.matches).toEqual([{ attendee_id: 'a0', matched_candidate_id: 'c0', confidence: 'none' }]);
+  });
+
+  it('throws on a response with no choices', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: async () => ({ choices: [] }) } as unknown as Response);
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('throws on empty response content', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(''));
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('throws on malformed JSON content', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse('not json'));
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('throws when matches is not an array', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: 'not an array' })));
+
+    await expect(service.reconcileAttendees(req, { attendees, candidates })).rejects.toThrow(/Failed to reconcile attendees/);
+  });
+
+  it('falls back to "unknown" in the prompt when zoom_user_name is falsy', async () => {
+    fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ matches: [] })));
+
+    await service.reconcileAttendees(req, { attendees: [{ attendee_id: 'a1', zoom_user_name: '' }], candidates });
+
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.messages[1].content).toContain('zoom_display_name: "unknown"');
   });
 });

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -6,6 +6,7 @@ import {
   AI_BRIEF_ACTION_ITEMS_SYSTEM_PROMPT,
   AI_MODEL,
   AI_NEWSLETTER_SYSTEM_PROMPT,
+  AI_RECONCILIATION_SYSTEM_PROMPT,
   AI_REQUEST_CONFIG,
   DURATION_ESTIMATION,
   NEWSLETTER_AI_MAX_TOKENS,
@@ -15,6 +16,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import {
+  AttendanceReconciliationConfidence,
   ExtractActionItemsRequest,
   ExtractActionItemsResponse,
   GenerateAgendaRequest,
@@ -23,6 +25,8 @@ import {
   GenerateNewsletterResponse,
   OpenAIChatRequest,
   OpenAIChatResponse,
+  ReconcileAttendeesRequest,
+  ReconcileAttendeesResponse,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -274,6 +278,136 @@ export class AiService {
       const cause = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to extract brief action items: ${cause}`);
     }
+  }
+
+  /**
+   * AI-assisted attendance reconciliation (GH-1672 / PCC-1452 port). Callers only send the
+   * ambiguous remainder left after a deterministic email/username pass, and must validate
+   * `matched_candidate_id` against the `candidates` they sent — this method itself only rejects
+   * candidate_ids that don't resolve against the request's own candidate list, not against any
+   * broader store.
+   */
+  public async reconcileAttendees(req: Request, request: ReconcileAttendeesRequest): Promise<ReconcileAttendeesResponse> {
+    this.assertConfigured();
+
+    const startTime = logger.startOperation(req, 'reconcile_attendees', {
+      attendeeCount: request.attendees.length,
+      candidateCount: request.candidates.length,
+    });
+
+    try {
+      const chatRequest: OpenAIChatRequest = {
+        model: this.model,
+        messages: [
+          { role: 'system', content: AI_RECONCILIATION_SYSTEM_PROMPT },
+          { role: 'user', content: this.buildReconciliationPrompt(request) },
+        ],
+        max_tokens: AI_REQUEST_CONFIG.MAX_TOKENS,
+        temperature: AI_REQUEST_CONFIG.TEMPERATURE,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'attendee_reconciliation',
+            description: 'Matched candidate (or none) and confidence tier for each attendee',
+            schema: {
+              type: 'object',
+              properties: {
+                matches: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      attendee_id: { type: 'string', description: 'The attendee_id from the input list' },
+                      matched_candidate_id: {
+                        type: ['string', 'null'],
+                        description: 'The candidate_id this attendee matches, or null if there is no plausible match',
+                      },
+                      confidence: {
+                        type: 'string',
+                        enum: ['high', 'medium', 'low', 'none'],
+                      },
+                    },
+                    required: ['attendee_id', 'matched_candidate_id', 'confidence'],
+                    additionalProperties: false,
+                  },
+                },
+              },
+              required: ['matches'],
+              additionalProperties: false,
+            },
+          },
+          strict: true,
+        },
+      };
+
+      const response = await this.makeAiRequest(chatRequest, AI_REQUEST_CONFIG.RECONCILIATION_TIMEOUT_MS);
+      const result = this.extractReconciliationMatches(request, response);
+
+      logger.success(req, 'reconcile_attendees', startTime, {
+        matchCount: result.matches.length,
+      });
+
+      return result;
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to reconcile attendees: ${cause}`);
+    }
+  }
+
+  private buildReconciliationPrompt(request: ReconcileAttendeesRequest): string {
+    const attendeeLines = request.attendees.map((a) => `- attendee_id: ${a.attendee_id}, zoom_display_name: "${a.zoom_user_name || 'unknown'}"`);
+    const candidateLines = request.candidates.map(
+      (c) =>
+        `- candidate_id: ${c.candidate_id}, name: "${[c.first_name, c.last_name].filter(Boolean).join(' ') || 'unknown'}"` +
+        `${c.org_name ? `, org: "${c.org_name}"` : ''} (source: ${c.source})`
+    );
+
+    return ['Attendees to match:', ...attendeeLines, '', 'Candidate pool:', ...candidateLines].join('\n');
+  }
+
+  /**
+   * Validates the model's response against the request it was given — rejects any
+   * `matched_candidate_id` that doesn't resolve to a real candidate_id (hallucination guard),
+   * and treats any `attendee_id` the model omitted as `confidence: 'none'` rather than losing it.
+   */
+  private extractReconciliationMatches(request: ReconcileAttendeesRequest, response: OpenAIChatResponse): ReconcileAttendeesResponse {
+    if (!response.choices || response.choices.length === 0) {
+      throw new Error('No reconciliation response generated');
+    }
+
+    const content = response.choices[0].message.content;
+    if (!content || content.trim().length === 0) {
+      throw new Error('Empty reconciliation response generated');
+    }
+
+    const parsed = JSON.parse(content.trim());
+    if (!Array.isArray(parsed.matches)) {
+      throw new Error('Invalid matches array in reconciliation response');
+    }
+
+    const candidateIds = new Set(request.candidates.map((c) => c.candidate_id));
+    const byAttendeeId = new Map<string, { matched_candidate_id: string | null; confidence: AttendanceReconciliationConfidence }>();
+
+    for (const match of parsed.matches) {
+      if (!match || typeof match.attendee_id !== 'string') {
+        continue;
+      }
+      const matchedCandidateId =
+        typeof match.matched_candidate_id === 'string' && candidateIds.has(match.matched_candidate_id) ? match.matched_candidate_id : null;
+      const confidence: AttendanceReconciliationConfidence = ['high', 'medium', 'low', 'none'].includes(match.confidence) ? match.confidence : 'none';
+      byAttendeeId.set(match.attendee_id, { matched_candidate_id: matchedCandidateId, confidence });
+    }
+
+    const matches = request.attendees.map((attendee) => {
+      const found = byAttendeeId.get(attendee.attendee_id);
+      return {
+        attendee_id: attendee.attendee_id,
+        matched_candidate_id: found?.matched_candidate_id ?? null,
+        confidence: found?.confidence ?? ('none' as const),
+      };
+    });
+
+    return { matches };
   }
 
   private extractBriefActionItemsFromResponse(response: OpenAIChatResponse): ExtractActionItemsResponse {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -218,5 +218,37 @@ describe('AttendanceReconciliationService', () => {
       expect(result.needs_review_count).toBe(1);
       expect(result.auto_applied_count).toBe(0);
     });
+
+    it('queues the whole chunk for review instead of failing the request when the AI call throws', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'alice@example.com', is_invited: true, is_attended: false }),
+        buildParticipant({ uid: 'attendee-2', email: '', is_attended: true, is_verified: false }),
+      ]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockRejectedValue(new Error('upstream AI timeout'));
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      // The deterministic email match for attendee-1 must survive even though the AI call for
+      // the ambiguous remainder (attendee-2) throws.
+      const deterministic = result.results.find((r) => r.attendee_id === 'attendee-1');
+      expect(deterministic).toMatchObject({ confidence: 'high', method: 'deterministic' });
+
+      const aiFailed = result.results.find((r) => r.attendee_id === 'attendee-2');
+      expect(aiFailed).toMatchObject({ confidence: 'none', method: 'ai', auto_applied: false });
+    });
+
+    it('downgrades a spec-violating response (non-none confidence with no resolvable candidate_id) to none', async () => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ uid: 'attendee-1', email: '', is_attended: true, is_verified: false })]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: null, confidence: 'high' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'none', auto_applied: false, matched_candidate: undefined });
+    });
   });
 });

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -1,0 +1,222 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
+// vitest config, so runtime collaborators (constants + the services this service instantiates
+// internally) need mocking.
+vi.mock('@lfx-one/shared/constants', () => ({
+  RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL: 30,
+  RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
+}));
+
+const { getPastMeetingParticipants, getPastOccurrencesForMeeting, updatePastMeetingParticipant } = vi.hoisted(() => ({
+  getPastMeetingParticipants: vi.fn(),
+  getPastOccurrencesForMeeting: vi.fn(),
+  updatePastMeetingParticipant: vi.fn(),
+}));
+vi.mock('./meeting.service', () => ({
+  MeetingService: class {
+    public getPastMeetingParticipants = getPastMeetingParticipants;
+    public getPastOccurrencesForMeeting = getPastOccurrencesForMeeting;
+    public updatePastMeetingParticipant = updatePastMeetingParticipant;
+  },
+}));
+
+const { getCommitteeMembers } = vi.hoisted(() => ({ getCommitteeMembers: vi.fn() }));
+vi.mock('./committee.service', () => ({
+  CommitteeService: class {
+    public getCommitteeMembers = getCommitteeMembers;
+  },
+}));
+
+const { isAiConfigured, reconcileAttendees } = vi.hoisted(() => ({ isAiConfigured: vi.fn(), reconcileAttendees: vi.fn() }));
+vi.mock('./ai.service', () => ({
+  AiService: class {
+    public isAiConfigured = isAiConfigured;
+    public reconcileAttendees = reconcileAttendees;
+  },
+}));
+
+vi.mock('./logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import type { PastMeeting, PastMeetingParticipant } from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+
+import { AttendanceReconciliationService } from './attendance-reconciliation.service';
+
+const req = {} as unknown as Request;
+
+function buildParticipant(overrides: Partial<PastMeetingParticipant> = {}): PastMeetingParticipant {
+  return {
+    uid: 'attendee-1',
+    meeting_id: 'meeting-1',
+    meeting_and_occurrence_id: 'occ-1',
+    past_meeting_id: 'past-1',
+    email: '',
+    first_name: 'Jane',
+    last_name: 'Doe',
+    host: false,
+    is_attended: true,
+    is_invited: false,
+    org_is_member: false,
+    org_is_project_member: false,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+const pastMeeting = { meeting_id: 'meeting-1', committees: [] } as unknown as PastMeeting;
+
+describe('AttendanceReconciliationService', () => {
+  let service: AttendanceReconciliationService;
+
+  beforeEach(() => {
+    getPastMeetingParticipants.mockReset();
+    getPastOccurrencesForMeeting.mockReset().mockResolvedValue([]);
+    updatePastMeetingParticipant.mockReset().mockResolvedValue(undefined);
+    getCommitteeMembers.mockReset().mockResolvedValue([]);
+    isAiConfigured.mockReset().mockReturnValue(false);
+    reconcileAttendees.mockReset();
+    service = new AttendanceReconciliationService();
+  });
+
+  describe('reconcilePastMeetingParticipants', () => {
+    it('returns an empty result with no upstream writes when nothing is unverified', async () => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ is_attended: true, is_verified: true })]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 });
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('auto-applies a deterministic exact-email match and marks it verified', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'alice@example.com', first_name: 'Alice', last_name: 'Smith', is_invited: true, is_attended: false }),
+      ]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'high', method: 'deterministic', auto_applied: true });
+      expect(result.auto_applied_count).toBe(1);
+      expect(result.needs_review_count).toBe(0);
+      expect(updatePastMeetingParticipant).toHaveBeenCalledWith(
+        req,
+        'occ-1',
+        'attendee-1',
+        expect.objectContaining({ is_verified: true, email: 'alice@example.com' })
+      );
+    });
+
+    it('never auto-applies a "none" confidence match and always queues it for review', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'ghost@example.com', is_attended: true, is_verified: false }),
+      ]);
+      isAiConfigured.mockReturnValue(false);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'none', auto_applied: false });
+      expect(result.auto_applied_count).toBe(0);
+      expect(result.needs_review_count).toBe(1);
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-apply a medium-confidence AI match, even with a resolved candidate', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: '', first_name: 'Jon', last_name: 'Doey', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'jon@example.com', first_name: 'Jon', last_name: 'Doe', is_invited: true, is_attended: false }),
+      ]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: 'c0', confidence: 'medium' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'medium', auto_applied: false });
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('treats a hallucinated candidate_id from the AI response as "none" rather than trusting it', async () => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ uid: 'attendee-1', email: '', is_attended: true, is_verified: false })]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: 'does-not-exist', confidence: 'high' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'none', auto_applied: false, matched_candidate: undefined });
+    });
+
+    it('defaults an attendee omitted from the AI response to "none" instead of dropping it', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: '', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'attendee-2', email: '', is_attended: true, is_verified: false }),
+      ]);
+      isAiConfigured.mockReturnValue(true);
+      reconcileAttendees.mockResolvedValue({
+        matches: [{ attendee_id: 'attendee-1', matched_candidate_id: null, confidence: 'low' }],
+      });
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toHaveLength(2);
+      const omitted = result.results.find((r) => r.attendee_id === 'attendee-2');
+      expect(omitted).toMatchObject({ confidence: 'none', auto_applied: false });
+    });
+
+    it('builds the candidate pool from invitees, committee members, and prior verified attendees, deduped by email', async () => {
+      getPastMeetingParticipants
+        .mockResolvedValueOnce([
+          buildParticipant({ uid: 'attendee-1', email: 'dup@example.com', is_attended: true, is_verified: false }),
+          buildParticipant({ uid: 'invitee-1', email: 'dup@example.com', is_invited: true, is_attended: false }),
+        ])
+        .mockResolvedValueOnce([buildParticipant({ uid: 'prior-1', email: 'dup@example.com', is_verified: true, is_attended: true })]);
+      getPastOccurrencesForMeeting.mockResolvedValue([{ meeting_and_occurrence_id: 'occ-0' }, { meeting_and_occurrence_id: 'occ-1' }]);
+      getCommitteeMembers.mockResolvedValue([{ email: 'dup@example.com', first_name: 'Dup', last_name: 'One' }]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', {
+        ...pastMeeting,
+        committees: [{ uid: 'committee-1' }],
+      } as unknown as PastMeeting);
+
+      // All three sources share the same email — the dedup comparator must collapse them to one.
+      expect(result.candidate_pool_size).toBe(1);
+      // The current occurrence must be fetched once for its own participants, and the prior-occurrence
+      // scan must exclude it (only 'occ-0' is scanned) — two calls total, not three.
+      expect(getPastMeetingParticipants).toHaveBeenCalledTimes(2);
+      expect(getPastMeetingParticipants).toHaveBeenCalledWith(req, 'occ-0');
+    });
+
+    it('leaves a high-confidence match for review when the write to persist it fails', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),
+        buildParticipant({ uid: 'invitee-1', email: 'alice@example.com', is_invited: true, is_attended: false }),
+      ]);
+      updatePastMeetingParticipant.mockRejectedValue(new Error('upstream 500'));
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results[0]).toMatchObject({ confidence: 'high', auto_applied: false });
+      expect(result.needs_review_count).toBe(1);
+      expect(result.auto_applied_count).toBe(0);
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -51,15 +51,12 @@ export class AttendanceReconciliationService {
     pastMeetingUid: string,
     pastMeeting: PastMeeting
   ): Promise<ReconcilePastMeetingParticipantsResponse> {
-    const startTime = logger.startOperation(req, 'reconcile_attendance_pool', {
-      past_meeting_id: pastMeetingUid,
-    });
+    logger.debug(req, 'reconcile_attendance_pool', 'Starting attendance reconciliation', { past_meeting_id: pastMeetingUid });
 
     const participants = await this.meetingService.getPastMeetingParticipants(req, pastMeetingUid);
     const unverified = participants.filter((p) => p.is_attended && !p.is_verified);
 
     if (unverified.length === 0) {
-      logger.success(req, 'reconcile_attendance_pool', startTime, { unverified_count: 0 });
       return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
     }
 
@@ -85,7 +82,7 @@ export class AttendanceReconciliationService {
     const autoAppliedCount = results.filter((r) => r.auto_applied).length;
     const needsReviewCount = results.filter((r) => !r.auto_applied).length;
 
-    logger.success(req, 'reconcile_attendance_pool', startTime, {
+    logger.info(req, 'reconcile_attendance_pool', 'Attendance reconciliation completed', {
       unverified_count: unverified.length,
       candidate_pool_size: candidates.length,
       auto_applied_count: autoAppliedCount,

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -201,7 +201,7 @@ export class AttendanceReconciliationService {
   /**
    * Identity comparator for candidate-pool dedup. Local to this service — does not depend on
    * PR #2060's `isSamePerson` (unmerged, non-stacked branch). Mirrors that comparator's branch
-   * order: prefer username (this repo's LFID-equivalent), then overlapping email, then
+   * order: prefer overlapping email, then username (this repo's LFID-equivalent), then
    * normalized name — an email match takes priority over username asymmetry, so two records
    * sharing an email still merge even if only one carries a username.
    */

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -1,0 +1,350 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL, RECONCILIATION_MAX_PRIOR_OCCURRENCES } from '@lfx-one/shared/constants';
+import {
+  AttendanceReconciliationCandidate,
+  AttendanceReconciliationResult,
+  ITXUpdatePastMeetingParticipantRequest,
+  PastMeeting,
+  PastMeetingParticipant,
+  ReconcilePastMeetingParticipantsResponse,
+} from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { AiService } from './ai.service';
+import { CommitteeService } from './committee.service';
+import { logger } from './logger.service';
+import { MeetingService } from './meeting.service';
+
+/**
+ * Attendance reconciliation for past-meeting participants (GH-1672 / PCC-1452 port).
+ *
+ * Kept out of MeetingService — this is matching/orchestration logic layered on top of
+ * MeetingService's existing participant CRUD (item 3), not a new CRUD surface of its own.
+ *
+ * Deliberately does NOT depend on PR #2060's `isSamePerson` comparator (unmerged, on a
+ * non-stacked branch) — `isSamePersonForReconciliation` below is a local equivalent so this
+ * branch has no cross-branch dependency.
+ */
+export class AttendanceReconciliationService {
+  private meetingService: MeetingService;
+  private committeeService: CommitteeService;
+  private aiService: AiService;
+
+  public constructor() {
+    this.meetingService = new MeetingService();
+    this.committeeService = new CommitteeService();
+    this.aiService = new AiService();
+  }
+
+  /**
+   * Runs reconciliation for every unverified participant of one past-meeting occurrence:
+   * builds a candidate pool (occurrence invitees + committee members + previously-verified
+   * attendees of prior occurrences), matches deterministically first, falls back to the AI
+   * service for the ambiguous remainder, and auto-applies only `confidence: 'high'` matches.
+   * `confidence: 'none'` is NEVER auto-applied — it is always returned for admin review, per
+   * the fix for PCC-1452's silent "auto-tagged unknown" bug.
+   */
+  public async reconcilePastMeetingParticipants(
+    req: Request,
+    pastMeetingUid: string,
+    pastMeeting: PastMeeting
+  ): Promise<ReconcilePastMeetingParticipantsResponse> {
+    const startTime = logger.startOperation(undefined, 'reconcile_past_meeting_participants', {
+      past_meeting_id: pastMeetingUid,
+    });
+
+    const participants = await this.meetingService.getPastMeetingParticipants(req, pastMeetingUid);
+    const unverified = participants.filter((p) => p.is_attended && !p.is_verified);
+
+    if (unverified.length === 0) {
+      logger.success(undefined, 'reconcile_past_meeting_participants', startTime, { unverified_count: 0 });
+      return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
+    }
+
+    const candidates = await this.buildCandidatePool(req, pastMeetingUid, pastMeeting, participants);
+
+    const { deterministic, remainder } = this.matchDeterministically(unverified, candidates);
+
+    const aiMatched = remainder.length > 0 ? await this.matchWithAi(req, remainder, candidates) : [];
+
+    const combined = [...deterministic, ...aiMatched];
+
+    const results = await Promise.all(
+      combined.map(async (result) => {
+        if (result.confidence !== 'high' || !result.matched_candidate) {
+          return result;
+        }
+
+        const applied = await this.applyMatch(req, pastMeetingUid, result.attendee_id, result.matched_candidate);
+        return { ...result, auto_applied: applied };
+      })
+    );
+
+    const autoAppliedCount = results.filter((r) => r.auto_applied).length;
+    const needsReviewCount = results.filter((r) => !r.auto_applied).length;
+
+    logger.success(undefined, 'reconcile_past_meeting_participants', startTime, {
+      unverified_count: unverified.length,
+      candidate_pool_size: candidates.length,
+      auto_applied_count: autoAppliedCount,
+      needs_review_count: needsReviewCount,
+    });
+
+    return {
+      results,
+      candidate_pool_size: candidates.length,
+      auto_applied_count: autoAppliedCount,
+      needs_review_count: needsReviewCount,
+    };
+  }
+
+  /**
+   * Union of three candidate sources, deduped via `isSamePersonForReconciliation` — a single-
+   * source pool (just that occurrence's invitees) was PCC's PCC-1452 root cause.
+   */
+  private async buildCandidatePool(
+    req: Request,
+    pastMeetingUid: string,
+    pastMeeting: PastMeeting,
+    occurrenceParticipants: PastMeetingParticipant[]
+  ): Promise<AttendanceReconciliationCandidate[]> {
+    const invitees = occurrenceParticipants.filter((p) => p.is_invited);
+
+    const committeeMembers = (
+      await Promise.all((pastMeeting.committees || []).map((committee) => this.committeeService.getCommitteeMembers(req, committee.uid).catch(() => [])))
+    ).flat();
+
+    const priorAttendees = await this.getPriorVerifiedAttendees(req, pastMeeting.meeting_id, pastMeetingUid);
+
+    const pool: AttendanceReconciliationCandidate[] = [];
+    let nextId = 0;
+
+    const pushIfNew = (candidate: Omit<AttendanceReconciliationCandidate, 'candidate_id'>): void => {
+      if (!candidate.email && !candidate.username && !candidate.lf_user_id && !(candidate.first_name && candidate.last_name)) {
+        return;
+      }
+      const existing = pool.find((c) => this.isSamePersonForReconciliation(c, candidate));
+      if (existing) {
+        return;
+      }
+      pool.push({ ...candidate, candidate_id: `c${nextId++}` });
+    };
+
+    invitees.forEach((p) =>
+      pushIfNew({
+        source: 'invitee',
+        email: p.email,
+        username: p.username,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        org_name: p.org_name,
+      })
+    );
+
+    committeeMembers.forEach((m) =>
+      pushIfNew({
+        source: 'committee_member',
+        email: m.email,
+        username: m.username,
+        first_name: m.first_name,
+        last_name: m.last_name,
+      })
+    );
+
+    priorAttendees.forEach((p) =>
+      pushIfNew({
+        source: 'prior_attendee',
+        email: p.email,
+        username: p.username,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        org_name: p.org_name,
+      })
+    );
+
+    return pool;
+  }
+
+  /**
+   * Scans up to RECONCILIATION_MAX_PRIOR_OCCURRENCES most-recent prior occurrences of the same
+   * series for participants already marked `is_verified` — Stephan's "we should even store it"
+   * carry-forward signal, and the direct answer to PCC-1451 for this port's candidate pool.
+   */
+  private async getPriorVerifiedAttendees(req: Request, meetingUid: string, currentOccurrenceId: string): Promise<PastMeetingParticipant[]> {
+    const occurrences = await this.meetingService.getPastOccurrencesForMeeting(req, meetingUid);
+    const priorOccurrences = occurrences.filter((o) => o.meeting_and_occurrence_id !== currentOccurrenceId).slice(-RECONCILIATION_MAX_PRIOR_OCCURRENCES);
+
+    const perOccurrence = await Promise.all(
+      priorOccurrences.map((o) => this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch(() => []))
+    );
+
+    return perOccurrence.flat().filter((p) => p.is_verified);
+  }
+
+  /**
+   * Identity comparator for candidate-pool dedup. Local to this service — does not depend on
+   * PR #2060's `isSamePerson` (unmerged, non-stacked branch). Mirrors that comparator's branch
+   * order: prefer username (this repo's LFID-equivalent), then overlapping email, then
+   * normalized name — an email match takes priority over username asymmetry, so two records
+   * sharing an email still merge even if only one carries a username.
+   */
+  private isSamePersonForReconciliation(
+    a: { email?: string; username?: string; first_name?: string; last_name?: string },
+    b: { email?: string; username?: string; first_name?: string; last_name?: string }
+  ): boolean {
+    const emailA = a.email?.trim().toLowerCase();
+    const emailB = b.email?.trim().toLowerCase();
+    if (emailA && emailB) {
+      return emailA === emailB;
+    }
+
+    const usernameA = a.username?.trim().toLowerCase();
+    const usernameB = b.username?.trim().toLowerCase();
+    if (usernameA && usernameB) {
+      return usernameA === usernameB;
+    }
+
+    const nameA = this.normalizeName(a.first_name, a.last_name);
+    const nameB = this.normalizeName(b.first_name, b.last_name);
+    return !!nameA && !!nameB && nameA === nameB;
+  }
+
+  private normalizeName(firstName?: string, lastName?: string): string | undefined {
+    if (!firstName || !lastName) {
+      return undefined;
+    }
+    return `${firstName.trim().toLowerCase()} ${lastName.trim().toLowerCase()}`;
+  }
+
+  /**
+   * Cheap deterministic pass: exact email match, then username match. No LLM call — only the
+   * genuinely ambiguous remainder is handed to `matchWithAi`.
+   */
+  private matchDeterministically(
+    unverified: PastMeetingParticipant[],
+    candidates: AttendanceReconciliationCandidate[]
+  ): {
+    deterministic: AttendanceReconciliationResult[];
+    remainder: PastMeetingParticipant[];
+  } {
+    const deterministic: AttendanceReconciliationResult[] = [];
+    const remainder: PastMeetingParticipant[] = [];
+
+    for (const attendee of unverified) {
+      const email = attendee.email?.trim().toLowerCase();
+      const username = attendee.username?.trim().toLowerCase();
+
+      const match =
+        (email && candidates.find((c) => c.email?.trim().toLowerCase() === email)) ||
+        (username && candidates.find((c) => c.username?.trim().toLowerCase() === username));
+
+      if (match) {
+        deterministic.push({
+          attendee_id: attendee.uid,
+          zoom_user_name: `${attendee.first_name} ${attendee.last_name}`.trim(),
+          confidence: 'high',
+          method: 'deterministic',
+          matched_candidate: match,
+          auto_applied: false,
+        });
+      } else {
+        remainder.push(attendee);
+      }
+    }
+
+    return { deterministic, remainder };
+  }
+
+  /**
+   * Sends the ambiguous remainder to AiService.reconcileAttendees, chunked at
+   * RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL so a large occurrence doesn't produce one
+   * unbounded prompt. Any attendee_id the model omits is treated as confidence 'none' rather
+   * than lost. Skips the call entirely (all 'none') when the AI service isn't configured —
+   * matching queues are still safe without it.
+   */
+  private async matchWithAi(
+    req: Request,
+    remainder: PastMeetingParticipant[],
+    candidates: AttendanceReconciliationCandidate[]
+  ): Promise<AttendanceReconciliationResult[]> {
+    if (!this.aiService.isAiConfigured()) {
+      return remainder.map((attendee) => ({
+        attendee_id: attendee.uid,
+        zoom_user_name: `${attendee.first_name} ${attendee.last_name}`.trim(),
+        confidence: 'none',
+        method: 'ai',
+        auto_applied: false,
+      }));
+    }
+
+    const chunks: PastMeetingParticipant[][] = [];
+    for (let i = 0; i < remainder.length; i += RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL) {
+      chunks.push(remainder.slice(i, i + RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL));
+    }
+
+    const chunkResults = await Promise.all(
+      chunks.map(async (chunk) => {
+        const response = await this.aiService.reconcileAttendees(req, {
+          attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: `${a.first_name} ${a.last_name}`.trim() })),
+          candidates,
+        });
+
+        const byId = new Map(response.matches.map((m) => [m.attendee_id, m]));
+
+        return chunk.map((attendee) => {
+          const match = byId.get(attendee.uid);
+          const matchedCandidate = match?.matched_candidate_id ? candidates.find((c) => c.candidate_id === match.matched_candidate_id) : undefined;
+
+          // Model omitted this attendee, or returned an unresolvable/hallucinated candidate_id —
+          // both degrade to 'none' rather than being silently dropped or trusted blindly.
+          const confidence = match && (matchedCandidate || !match.matched_candidate_id) ? match.confidence : ('none' as const);
+
+          return {
+            attendee_id: attendee.uid,
+            zoom_user_name: `${attendee.first_name} ${attendee.last_name}`.trim(),
+            confidence,
+            method: 'ai' as const,
+            matched_candidate: matchedCandidate,
+            auto_applied: false,
+          };
+        });
+      })
+    );
+
+    return chunkResults.flat();
+  }
+
+  /**
+   * Writes a high-confidence match back onto the attendee's participant record.
+   * `ITXUpdatePastMeetingParticipantRequest` does not accept `is_ai_reconciled`/`is_auto_matched`
+   * (response-only fields, per item 3's documented request/response asymmetry) — this writes the
+   * matched candidate's identity fields plus `is_verified: true` instead. `AttendanceReconciliationResult.method`/
+   * `auto_applied` (this service's own response shape) is what the future review UI (item 5)
+   * relies on to know a match was AI-applied, not the upstream record's flags.
+   */
+  private async applyMatch(req: Request, pastMeetingUid: string, attendeeId: string, candidate: AttendanceReconciliationCandidate): Promise<boolean> {
+    const update: ITXUpdatePastMeetingParticipantRequest = {
+      is_verified: true,
+      ...(candidate.email && { email: candidate.email }),
+      ...(candidate.username && { username: candidate.username }),
+      ...(candidate.lf_user_id && { lf_user_id: candidate.lf_user_id }),
+      ...(candidate.first_name && { first_name: candidate.first_name }),
+      ...(candidate.last_name && { last_name: candidate.last_name }),
+      ...(candidate.org_name && { org_name: candidate.org_name }),
+    };
+
+    try {
+      await this.meetingService.updatePastMeetingParticipant(req, pastMeetingUid, attendeeId, update);
+      return true;
+    } catch (error) {
+      logger.warning(undefined, 'reconcile_past_meeting_participants', 'Failed to auto-apply high-confidence match, leaving for review', {
+        past_meeting_id: pastMeetingUid,
+        attendee_id: attendeeId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return false;
+    }
+  }
+}

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -294,30 +294,50 @@ export class AttendanceReconciliationService {
 
     const chunkResults = await Promise.all(
       chunks.map(async (chunk) => {
-        const response = await this.aiService.reconcileAttendees(req, {
-          attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: this.getDisplayName(a) })),
-          candidates,
-        });
+        try {
+          const response = await this.aiService.reconcileAttendees(req, {
+            attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: this.getDisplayName(a) })),
+            candidates,
+          });
 
-        const byId = new Map(response.matches.map((m) => [m.attendee_id, m]));
+          const byId = new Map(response.matches.map((m) => [m.attendee_id, m]));
 
-        return chunk.map((attendee) => {
-          const match = byId.get(attendee.uid);
-          const matchedCandidate = match?.matched_candidate_id ? candidates.find((c) => c.candidate_id === match.matched_candidate_id) : undefined;
+          return chunk.map((attendee) => {
+            const match = byId.get(attendee.uid);
+            const matchedCandidate = match?.matched_candidate_id ? candidates.find((c) => c.candidate_id === match.matched_candidate_id) : undefined;
 
-          // Model omitted this attendee, or returned an unresolvable/hallucinated candidate_id —
-          // both degrade to 'none' rather than being silently dropped or trusted blindly.
-          const confidence = match && (matchedCandidate || !match.matched_candidate_id) ? match.confidence : ('none' as const);
+            // Only trust the model's stated confidence when its candidate_id actually resolved.
+            // A resolved-confidence + no-candidate combination (omitted attendee, hallucinated
+            // candidate_id, or a spec-violating null-candidate-but-non-none-confidence response)
+            // always degrades to 'none' rather than surfacing a misleading confidence with nothing
+            // attached to it.
+            const confidence = match && matchedCandidate ? match.confidence : ('none' as const);
 
-          return {
+            return {
+              attendee_id: attendee.uid,
+              zoom_user_name: this.getDisplayName(attendee),
+              confidence,
+              method: 'ai' as const,
+              matched_candidate: matchedCandidate,
+              auto_applied: false,
+            };
+          });
+        } catch (error) {
+          // A transient AI failure on one chunk must not sink the whole reconciliation call —
+          // the deterministic matches already computed for other attendees would otherwise be
+          // lost along with it. Degrade this chunk to 'none' so it queues for review instead.
+          logger.warning(req, 'reconcile_attendance_pool', 'AI reconciliation chunk failed, queuing attendees for review', {
+            attendee_count: chunk.length,
+            err: error,
+          });
+          return chunk.map((attendee) => ({
             attendee_id: attendee.uid,
             zoom_user_name: this.getDisplayName(attendee),
-            confidence,
+            confidence: 'none' as const,
             method: 'ai' as const,
-            matched_candidate: matchedCandidate,
             auto_applied: false,
-          };
-        });
+          }));
+        }
       })
     );
 

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -51,7 +51,7 @@ export class AttendanceReconciliationService {
     pastMeetingUid: string,
     pastMeeting: PastMeeting
   ): Promise<ReconcilePastMeetingParticipantsResponse> {
-    const startTime = logger.startOperation(undefined, 'reconcile_past_meeting_participants', {
+    const startTime = logger.startOperation(req, 'reconcile_attendance_pool', {
       past_meeting_id: pastMeetingUid,
     });
 
@@ -59,7 +59,7 @@ export class AttendanceReconciliationService {
     const unverified = participants.filter((p) => p.is_attended && !p.is_verified);
 
     if (unverified.length === 0) {
-      logger.success(undefined, 'reconcile_past_meeting_participants', startTime, { unverified_count: 0 });
+      logger.success(req, 'reconcile_attendance_pool', startTime, { unverified_count: 0 });
       return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
     }
 
@@ -85,7 +85,7 @@ export class AttendanceReconciliationService {
     const autoAppliedCount = results.filter((r) => r.auto_applied).length;
     const needsReviewCount = results.filter((r) => !r.auto_applied).length;
 
-    logger.success(undefined, 'reconcile_past_meeting_participants', startTime, {
+    logger.success(req, 'reconcile_attendance_pool', startTime, {
       unverified_count: unverified.length,
       candidate_pool_size: candidates.length,
       auto_applied_count: autoAppliedCount,
@@ -219,6 +219,17 @@ export class AttendanceReconciliationService {
   }
 
   /**
+   * A raw, not-yet-identified Zoom attendee (the exact population this feature targets) has no
+   * reason to carry a populated `first_name`/`last_name` — those are enrichment fields set once a
+   * match is found. `zoom_user_name` is the only display name guaranteed to exist for such an
+   * attendee, so it must be preferred over reconstructing from first/last name, which is empty for
+   * the very attendees this service is trying to match.
+   */
+  private getDisplayName(attendee: PastMeetingParticipant): string {
+    return attendee.zoom_user_name || `${attendee.first_name} ${attendee.last_name}`.trim();
+  }
+
+  /**
    * Cheap deterministic pass: exact email match, then username match. No LLM call — only the
    * genuinely ambiguous remainder is handed to `matchWithAi`.
    */
@@ -243,7 +254,7 @@ export class AttendanceReconciliationService {
       if (match) {
         deterministic.push({
           attendee_id: attendee.uid,
-          zoom_user_name: `${attendee.first_name} ${attendee.last_name}`.trim(),
+          zoom_user_name: this.getDisplayName(attendee),
           confidence: 'high',
           method: 'deterministic',
           matched_candidate: match,
@@ -272,7 +283,7 @@ export class AttendanceReconciliationService {
     if (!this.aiService.isAiConfigured()) {
       return remainder.map((attendee) => ({
         attendee_id: attendee.uid,
-        zoom_user_name: `${attendee.first_name} ${attendee.last_name}`.trim(),
+        zoom_user_name: this.getDisplayName(attendee),
         confidence: 'none',
         method: 'ai',
         auto_applied: false,
@@ -287,7 +298,7 @@ export class AttendanceReconciliationService {
     const chunkResults = await Promise.all(
       chunks.map(async (chunk) => {
         const response = await this.aiService.reconcileAttendees(req, {
-          attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: `${a.first_name} ${a.last_name}`.trim() })),
+          attendees: chunk.map((a) => ({ attendee_id: a.uid, zoom_user_name: this.getDisplayName(a) })),
           candidates,
         });
 
@@ -303,7 +314,7 @@ export class AttendanceReconciliationService {
 
           return {
             attendee_id: attendee.uid,
-            zoom_user_name: `${attendee.first_name} ${attendee.last_name}`.trim(),
+            zoom_user_name: this.getDisplayName(attendee),
             confidence,
             method: 'ai' as const,
             matched_candidate: matchedCandidate,
@@ -339,10 +350,10 @@ export class AttendanceReconciliationService {
       await this.meetingService.updatePastMeetingParticipant(req, pastMeetingUid, attendeeId, update);
       return true;
     } catch (error) {
-      logger.warning(undefined, 'reconcile_past_meeting_participants', 'Failed to auto-apply high-confidence match, leaving for review', {
+      logger.warning(req, 'reconcile_attendance_pool', 'Failed to auto-apply high-confidence match, leaving for review', {
         past_meeting_id: pastMeetingUid,
         attendee_id: attendeeId,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        err: error,
       });
       return false;
     }

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -110,7 +110,17 @@ export class AttendanceReconciliationService {
     const invitees = occurrenceParticipants.filter((p) => p.is_invited);
 
     const committeeMembers = (
-      await Promise.all((pastMeeting.committees || []).map((committee) => this.committeeService.getCommitteeMembers(req, committee.uid).catch(() => [])))
+      await Promise.all(
+        (pastMeeting.committees || []).map((committee) =>
+          this.committeeService.getCommitteeMembers(req, committee.uid).catch((error) => {
+            logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch committee members, continuing without them', {
+              committee_uid: committee.uid,
+              err: error,
+            });
+            return [];
+          })
+        )
+      )
     ).flat();
 
     const priorAttendees = await this.getPriorVerifiedAttendees(req, pastMeeting.meeting_id, pastMeetingUid);
@@ -174,7 +184,15 @@ export class AttendanceReconciliationService {
     const priorOccurrences = occurrences.filter((o) => o.meeting_and_occurrence_id !== currentOccurrenceId).slice(-RECONCILIATION_MAX_PRIOR_OCCURRENCES);
 
     const perOccurrence = await Promise.all(
-      priorOccurrences.map((o) => this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch(() => []))
+      priorOccurrences.map((o) =>
+        this.meetingService.getPastMeetingParticipants(req, o.meeting_and_occurrence_id).catch((error) => {
+          logger.warning(req, 'reconcile_attendance_pool', 'Failed to fetch prior occurrence participants, continuing without them', {
+            past_meeting_id: o.meeting_and_occurrence_id,
+            err: error,
+          });
+          return [];
+        })
+      )
     );
 
     return perOccurrence.flat().filter((p) => p.is_verified);

--- a/packages/shared/src/constants/ai.constants.ts
+++ b/packages/shared/src/constants/ai.constants.ts
@@ -154,6 +154,27 @@ You must respond with a valid JSON object in this exact format:
 Do not include any text outside the JSON object.`;
 
 /**
+ * System prompt for AI-assisted attendance reconciliation (GH-1672 / PCC-1452 port).
+ *
+ * Only the genuinely ambiguous remainder reaches this prompt — exact email/username/lf_user_id
+ * matches are resolved deterministically in code before this call, and every candidate this
+ * prompt sees already comes from a pool wider than just the current occurrence's invitees
+ * (committee members and prior-occurrence verified attendees are included too). The caller
+ * validates `matched_candidate_id` against the candidate set it sent — never trust it blindly.
+ */
+export const AI_RECONCILIATION_SYSTEM_PROMPT = `You are matching Zoom meeting attendees (identified only by their Zoom display name) to known identities from a candidate pool (meeting invitees, project committee members, and previously-verified attendees of earlier occurrences of the same recurring meeting).
+
+For each attendee:
+- If the Zoom display name clearly matches exactly one candidate's first + last name (allowing for minor variations like nicknames, middle initials, or reordering), return that candidate's candidate_id with confidence "high".
+- If the name plausibly matches a candidate but with meaningful ambiguity (partial match, common name, multiple similarly-close candidates), return your best-guess candidate_id with confidence "medium" or "low".
+- If there is no plausible match in the candidate pool, return matched_candidate_id: null with confidence "none". Do NOT guess a candidate just to avoid returning null.
+- Never invent a candidate_id that was not in the provided candidate list.
+
+You must return exactly one entry per attendee_id you were given, in any order. Do not omit any attendee.
+
+Respond with a JSON object matching the provided schema exactly. Do not include any text outside the JSON object.`;
+
+/**
  * AI model configuration
  */
 export const AI_MODEL = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
@@ -193,6 +214,13 @@ export const AI_REQUEST_CONFIG = {
    * generously-bounded wait there is an availability risk, not just slowness.
    */
   EXTRACTION_TIMEOUT_MS: 15_000,
+  /**
+   * AbortSignal.timeout bound for reconcileAttendees. Runs on a manual admin button click (not a
+   * page-load path), so it can afford more headroom than EXTRACTION_TIMEOUT_MS, but the prompt is
+   * bounded to RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL candidates so it shouldn't need
+   * NEWSLETTER_TIMEOUT_MS's budget either — sized independently rather than reusing either.
+   */
+  RECONCILIATION_TIMEOUT_MS: 60_000,
 };
 
 /**

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -682,6 +682,27 @@ export const PAST_MEETING_SORT = {
   UPDATED_ASC: 'updated_asc',
 } as const;
 
+// ============================================================================
+// Attendance Reconciliation (GH-1672 / PCC-1452 port)
+// ============================================================================
+
+/**
+ * Max prior occurrences of a meeting series scanned when assembling the candidate pool's
+ * "previously-verified attendee" source. Unbounded series history would mean an unbounded
+ * number of per-occurrence participant fetches for a single reconcile call; recent occurrences
+ * carry the most relevant identity signal anyway (attendance patterns and org affiliation
+ * change over time), so older ones aren't worth the extra roundtrips.
+ */
+export const RECONCILIATION_MAX_PRIOR_OCCURRENCES = 10;
+
+/**
+ * Max ambiguous attendees sent to the LLM in a single reconcileAttendees call. Bounds prompt
+ * size and keeps the call within AI_REQUEST_CONFIG's reconciliation timeout; a meeting with more
+ * ambiguous attendees than this is chunked into multiple sequential calls rather than one
+ * unbounded prompt.
+ */
+export const RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL = 30;
+
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's
  * notes_added leg treats as a note. A single source of truth for both the upstream `filters_all`

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -697,9 +697,9 @@ export const RECONCILIATION_MAX_PRIOR_OCCURRENCES = 10;
 
 /**
  * Max ambiguous attendees sent to the LLM in a single reconcileAttendees call. Bounds prompt
- * size and keeps the call within AI_REQUEST_CONFIG's reconciliation timeout; a meeting with more
- * ambiguous attendees than this is chunked into multiple sequential calls rather than one
- * unbounded prompt.
+ * size and keeps each call within AI_REQUEST_CONFIG's reconciliation timeout; a meeting with more
+ * ambiguous attendees than this is chunked into multiple calls dispatched concurrently (not one
+ * unbounded prompt), with each chunk independently degrading to `confidence: 'none'` on failure.
  */
 export const RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL = 30;
 

--- a/packages/shared/src/interfaces/ai.interface.ts
+++ b/packages/shared/src/interfaces/ai.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingType } from '../enums';
+import { AttendanceReconciliationCandidate, AttendanceReconciliationConfidence } from './meeting.interface';
 
 /**
  * Request interface for AI agenda generation
@@ -71,6 +72,32 @@ export interface ExtractActionItemsResponse {
     text: string;
     /** Suggested owner role/persona for the item, when the model can infer one */
     suggested_owner_role?: string;
+  }[];
+}
+
+/**
+ * Request interface for AI-assisted attendance reconciliation — sent only for attendees the
+ * deterministic pass (exact email/username/lf_user_id match) couldn't resolve.
+ */
+export interface ReconcileAttendeesRequest {
+  attendees: {
+    attendee_id: string;
+    zoom_user_name?: string;
+  }[];
+  candidates: AttendanceReconciliationCandidate[];
+}
+
+/**
+ * Response interface for AI-assisted attendance reconciliation. `matched_candidate_id` must be
+ * validated by the caller against the `candidate_id`s it sent — the model can hallucinate one
+ * (see AiService.reconcileAttendees). Every input `attendee_id` should appear exactly once; any
+ * omitted by the model is treated as `confidence: 'none'` by the caller rather than lost.
+ */
+export interface ReconcileAttendeesResponse {
+  matches: {
+    attendee_id: string;
+    matched_candidate_id: string | null;
+    confidence: AttendanceReconciliationConfidence;
   }[];
 }
 

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1149,6 +1149,55 @@ export interface ITXPastMeetingParticipantResult {
   modified_by?: MeetingUserInfo;
 }
 
+/**
+ * How confidently an attendance-reconciliation match was made.
+ * `high` may be auto-applied; `medium`/`low`/`none` are always queued for admin review —
+ * `none` must never be silently auto-tagged as unknown (see GH-1672, PCC-1452 root cause).
+ */
+export type AttendanceReconciliationConfidence = 'high' | 'medium' | 'low' | 'none';
+
+/** Which layer of the candidate pool a reconciliation candidate came from. */
+export type AttendanceReconciliationCandidateSource = 'invitee' | 'committee_member' | 'prior_attendee';
+
+/**
+ * A known-identity candidate an unverified attendee can be matched against. Assembled from
+ * three sources (occurrence invitees, project committee members, previously-verified attendees
+ * of prior occurrences in the same series) — a single-source pool was PCC's root cause for its
+ * high "unknown" rate (PCC-1452): an attendee who joined without being an invitee on that exact
+ * occurrence had zero candidates and was unmatchable by construction.
+ */
+export interface AttendanceReconciliationCandidate {
+  /** Stable identifier for this candidate within one reconciliation run (not a persisted UID) */
+  candidate_id: string;
+  source: AttendanceReconciliationCandidateSource;
+  email?: string;
+  username?: string;
+  lf_user_id?: string;
+  first_name?: string;
+  last_name?: string;
+  org_name?: string;
+}
+
+/** Outcome of attempting to match one unverified attendee against the candidate pool. */
+export interface AttendanceReconciliationResult {
+  /** The attendee record's `id` (attendee_id) from ITXPastMeetingParticipantResult / participant uid */
+  attendee_id: string;
+  zoom_user_name?: string;
+  confidence: AttendanceReconciliationConfidence;
+  method: 'deterministic' | 'ai';
+  matched_candidate?: AttendanceReconciliationCandidate;
+  /** True when this match was written back via updatePastMeetingParticipant */
+  auto_applied: boolean;
+}
+
+/** Response from POST /api/past-meetings/:uid/reconcile. */
+export interface ReconcilePastMeetingParticipantsResponse {
+  results: AttendanceReconciliationResult[];
+  candidate_pool_size: number;
+  auto_applied_count: number;
+  needs_review_count: number;
+}
+
 /** Attendance filter for the past-meeting participant list. */
 export type PastParticipantAttendanceFilter = 'all' | 'attended' | 'absent';
 /** Invitation filter for the past-meeting participant list. */


### PR DESCRIPTION
## Summary

Item 4 of the [GH-1672](https://github.com/linuxfoundation/lfx-self-serve/issues/1672) roadmap (porting PCC's "Auto-Reconcile" feature to LFX V2). Adds AI-assisted attendance reconciliation matching for past-meeting participants:

- New `POST /api/past-meetings/:uid/reconcile` endpoint (organizer-only, fail-closed authorization).
- `AttendanceReconciliationService` builds a candidate pool from occurrence invitees + committee members + previously-verified attendees of prior occurrences of the same meeting series — avoiding PCC's PCC-1452 bug where a single-source pool (just that occurrence's invitees) made anyone else unmatchable by construction.
- Deterministic matching (email, then username/lf_user_id) runs first; only the genuinely ambiguous remainder goes to the AI service for fuzzy name matching.
- Confidence tiers: `high` / `medium` / `low` / `none`. Only `high` auto-applies. **`none` is never auto-tagged as unknown** — it's always returned for admin review, directly fixing PCC's silent "auto-tagged unknown" bug (PCC-1452).
- Hallucination guard: the AI response is validated against the actual candidate set — any unresolved/hallucinated `matched_candidate_id` is downgraded to `confidence: 'none'` rather than trusted.
- Per-source failure isolation: committee-member and prior-occurrence fetches are individually try/catch-guarded (logged via `logger.warning`) so one bad upstream call can't sink the whole reconciliation run.

Item 5 (the three-tab admin review UI) is explicitly out of scope — this PR only produces and exposes matching results in a shape item 5 can later consume via item 3's existing create/update/delete participant routes.

## Stacking

This branch is stacked on **#2062** (item 3, `feat/issue-1672-reconciliation-routes`) — it depends on that PR's write routes (`createPastMeetingParticipant`/`updatePastMeetingParticipant`/`deletePastMeetingParticipant`) and shared interfaces (`ITXPastMeetingParticipantResult`, `ITXCreatePastMeetingParticipantRequest`, `ITXUpdatePastMeetingParticipantRequest`, `ITXParticipantSession`). This PR is based against `feat/issue-1672-reconciliation-routes` rather than `main` so the diff shown here is scoped to item 4's own 8 commits; it should be re-based/merged after #2062 lands.

## Documented trade-off

`AiService`'s new reconciliation methods (`reconcileAttendees`, `extractReconciliationMatches`) use raw `new Error(...)` on failure, without a `logger.error()` call. This matches the pre-existing pattern already used by `generateMeetingAgenda`, `generateNewsletter`, and `extractBriefActionItems` in the same file — deliberately not refactored file-wide as part of this PR, since that would touch 14+ pre-existing, unrelated call sites. Left as consistent-with-existing-code rather than a new inconsistency.

## Protected files

`apps/lfx-one/src/server/services/ai.service.ts` is flagged by the repo's protected-files guard (AI integration service). Changes are additive (two new methods) and follow the file's existing patterns — flagging here for code-owner awareness per repo convention.

## Test plan

- [x] `attendance-reconciliation.service.spec.ts` — candidate-pool dedup, deterministic matching, confidence-tier gating, partial-failure isolation
- [x] `past-meeting.controller.spec.ts` — organizer-gate authorization (unauthenticated, non-organizer, access-check-throws, happy path)
- [x] `ai.service.spec.ts` — reconciliation prompt/response handling, hallucination guard
- [x] `meeting.service.spec.ts` — updated for new participant fetch/filter paths
- [x] Full pre-PR review cycle: post-commit reviewer trio (general + self-serve-conventions + self-serve-learnings) clean on every commit; full-branch sweep against `origin/main` clean (2 rounds, addressing an in-scope logging gap and a doc-comment precedence fix along the way)
- [x] `/lfx-self-serve-pr-readiness` — READY WITH CHANGES (documented above: stacked-branch base, inherited diff size from #2062, protected `ai.service.ts`)
- [x] `/preflight` — license headers, format, lint, build all pass

Refs #1672