### PR TITLE
fix(committees): distinguish truncated activity tally from no-tally case

### DIFF
--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -991,6 +991,9 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
     await expect(tally).toContainText('This week so far:');
     await expect(tally).toContainText('1 meeting held');
     await expect(tally).toContainText('1 vote closed');
+    // Negative side of the GH-1998 truncation-note tests below: a populated, non-truncated
+    // tally must not carry the note.
+    await expect(page.getByTestId('weekly-brief-card-current-activity-truncation-note')).toHaveCount(0);
 
     const toggle = page.getByTestId('weekly-brief-card-current-activity-toggle-meeting');
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1070,11 +1070,12 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
     const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
     await expect(note).toBeVisible();
     // Pins the non-empty-tally variant specifically — the empty-tally variant shares the trailing
-    // "view Recent Activity for the full list" and wouldn't be caught by that substring alone.
+    // "see Recent Activity below for the latest events" and wouldn't be caught by that substring
+    // alone.
     await expect(note).toContainText('This count may be incomplete');
     // The note's only actionable content is the CTA — keep asserting it survives alongside the
     // variant-specific text above.
-    await expect(note).toContainText('view Recent Activity for the full list');
+    await expect(note).toContainText('see Recent Activity below for the latest events');
   });
 
   test('renders "activity couldn\'t be counted" (not "no activity yet") when truncated is true but every ref was filtered/unmapped away (GH-1998)', async ({
@@ -1103,7 +1104,7 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
     const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
     await expect(note).toBeVisible();
     await expect(note).toContainText('could not be fully counted');
-    await expect(note).toContainText('view Recent Activity for the full list');
+    await expect(note).toContainText('see Recent Activity below for the latest events');
   });
 });
 

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1072,6 +1072,38 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
     // Pins the non-empty-tally variant specifically — the empty-tally variant shares the trailing
     // "view Recent Activity for the full list" and wouldn't be caught by that substring alone.
     await expect(note).toContainText('This count may be incomplete');
+    // The note's only actionable content is the CTA — keep asserting it survives alongside the
+    // variant-specific text above.
+    await expect(note).toContainText('view Recent Activity for the full list');
+  });
+
+  test('renders "activity couldn\'t be counted" (not "no activity yet") when truncated is true but every ref was filtered/unmapped away (GH-1998)', async ({
+    page,
+  }) => {
+    await mockCommitteeShell(page, { category: 'Board' });
+    await mockCurrentBrief(page, {
+      brief: GENERATED_BRIEF,
+      throttle: USED_THROTTLE_AFTER_GENERATE,
+      current_activity: {
+        window_start: '2026-08-24T00:00:00.000Z',
+        window_end: '2026-08-27T12:00:00.000Z',
+        source_refs: [],
+        truncated: true,
+      },
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    const tally = page.getByTestId('weekly-brief-card-current-activity');
+    await expect(tally).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(tally).toContainText("activity couldn't be counted");
+    await expect(tally).not.toContainText('no activity yet');
+
+    const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('could not be fully counted');
+    await expect(note).toContainText('view Recent Activity for the full list');
   });
 });
 

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1101,12 +1101,12 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
 
     const tally = page.getByTestId('weekly-brief-card-current-activity');
     await expect(tally).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    await expect(tally).toContainText("activity couldn't be counted");
+    await expect(tally).toContainText('activity may be incomplete');
     await expect(tally).not.toContainText('no activity yet');
 
     const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
     await expect(note).toBeVisible();
-    await expect(note).toContainText('could not be fully counted');
+    await expect(note).toContainText('Activity this week may be incomplete');
     await expect(note).toContainText('see Recent Activity below for the latest events');
   });
 });

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1069,7 +1069,9 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
 
     const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
     await expect(note).toBeVisible();
-    await expect(note).toContainText('view Recent Activity for the full list');
+    // Pins the non-empty-tally variant specifically — the empty-tally variant shares the trailing
+    // "view Recent Activity for the full list" and wouldn't be caught by that substring alone.
+    await expect(note).toContainText('This count may be incomplete');
   });
 });
 

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1106,7 +1106,7 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
 
     const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
     await expect(note).toBeVisible();
-    await expect(note).toContainText('Activity this week may be incomplete');
+    await expect(note).toContainText('The activity feed hit its page limit, so this week may have had more');
     await expect(note).toContainText('see Recent Activity below for the latest events');
   });
 });

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1081,7 +1081,7 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
     await expect(note).toContainText('see Recent Activity below for the latest events');
   });
 
