### PR TITLE
fix(cla): add Gerrit contract-type picker before Console hand-off (#2066)

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -574,7 +574,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
   /** Records dialog opens in order, so "which dialog, and was it opened at all" is assertable. */
   let opened: unknown[];
   /** Records what each dialog was opened with, so the identity step's inputs are assertable. */
-  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData | { iclaEnabled?: boolean } } }[];
+  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData } }[];
 
   async function setup(
     options: {
@@ -1338,6 +1338,39 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     await sign(fixture);
 
     expect(location.href).toContain('/#/cla/gerrit/project/cg-1/corporate');
+  });
+
+  it('navigates nowhere and releases Sign CLA when the contract-type step is dismissed', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+      contractTypeClosesWith: null,
+    });
+
+    await sign(fixture);
+
+    // The identity was confirmed but the agreement type was not. Falling through to `individual`
+    // here would sign an agreement the contributor withdrew from choosing, which is #2066 again.
+    expect(location.href).toBe(HOME);
+    expect(isStarting(fixture)).toBe(false);
+  });
+
+  it('releases Sign CLA when the contract-type step is destroyed without onClose (header X)', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+      dismissContractType: 'destroy',
+    });
+
+    await sign(fixture);
+    await Promise.resolve();
+
+    expect(location.href).toBe(HOME);
+    expect(isStarting(fixture)).toBe(false);
   });
 
   it('stops rather than navigating when neither contract type is enabled', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -24,6 +24,7 @@ import type {
   PrepareSignResponse,
   SignIdentityDialogData,
   SignIdentitySelectResult,
+  SignContractTypeSelectResult,
 } from '@lfx-one/shared/interfaces';
 import { BadgeComponent } from '@components/badge/badge.component';
 import { ButtonComponent } from '@components/button/button.component';
@@ -41,6 +42,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ClaGroupSelectComponent } from './cla-group-select.component';
 import { GitlabUnsupportedComponent } from './gitlab-unsupported.component';
 import { ProfileClasComponent } from './profile-clas.component';
