### PR TITLE
fix(cla): keep long ECLA type pills inside the badge

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -109,14 +109,15 @@ SPDX-License-Identifier: MIT
               </div>
             </td>
 
-            <td class="px-5 py-3.5">
+            <td class="px-5 py-3.5 align-middle">
               @if (row.agreement.kind === 'ECLA') {
                 <lfx-badge
                   [value]="row.agreement.companyName ? 'ECLA · ' + row.agreement.companyName : 'ECLA'"
                   severity="secondary"
-                  styleClass="!bg-purple-100 !text-purple-800" />
+                  styleClass="!bg-purple-100 !text-purple-800 !h-auto !min-h-5 !max-w-full !whitespace-normal !leading-snug !py-0.5"
+                  [attr.data-testid]="'agreement-type-' + row.id" />
               } @else {
-                <lfx-badge value="ICLA" severity="info" />
+                <lfx-badge value="ICLA" severity="info" [attr.data-testid]="'agreement-type-' + row.id" />
               }
             </td>
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -24,6 +24,7 @@ import type {
   SignIdentityDialogData,
   SignIdentitySelectResult,
 } from '@lfx-one/shared/interfaces';
+import { BadgeComponent } from '@components/badge/badge.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { MenuComponent } from '@components/menu/menu.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -217,6 +218,17 @@ describe('ProfileClasComponent', () => {
 
     expect(headers()).toEqual(['Project', 'Type', 'Status', 'Signed', 'Actions']);
     expect(fixture.nativeElement.textContent).not.toContain('Document');
+  });
+
+  it('lets a long ECLA company name wrap inside a height-auto type pill', async () => {
+    await render([agreement({ id: 's-long', kind: 'ECLA', companyName: 'The Linux Foundation', pdfAvailable: false })]);
+
+    const badge = fixture.debugElement.query(By.css('[data-testid="agreement-type-s-long"]'));
+    expect(badge).toBeTruthy();
+    expect(badge.componentInstance).toBeInstanceOf(BadgeComponent);
+    expect(badge.componentInstance.value()).toBe('ECLA · The Linux Foundation');
+    expect(badge.componentInstance.styleClass()).toContain('!h-auto');
+    expect(badge.componentInstance.styleClass()).toContain('!whitespace-normal');
   });
 
   it('offers an enabled Download PDF item on an ICLA row with a document', async () => {


### PR DESCRIPTION
## Summary
- My CLAs Type-column ECLA `lfx-badge` now uses `!h-auto` / wrap-friendly classes so a long `ECLA · {companyName}` stays inside the pill
- Type cells are `align-middle`

## Why
#2067 (ECLA type pill overflows) — PrimeNG `.p-badge-sm` is a fixed `1.25rem` height, so wrapped company names overflow the purple background.

## Out of scope (intentionally)
- Restyling the pill from purple to violet
- Adding `min-w-0` / `break-words` on the Type cell

## Test plan
- [ ] `yarn workspace lfx-one-ui ng test --include=src/app/modules/profile/clas/profile-clas.component.spec.ts`
- [ ] Profile → My CLAs, find an ECLA with a long company name (e.g. "The Linux Foundation") and confirm the full label sits inside the pill

Closes #2067