-  test('renders "activity couldn\'t be counted" (not "no activity yet") when truncated is true but every ref was filtered/unmapped away (GH-1998)', async ({
+  test('renders "activity may be incomplete" (not "no activity yet") when truncated is true but every ref was filtered/unmapped away (GH-1998)', async ({
     page,
   }) => {
     await mockCommitteeShell(page, { category: 'Board' });

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1046,6 +1046,31 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
 
     await expect(page.getByTestId('weekly-brief-card-current-activity')).toContainText('no activity yet', { timeout: DATA_LOAD_TIMEOUT });
   });
+
+  test('renders the tally PLUS a truncation disclosure when current_activity.truncated is true (GH-1998)', async ({ page }) => {
+    await mockCommitteeShell(page, { category: 'Board' });
+    await mockCurrentBrief(page, {
+      brief: GENERATED_BRIEF,
+      throttle: USED_THROTTLE_AFTER_GENERATE,
+      current_activity: {
+        window_start: '2026-08-24T00:00:00.000Z',
+        window_end: '2026-08-27T12:00:00.000Z',
+        source_refs: [{ id: 'act-meeting-1', kind: 'meeting', title: 'Board Sync' }],
+        truncated: true,
+      },
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    const tally = page.getByTestId('weekly-brief-card-current-activity');
+    await expect(tally).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(tally).toContainText('1 meeting held');
+
+    const note = page.getByTestId('weekly-brief-card-current-activity-truncation-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('view Recent Activity for the full list');
+  });
 });
 
 test.describe('WG Weekly Brief card — Edit → Save round-trip', () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -40,6 +40,17 @@
         <span>no activity yet</span>
       }
     </div>
+    @if (isTruncated()) {
+      <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
+           floor, not the total — styled after org-roi-projects-bar.component.html's own
+           truncation-note precedent. -->
+      <p
+        class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
+        data-testid="weekly-brief-card-current-activity-truncation-note">
+        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span>{{ currentActivityTruncationNote }}</span>
+      </p>
+    }
     @for (section of currentActivity(); track section.kind) {
       @if (expandedActivityKinds().has(section.kind)) {
         <div

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -56,11 +56,11 @@
       <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
            lower bound, not proof of partiality (see WeeklyBriefCurrentActivity.truncated's own
            doc comment) — styled after org-roi-projects-bar.component.html's own truncation-note
-           precedent (that one gets its gap from a parent flex-col container;
-           this note is a bare sibling of the tally above with no such wrapper, so mt-2 is the
-           local substitute for that gap, not a pixel match to it). Placed after the expanded
-           @for above (not before it) so the per-kind toggle buttons stay DOM-adjacent to the
-           content their aria-controls targets. -->
+           precedent (that one gets its gap from a parent flex-col container; this note is a bare
+           sibling of the tally above with no such wrapper, so mt-2 is the local substitute for
+           that gap, not a pixel match to it). Placed after the expanded @for above (not before
+           it) so the per-kind toggle buttons stay DOM-adjacent to the content their aria-controls
+           targets. -->
       <p
         class="mt-2 flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
         data-testid="weekly-brief-card-current-activity-truncation-note">

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -37,7 +37,7 @@
           </button>
         }
       } @else {
-        <span>no activity yet</span>
+        <span>{{ currentActivityEmptyText() }}</span>
       }
     </div>
     @for (section of currentActivity(); track section.kind) {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -40,17 +40,6 @@
         <span>no activity yet</span>
       }
     </div>
-    @if (isTruncated()) {
-      <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
-           floor, not the total — styled after org-roi-projects-bar.component.html's own
-           truncation-note precedent. -->
-      <p
-        class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
-        data-testid="weekly-brief-card-current-activity-truncation-note">
-        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
-        <span>{{ currentActivityTruncationNote }}</span>
-      </p>
-    }
     @for (section of currentActivity(); track section.kind) {
       @if (expandedActivityKinds().has(section.kind)) {
         <div
@@ -62,6 +51,18 @@
           }
         </div>
       }
+    }
+    @if (isTruncated()) {
+      <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
+           floor, not the total — styled after org-roi-projects-bar.component.html's own
+           truncation-note precedent. Placed after the expanded @for above (not before it) so the
+           per-kind toggle buttons stay DOM-adjacent to the content their aria-controls targets. -->
+      <p
+        class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
+        data-testid="weekly-brief-card-current-activity-truncation-note">
+        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span>{{ currentActivityTruncationNote }}</span>
+      </p>
     }
   }
   @if (fetchLoading()) {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -61,7 +61,7 @@
         class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
         data-testid="weekly-brief-card-current-activity-truncation-note">
         <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
-        <span>{{ currentActivityTruncationNote }}</span>
+        <span>{{ currentActivityTruncationNote() }}</span>
       </p>
     }
   }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -54,8 +54,9 @@
     }
     @if (isTruncated()) {
       <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
-           floor, not the total — styled after org-roi-projects-bar.component.html's own
-           truncation-note precedent (that one gets its gap from a parent flex-col container;
+           lower bound, not proof of partiality (see WeeklyBriefCurrentActivity.truncated's own
+           doc comment) — styled after org-roi-projects-bar.component.html's own truncation-note
+           precedent (that one gets its gap from a parent flex-col container;
            this note is a bare sibling of the tally above with no such wrapper, so mt-2 is the
            local substitute for that gap, not a pixel match to it). Placed after the expanded
            @for above (not before it) so the per-kind toggle buttons stay DOM-adjacent to the

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -56,9 +56,10 @@
       <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
            floor, not the total — styled after org-roi-projects-bar.component.html's own
            truncation-note precedent (that one gets its gap from a parent flex-col container;
-           this note is a bare sibling of the tally above, so mt-2 reproduces the same spacing
-           directly). Placed after the expanded @for above (not before it) so the per-kind toggle
-           buttons stay DOM-adjacent to the content their aria-controls targets. -->
+           this note is a bare sibling of the tally above with no such wrapper, so mt-2 is the
+           local substitute for that gap, not a pixel match to it). Placed after the expanded
+           @for above (not before it) so the per-kind toggle buttons stay DOM-adjacent to the
+           content their aria-controls targets. -->
       <p
         class="mt-2 flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
         data-testid="weekly-brief-card-current-activity-truncation-note">

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -55,10 +55,12 @@
     @if (isTruncated()) {
       <!-- GH-1998: current-week activity filled a full upstream page, so source_refs above is a
            floor, not the total — styled after org-roi-projects-bar.component.html's own
-           truncation-note precedent. Placed after the expanded @for above (not before it) so the
-           per-kind toggle buttons stay DOM-adjacent to the content their aria-controls targets. -->
+           truncation-note precedent (that one gets its gap from a parent flex-col container;
+           this note is a bare sibling of the tally above, so mt-2 reproduces the same spacing
+           directly). Placed after the expanded @for above (not before it) so the per-kind toggle
+           buttons stay DOM-adjacent to the content their aria-controls targets. -->
       <p
-        class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
+        class="mt-2 flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600"
         data-testid="weekly-brief-card-current-activity-truncation-note">
         <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
         <span>{{ currentActivityTruncationNote() }}</span>

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -712,7 +712,44 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
     expect(note.textContent as string).toContain('view Recent Activity for the full list');
-    expect(tally.getAttribute('aria-label')).toContain('view Recent Activity for the full list');
+    // The note is its own visible element (not folded into the tally's aria-label) — a screen
+    // reader must not hear it announced twice, once for the group and once for the note itself.
+    expect(tally.getAttribute('aria-label')).not.toContain('view Recent Activity for the full list');
+  });
+
+  it('does not render the truncation note when truncated is true but every ref was filtered/unmapped away, to avoid contradicting "no activity yet" (GH-1998)', async () => {
+    const truncatedEmpty = {
+      ...briefResponse([]),
+      current_activity: {
+        window_start: '2026-08-24T00:00:00Z',
+        window_end: '2026-08-27T12:00:00Z',
+        source_refs: [],
+        truncated: true,
+      },
+    };
+    getWeeklyBrief = vi.fn(() => of(truncatedEmpty));
+    await TestBed.configureTestingModule({
+      imports: [WeeklyBriefCardComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        ConfirmationService,
+        { provide: UserService, useValue: { impersonating: signal(false) } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('committee', BOARD_COMMITTEE);
+    fixture.componentRef.setInput('canEdit', true);
+    await fixture.whenStable();
+
+    expect(component.isTruncated()).toBe(false);
+    const tally = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('no activity yet');
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]')).toBeNull();
   });
 
   it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -592,6 +592,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
 
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el).not.toBeNull();
+    // Negative side of the GH-1998 truncation-note tests below: a populated, non-truncated
+    // tally must not carry the note — only isTruncated() gates it in.
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]')).toBeNull();
     const text = (el.textContent as string).replace(/\s+/g, ' ').trim();
     expect(text).toContain('This week so far:');
     expect(text).toContain('1 meeting held');

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -661,8 +661,8 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el).not.toBeNull();
     expect(el.textContent).toContain('no activity yet');
-    // Symmetric negative to the populated-tally case above: an empty, non-truncated tally is a
-    // genuine quiet week and must not carry the note either. (The isTruncated/length-gate
+    // Pins that this fixture really is the non-truncated path, so the note-absence assertion
+    // below is testing that path and not a truncated one. (The isTruncated/length-gate
     // regression itself is covered by the truncated-and-empty case below, where truncated is
     // actually true — here truncated is already false, so a length-gate mutation wouldn't flip
     // this assertion.)

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -489,6 +489,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     callerRating: WeeklyBriefRating | null = null,
     options: { truncated?: boolean } = {}
   ): WeeklyBriefCurrentResponse {
+    if (activityRefs === null && options.truncated) {
+      throw new Error('truncated has no meaning when current_activity is omitted (activityRefs === null)');
+    }
     return {
       brief: {
         uid: 'brief-1',

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -676,6 +676,45 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]')).toBeNull();
   });
 