+import { SignContractTypeSelectComponent } from './sign-contract-type-select.component';
 import { SignIdentitySelectComponent } from './sign-identity-select.component';
 
 describe('ProfileClasComponent', () => {
@@ -572,7 +574,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
   /** Records dialog opens in order, so "which dialog, and was it opened at all" is assertable. */
   let opened: unknown[];
   /** Records what each dialog was opened with, so the identity step's inputs are assertable. */
-  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData } }[];
+  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData | { iclaEnabled?: boolean } } }[];
 
   async function setup(
     options: {
@@ -586,7 +588,11 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       dismissAccount?: 'close' | 'destroy' | 'hold';
       /** Linked organizations on the selected group — the sole input to the routing decision. */
       organizations?: ClaGroupOrg[];
+      iclaEnabled?: boolean;
+      cclaEnabled?: boolean;
       viewerUsername?: string | null;
+      contractTypeClosesWith?: SignContractTypeSelectResult | null;
+      dismissContractType?: 'close' | 'destroy' | 'hold';
       /** Loaded My CLAs list handed to the group picker (#1914). */
       agreements?: MyClaAgreement[];
       /** Leaves the My CLAs request unresolved, so the loading state is assertable (#1914). */
@@ -605,7 +611,12 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     // rather than a bare TypeError. Production must never reach it (FR-004).
     buildSignUrlFor = vi.fn(() => SIGN_URL);
 
-    const selectedGroup: ClaGroupOption = { ...CLA_GROUP, organizations: options.organizations ?? [] };
+    const selectedGroup: ClaGroupOption = {
+      ...CLA_GROUP,
+      organizations: options.organizations ?? [],
+      iclaEnabled: options.iclaEnabled ?? true,
+      cclaEnabled: options.cclaEnabled ?? false,
+    };
 
     open = vi.fn((component: unknown, config?: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData }) => {
       opened.push(component);
@@ -614,6 +625,12 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
         return dialogEvents(
           'accountClosesWith' in options ? options.accountClosesWith : { kind: 'github', githubId: '12345' },
           options.dismissAccount ?? 'close'
+        );
+      }
+      if (component === SignContractTypeSelectComponent) {
+        return dialogEvents(
+          'contractTypeClosesWith' in options ? options.contractTypeClosesWith : { contractType: 'individual' },
+          options.dismissContractType ?? 'close'
         );
       }
       if (component === GitlabUnsupportedComponent) {
@@ -1279,6 +1296,63 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     // Composed from our own origin rather than taken from a header, and encoded so its own
     // query string cannot merge into the Console's.
     expect(location.href).toContain(`redirect=${encodeURIComponent(HOME)}`);
+  });
+
+  it('shows the contract-type step when both ICLA and CCLA are enabled', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+    });
+
+    await sign(fixture);
+
+    expect(opened).toContain(SignContractTypeSelectComponent);
+    expect(location.href).toContain('/#/cla/gerrit/project/cg-1/individual');
+  });
+
+  it('hands off at corporate when only CCLA is enabled', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: false,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+    });
+
+    await sign(fixture);
+
+    expect(opened).not.toContain(SignContractTypeSelectComponent);
+    expect(location.href).toContain('/#/cla/gerrit/project/cg-1/corporate');
+  });
+
+  it('navigates at corporate when the contributor picks Corporate Contributor', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+      contractTypeClosesWith: { contractType: 'corporate' },
+    });
+
+    await sign(fixture);
+
+    expect(location.href).toContain('/#/cla/gerrit/project/cg-1/corporate');
+  });
+
+  it('stops rather than navigating when neither contract type is enabled', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: false,
+      cclaEnabled: false,
+      accountClosesWith: { kind: 'gerrit' },
+    });
+
+    await sign(fixture);
+
+    expect(opened).not.toContain(SignContractTypeSelectComponent);
+    expect(location.href).toBe(HOME);
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
   });
 
   // Blank and absent are one case, not two: the dialog trims before it builds the card, so a

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -23,7 +23,6 @@ import type {
   MyClaAgreement,
   MyClasState,
   PrepareSignResponse,
-  SignContractTypeDialogData,
   SignContractTypeSelectResult,
   SignIdentityDialogData,
   SignIdentitySelectResult,
@@ -433,18 +432,15 @@ export class ProfileClasComponent {
 
     this.signDialogOpen.set(true);
 
-    const data: SignContractTypeDialogData = {
-      iclaEnabled: true,
-      cclaEnabled: true,
-    };
-
+    // No data: the step renders both cards unconditionally, and it is only reachable for a group
+    // that enables both. Passing the flags it would have to ignore invites a later caller to open
+    // it for a single-type group, which is the hand-off this branch exists to make without asking.
     const dialogRef = this.dialogService.open(SignContractTypeSelectComponent, {
       header: SIGN_CONTRACT_TYPE_COPY.header,
       width: '32rem',
       modal: true,
       closable: true,
       dismissableMask: true,
-      data,
     }) as DynamicDialogRef;
 
     this.whenDialogSettles<SignContractTypeSelectResult>(dialogRef, (result) => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -5,16 +5,26 @@ import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal, viewChildren } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
-import { ECLA_COVERED_DOWNLOAD_LABEL, GITLAB_UNSUPPORTED_HEADER, MY_CLAS_M2_ENABLED_FLAG, MY_CLAS_PATH, SIGN_IDENTITY_COPY } from '@lfx-one/shared/constants';
+import {
+  ECLA_COVERED_DOWNLOAD_LABEL,
+  GITLAB_UNSUPPORTED_HEADER,
+  MY_CLAS_M2_ENABLED_FLAG,
+  MY_CLAS_PATH,
+  SIGN_CONTRACT_TYPE_COPY,
+  SIGN_IDENTITY_COPY,
+} from '@lfx-one/shared/constants';
 import type {
   ClaGroupOption,
   ClaRow,
   ClaSignRoute,
   ClaStatus,
+  GerritContractType,
   GithubAccountOption,
   MyClaAgreement,
   MyClasState,
   PrepareSignResponse,
+  SignContractTypeDialogData,
+  SignContractTypeSelectResult,
   SignIdentityDialogData,
   SignIdentitySelectResult,
   SignIdentityVariant,
@@ -28,6 +38,7 @@ import {
   formatClaSignedOn,
   gerritSignUrl,
   isMyClasEmpty,
+  resolveGerritContractType,
   signedAsLine,
 } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
@@ -52,6 +63,7 @@ import { ClaGroupSelectComponent } from './cla-group-select.component';
 import { buildContactClaManagerMenuItems } from './contact-cla-manager-menu';
 import { GitlabUnsupportedComponent } from './gitlab-unsupported.component';
 import { buildManageInCclaConsoleMenuItems } from './manage-ccla-console-menu';
+import { SignContractTypeSelectComponent } from './sign-contract-type-select.component';
 import { SignIdentitySelectComponent } from './sign-identity-select.component';
 
 /**
@@ -365,7 +377,7 @@ export class ProfileClasComponent {
       }
 
       if (result.kind === 'gerrit') {
-        this.handOffToGerrit(option);
+        this.chooseContractTypeThenHandOffToGerrit(option);
         return;
       }
 
@@ -402,7 +414,51 @@ export class ProfileClasComponent {
   }
 
   /**
-   * Leaves for the Console's Gerrit signing route (#2002).
+   * Asks which contract type the Gerrit signature will use when both are enabled (#2066).
+   * Single-type groups skip this step; neither-enabled groups fail visibly.
+   */
+  private chooseContractTypeThenHandOffToGerrit(option: ClaGroupOption): void {
+    const resolved = resolveGerritContractType(option.iclaEnabled === true, option.cclaEnabled === true);
+
+    if (resolved === 'none') {
+      this.starting.set(false);
+      this.reportGerritContractTypeUnavailable();
+      return;
+    }
+
+    if (resolved !== 'chooser') {
+      this.handOffToGerrit(option, resolved);
+      return;
+    }
+
+    this.signDialogOpen.set(true);
+
+    const data: SignContractTypeDialogData = {
+      iclaEnabled: true,
+      cclaEnabled: true,
+    };
+
+    const dialogRef = this.dialogService.open(SignContractTypeSelectComponent, {
+      header: SIGN_CONTRACT_TYPE_COPY.header,
+      width: '32rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data,
+    }) as DynamicDialogRef;
+
+    this.whenDialogSettles<SignContractTypeSelectResult>(dialogRef, (result) => {
+      this.signDialogOpen.set(false);
+      this.starting.set(false);
+
+      if (!result) return;
+
+      this.handOffToGerrit(option, result.contractType);
+    });
+  }
+
+  /**
+   * Leaves for the Console's Gerrit signing route (#2002, #2066).
    *
    * No prepare-sign call, and no identity of any kind on the wire. The Console resolves the
    * EasyCLA user from the LF SSO token on this route, and its Gerrit branch takes its return
@@ -415,7 +471,7 @@ export class ProfileClasComponent {
    * returns the contributor here afterwards, which only reads as one continuous flow if they
    * never left this tab.
    */
-  private handOffToGerrit(option: ClaGroupOption): void {
+  private handOffToGerrit(option: ClaGroupOption, contractType: GerritContractType): void {
     this.starting.set(true);
 
     // Read here rather than held as a field: this runs only from the contributor's click, so
@@ -423,7 +479,7 @@ export class ProfileClasComponent {
     // own origin, which is the same value the server derives from the request host for
     // prepare-sign — arrived at without needing that host to be checked against a trusted list.
     const returnUrl = `${this.document.location.origin}${MY_CLAS_PATH}`;
-    const url = gerritSignUrl(environment.urls.contributorConsole, option.claGroupId, returnUrl);
+    const url = gerritSignUrl(environment.urls.contributorConsole, option.claGroupId, returnUrl, contractType);
 
     if (!url) {
       this.starting.set(false);
@@ -545,6 +601,15 @@ export class ProfileClasComponent {
       severity: 'error',
       summary: 'Could not start signing',
       detail: 'We could not confirm which identity you would sign with. Please try again.',
+    });
+  }
+
+  /** Stops a Gerrit hand-off when the group enables neither ICLA nor CCLA (#2066). */
+  private reportGerritContractTypeUnavailable(): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Could not start signing',
+      detail: 'This CLA group is not configured for individual or corporate signing from here. Contact the project CLA manager.',
     });
   }
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -376,7 +376,11 @@ export class ProfileClasComponent {
       }
 
       if (result.kind === 'gerrit') {
-        this.chooseContractTypeThenHandOffToGerrit(option);
+        // Held closed again across the wait below. Between this dialog's teardown and the next
+        // step opening there is a gap of one leave animation, and a second Sign CLA in that
+        // window would start a parallel hand-off.
+        this.signDialogOpen.set(true);
+        this.afterDialogTornDown(dialogRef, () => this.chooseContractTypeThenHandOffToGerrit(option));
         return;
       }
 
@@ -415,17 +419,22 @@ export class ProfileClasComponent {
   /**
    * Asks which contract type the Gerrit signature will use when both are enabled (#2066).
    * Single-type groups skip this step; neither-enabled groups fail visibly.
+   *
+   * Reached from the identity step's teardown rather than its close, so every exit here is
+   * responsible for reopening the gate the caller held shut across that wait.
    */
   private chooseContractTypeThenHandOffToGerrit(option: ClaGroupOption): void {
     const resolved = resolveGerritContractType(option.iclaEnabled === true, option.cclaEnabled === true);
 
     if (resolved === 'none') {
+      this.signDialogOpen.set(false);
       this.starting.set(false);
       this.reportGerritContractTypeUnavailable();
       return;
     }
 
     if (resolved !== 'chooser') {
+      this.signDialogOpen.set(false);
       this.handOffToGerrit(option, resolved);
       return;
     }
@@ -485,6 +494,22 @@ export class ProfileClasComponent {
 
     this.starting.set(false);
     this.document.location.href = url;
+  }
+
+  /**
+   * Runs `next` once the dialog is not merely closed but torn down (#2066).
+   *
+   * `DynamicDialogRef.close()` emits `onClose` synchronously and starts the leave animation from
+   * that same emission; the animation's end is what drops `p-overflow-hidden` from the body. So a
+   * dialog opened from inside `onClose` has its own scroll lock stripped a moment after it
+   * appears, and the page scrolls behind it. `onDestroy` fires immediately after that teardown,
+   * which is the boundary a follow-on step has to wait for.
+   *
+   * The GitHub path needs none of this: its next step opens after the linked-account request,
+   * which lands long after the animation is done.
+   */
+  private afterDialogTornDown(dialogRef: DynamicDialogRef, next: () => void): void {
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => next());
   }
 
   private whenDialogSettles<T>(dialogRef: DynamicDialogRef, onSettle: (value: T | null | undefined) => void): void {

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
@@ -7,29 +7,25 @@ SPDX-License-Identifier: MIT
   <p class="mb-4 text-sm text-slate-600">{{ copy.body }}</p>
 
   <div role="listbox" aria-label="Contributor types" class="flex flex-col gap-3">
-    @if (iclaEnabled()) {
-      <div class="flex flex-col gap-1">
-        <lfx-selectable-card
-          [form]="selectForm"
-          control="contractType"
-          [value]="individualValue"
-          [label]="copy.individual.label"
-          testId="sign-contract-type-select-individual" />
-        <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.individual.description }}</p>
-      </div>
-    }
+    <div class="flex flex-col gap-1">
+      <lfx-selectable-card
+        [form]="selectForm"
+        control="contractType"
+        [value]="individualValue"
+        [label]="copy.individual.label"
+        testId="sign-contract-type-select-individual" />
+      <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.individual.description }}</p>
+    </div>
 
-    @if (cclaEnabled()) {
-      <div class="flex flex-col gap-1">
-        <lfx-selectable-card
-          [form]="selectForm"
-          control="contractType"
-          [value]="corporateValue"
-          [label]="copy.corporate.label"
-          testId="sign-contract-type-select-corporate" />
-        <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.corporate.description }}</p>
-      </div>
-    }
+    <div class="flex flex-col gap-1">
+      <lfx-selectable-card
+        [form]="selectForm"
+        control="contractType"
+        [value]="corporateValue"
+        [label]="copy.corporate.label"
+        testId="sign-contract-type-select-corporate" />
+      <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.corporate.description }}</p>
+    </div>
   </div>
 
   <div class="mt-4 flex justify-end gap-2.5">

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
@@ -6,6 +6,11 @@ SPDX-License-Identifier: MIT
 <div class="flex flex-col" data-testid="sign-contract-type-select-dialog">
   <p class="mb-4 text-sm text-slate-600">{{ copy.body }}</p>
 
+  <!--
+    Each card is described by the paragraph under it. Which type a contributor is depends on who
+    owns the work, and that is what these two sentences say — the labels alone do not distinguish
+    them. Focus lands on the card, so without `describedBy` the text is announced to nobody.
+  -->
   <div role="listbox" aria-label="Contributor types" class="flex flex-col gap-3">
     <div class="flex flex-col gap-1">
       <lfx-selectable-card
@@ -13,8 +18,11 @@ SPDX-License-Identifier: MIT
         control="contractType"
         [value]="individualValue"
         [label]="copy.individual.label"
+        describedBy="sign-contract-type-select-individual-description"
         testId="sign-contract-type-select-individual" />
-      <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.individual.description }}</p>
+      <p id="sign-contract-type-select-individual-description" class="pl-1 text-xs leading-relaxed text-slate-500">
+        {{ copy.individual.description }}
+      </p>
     </div>
 
     <div class="flex flex-col gap-1">
@@ -23,8 +31,11 @@ SPDX-License-Identifier: MIT
         control="contractType"
         [value]="corporateValue"
         [label]="copy.corporate.label"
+        describedBy="sign-contract-type-select-corporate-description"
         testId="sign-contract-type-select-corporate" />
-      <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.corporate.description }}</p>
+      <p id="sign-contract-type-select-corporate-description" class="pl-1 text-xs leading-relaxed text-slate-500">
+        {{ copy.corporate.description }}
+      </p>
     </div>
   </div>
 

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
@@ -1,0 +1,45 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+-->
+
+<div class="flex flex-col" data-testid="sign-contract-type-select-dialog">
+  <p class="mb-4 text-sm text-slate-600">{{ copy.body }}</p>
+
+  <div role="listbox" aria-label="Contributor types" class="flex flex-col gap-3">
+    @if (iclaEnabled()) {
+      <div class="flex flex-col gap-1">
+        <lfx-selectable-card
+          [form]="selectForm"
+          control="contractType"
+          [value]="individualValue"
+          [label]="copy.individual.label"
+          testId="sign-contract-type-select-individual" />
+        <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.individual.description }}</p>
+      </div>
+    }
+
+    @if (cclaEnabled()) {
+      <div class="flex flex-col gap-1">
+        <lfx-selectable-card
+          [form]="selectForm"
+          control="contractType"
+          [value]="corporateValue"
+          [label]="copy.corporate.label"
+          testId="sign-contract-type-select-corporate" />
+        <p class="pl-1 text-xs leading-relaxed text-slate-500">{{ copy.corporate.description }}</p>
+      </div>
+    }
+  </div>
+
+  <div class="mt-4 flex justify-end gap-2.5">
+    <lfx-button label="Cancel" [text]="true" (onClick)="onCancel()" data-testid="sign-contract-type-select-cancel" />
+    <lfx-button
+      label="Continue to sign"
+      icon="fa-light fa-arrow-right"
+      iconPos="right"
+      [disabled]="!selectedType()"
+      (onClick)="onContinue()"
+      data-testid="sign-contract-type-select-continue" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
@@ -63,6 +63,22 @@ describe('SignContractTypeSelectComponent', () => {
     expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.corporate.description);
   });
 