+  it('renders the tally PLUS a truncation disclosure when current_activity.truncated is true (GH-1998) — the partial count still shows, it is not discarded', async () => {
+    const truncated = {
+      ...briefResponse([activityRef('meeting-1', 'meeting', 'Board Sync')]),
+      current_activity: {
+        window_start: '2026-08-24T00:00:00Z',
+        window_end: '2026-08-27T12:00:00Z',
+        source_refs: [activityRef('meeting-1', 'meeting', 'Board Sync')],
+        truncated: true,
+      },
+    };
+    getWeeklyBrief = vi.fn(() => of(truncated));
+    await TestBed.configureTestingModule({
+      imports: [WeeklyBriefCardComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        ConfirmationService,
+        { provide: UserService, useValue: { impersonating: signal(false) } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('committee', BOARD_COMMITTEE);
+    fixture.componentRef.setInput('canEdit', true);
+    await fixture.whenStable();
+
+    expect(component.isTruncated()).toBe(true);
+    const tally = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(tally).not.toBeNull();
+    expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('1 meeting held');
+    const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
+    expect(note).not.toBeNull();
+    expect(note.textContent as string).toContain('view Recent Activity for the full list');
+    expect(tally.getAttribute('aria-label')).toContain('view Recent Activity for the full list');
+  });
+
   it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {
     await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync'), activityRef('vote-1', 'vote', 'Q3 Resolution')]);
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -537,7 +537,11 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     callerRating: WeeklyBriefRating | null = null,
     options: { truncated?: boolean } = {}
   ): Promise<void> {
-    getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs, callerRating, options)));
+    // Built eagerly (not inside the vi.fn factory) so briefResponse's guard throws synchronously
+    // at the setup() call site — inside the switchMap project fn it would instead surface as an
+    // unhandled RxJS error blamed on whichever test happens to run next.
+    const response = briefResponse(activityRefs, callerRating, options);
+    getWeeklyBrief = vi.fn(() => of(response));
 
     await TestBed.configureTestingModule({
       imports: [WeeklyBriefCardComponent],

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -478,8 +478,17 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     return { id, kind, title };
   }
 
-  /** `activityRefs: null` omits `current_activity` entirely — simulates a server-side degrade (non-governance committee, or a failed lookup/fetch — see weekly-brief.service.ts#buildCurrentActivity). */
-  function briefResponse(activityRefs: WeeklyBriefSourceRef[] | null, callerRating: WeeklyBriefRating | null = null): WeeklyBriefCurrentResponse {
+  /**
+   * `activityRefs: null` omits `current_activity` entirely — simulates a server-side degrade
+   * (non-governance committee, or a failed lookup/fetch — see
+   * weekly-brief.service.ts#buildCurrentActivity). `options.truncated` layers GH-1998's
+   * truncated: true onto a present `current_activity` — the raw upstream page filled a full page.
+   */
+  function briefResponse(
+    activityRefs: WeeklyBriefSourceRef[] | null,
+    callerRating: WeeklyBriefRating | null = null,
+    options: { truncated?: boolean } = {}
+  ): WeeklyBriefCurrentResponse {
     return {
       brief: {
         uid: 'brief-1',
@@ -500,7 +509,14 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       throttle: { generates_used: 0, generates_limit: 2, regenerations_used: 0, regenerations_limit: 3, window_resets_at: '2026-08-09T00:00:00Z' },
       caller_rating: callerRating,
       ...(activityRefs !== null
-        ? { current_activity: { window_start: '2026-08-24T00:00:00Z', window_end: '2026-08-27T12:00:00Z', source_refs: activityRefs } }
+        ? {
+            current_activity: {
+              window_start: '2026-08-24T00:00:00Z',
+              window_end: '2026-08-27T12:00:00Z',
+              source_refs: activityRefs,
+              ...(options.truncated ? { truncated: true } : {}),
+            },
+          }
         : {}),
     };
   }
@@ -515,9 +531,10 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     committee: Committee,
     activityRefs: WeeklyBriefSourceRef[] | null,
     generateWeeklyBrief: ReturnType<typeof vi.fn> = vi.fn(),
-    callerRating: WeeklyBriefRating | null = null
+    callerRating: WeeklyBriefRating | null = null,
+    options: { truncated?: boolean } = {}
   ): Promise<void> {
-    getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs, callerRating)));
+    getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs, callerRating, options)));
 
     await TestBed.configureTestingModule({
       imports: [WeeklyBriefCardComponent],
@@ -677,33 +694,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
   });
 
   it('renders the tally PLUS a truncation disclosure when current_activity.truncated is true (GH-1998) — the partial count still shows, it is not discarded', async () => {
-    const truncated = {
-      ...briefResponse([activityRef('meeting-1', 'meeting', 'Board Sync')]),
-      current_activity: {
-        window_start: '2026-08-24T00:00:00Z',
-        window_end: '2026-08-27T12:00:00Z',
-        source_refs: [activityRef('meeting-1', 'meeting', 'Board Sync')],
-        truncated: true,
-      },
-    };
-    getWeeklyBrief = vi.fn(() => of(truncated));
-    await TestBed.configureTestingModule({
-      imports: [WeeklyBriefCardComponent],
-      providers: [
-        provideRouter([]),
-        provideNoopAnimations(),
-        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
-        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
-        { provide: MessageService, useValue: { add: vi.fn() } },
-        ConfirmationService,
-        { provide: UserService, useValue: { impersonating: signal(false) } },
-      ],
-    }).compileComponents();
-    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('committee', BOARD_COMMITTEE);
-    fixture.componentRef.setInput('canEdit', true);
-    await fixture.whenStable();
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], undefined, null, { truncated: true });
 
     expect(component.isTruncated()).toBe(true);
     const tally = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
@@ -711,45 +702,20 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('1 meeting held');
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
-    // Pins the non-empty-tally variant specifically — 'view Recent Activity for the full list'
-    // alone is shared by both variants and wouldn't catch the empty-tally wording rendering here.
+    // Pins the non-empty-tally variant specifically — 'see Recent Activity below for the latest
+    // events' alone is shared by both variants and wouldn't catch the empty-tally wording
+    // rendering here.
     expect(note.textContent as string).toContain('This count may be incomplete');
     // The note's only actionable content is the CTA — keep asserting it survives alongside the
     // variant-specific text above.
-    expect(note.textContent as string).toContain('view Recent Activity for the full list');
+    expect(note.textContent as string).toContain('see Recent Activity below for the latest events');
     // The note is its own visible element (not folded into the tally's aria-label) — a screen
     // reader must not hear it announced twice, once for the group and once for the note itself.
-    expect(tally.getAttribute('aria-label')).not.toContain('view Recent Activity for the full list');
+    expect(tally.getAttribute('aria-label')).not.toContain('see Recent Activity below for the latest events');
   });
 
   it('still renders a truncation note, with different wording, when truncated is true but every ref was filtered/unmapped away (GH-1998)', async () => {
-    const truncatedEmpty = {
-      ...briefResponse([]),
-      current_activity: {
-        window_start: '2026-08-24T00:00:00Z',
-        window_end: '2026-08-27T12:00:00Z',
-        source_refs: [],
-        truncated: true,
-      },
-    };
-    getWeeklyBrief = vi.fn(() => of(truncatedEmpty));
-    await TestBed.configureTestingModule({
-      imports: [WeeklyBriefCardComponent],
-      providers: [
-        provideRouter([]),
-        provideNoopAnimations(),
-        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
-        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
-        { provide: MessageService, useValue: { add: vi.fn() } },
-        ConfirmationService,
-        { provide: UserService, useValue: { impersonating: signal(false) } },
-      ],
-    }).compileComponents();
-    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('committee', BOARD_COMMITTEE);
-    fixture.componentRef.setInput('canEdit', true);
-    await fixture.whenStable();
+    await setup(BOARD_COMMITTEE, [], undefined, null, { truncated: true });
 
     // A bare, unqualified "no activity yet" would be a false-complete signal here — the raw
     // upstream page was full, so this genuinely might not be a quiet week (GH-1922: "do NOT
@@ -764,7 +730,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
     expect(note.textContent as string).toContain('could not be fully counted');
-    expect(note.textContent as string).toContain('view Recent Activity for the full list');
+    expect(note.textContent as string).toContain('see Recent Activity below for the latest events');
   });
 
   it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -711,7 +711,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('1 meeting held');
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
-    expect(note.textContent as string).toContain('view Recent Activity for the full list');
+    // Pins the non-empty-tally variant specifically — 'view Recent Activity for the full list'
+    // alone is shared by both variants and wouldn't catch the empty-tally wording rendering here.
+    expect(note.textContent as string).toContain('This count may be incomplete');
     // The note is its own visible element (not folded into the tally's aria-label) — a screen
     // reader must not hear it announced twice, once for the group and once for the note itself.
     expect(tally.getAttribute('aria-label')).not.toContain('view Recent Activity for the full list');
@@ -748,11 +750,14 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
 
     // A bare, unqualified "no activity yet" would be a false-complete signal here — the raw
     // upstream page was full, so this genuinely might not be a quiet week (GH-1922: "do NOT
-    // fabricate ... degrade gracefully"). isTruncated stays true and the note still renders,
-    // just with wording that doesn't claim the (possibly wrong) partial count is a real count.
+    // fabricate ... degrade gracefully"). isTruncated stays true and both the tally line's own
+    // placeholder and the separate note reflect that, so a screen-reader user reading only the
+    // group's aria-label (not the note, a sibling element) still gets the honest signal.
     expect(component.isTruncated()).toBe(true);
     const tally = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
-    expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('no activity yet');
+    expect((tally.textContent as string).replace(/\s+/g, ' ')).not.toContain('no activity yet');
+    expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain("activity couldn't be counted");
+    expect(tally.getAttribute('aria-label')).toContain("activity couldn't be counted");
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
     expect(note.textContent as string).toContain('could not be fully counted');

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -746,7 +746,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(tally.getAttribute('aria-label')).toContain('activity may be incomplete');
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
-    expect(note.textContent as string).toContain('Activity this week may be incomplete');
+    expect(note.textContent as string).toContain('The activity feed hit its page limit, so this week may have had more');
     expect(note.textContent as string).toContain('see Recent Activity below for the latest events');
   });
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -661,6 +661,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el).not.toBeNull();
     expect(el.textContent).toContain('no activity yet');
+    // isTruncated must not additionally gate on currentActivity().length — an empty-but-present,
+    // non-truncated tally is a genuine quiet week and must not carry the truncation note either.
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]')).toBeNull();
   });
 
   it('renders nothing at all when current_activity is absent — a server-side degrade must not be presented as "no activity yet" (GH-1922)', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -717,7 +717,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(tally.getAttribute('aria-label')).not.toContain('view Recent Activity for the full list');
   });
 
-  it('does not render the truncation note when truncated is true but every ref was filtered/unmapped away, to avoid contradicting "no activity yet" (GH-1998)', async () => {
+  it('still renders a truncation note, with different wording, when truncated is true but every ref was filtered/unmapped away (GH-1998)', async () => {
     const truncatedEmpty = {
       ...briefResponse([]),
       current_activity: {
@@ -746,10 +746,16 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     fixture.componentRef.setInput('canEdit', true);
     await fixture.whenStable();
 
-    expect(component.isTruncated()).toBe(false);
+    // A bare, unqualified "no activity yet" would be a false-complete signal here — the raw
+    // upstream page was full, so this genuinely might not be a quiet week (GH-1922: "do NOT
+    // fabricate ... degrade gracefully"). isTruncated stays true and the note still renders,
+    // just with wording that doesn't claim the (possibly wrong) partial count is a real count.
+    expect(component.isTruncated()).toBe(true);
     const tally = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('no activity yet');
-    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]')).toBeNull();
+    const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
+    expect(note).not.toBeNull();
+    expect(note.textContent as string).toContain('could not be fully counted');
   });
 
   it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -742,11 +742,11 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(component.isTruncated()).toBe(true);
     const tally = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect((tally.textContent as string).replace(/\s+/g, ' ')).not.toContain('no activity yet');
-    expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain("activity couldn't be counted");
-    expect(tally.getAttribute('aria-label')).toContain("activity couldn't be counted");
+    expect((tally.textContent as string).replace(/\s+/g, ' ')).toContain('activity may be incomplete');
+    expect(tally.getAttribute('aria-label')).toContain('activity may be incomplete');
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
-    expect(note.textContent as string).toContain('could not be fully counted');
+    expect(note.textContent as string).toContain('Activity this week may be incomplete');
     expect(note.textContent as string).toContain('see Recent Activity below for the latest events');
   });
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -714,6 +714,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     // Pins the non-empty-tally variant specifically — 'view Recent Activity for the full list'
     // alone is shared by both variants and wouldn't catch the empty-tally wording rendering here.
     expect(note.textContent as string).toContain('This count may be incomplete');
+    // The note's only actionable content is the CTA — keep asserting it survives alongside the
+    // variant-specific text above.
+    expect(note.textContent as string).toContain('view Recent Activity for the full list');
     // The note is its own visible element (not folded into the tally's aria-label) — a screen
     // reader must not hear it announced twice, once for the group and once for the note itself.
     expect(tally.getAttribute('aria-label')).not.toContain('view Recent Activity for the full list');
@@ -761,6 +764,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const note = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]');
     expect(note).not.toBeNull();
     expect(note.textContent as string).toContain('could not be fully counted');
+    expect(note.textContent as string).toContain('view Recent Activity for the full list');
   });
 
   it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -661,8 +661,12 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el).not.toBeNull();
     expect(el.textContent).toContain('no activity yet');
-    // isTruncated must not additionally gate on currentActivity().length — an empty-but-present,
-    // non-truncated tally is a genuine quiet week and must not carry the truncation note either.
+    // Symmetric negative to the populated-tally case above: an empty, non-truncated tally is a
+    // genuine quiet week and must not carry the note either. (The isTruncated/length-gate
+    // regression itself is covered by the truncated-and-empty case below, where truncated is
+    // actually true — here truncated is already false, so a length-gate mutation wouldn't flip
+    // this assertion.)
+    expect(component.isTruncated()).toBe(false);
     expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-truncation-note"]')).toBeNull();
   });
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -262,11 +262,21 @@ export class WeeklyBriefCardComponent {
   // the visible text can't drift apart on a future copy edit.
   protected readonly currentActivityPrefix = 'This week so far:';
 
+  // GH-1998: current-week activity filled a full upstream page — source_refs is a floor, not the
+  // total. Starting-point copy, flagged for product review, not locked in.
+  protected readonly currentActivityTruncationNote = '50+ events this week — view Recent Activity for the full list.';
+
+  public readonly isTruncated: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity?.truncated);
+
   // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet".