+  it('announces each type’s description with the card it belongs to', async () => {
+    // Which type applies depends on who owns the work, and only the descriptions say so. Focus
+    // lands on the card, so a description that is merely adjacent is announced to nobody. Resolved
+    // through the DOM rather than compared as a string, because a stale or swapped id is exactly
+    // the failure this guards — and it would still read as a present `aria-describedby`.
+    for (const [testId, description] of [
+      ['sign-contract-type-select-individual', SIGN_CONTRACT_TYPE_COPY.individual.description],
+      ['sign-contract-type-select-corporate', SIGN_CONTRACT_TYPE_COPY.corporate.description],
+    ] as const) {
+      const describedBy = query(testId)?.getAttribute('aria-describedby');
+
+      expect(describedBy).toBeTruthy();
+      expect(fixture.nativeElement.querySelector(`#${describedBy}`)?.textContent).toContain(description);
+    }
+  });
+
   it('preselects nothing, and cannot be continued until a type is chosen', async () => {
     // A preselection is indistinguishable from a choice once submitted, and which agreement a
     // contributor signs is not a decision this dialog may make on their behalf.

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
@@ -5,33 +5,30 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { SIGN_CONTRACT_TYPE_COPY } from '@lfx-one/shared/constants';
-import type { SignContractTypeDialogData } from '@lfx-one/shared/interfaces';
-import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { describe, expect, it, vi } from 'vitest';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SignContractTypeSelectComponent } from './sign-contract-type-select.component';
 
+/**
+ * Covers the Gerrit contract-type step opened by DialogService (#2066).
+ *
+ * What these tests protect is the binding between the card the contributor reads and the route
+ * segment the hand-off uses. The two are joined only by a template `[value]`, and getting them
+ * the wrong way round would send a contributor who chose "Individual Contributor" to sign a
+ * corporate agreement — so the choice is always made by clicking, never by writing to the form.
+ */
 describe('SignContractTypeSelectComponent', () => {
   let close: ReturnType<typeof vi.fn>;
   let fixture: ComponentFixture<SignContractTypeSelectComponent>;
 
-  async function setup(data: Partial<SignContractTypeDialogData> = {}): Promise<void> {
+  async function setup(): Promise<void> {
     TestBed.resetTestingModule();
     close = vi.fn();
 
     TestBed.configureTestingModule({
       imports: [SignContractTypeSelectComponent],
-      providers: [
-        provideRouter([]),
-        provideNoopAnimations(),
-        { provide: DynamicDialogRef, useValue: { close } },
-        {
-          provide: DynamicDialogConfig,
-          useValue: {
-            data: { iclaEnabled: true, cclaEnabled: true, ...data } satisfies SignContractTypeDialogData,
-          },
-        },
-      ],
+      providers: [provideRouter([]), provideNoopAnimations(), { provide: DynamicDialogRef, useValue: { close } }],
     });
 
     fixture = TestBed.createComponent(SignContractTypeSelectComponent);
@@ -39,31 +36,74 @@ describe('SignContractTypeSelectComponent', () => {
     await fixture.whenStable();
   }
 
-  it('shows both contributor cards and keeps Continue disabled until one is chosen', async () => {
-    await setup();
+  function query(testId: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
+  }
 
-    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.body);
-    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.individual.label);
-    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.corporate.label);
-    expect(fixture.nativeElement.querySelector('[data-testid="sign-contract-type-select-individual"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="sign-contract-type-select-corporate"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="sign-contract-type-select-continue"] button')?.disabled).toBe(true);
+  /** Picks a card the way a click does — the card writes the chosen value into the form. */
+  async function choose(testId: string): Promise<void> {
+    query(testId)?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function continueToSign(): void {
+    (fixture.componentInstance as any).onContinue();
+  }
+
+  beforeEach(async () => {
+    await setup();
   });
 
-  it('closes with the selected contract type', async () => {
-    await setup();
+  it('offers both contributor types, with the Console decision screen’s wording', async () => {
+    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.body);
+    expect(query('sign-contract-type-select-individual')?.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.individual.label);
+    expect(query('sign-contract-type-select-corporate')?.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.corporate.label);
+    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.individual.description);
+    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.corporate.description);
+  });
 
-    fixture.componentInstance['selectForm'].controls.contractType.setValue('corporate');
-    fixture.detectChanges();
-    fixture.componentInstance['onContinue']();
+  it('preselects nothing, and cannot be continued until a type is chosen', async () => {
+    // A preselection is indistinguishable from a choice once submitted, and which agreement a
+    // contributor signs is not a decision this dialog may make on their behalf.
+    expect((fixture.componentInstance as any).selectedType()).toBeNull();
+    expect(query('sign-contract-type-select-continue')?.querySelector('button')?.disabled).toBe(true);
+
+    continueToSign();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('closes with individual when the contributor picks the Individual Contributor card', async () => {
+    await choose('sign-contract-type-select-individual');
+    continueToSign();
+
+    expect(close).toHaveBeenCalledWith({ contractType: 'individual' });
+  });
+
+  it('closes with corporate when the contributor picks the Corporate Contributor card', async () => {
+    await choose('sign-contract-type-select-corporate');
+    continueToSign();
 
     expect(close).toHaveBeenCalledWith({ contractType: 'corporate' });
   });
 
-  it('closes with null when cancelled', async () => {
-    await setup();
+  it('closes with the later choice when the contributor changes their mind', async () => {
+    await choose('sign-contract-type-select-individual');
+    await choose('sign-contract-type-select-corporate');
+    continueToSign();
 
-    fixture.componentInstance['onCancel']();
+    expect(close).toHaveBeenCalledWith({ contractType: 'corporate' });
+  });
+
+  it('enables Continue once a card is chosen', async () => {
+    await choose('sign-contract-type-select-corporate');
+
+    expect(query('sign-contract-type-select-continue')?.querySelector('button')?.disabled).toBe(false);
+  });
+
+  it('closes with null when cancelled', async () => {
+    (fixture.componentInstance as any).onCancel();
 
     expect(close).toHaveBeenCalledWith(null);
   });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { SIGN_CONTRACT_TYPE_COPY } from '@lfx-one/shared/constants';
+import type { SignContractTypeDialogData } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SignContractTypeSelectComponent } from './sign-contract-type-select.component';
+
+describe('SignContractTypeSelectComponent', () => {
+  let close: ReturnType<typeof vi.fn>;
+  let fixture: ComponentFixture<SignContractTypeSelectComponent>;
+
+  async function setup(data: Partial<SignContractTypeDialogData> = {}): Promise<void> {
+    TestBed.resetTestingModule();
+    close = vi.fn();
+
+    TestBed.configureTestingModule({
+      imports: [SignContractTypeSelectComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close } },
+        {
+          provide: DynamicDialogConfig,
+          useValue: {
+            data: { iclaEnabled: true, cclaEnabled: true, ...data } satisfies SignContractTypeDialogData,
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(SignContractTypeSelectComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  it('shows both contributor cards and keeps Continue disabled until one is chosen', async () => {
+    await setup();
+
+    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.body);
+    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.individual.label);
+    expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.corporate.label);
+    expect(fixture.nativeElement.querySelector('[data-testid="sign-contract-type-select-individual"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="sign-contract-type-select-corporate"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="sign-contract-type-select-continue"] button')?.disabled).toBe(true);
+  });
+
+  it('closes with the selected contract type', async () => {
+    await setup();
+
+    fixture.componentInstance['selectForm'].controls.contractType.setValue('corporate');
+    fixture.detectChanges();
+    fixture.componentInstance['onContinue']();
+
+    expect(close).toHaveBeenCalledWith({ contractType: 'corporate' });
+  });
+
+  it('closes with null when cancelled', async () => {
+    await setup();
+
+    fixture.componentInstance['onCancel']();
+
+    expect(close).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { GERRIT_CONTRACT_TYPE_CORPORATE, GERRIT_CONTRACT_TYPE_INDIVIDUAL, SIGN_CONTRACT_TYPE_COPY } from '@lfx-one/shared/constants';
+import type { GerritContractType, SignContractTypeDialogData, SignContractTypeSelectResult } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
+
+/**
+ * Which contract type a Gerrit contributor will sign under (#2066).
+ *
+ * Shown after the contributor confirms their Gerrit identity and before navigation to the
+ * Console, only when both ICLA and CCLA are enabled for the selected group. Copy mirrors the
+ * Contributor Console decision screen; nothing is preselected.
+ */
+@Component({
+  selector: 'lfx-sign-contract-type-select',
+  imports: [ReactiveFormsModule, ButtonComponent, SelectableCardComponent],
+  templateUrl: './sign-contract-type-select.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SignContractTypeSelectComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly config = inject<DynamicDialogConfig<SignContractTypeDialogData>>(DynamicDialogConfig);
+
+  protected readonly copy = SIGN_CONTRACT_TYPE_COPY;
+  protected readonly individualValue = GERRIT_CONTRACT_TYPE_INDIVIDUAL;
+  protected readonly corporateValue = GERRIT_CONTRACT_TYPE_CORPORATE;
+
+  protected readonly iclaEnabled = computed(() => this.config.data?.iclaEnabled === true);
+  protected readonly cclaEnabled = computed(() => this.config.data?.cclaEnabled === true);
+
+  protected readonly selectForm = new FormGroup({
+    contractType: new FormControl<GerritContractType | null>(null),
+  });
+
+  protected readonly selectedType = signal<GerritContractType | null>(null);
+
+  public constructor() {
+    this.selectForm.controls.contractType.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => this.selectedType.set(value));
+  }
+
+  protected onContinue(): void {
+    const contractType = this.selectedType();
+    if (!contractType) return;
+
+    this.ref.close({ contractType } satisfies SignContractTypeSelectResult);
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+}

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
@@ -1,12 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { GERRIT_CONTRACT_TYPE_CORPORATE, GERRIT_CONTRACT_TYPE_INDIVIDUAL, SIGN_CONTRACT_TYPE_COPY } from '@lfx-one/shared/constants';
-import type { GerritContractType, SignContractTypeDialogData, SignContractTypeSelectResult } from '@lfx-one/shared/interfaces';
-import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import type { GerritContractType, SignContractTypeSelectResult } from '@lfx-one/shared/interfaces';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
@@ -15,8 +15,12 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
  * Which contract type a Gerrit contributor will sign under (#2066).
  *
  * Shown after the contributor confirms their Gerrit identity and before navigation to the
- * Console, only when both ICLA and CCLA are enabled for the selected group. Copy mirrors the
- * Contributor Console decision screen; nothing is preselected.
+ * Console. Copy mirrors the Contributor Console decision screen; nothing is preselected.
+ *
+ * Both cards are always rendered, and the dialog takes no enablement data. A group with only one
+ * type enabled never reaches here — the caller resolves that type and hands off without asking —
+ * so a flag on this dialog could only ever say "both", and a dialog that could render one card is
+ * one that could render none.
  */
 @Component({
   selector: 'lfx-sign-contract-type-select',
@@ -26,14 +30,10 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
 })
 export class SignContractTypeSelectComponent {
   private readonly ref = inject(DynamicDialogRef);
-  private readonly config = inject<DynamicDialogConfig<SignContractTypeDialogData>>(DynamicDialogConfig);
 
   protected readonly copy = SIGN_CONTRACT_TYPE_COPY;
   protected readonly individualValue = GERRIT_CONTRACT_TYPE_INDIVIDUAL;
   protected readonly corporateValue = GERRIT_CONTRACT_TYPE_CORPORATE;
-
-  protected readonly iclaEnabled = computed(() => this.config.data?.iclaEnabled === true);
-  protected readonly cclaEnabled = computed(() => this.config.data?.cclaEnabled === true);
 
   protected readonly selectForm = new FormGroup({
     contractType: new FormControl<GerritContractType | null>(null),

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.html
@@ -21,6 +21,7 @@
   [attr.role]="'option'"
   [attr.aria-selected]="isSelected()"
   [attr.aria-disabled]="isDisabled()"
+  [attr.aria-describedby]="describedBy() || null"
   (click)="onCardClick()"
   (keydown)="onKeydown($event)">
   <!-- Label -->

--- a/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/selectable-card/selectable-card.component.ts
@@ -30,6 +30,15 @@ export class SelectableCardComponent {
    * of the tab order is one a keyboard-only contributor can never ask about.
    */
   public readonly disabledReason = input<string>('');
+  /**
+   * ID of an element describing this card, for cards whose meaning lives in adjacent prose.
+   *
+   * The option element is the only thing focus lands on, so text merely sitting next to the card
+   * is never announced — a reader hears the label and nothing else. Where that adjacent text *is*
+   * the decision rather than a gloss on it, pass its ID here. Empty leaves the attribute off
+   * rather than setting it blank, which would name a nonexistent element.
+   */
+  public readonly describedBy = input<string>('');
   public readonly styleClass = input<string>('');
   public readonly testId = input<string>('');
 

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -476,7 +476,7 @@ describe('toClaGroupSearchResponse', () => {
     expect(mapped.results[0]).toMatchObject({ matchedRepositoryName: 'cncf/foo', matchedRepositoryURL: 'https://github.com/cncf/foo' });
   });
 
-  it('drops the producer fields the modal has no use for', () => {
+  it('forwards ICLA/CCLA enablement flags for Gerrit contract-type routing (#2066)', () => {
     const mapped = toClaGroupSearchResponse({
       searchTerm: 'cncf',
       resultCount: 1,
@@ -484,11 +484,8 @@ describe('toClaGroupSearchResponse', () => {
       results: [result({ projectSFID: 'a09', foundationSFID: 'a09f', projectExternalID: 'ext', iclaEnabled: true, cclaEnabled: false })],
     });
 
-    // Passing these on would invite a later consumer to branch on signing configuration the
-    // picker never asked for and cannot honour.
     expect(mapped.results[0]).not.toHaveProperty('projectSFID');
-    expect(mapped.results[0]).not.toHaveProperty('iclaEnabled');
-    expect(mapped.results[0]).not.toHaveProperty('cclaEnabled');
+    expect(mapped.results[0]).toMatchObject({ iclaEnabled: true, cclaEnabled: false });
   });
 
   it('answers an absent upstream body with an empty, non-truncated set for the term', () => {

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -105,6 +105,8 @@ function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
       .filter((org) => !!org.name),
     ...(result.matchedRepositoryName ? { matchedRepositoryName: result.matchedRepositoryName } : {}),
     ...(result.matchedRepositoryURL ? { matchedRepositoryURL: result.matchedRepositoryURL } : {}),
+    iclaEnabled: result.iclaEnabled === true,
+    cclaEnabled: result.cclaEnabled === true,
   };
 }
 
@@ -114,9 +116,8 @@ function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
  * The envelope is mirrored rather than flattened to an array because `truncated` describes the
  * result *set* — a cap cannot ride inside one of the results. The one field renamed is the
  * identifier (`claGroupID` → `claGroupId`), so Angular is not made to carry two spellings of the
- * same UUID. Salesforce ids and the ICLA/CCLA enablement flags are deliberately not carried
- * across: the modal does not use them, and forwarding them invites a consumer to branch on
- * signing configuration this route never promised to keep current.
+ * same UUID. Salesforce ids are deliberately not carried across. ICLA/CCLA enablement flags are
+ * forwarded for Gerrit contract-type routing (#2066); the GitHub prepare-sign path does not branch on them.
  *
  * `searchTerm` falls back to the term the BFF actually sent, so the client can always tell which
  * query a set belongs to even if the producer echoes nothing.

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -61,7 +61,7 @@ export const GERRIT_CONTRACT_TYPE_CORPORATE = 'corporate';
  */
 export const SIGN_CONTRACT_TYPE_COPY = {
   header: 'What type of contributor are you?',
-  body: 'Choose how you will sign for this project — you will be redirected to EasyCLA to complete it.',
+  body: "Choose how you'll sign for this project — you'll be redirected to EasyCLA to complete it.",
   individual: {
     label: 'Individual Contributor',
     description:

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -46,12 +46,32 @@ export const MY_CLAS_PATH = '/profile/clas';
 
 /**
  * The Contributor Console's Gerrit signing route, as its own router declares it
- * (`cla/gerrit/project/:projectId/:contractType`). Always the individual agreement: every
- * Gerrit-linked CLA Group in production has ICLA enabled, and the search response deliberately
- * omits the enablement flags, so there is nothing to read and nothing to choose.
+ * (`cla/gerrit/project/:projectId/:contractType`). The contract-type segment is chosen on
+ * the Gerrit path from the group's enablement flags (#2066).
  */
 export const GERRIT_CONSOLE_ROUTE_PREFIX = '#/cla/gerrit/project';
-export const GERRIT_CONSOLE_CONTRACT_TYPE = 'individual';
+
+/** Contract-type segments the Console Gerrit route accepts (#2066). */
+export const GERRIT_CONTRACT_TYPE_INDIVIDUAL = 'individual';
+export const GERRIT_CONTRACT_TYPE_CORPORATE = 'corporate';
+
+/**
+ * Copy for the Gerrit contract-type step (#2066), mirroring the Contributor Console decision
+ * screen rather than inventing new wording.
+ */
+export const SIGN_CONTRACT_TYPE_COPY = {
+  header: 'What type of contributor are you?',
+  body: 'Choose how you will sign for this project — you will be redirected to EasyCLA to complete it.',
+  individual: {
+    label: 'Individual Contributor',
+    description:
+      'If you are making a contribution of content that you own, and not content owned by your employer, you should proceed as an individual contributor.',
+  },
+  corporate: {
+    label: 'Corporate Contributor',
+    description: 'If you are making a contribution of content owned by your employer, you should proceed as a corporate contributor.',
+  },
+} as const;
 
 /**
  * The value the Gerrit card writes into the step's form control.

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -345,13 +345,12 @@ export type SignIdentitySelectResult = { kind: 'github'; githubId: string } | { 
 /** Console Gerrit route contract-type segment (#2066). */
 export type GerritContractType = 'individual' | 'corporate';
 
-/** What the Gerrit contract-type step is given to render (#2066). */
-export interface SignContractTypeDialogData {
-  iclaEnabled: boolean;
-  cclaEnabled: boolean;
-}
-
-/** What the contract-type step closes with, or `null` for a dismissal (#2066). */
+/**
+ * What the contract-type step closes with, or `null` for a dismissal (#2066).
+ *
+ * The step takes no input data: it opens only for a group with both types enabled, so there is
+ * nothing about the group left for it to branch on.
+ */
 export interface SignContractTypeSelectResult {
   contractType: GerritContractType;
 }

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -187,6 +187,10 @@ export interface ClaGroupOption {
   matchTypes: ClaGroupMatchType[];
   /** All linked organizations, sorted by source then name upstream. May be empty. */
   organizations: ClaGroupOrg[];
+  /** Whether the group accepts an individual (ICLA) agreement — used for Gerrit contract-type routing (#2066). */
+  iclaEnabled?: boolean;
+  /** Whether the group accepts a corporate (CCLA) agreement — used for Gerrit contract-type routing (#2066). */
+  cclaEnabled?: boolean;
   /** Full repository name the term resolved to — set only when `matchTypes` includes `repository`. */
   matchedRepositoryName?: string;
   matchedRepositoryURL?: string;
@@ -337,6 +341,20 @@ export interface SignIdentityDialogData {
  * chosen, and only one of them should move the contributor off the page they started from.
  */
 export type SignIdentitySelectResult = { kind: 'github'; githubId: string } | { kind: 'gerrit' } | { linkAccounts: true };
+
+/** Console Gerrit route contract-type segment (#2066). */
+export type GerritContractType = 'individual' | 'corporate';
+
+/** What the Gerrit contract-type step is given to render (#2066). */
+export interface SignContractTypeDialogData {
+  iclaEnabled: boolean;
+  cclaEnabled: boolean;
+}
+
+/** What the contract-type step closes with, or `null` for a dismissal (#2066). */
+export interface SignContractTypeSelectResult {
+  contractType: GerritContractType;
+}
 
 /** Response for `GET /api/me/clas/github-accounts`. */
 export interface GithubAccountOptions {

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -167,10 +167,12 @@ export interface ClaGroupOrg {
 /**
  * A CLA Group the contributor can choose to sign against (Sign CLA hand-off, #1251).
  *
- * The hand-off needs `claGroupId` and nothing else; every other field is here so the picker
- * can show which group this is and why it matched. Consumers MUST ignore unknown fields
- * rather than validate exhaustively, so the search can keep enriching this without touching
- * the hand-off.
+ * The hand-off needs `claGroupId`, plus `iclaEnabled` / `cclaEnabled` on the Gerrit route, where
+ * they decide the contract type and whether the contributor is asked for it (#2066). Every other
+ * field is here so the picker can show which group this is and why it matched. Consumers MUST
+ * ignore unknown fields rather than validate exhaustively, so the search can keep enriching this
+ * without touching the hand-off — but the enablement flags are not that kind of field: dropping
+ * them in a mapper reinstates #2066's silent default rather than degrading the display.
  *
  * Both display names are optional because the producer omits each independently: `projectName`
  * when the group maps to several projects with no foundation marker, `claGroupName` when the

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -23,6 +23,7 @@ import {
   formatClaSignedOn,
   gerritSignUrl,
   isMyClasEmpty,
+  resolveGerritContractType,
   shouldShowGithubCta,
   signedAsLine,
   splitAgreementsByKind,
@@ -495,19 +496,25 @@ describe('gerritSignUrl', () => {
   const RETURN_URL = 'https://app.dev.lfx.dev/profile/clas';
 
   it('composes the Console Gerrit route for the individual agreement', () => {
-    expect(gerritSignUrl('https://easycla.example.org', 'cg-1', RETURN_URL)).toBe(
+    expect(gerritSignUrl('https://easycla.example.org', 'cg-1', RETURN_URL, 'individual')).toBe(
       'https://easycla.example.org/#/cla/gerrit/project/cg-1/individual?redirect=https%3A%2F%2Fapp.dev.lfx.dev%2Fprofile%2Fclas'
     );
   });
 
+  it('composes the Console Gerrit route for the corporate agreement', () => {
+    expect(gerritSignUrl('https://easycla.example.org', 'cg-1', RETURN_URL, 'corporate')).toBe(
+      'https://easycla.example.org/#/cla/gerrit/project/cg-1/corporate?redirect=https%3A%2F%2Fapp.dev.lfx.dev%2Fprofile%2Fclas'
+    );
+  });
+
   it('tolerates a base with trailing slashes, as every configured one has', () => {
-    expect(gerritSignUrl('https://easycla.example.org//', 'cg-1', RETURN_URL)).toBe(
+    expect(gerritSignUrl('https://easycla.example.org//', 'cg-1', RETURN_URL, 'individual')).toBe(
       'https://easycla.example.org/#/cla/gerrit/project/cg-1/individual?redirect=https%3A%2F%2Fapp.dev.lfx.dev%2Fprofile%2Fclas'
     );
   });
 
   it('encodes the return address so its own query string cannot escape into ours', () => {
-    const url = gerritSignUrl('https://easycla.example.org', 'cg-1', 'https://app.example.org/profile/clas?a=1&b=2');
+    const url = gerritSignUrl('https://easycla.example.org', 'cg-1', 'https://app.example.org/profile/clas?a=1&b=2', 'individual');
 
     expect(url).toContain('redirect=https%3A%2F%2Fapp.example.org%2Fprofile%2Fclas%3Fa%3D1%26b%3D2');
     // One query parameter, not three: an unencoded return address would have added two more.
@@ -517,16 +524,34 @@ describe('gerritSignUrl', () => {
   it('returns nothing when the Console base is unset', () => {
     // The caller reports a failure instead. Navigating to a relative address would resolve it
     // against our own origin and land the contributor on a page that cannot sign anything.
-    expect(gerritSignUrl('', 'cg-1', RETURN_URL)).toBeNull();
-    expect(gerritSignUrl('   ', 'cg-1', RETURN_URL)).toBeNull();
+    expect(gerritSignUrl('', 'cg-1', RETURN_URL, 'individual')).toBeNull();
+    expect(gerritSignUrl('   ', 'cg-1', RETURN_URL, 'individual')).toBeNull();
   });
 
   it('returns nothing when the Console base is not an absolute address', () => {
-    expect(gerritSignUrl('easycla.example.org', 'cg-1', RETURN_URL)).toBeNull();
+    expect(gerritSignUrl('easycla.example.org', 'cg-1', RETURN_URL, 'individual')).toBeNull();
   });
 
   it('returns nothing when the CLA group id is missing', () => {
-    expect(gerritSignUrl('https://easycla.example.org', '', RETURN_URL)).toBeNull();
-    expect(gerritSignUrl('https://easycla.example.org', '  ', RETURN_URL)).toBeNull();
+    expect(gerritSignUrl('https://easycla.example.org', '', RETURN_URL, 'individual')).toBeNull();
+    expect(gerritSignUrl('https://easycla.example.org', '  ', RETURN_URL, 'individual')).toBeNull();
+  });
+});
+
+describe('resolveGerritContractType', () => {
+  it('returns chooser when both types are enabled', () => {
+    expect(resolveGerritContractType(true, true)).toBe('chooser');
+  });
+
+  it('returns individual when only ICLA is enabled', () => {
+    expect(resolveGerritContractType(true, false)).toBe('individual');
+  });
+
+  it('returns corporate when only CCLA is enabled', () => {
+    expect(resolveGerritContractType(false, true)).toBe('corporate');
+  });
+
+  it('returns none when neither type is enabled', () => {
+    expect(resolveGerritContractType(false, false)).toBe('none');
   });
 });

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -10,8 +10,9 @@ import {
   CLA_GROUP_MATCH_TYPE_LABELS,
   CLA_GROUP_ORG_SOURCE_ICONS,
   CLA_GROUP_ORG_SOURCE_LABELS,
-  GERRIT_CONSOLE_CONTRACT_TYPE,
   GERRIT_CONSOLE_ROUTE_PREFIX,
+  GERRIT_CONTRACT_TYPE_CORPORATE,
+  GERRIT_CONTRACT_TYPE_INDIVIDUAL,
   UNNAMED_CLA_GROUP,
 } from '../constants/cla.constants';
 import { PROFILE_TABS } from '../constants/profile.constants';
@@ -256,7 +257,7 @@ export function claSignRoute(organizations: ClaGroupOrg[]): ClaSignRoute {
  * Returns `null` rather than a malformed address when the base or the group id is unusable,
  * so the caller reports a failure instead of navigating somewhere that cannot work.
  */
-export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, returnUrl: string): string | null {
+export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, returnUrl: string, contractType: 'individual' | 'corporate'): string | null {
   // Trailing slashes are stripped by scanning, not by an anchored `/\/+$/`: that pattern
   // backtracks polynomially on a long run of slashes, which CodeQL flags as a ReDoS even
   // though this particular input is build-time configuration.
@@ -275,7 +276,21 @@ export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, return
   }
 
   const redirect = encodeURIComponent(returnUrl);
-  return `${base}/${GERRIT_CONSOLE_ROUTE_PREFIX}/${encodeURIComponent(groupId)}/${GERRIT_CONSOLE_CONTRACT_TYPE}?redirect=${redirect}`;
+  const segment = contractType === GERRIT_CONTRACT_TYPE_CORPORATE ? GERRIT_CONTRACT_TYPE_CORPORATE : GERRIT_CONTRACT_TYPE_INDIVIDUAL;
+  return `${base}/${GERRIT_CONSOLE_ROUTE_PREFIX}/${encodeURIComponent(groupId)}/${segment}?redirect=${redirect}`;
+}
+
+/**
+ * Whether the Gerrit hand-off needs a contract-type step, and which segment to use when it does not (#2066).
+ *
+ * Returns `chooser` when both ICLA and CCLA are enabled; a concrete type when exactly one is;
+ * `none` when neither is — the caller must fail visibly rather than navigate.
+ */
+export function resolveGerritContractType(iclaEnabled: boolean, cclaEnabled: boolean): 'individual' | 'corporate' | 'chooser' | 'none' {
+  if (iclaEnabled && cclaEnabled) return 'chooser';
+  if (iclaEnabled) return 'individual';
+  if (cclaEnabled) return 'corporate';
+  return 'none';
 }
 
 /**

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -25,6 +25,7 @@ import type {
   ClaSignedVia,
   ClaSignRoute,
   ClaStatus,
+  GerritContractType,
   MyClaAgreement,
   MyClasIdentitySummary,
   SignIdentityRef,
@@ -257,7 +258,7 @@ export function claSignRoute(organizations: ClaGroupOrg[]): ClaSignRoute {
  * Returns `null` rather than a malformed address when the base or the group id is unusable,
  * so the caller reports a failure instead of navigating somewhere that cannot work.
  */
-export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, returnUrl: string, contractType: 'individual' | 'corporate'): string | null {
+export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, returnUrl: string, contractType: GerritContractType): string | null {
   // Trailing slashes are stripped by scanning, not by an anchored `/\/+$/`: that pattern
   // backtracks polynomially on a long run of slashes, which CodeQL flags as a ReDoS even
   // though this particular input is build-time configuration.
@@ -275,9 +276,11 @@ export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, return
     return null;
   }
 
+  // The segment is the contract type verbatim. Coercing an unrecognized value to `individual`
+  // would reinstate #2066's silent default in the one function that decides the route, so the
+  // type is the only guard — a bad caller must fail to compile, not sign the wrong agreement.
   const redirect = encodeURIComponent(returnUrl);
-  const segment = contractType === GERRIT_CONTRACT_TYPE_CORPORATE ? GERRIT_CONTRACT_TYPE_CORPORATE : GERRIT_CONTRACT_TYPE_INDIVIDUAL;
-  return `${base}/${GERRIT_CONSOLE_ROUTE_PREFIX}/${encodeURIComponent(groupId)}/${segment}?redirect=${redirect}`;
+  return `${base}/${GERRIT_CONSOLE_ROUTE_PREFIX}/${encodeURIComponent(groupId)}/${contractType}?redirect=${redirect}`;
 }
 
 /**
@@ -286,10 +289,10 @@ export function gerritSignUrl(consoleBaseUrl: string, claGroupId: string, return
  * Returns `chooser` when both ICLA and CCLA are enabled; a concrete type when exactly one is;
  * `none` when neither is — the caller must fail visibly rather than navigate.
  */
-export function resolveGerritContractType(iclaEnabled: boolean, cclaEnabled: boolean): 'individual' | 'corporate' | 'chooser' | 'none' {
+export function resolveGerritContractType(iclaEnabled: boolean, cclaEnabled: boolean): GerritContractType | 'chooser' | 'none' {
   if (iclaEnabled && cclaEnabled) return 'chooser';
-  if (iclaEnabled) return 'individual';
-  if (cclaEnabled) return 'corporate';
+  if (iclaEnabled) return GERRIT_CONTRACT_TYPE_INDIVIDUAL;
+  if (cclaEnabled) return GERRIT_CONTRACT_TYPE_CORPORATE;
   return 'none';
 }
 


### PR DESCRIPTION
## Summary

- After a contributor confirms their Gerrit identity, show an Individual/Corporate picker when both ICLA and CCLA are enabled for the selected CLA group.
- Single-type groups skip the picker and route directly to the sole contract type; a group with neither enabled fails visibly instead of navigating.
- BFF search now forwards `iclaEnabled` / `cclaEnabled`; `gerritSignUrl` takes a contract type for the Console hand-off.

The route segments `individual` and `corporate` are the two the Contributor Console's Gerrit route accepts, and each was confirmed against DEV to resolve to its matching dashboard. Picker copy is taken verbatim from the Console decision screen rather than reworded.

Closes #2066

## Test plan

- [x] `./check-headers.sh && yarn format:check && yarn lint:check && yarn check-types`
- [x] `yarn workspace @lfx-one/shared test` — `cla-view.utils.spec.ts`
- [x] `yarn workspace lfx-one-ui test` — `profile-clas`, `sign-contract-type-select`
- [x] DEV: Gerrit group with both types enabled — picker appears after identity confirm, nothing preselected; Corporate reaches the Console Gerrit route at `corporate` and lands on the CCLA Select Organization step. Search response carries both enablement flags. Dismissing the picker navigates nowhere and releases the Sign CLA action.
- [ ] Gerrit group with only one type enabled — no DEV fixture exists (the single Gerrit-linked group in DEV enables both), so the skip path is covered by unit tests only.

## Review notes

The contract-type step is chosen by clicking a card, and the card's label is joined to the route segment only by a template `[value]`. The spec therefore always chooses by clicking rather than by writing to the form control — a swapped binding would otherwise send a contributor who picked "Individual Contributor" to sign a corporate agreement with the suite still green.

Dismissing the contract-type step is covered on both exit paths. It matters more here than on the identity step: the identity is already confirmed at that point, so falling through to a default type would sign an agreement the contributor withdrew from choosing.

`gerritSignUrl` does not coerce an unrecognized contract type back to `individual`. That silent default is the defect this PR fixes, and the parameter type is the guard instead.

Each card carries `aria-describedby` pointing at the description under it. The labels are only "Individual Contributor" and "Corporate Contributor"; which one applies depends on who owns the work, and that is stated solely in those paragraphs. Focus lands on the card, so adjacent text alone is announced to nobody. The `describedBy` input added to `SelectableCard` is opt-in and leaves the attribute off when empty, so no existing consumer changes behaviour.

The step opens on the identity dialog's `onDestroy` rather than its `onClose`. `DynamicDialogRef.close()` emits `onClose` synchronously and starts the leave animation from that same emission, and the animation's end is what drops `p-overflow-hidden` from the body — so a dialog opened inside `onClose` has its own scroll lock stripped a moment after it appears, letting the page scroll behind the modal. The re-entry gate is held closed across that wait so a second Sign CLA cannot start a parallel hand-off in the gap. The GitHub path needs none of this, because its next step opens after the linked-account request, which lands long after the animation is done.