+  // Includes the truncation note (GH-1998) so the aria-label carries the same information as
+  // the visible text, which renders the note as a separate disclosure element.
   public readonly currentActivityLine: Signal<string> = computed(() => {
     const sections = this.currentActivity();
-    if (!sections.length) return `${this.currentActivityPrefix} no activity yet`;
-    return `${this.currentActivityPrefix} ${sections.map((section) => section.countText).join(', ')}`;
+    const base = !sections.length
+      ? `${this.currentActivityPrefix} no activity yet`
+      : `${this.currentActivityPrefix} ${sections.map((section) => section.countText).join(', ')}`;
+    return this.isTruncated() ? `${base}. ${this.currentActivityTruncationNote}` : base;
   });
 
   // "no_sources" is the only error_reason meaningful to the UI today (LFXV2-3000) —

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -283,7 +283,7 @@ export class WeeklyBriefCardComponent {
   protected readonly currentActivityTruncationNote: Signal<string> = computed(() =>
     this.currentActivity().length
       ? 'This count may be incomplete — see Recent Activity below for the latest events.'
-      : 'Activity this week could not be fully counted — see Recent Activity below for the latest events.'
+      : 'Activity this week may be incomplete — see Recent Activity below for the latest events.'
   );
 
   // The server's raw truncated flag — do not additionally gate this on currentActivity().length.
@@ -298,10 +298,10 @@ export class WeeklyBriefCardComponent {
   // claim this whole fix exists to avoid, just relocated to the tally line instead of the note.
   // Read by both the visible @else span and currentActivityLine (its aria-label) below, so the
   // two can't drift out of sync the way "no activity yet" vs. the note text did before this fix.
-  protected readonly currentActivityEmptyText: Signal<string> = computed(() => (this.isTruncated() ? "activity couldn't be counted" : 'no activity yet'));
+  protected readonly currentActivityEmptyText: Signal<string> = computed(() => (this.isTruncated() ? 'activity may be incomplete' : 'no activity yet'));
 
   // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet" /
-  // "This week so far: activity couldn't be counted". The truncation note (GH-1998) is a separate
+  // "This week so far: activity may be incomplete". The truncation note (GH-1998) is a separate
   // visible element (see the template), not folded in here — this stays the accessible name for
   // the tally group alone, so a screen reader doesn't hear the note announced twice (once for
   // this group, once for its own sibling paragraph).

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -262,17 +262,19 @@ export class WeeklyBriefCardComponent {
   // the visible text can't drift apart on a future copy edit.
   protected readonly currentActivityPrefix = 'This week so far:';
 
-  // GH-1998: current-week activity filled a full upstream page — source_refs is a floor, not the
-  // total. Deliberately doesn't name a count: the truncation gate fires on the raw upstream page
-  // size, before the window_end filter and kind-mapping this component's own tally is built from,
-  // so a specific number here (e.g. "50+ events") could overstate what actually happened this
-  // week. Two variants, not one static string: a page full of raw events that all get
-  // filtered/unmapped away (see buildCurrentActivity's own doc comment) still carries
-  // truncated: true with an empty tally, and pairing that with "This count may be incomplete"
-  // would read as "no activity yet" when the truth is closer to "we don't actually know." Hiding
-  // the note in that case instead (as an earlier version of this fix did) would be worse — a
-  // false-complete "no activity yet" is exactly the outcome GH-1922 says to avoid; the fix is
-  // to say the honest thing, not to say nothing. Starting-point copy, flagged for product
+  // GH-1998: current-week activity filled a full upstream page — source_refs is a lower bound,
+  // not proof of partiality (see WeeklyBriefCurrentActivity.truncated's own doc comment).
+  // Deliberately doesn't name a count: the truncation gate fires on the raw upstream page size,
+  // before the window_end filter and kind-mapping this component's own tally is built from, so a
+  // specific number here (e.g. "50+ events") could overstate what actually happened this week.
+  // Two variants, not one static string: a page full of raw events that all get filtered/unmapped
+  // away (see buildCurrentActivity's own doc comment) still carries truncated: true with an empty
+  // tally, so "This count may be incomplete" would misdescribe an on-screen count of zero as a
+  // count at all — the empty variant exists to qualify that absence honestly, not to avoid a
+  // separate "no activity yet" string (currentActivityEmptyText, below, already guards that).
+  // Hiding the note in the empty case instead (as an earlier version of this fix did) would be
+  // worse — a false-complete "no activity yet" is exactly the outcome GH-1922 says to avoid; the
+  // fix is to say the honest thing, not to say nothing. Starting-point copy, flagged for product
   // review, not locked in. Deliberately does NOT say "for the full list" — the Recent Activity
   // section below renders a fixed ACTIVITY_FEED_DEFAULT_PAGE_SIZE (8) rows with no "view all" or
   // pagination affordance of its own (CommitteeService.getCommitteeActivity sends no page_size),

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -283,7 +283,7 @@ export class WeeklyBriefCardComponent {
   protected readonly currentActivityTruncationNote: Signal<string> = computed(() =>
     this.currentActivity().length
       ? 'This count may be incomplete — see Recent Activity below for the latest events.'
-      : 'Activity this week may be incomplete — see Recent Activity below for the latest events.'
+      : 'The activity feed hit its page limit, so this week may have had more — see Recent Activity below for the latest events.'
   );
 
   // The server's raw truncated flag — do not additionally gate this on currentActivity().length.

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -266,14 +266,26 @@ export class WeeklyBriefCardComponent {
   // total. Deliberately doesn't name a count: the truncation gate fires on the raw upstream page
   // size, before the window_end filter and kind-mapping this component's own tally is built from,
   // so a specific number here (e.g. "50+ events") could overstate what actually happened this
-  // week. Starting-point copy, flagged for product review, not locked in.
-  protected readonly currentActivityTruncationNote = 'This count may be incomplete — view Recent Activity for the full list.';
-
-  // Gated on currentActivity().length too — not just the server's truncated flag — so the note
-  // can never render alongside "no activity yet": a page full of raw events that all get
+  // week. Two variants, not one static string: a page full of raw events that all get
   // filtered/unmapped away (see buildCurrentActivity's own doc comment) still carries
-  // truncated: true, and "no activity yet. This count may be incomplete" would contradict itself.
-  public readonly isTruncated: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity?.truncated && this.currentActivity().length > 0);
+  // truncated: true with an empty tally, and pairing that with "This count may be incomplete"
+  // would read as "no activity yet" when the truth is closer to "we don't actually know." Hiding
+  // the note in that case instead (as an earlier version of this fix did) would be worse — a
+  // false-complete "no activity yet" is exactly the outcome GH-1922 says to avoid; the fix is
+  // to say the honest thing, not to say nothing. Starting-point copy, flagged for product
+  // review, not locked in.
+  protected readonly currentActivityTruncationNote: Signal<string> = computed(() =>
+    this.currentActivity().length
+      ? 'This count may be incomplete — view Recent Activity for the full list.'
+      : 'Activity this week could not be fully counted — view Recent Activity for the full list.'
+  );
+
+  // The server's raw truncated flag — do not additionally gate this on currentActivity().length.
+  // The template always shows *some* truncation note once this is true (see
+  // currentActivityTruncationNote's two variants above); a reader reaching for isTruncated to ask
+  // "is this data complete?" must get a truthful answer regardless of whether the surviving tally
+  // happens to be empty.
+  public readonly isTruncated: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity?.truncated);
 
   // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet". The
   // truncation note (GH-1998) is a separate visible element (see the template), not folded in

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -249,12 +249,12 @@ export class WeeklyBriefCardComponent {
 
   // Distinguishes "no value to show" (absent — either a transient server-side degrade, or this
   // card's own deliberate includeCurrentActivity: false opt-out — or null — a settled
-  // non-governance/full-page answer; see WeeklyBriefCurrentResponse's own current_activity doc
-  // comment, in @lfx-one/shared/interfaces, for that three-state contract, which
-  // pollUntilTerminal's poll loop below depends on but rendering here doesn't) from "the field
-  // is a real object, every kind possibly zero" (a genuine quiet week) — the template must
-  // render neither line nor "no activity yet" for the former, only the latter (GH-1922: "do NOT
-  // fabricate ... degrade gracefully").
+  // non-governance answer; see WeeklyBriefCurrentResponse's own current_activity doc comment, in
+  // @lfx-one/shared/interfaces, for that three-state contract, which pollUntilTerminal's poll
+  // loop below depends on but rendering here doesn't) from "the field is a real object, every
+  // kind possibly zero, possibly truncated: true" (a genuine quiet week, or a real-but-partial
+  // tally) — the template must render neither line nor "no activity yet" for the former, only
+  // the latter (GH-1922: "do NOT fabricate ... degrade gracefully").
   public readonly hasCurrentActivityData: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity);
 
   // Single source of truth for the visible prefix, shared with the template's own span
@@ -263,20 +263,27 @@ export class WeeklyBriefCardComponent {
   protected readonly currentActivityPrefix = 'This week so far:';
 
   // GH-1998: current-week activity filled a full upstream page — source_refs is a floor, not the
-  // total. Starting-point copy, flagged for product review, not locked in.
-  protected readonly currentActivityTruncationNote = '50+ events this week — view Recent Activity for the full list.';
+  // total. Deliberately doesn't name a count: the truncation gate fires on the raw upstream page
+  // size, before the window_end filter and kind-mapping this component's own tally is built from,
+  // so a specific number here (e.g. "50+ events") could overstate what actually happened this
+  // week. Starting-point copy, flagged for product review, not locked in.
+  protected readonly currentActivityTruncationNote = 'This count may be incomplete — view Recent Activity for the full list.';
 
-  public readonly isTruncated: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity?.truncated);
+  // Gated on currentActivity().length too — not just the server's truncated flag — so the note
+  // can never render alongside "no activity yet": a page full of raw events that all get
+  // filtered/unmapped away (see buildCurrentActivity's own doc comment) still carries
+  // truncated: true, and "no activity yet. This count may be incomplete" would contradict itself.
+  public readonly isTruncated: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity?.truncated && this.currentActivity().length > 0);
 
-  // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet".
-  // Includes the truncation note (GH-1998) so the aria-label carries the same information as
-  // the visible text, which renders the note as a separate disclosure element.
+  // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet". The
+  // truncation note (GH-1998) is a separate visible element (see the template), not folded in
+  // here — this stays the accessible name for the tally group alone, so a screen reader doesn't
+  // hear the note announced twice (once for this group, once for its own sibling paragraph).
   public readonly currentActivityLine: Signal<string> = computed(() => {
     const sections = this.currentActivity();
-    const base = !sections.length
+    return !sections.length
       ? `${this.currentActivityPrefix} no activity yet`
       : `${this.currentActivityPrefix} ${sections.map((section) => section.countText).join(', ')}`;
-    return this.isTruncated() ? `${base}. ${this.currentActivityTruncationNote}` : base;
   });
 
   // "no_sources" is the only error_reason meaningful to the UI today (LFXV2-3000) —
@@ -891,10 +898,9 @@ export class WeeklyBriefCardComponent {
           // actually present on the response — `=== undefined` here, not a falsy/truthy check,
           // because the BFF distinguishes "couldn't determine yet" (key absent — transient,
           // worth asking again) from "known, settled, doesn't apply" (key present as `null` —
-          // non-governance, or this week's activity fills a full page; see
-          // WeeklyBriefCurrentResponse.current_activity's doc comment). A `!value` check would
-          // treat that settled `null` the same as "unknown" and re-ask forever for exactly the
-          // two cases that can never resolve differently within this poll cycle.
+          // non-governance only; see WeeklyBriefCurrentResponse.current_activity's doc comment).
+          // A `!value` check would treat that settled `null` the same as "unknown" and re-ask
+          // forever for a case that can't resolve differently within this poll cycle.
           //
           // Also gated on isGoverningBoardCommittee() — a non-governance committee's every
           // non-poll load (see initBriefResponseSubscription's own combineLatest sources for

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -273,11 +273,15 @@ export class WeeklyBriefCardComponent {
   // the note in that case instead (as an earlier version of this fix did) would be worse — a
   // false-complete "no activity yet" is exactly the outcome GH-1922 says to avoid; the fix is
   // to say the honest thing, not to say nothing. Starting-point copy, flagged for product
-  // review, not locked in.
+  // review, not locked in. Deliberately does NOT say "for the full list" — the Recent Activity
+  // section below renders a fixed ACTIVITY_FEED_DEFAULT_PAGE_SIZE (8) rows with no "view all" or
+  // pagination affordance of its own (CommitteeService.getCommitteeActivity sends no page_size),
+  // so promising "the full list" there would just relocate this same fix's false-complete problem
+  // into its own remedy.
   protected readonly currentActivityTruncationNote: Signal<string> = computed(() =>
     this.currentActivity().length
-      ? 'This count may be incomplete — view Recent Activity for the full list.'
-      : 'Activity this week could not be fully counted — view Recent Activity for the full list.'
+      ? 'This count may be incomplete — see Recent Activity below for the latest events.'
+      : 'Activity this week could not be fully counted — see Recent Activity below for the latest events.'
   );
 
   // The server's raw truncated flag — do not additionally gate this on currentActivity().length.

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -287,14 +287,22 @@ export class WeeklyBriefCardComponent {
   // happens to be empty.
   public readonly isTruncated: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity?.truncated);
 
-  // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet". The
-  // truncation note (GH-1998) is a separate visible element (see the template), not folded in
-  // here — this stays the accessible name for the tally group alone, so a screen reader doesn't
-  // hear the note announced twice (once for this group, once for its own sibling paragraph).
+  // GH-1998: the empty-tally placeholder itself, not just the separate truncation note below it,
+  // must not assert "no activity yet" when isTruncated() is true — that's the same false-complete
+  // claim this whole fix exists to avoid, just relocated to the tally line instead of the note.
+  // Read by both the visible @else span and currentActivityLine (its aria-label) below, so the
+  // two can't drift out of sync the way "no activity yet" vs. the note text did before this fix.
+  protected readonly currentActivityEmptyText: Signal<string> = computed(() => (this.isTruncated() ? "activity couldn't be counted" : 'no activity yet'));
+
+  // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet" /
+  // "This week so far: activity couldn't be counted". The truncation note (GH-1998) is a separate
+  // visible element (see the template), not folded in here — this stays the accessible name for
+  // the tally group alone, so a screen reader doesn't hear the note announced twice (once for
+  // this group, once for its own sibling paragraph).
   public readonly currentActivityLine: Signal<string> = computed(() => {
     const sections = this.currentActivity();
     return !sections.length
-      ? `${this.currentActivityPrefix} no activity yet`
+      ? `${this.currentActivityPrefix} ${this.currentActivityEmptyText()}`
       : `${this.currentActivityPrefix} ${sections.map((section) => section.countText).join(', ')}`;
   });
 

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -51,8 +51,8 @@ export class WeeklyBriefService {
    * opts out on top of that (also gated on `isGoverningBoardCommittee()`, so it never mistakes
    * that deliberate non-poll-load opt-out for a transient degrade) once the current_activity KEY
    * is present on what it already holds — `null` counts as present (a settled "doesn't apply"
-   * answer for a non-governance committee, or a week whose activity fills a full page) and stops
-   * the asking just as a real value would; only a genuinely absent key on a governance committee
+   * answer for a non-governance committee) and stops the asking just as a real value (possibly
+   * `truncated: true`) would; only a genuinely absent key on a governance committee
    * keeps the poll asking, up to its own attempt cap — see
    * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the three-state
    * absent/null/present contract this depends on.

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1011,6 +1011,39 @@ describe('WeeklyBriefService', () => {
       );
     });
 
+    it('DOES truncate with an empty source_refs when a full raw page is entirely future-stamped noise — the whole point of a wholly-new copy path (GH-1998) would be untested if every truncation case left mappable events on the page', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+
+        // A full raw page (ACTIVITY_FEED_MAX_PAGE_SIZE) that is ENTIRELY administratively-closed
+        // votes stamped from a still-future end_time — no real in-window activity survives the
+        // window_end filter at all, so source_refs comes out empty even though truncated is true.
+        const futureNoise = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE }, (_, i) => ({
+          type: 'vote_closed' as const,
+          occurred_at: '2026-01-14T13:00:00.000Z', // after window_end (2026-01-14T12:00:00.000Z)
+          committee_uid: 'committee-1',
+          payload: { vote_uid: `future-v${i}`, name: 'Future Vote', status: 'Ended' as const },
+        }));
+        getCommitteeActivityMock.mockResolvedValue({ data: futureNoise, page_token: undefined });
+
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        expect(result.current_activity).toEqual(expect.objectContaining({ truncated: true, source_refs: [] }));
+        expect(logger.warning).toHaveBeenCalledWith(
+          req,
+          'get_weekly_brief_current_activity',
+          expect.stringContaining('fills a full page'),
+          expect.objectContaining({ committee_id: 'committee-1' })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -818,8 +818,9 @@ describe('WeeklyBriefService', () => {
       // feature's whole point is that absent/null/present are three distinct states, not two.
       expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       // GH-1998: the gate fires on data.length, not source_refs.length — a below-the-cap page
-      // must not carry the flag at all (not even `truncated: false`), so the client's `!!` read
-      // stays honest.
+      // must not carry the flag at all. truncated?: boolean is present-only by contract (never
+      // `false`), so this pins the gate actually omits the key here rather than just resolving
+      // falsy.
       expect(result.current_activity).not.toHaveProperty('truncated');
       const refs = result.current_activity?.source_refs ?? [];
       expect(refs).toHaveLength(4);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -817,6 +817,10 @@ describe('WeeklyBriefService', () => {
       // also pass on the OTHER two states (undefined, or toBeDefined() on null), and this
       // feature's whole point is that absent/null/present are three distinct states, not two.
       expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
+      // GH-1998: the gate fires on data.length, not source_refs.length — a below-the-cap page
+      // must not carry the flag at all (not even `truncated: false`), so the client's `!!` read
+      // stays honest.
+      expect(result.current_activity).not.toHaveProperty('truncated');
       const refs = result.current_activity?.source_refs ?? [];
       expect(refs).toHaveLength(4);
       expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'other', 'vote']);
@@ -1030,6 +1034,9 @@ describe('WeeklyBriefService', () => {
       // not.toBeNull()/toBeDefined() alone.
       expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       expect(result.current_activity?.source_refs).toHaveLength(1);
+      // A saturating page_token is a near-miss for the truncation gate — pin that it doesn't
+      // also trip it (the gate is data.length-only, see buildCurrentActivity's own comment).
+      expect(result.current_activity).not.toHaveProperty('truncated');
     });
 
     it('renders a genuine quiet week as current_activity present with an empty source_refs array, not absent', async () => {
@@ -1294,6 +1301,9 @@ describe('WeeklyBriefService', () => {
 
       expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       expect(result.current_activity?.source_refs).toHaveLength(1);
+      // A saturated leg is also a near-miss for the truncation gate — pin that it doesn't also
+      // trip it (the gate is data.length-only, see buildCurrentActivity's own comment).
+      expect(result.current_activity).not.toHaveProperty('truncated');
     });
 
     it('degrades to current_activity: undefined once WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS elapses, rather than letting a slow (not erroring) upstream hold the whole response hostage', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -977,9 +977,9 @@ describe('WeeklyBriefService', () => {
       // type-legal, never actually constructed by CommitteeActivityService today (see that
       // interface's own doc comment) — that mapActivityEventToCurrentActivityRef's `default:
       // return null` branch exists to handle. These events are genuinely in-window — this method
-      // just has no rendering for them — so a full raw page dominated by them gates to null, same
-      // as the future-noise case above: the gate runs on the raw `data.length`, not on what
-      // survived mapping, so composition doesn't change the outcome.
+      // just has no rendering for them — so a full raw page dominated by them still gates to
+      // truncated: true, same as the future-noise case above: the gate runs on the raw
+      // `data.length`, not on what survived mapping, so composition doesn't change the outcome.
       const unrecognized = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE - 2 }, () => ({
         type: 'member_joined' as const,
         occurred_at: '2026-01-12T10:00:00Z',

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -818,9 +818,9 @@ describe('WeeklyBriefService', () => {
       // feature's whole point is that absent/null/present are three distinct states, not two.
       expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       // GH-1998: the gate fires on data.length, not source_refs.length — a below-the-cap page
-      // must not carry the flag at all. truncated?: boolean is present-only by contract (never
-      // `false`), so this pins the gate actually omits the key here rather than just resolving
-      // falsy.
+      // must not carry the flag at all. truncated?: true is present-only by contract (the type
+      // itself forbids `false`), so this pins the gate actually omits the key here rather than
+      // just resolving falsy.
       expect(result.current_activity).not.toHaveProperty('truncated');
       const refs = result.current_activity?.source_refs ?? [];
       expect(refs).toHaveLength(4);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1011,7 +1011,7 @@ describe('WeeklyBriefService', () => {
       );
     });
 
-    it('DOES truncate with an empty source_refs when a full raw page is entirely future-stamped noise — the whole point of a wholly-new copy path (GH-1998) would be untested if every truncation case left mappable events on the page', async () => {
+    it('produces truncated: true with an empty source_refs when a full raw page is entirely future-stamped noise — this service-level state (not the copy that renders it, already covered by the component/e2e specs) is what is uniquely tested here (GH-1998)', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -889,7 +889,7 @@ describe('WeeklyBriefService', () => {
       expect(refs[0].id).not.toBe(refs[1].id);
     });
 
-    it('sets current_activity to null (a settled, not a transient, absence) when the returned page itself is full', async () => {
+    it('sets current_activity.truncated to true (a settled, not a transient, floor) when the returned page itself is full', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
@@ -910,10 +910,12 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      // null, not undefined: more in-window activity only ever accumulates within a poll cycle,
-      // so a caller (the client's pollUntilTerminal) is right to treat this as settled and stop
-      // asking, unlike a genuine transient failure — see buildCurrentActivity's doc comment.
-      expect(result.current_activity).toBeNull();
+      // truncated: true, not null: more in-window activity only ever accumulates within a poll
+      // cycle, so a caller (the client's pollUntilTerminal) is right to treat this as settled and
+      // stop asking, unlike a genuine transient failure — see buildCurrentActivity's doc comment.
+      // source_refs is still a real, if partial, count — a floor, not discarded.
+      expect(result.current_activity).toEqual(expect.objectContaining({ truncated: true, source_refs: expect.any(Array) }));
+      expect(result.current_activity?.source_refs).toHaveLength(ACTIVITY_FEED_MAX_PAGE_SIZE);
       expect(logger.warning).toHaveBeenCalledWith(
         req,
         'get_weekly_brief_current_activity',
@@ -922,7 +924,7 @@ describe('WeeklyBriefService', () => {
       );
     });
 
-    it('DOES settle to null when a full raw page is mostly future-stamped noise the window_end filter drops — the descending sort in CommitteeActivityService means those rows can crowd out real in-window events before this method ever sees them, so the gate must run on the raw page size, not the filtered count', async () => {
+    it('DOES truncate when a full raw page is mostly future-stamped noise the window_end filter drops — the descending sort in CommitteeActivityService means those rows can crowd out real in-window events before this method ever sees them, so the gate must run on the raw page size, not the filtered count', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
@@ -954,7 +956,8 @@ describe('WeeklyBriefService', () => {
 
         const result = await service.getCurrentBrief(req, 'committee-1');
 
-        expect(result.current_activity).toBeNull();
+        expect(result.current_activity).toEqual(expect.objectContaining({ truncated: true, source_refs: expect.any(Array) }));
+        expect(result.current_activity?.source_refs).toHaveLength(3);
         expect(logger.warning).toHaveBeenCalledWith(
           req,
           'get_weekly_brief_current_activity',
@@ -966,7 +969,7 @@ describe('WeeklyBriefService', () => {
       }
     });
 
-    it('DOES settle to null when a full raw page is mostly unrecognized-but-in-window event types — an unmapped event is not proven irrelevant to the tally, so it must still count toward the truncation gate', async () => {
+    it('DOES truncate when a full raw page is mostly unrecognized-but-in-window event types — an unmapped event is not proven irrelevant to the tally, so it must still count toward the truncation gate', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
@@ -993,7 +996,8 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).toBeNull();
+      expect(result.current_activity).toEqual(expect.objectContaining({ truncated: true, source_refs: expect.any(Array) }));
+      expect(result.current_activity?.source_refs).toHaveLength(2);
       expect(logger.warning).toHaveBeenCalledWith(
         req,
         'get_weekly_brief_current_activity',

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1483,9 +1483,9 @@ export class WeeklyBriefService {
         // committee on one vote), a full page is graceful degradation of the tally itself: every
         // consumer of this response is now getting a floor instead of the true count, repeating on
         // every GET /current until the committee's volume drops. That's exactly the
-        // "error conditions with graceful degradation (returning null/empty arrays)" WARN criterion
-        // in .claude/rules/logging-patterns.md, and worth an operator noticing if ACTIVITY_FEED_MAX_PAGE_SIZE
-        // needs raising for this committee.
+        // "error conditions with graceful degradation (returning null/empty arrays)" WARN
+        // criterion in .claude/rules/logging-patterns.md, and worth an operator noticing if
+        // ACTIVITY_FEED_MAX_PAGE_SIZE needs raising for this committee.
         logger.warning(
           req,
           'get_weekly_brief_current_activity',

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1481,15 +1481,16 @@ export class WeeklyBriefService {
       if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
         // WARN, not DEBUG — unlike the vote-leg drop above (a modeled, expected shape for one
         // committee on one vote), a full page is graceful degradation of the tally itself: every
-        // consumer of this response is now getting a floor instead of the true count, repeating on
-        // every GET /current until the committee's volume drops. That's exactly the
+        // consumer of this response is now getting a lower bound, not proof of partiality (see
+        // WeeklyBriefCurrentActivity.truncated's own doc comment), repeating on every GET /current
+        // until the committee's volume drops. That's exactly the
         // "error conditions with graceful degradation (returning null/empty arrays)" WARN
         // criterion in .claude/rules/logging-patterns.md, and worth an operator noticing if
         // ACTIVITY_FEED_MAX_PAGE_SIZE needs raising for this committee.
         logger.warning(
           req,
           'get_weekly_brief_current_activity',
-          'Current-week activity fills a full page — publishing source_refs as a floor with truncated: true rather than a count stated as fact',
+          'Current-week activity fills a full page — publishing source_refs as a lower bound via truncated: true, not proof of partiality',
           {
             committee_id: committeeId,
           }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1329,10 +1329,11 @@ export class WeeklyBriefService {
    * window_end filter. Gating on `data.length >= limit` instead catches that: a full raw page is
    * treated as "possibly truncated" regardless of composition. The cost is the mirror-image false
    * positive — a committee whose only this-week activity actually is `limit`-many future-stamped
-   * votes gets `null` instead of an honest small `sourceRefs`, since this method can't tell the two
-   * cases apart with the signal `getCommitteeActivity` exposes today. Consistent with this
-   * method's own bias (see `WeeklyBriefCurrentResponse.current_activity`'s doc comment): an
-   * unnecessary `null` is a safe, if slightly annoying, degradation; a false-complete count is not.
+   * votes gets `truncated: true` alongside its (already-honest) small `sourceRefs`, since this
+   * method can't tell the two cases apart with the signal `getCommitteeActivity` exposes today.
+   * Consistent with this method's own bias (see `WeeklyBriefCurrentResponse.current_activity`'s
+   * doc comment): an unnecessary `truncated: true` is a safe, if slightly annoying, degradation
+   * that still surfaces the real `sourceRefs` it has; a false-complete count is not.
    *
    * Known v1 residual (accepted, not solved): `data.length < limit` is a heuristic, not a
    * proof of completeness. `committee-activity.service.ts` documents — in its own "Filter
@@ -1407,8 +1408,8 @@ export class WeeklyBriefService {
       // degrades to `{ events: [], saturated: false }` in committee-activity.service.ts,
       // indistinguishable from a leg that genuinely had nothing this week. `undefined`, not
       // `null` — a leg failure is transient (the same upstream call can succeed on the next poll
-      // tick), unlike the page-fill gate's `null`, which this method's own doc comment already
-      // establishes is provably permanent within a poll cycle.
+      // tick), unlike the page-fill gate's `truncated: true`, which this method's own doc comment
+      // already establishes is provably permanent within a poll cycle.
       if (any_leg_failed) {
         logger.warning(req, 'get_weekly_brief_current_activity', 'One or more activity legs failed, omitting the tally rather than publishing an undercount', {
           committee_id: committeeId,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1479,6 +1479,13 @@ export class WeeklyBriefService {
       }
 
       if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
+        // WARN, not DEBUG — unlike the vote-leg drop above (a modeled, expected shape for one
+        // committee on one vote), a full page is graceful degradation of the tally itself: every
+        // consumer of this response is now getting a floor instead of the true count, repeating on
+        // every GET /current until the committee's volume drops. That's exactly the
+        // "error conditions with graceful degradation (returning null/empty arrays)" WARN criterion
+        // in .claude/rules/logging-patterns.md, and worth an operator noticing if ACTIVITY_FEED_MAX_PAGE_SIZE
+        // needs raising for this committee.
         logger.warning(
           req,
           'get_weekly_brief_current_activity',

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1480,15 +1480,16 @@ export class WeeklyBriefService {
         logger.warning(
           req,
           'get_weekly_brief_current_activity',
-          'Current-week activity fills a full page — publishing null (settled, not a count) rather than a truncated count stated as fact',
+          'Current-week activity fills a full page — publishing source_refs as a floor with truncated: true rather than a count stated as fact',
           {
             committee_id: committeeId,
           }
         );
-        // null, not undefined — more in-window activity only ever accumulates within a poll
-        // cycle, never un-fills a full page, so this can't resolve differently on a later tick
-        // within the same cycle either.
-        return null;
+        // truncated: true, not null — more in-window activity only ever accumulates within a
+        // poll cycle, never un-fills a full page, so this can't resolve differently on a later
+        // tick within the same cycle either, but the already-mapped source_refs are still a real
+        // (if partial) count worth showing rather than discarding.
+        return { window_start, window_end, source_refs: sourceRefs, truncated: true };
       }
 
       return { window_start, window_end, source_refs: sourceRefs };

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1499,8 +1499,8 @@ export class WeeklyBriefService {
         committee_id: committeeId,
         err,
       });
-      // undefined, not null — this failure is transient (a lookup/fetch error), unlike the two
-      // null cases above, so a caller is right to ask again.
+      // undefined, not null — this failure is transient (a lookup/fetch error), unlike the settled
+      // null case above (non-governance), so a caller is right to ask again.
       return undefined;
     }
   }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1313,8 +1313,9 @@ export class WeeklyBriefService {
    * their own doc comments in `committee-activity.service.ts` for why), so they fetch each
    * committee's newest `fetchSize` rows by `updated_desc` and filter to the window in memory —
    * their own `saturated` flag reflects whether the committee has more than `fetchSize` *lifetime*
-   * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would silently
-   * hide the tally for exactly the long-lived, active committees it exists to help.
+   * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would show a
+   * near-permanent, usually-wrong `truncated: true` note on exactly the long-lived, active
+   * committees it exists to help.
    *
    * Gate on the raw, unfiltered `data.length` hitting `limit` (Copilot review), NOT on
    * `sourceRefs.length + unmappedInWindow` as this method originally did. That original gate
@@ -1351,8 +1352,8 @@ export class WeeklyBriefService {
    * comments). Nothing crosses the `getCommitteeActivity` boundary as a signal this caller could
    * gate on for that narrower remainder today. `any_leg_saturated` deliberately still isn't part
    * of this gate, unlike `any_leg_failed` above — see this method's own comment on why two of the
-   * five legs' saturation reflects lifetime volume, not this week's, and would falsely hide the
-   * tally for exactly the long-lived committees it exists to help.
+   * five legs' saturation reflects lifetime volume, not this week's, and would falsely show a
+   * near-permanent incompleteness note for exactly the long-lived committees it exists to help.
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
     try {

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -208,8 +208,9 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * linuxfoundation/lfx-self-serve#1934) and never constructs a `member_joined`/`member_left`
  * event (a known, permanently-deferred v1 limitation, not a tracked issue — no upstream
  * membership-timestamp/deletion-history signal to build one from). A week whose only real
- * activity was on one of these two kinds still renders "no activity yet" — an accepted v1 gap in
- * what the tally can attest to, not a claim that no such activity occurred.
+ * activity was on one of these two kinds still renders "no activity yet" (or, if the same
+ * response also happens to be truncated, GH-1998's "activity couldn't be counted" instead) — an
+ * accepted v1 gap in what the tally can attest to, not a claim that no such activity occurred.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES: readonly WeeklyBriefCurrentActivityPhrase[] = [
   { kind: 'meeting', singular: 'meeting held', plural: 'meetings held' },

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -209,7 +209,7 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * event (a known, permanently-deferred v1 limitation, not a tracked issue — no upstream
  * membership-timestamp/deletion-history signal to build one from). A week whose only real
  * activity was on one of these two kinds still renders "no activity yet" (or, if the same
- * response also happens to be truncated, GH-1998's "activity couldn't be counted" instead) — an
+ * response also happens to be truncated, GH-1998's "activity may be incomplete" instead) — an
  * accepted v1 gap in what the tally can attest to, not a claim that no such activity occurred.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES: readonly WeeklyBriefCurrentActivityPhrase[] = [

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -219,9 +219,12 @@ export interface WeeklyBriefCurrentResponse {
    *     distinction (e.g. `weekly-brief-card.component.ts`'s `pollUntilTerminal`) would spend
    *     calls forever for no reason.
    *   - **Present**: the real tally, possibly with an empty `source_refs` (a genuine quiet week
-   *     — still a real answer, not absence). `truncated: true` when the current week's activity
-   *     exceeds what a single upstream page can return — `source_refs` is then a real but
-   *     partial count, not a silently-truncated one stated as fact.
+   *     — still a real answer, not absence). `truncated: true` when the current week's raw
+   *     activity page reached the upstream page-size cap — `source_refs` is then a lower bound
+   *     that is usually, but not provably, partial (see `buildCurrentActivity`'s own doc comment
+   *     for the accepted false-positive case: a coincidentally exactly-full page can still be
+   *     complete). Either way it's a real, non-fabricated count, not a silently-truncated one
+   *     stated as fact.
    */
   current_activity?: WeeklyBriefCurrentActivity | null;
 }
@@ -231,8 +234,15 @@ export interface WeeklyBriefCurrentActivity {
   window_start: string;
   window_end: string;
   source_refs: WeeklyBriefSourceRef[];
-  /** True when the current week's activity filled a full upstream page — `source_refs` is a floor, not the total. */
-  truncated?: boolean;
+  /**
+   * `true` when the current week's raw activity page reached the upstream page-size cap —
+   * `source_refs` is then a lower bound that's usually, but not provably, partial (a
+   * coincidentally exactly-full page can still be complete; see
+   * `weekly-brief.service.ts#buildCurrentActivity`'s own doc comment for why this is an accepted
+   * heuristic, not a proof). Present-only by contract: a producer must never emit `false` here,
+   * so the type itself forbids it.
+   */
+  truncated?: true;
 }
 
 /** A caller's one-tap quality rating on a specific weekly-brief revision. BFF-only — no upstream equivalent. */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -214,13 +214,14 @@ export interface WeeklyBriefCurrentResponse {
    *     whether asking is worthwhile at all — see `weekly-brief-card.component.ts`'s `pollUntilTerminal`,
    *     which additionally gates on `isGoverningBoardCommittee()` for exactly this reason.
    *   - **`null`**: known, definitively, not to apply — the committee isn't
-   *     governance-classified, or the current week's activity exceeds what a single upstream
-   *     page can return (never a silently-truncated count). Not transient; re-asking within the
-   *     same poll cycle can't change either answer, so a caller that retries on any falsy value
-   *     without checking for this distinction (e.g. `weekly-brief-card.component.ts`'s
-   *     `pollUntilTerminal`) would spend calls forever for no reason.
+   *     governance-classified. Not transient; re-asking within the same poll cycle can't change
+   *     this answer, so a caller that retries on any falsy value without checking for this
+   *     distinction (e.g. `weekly-brief-card.component.ts`'s `pollUntilTerminal`) would spend
+   *     calls forever for no reason.
    *   - **Present**: the real tally, possibly with an empty `source_refs` (a genuine quiet week
-   *     — still a real answer, not absence).
+   *     — still a real answer, not absence). `truncated: true` when the current week's activity
+   *     exceeds what a single upstream page can return — `source_refs` is then a real but
+   *     partial count, not a silently-truncated one stated as fact.
    */
   current_activity?: WeeklyBriefCurrentActivity | null;
 }
@@ -230,6 +231,8 @@ export interface WeeklyBriefCurrentActivity {
   window_start: string;
   window_end: string;
   source_refs: WeeklyBriefSourceRef[];
+  /** True when the current week's activity filled a full upstream page — `source_refs` is a floor, not the total. */
+  truncated?: boolean;
 }
 
 /** A caller's one-tap quality rating on a specific weekly-brief revision. BFF-only — no upstream equivalent. */


### PR DESCRIPTION
## Summary

- `buildCurrentActivity()` in `weekly-brief.service.ts` collapsed two distinct cases into the same `current_activity: null` value: a committee that isn't governance-classified (no tally applies), and a governance committee whose current-week activity fills a full 50-event upstream page (tally truncated). A viewer couldn't tell "not applicable" from "too much happened to count."
- The truncation path now returns `{ window_start, window_end, source_refs, truncated: true }` instead of `null`, keeping the already-mapped `source_refs` as a floor count. The non-governance path is untouched and still returns bare `null`.
- Added `truncated?: boolean` to `WeeklyBriefCurrentActivity` (present-only by contract, never explicitly `false`) and a disclosure note in the weekly brief card UI, styled after the existing `org-roi-projects-bar` truncation-note precedent.

Closes #1998

## Test plan

- [x] `weekly-brief.service.spec.ts` — truncation-gate assertions updated from `toBeNull()` to the new `{ ..., truncated: true }` shape; non-governance case still asserts bare `null`
- [x] `weekly-brief-card.component.spec.ts` — new case asserting the truncated object renders the tally plus the disclosure note
- [x] `e2e/weekly-brief-card.spec.ts` — new Playwright case for the truncated state
- [x] `yarn lint && yarn format:check && yarn test && yarn build` all pass
- [x] Rebased on `origin/main`, all commits DCO + GPG signed
