### PR TITLE
test(cla): prove the Gerrit contract-type step waits for teardown

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -575,6 +575,15 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
   let opened: unknown[];
   /** Records what each dialog was opened with, so the identity step's inputs are assertable. */
   let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData } }[];
+  /**
+   * Manual control of the identity step's teardown, under `stepIdentityTeardown`.
+   *
+   * `onClose` and `onDestroy` are one event apart in PrimeNG but a whole leave animation apart in
+   * time, and the scroll lock is dropped at the end of it. Emitting both from `of()` collapses
+   * that distance, so a step reopened from `onClose` — the bug — passes as readily as one that
+   * waits. Separate subjects keep them tellable apart.
+   */
+  let identitySteps: { close: Subject<unknown>; destroy: Subject<unknown> };
 
   async function setup(
     options: {
@@ -586,6 +595,11 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       accountClosesWith?: SignIdentitySelectResult | null;
       dismissGroup?: 'close' | 'destroy' | 'hold';
       dismissAccount?: 'close' | 'destroy' | 'hold';
+      /**
+       * Drives the identity step's `onClose` and `onDestroy` from `identitySteps` instead of
+       * emitting both at once, so which of the two a follow-on step waits for is assertable.
+       */
+      stepIdentityTeardown?: boolean;
       /** Linked organizations on the selected group — the sole input to the routing decision. */
       organizations?: ClaGroupOrg[];
       iclaEnabled?: boolean;
@@ -605,6 +619,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     messageAdd = vi.fn();
     opened = [];
     openedWith = [];
+    identitySteps = { close: new Subject<unknown>(), destroy: new Subject<unknown>() };
     getGithubAccounts = vi.fn(options.accounts ?? (() => of(TWO_ACCOUNTS)));
     prepareSign = vi.fn(options.prepare ?? (() => of(PREPARED)));
     // Kept on the stub purely so a regression to client-side URL construction is assertable
@@ -622,6 +637,9 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       opened.push(component);
       openedWith.push({ component, config: config ?? {} });
       if (component === SignIdentitySelectComponent) {
+        if (options.stepIdentityTeardown) {
+          return { onClose: identitySteps.close.asObservable(), onDestroy: identitySteps.destroy.asObservable() };
+        }
         return dialogEvents(
           'accountClosesWith' in options ? options.accountClosesWith : { kind: 'github', githubId: '12345' },
           options.dismissAccount ?? 'close'
@@ -1373,6 +1391,37 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     expect(isStarting(fixture)).toBe(false);
   });
 
+  it('waits for the identity step to be torn down before opening the contract-type step', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      stepIdentityTeardown: true,
+    });
+
+    await sign(fixture);
+    identitySteps.close.next({ kind: 'gerrit' });
+    await fixture.whenStable();
+
+    // Closed is not gone. PrimeNG starts the leave animation from this same emission, and its end
+    // is what drops `p-overflow-hidden` — so a step opened here has its own scroll lock stripped a
+    // moment after it appears, and the page scrolls behind it.
+    expect(opened).not.toContain(SignContractTypeSelectComponent);
+
+    // Re-entry stays refused across that gap, asserted through the action rather than the signal
+    // behind it: a second Sign CLA here is what would start a parallel hand-off.
+    const openedBefore = opened.length;
+    (fixture.componentInstance as any).openSignDialog();
+    await fixture.whenStable();
+
+    expect(opened).toHaveLength(openedBefore);
+
+    identitySteps.destroy.next(undefined);
+    await fixture.whenStable();
+
+    expect(opened).toContain(SignContractTypeSelectComponent);
+  });
+
   it('stops rather than navigating when neither contract type is enabled', async () => {
     const fixture = await setup({
       organizations: [org('gerrit')],
@@ -1385,7 +1434,14 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
 
     expect(opened).not.toContain(SignContractTypeSelectComponent);
     expect(location.href).toBe(HOME);
-    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
+    // Asserted word for word. The contributor is being turned away at the last step before a
+    // signature, so the message has to say the group is misconfigured and who can fix it —
+    // a generic failure would read as a transient glitch worth retrying forever.
+    expect(messageAdd).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Could not start signing',
+      detail: 'This CLA group is not configured for individual or corporate signing from here. Contact the project CLA manager.',
+    });
   });
 
   // Blank and absent are one case, not two: the dialog trims before it builds the card, so a

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -224,12 +224,13 @@ describe('ProfileClasComponent', () => {
   });
 
   it('lets a long ECLA company name wrap inside a height-auto type pill', async () => {
-    await render([agreement({ id: 's-long', kind: 'ECLA', companyName: 'The Linux Foundation', pdfAvailable: false })]);
+    const longCompanyName = 'Example Employer With A Very Long Legal Name Corp.';
+    await render([agreement({ id: 's-long', kind: 'ECLA', companyName: longCompanyName, pdfAvailable: false })]);
 
     const badge = fixture.debugElement.query(By.css('[data-testid="agreement-type-s-long"]'));
     expect(badge).toBeTruthy();
     expect(badge.componentInstance).toBeInstanceOf(BadgeComponent);
-    expect(badge.componentInstance.value()).toBe('ECLA · The Linux Foundation');
+    expect(badge.componentInstance.value()).toBe(`ECLA · ${longCompanyName}`);
     expect(badge.componentInstance.styleClass()).toContain('!h-auto');
     expect(badge.componentInstance.styleClass()).toContain('!whitespace-normal');
   });

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -171,8 +171,10 @@ export interface ClaGroupOrg {
  * they decide the contract type and whether the contributor is asked for it (#2066). Every other
  * field is here so the picker can show which group this is and why it matched. Consumers MUST
  * ignore unknown fields rather than validate exhaustively, so the search can keep enriching this
- * without touching the hand-off — but the enablement flags are not that kind of field: dropping
- * them in a mapper reinstates #2066's silent default rather than degrading the display.
+ * without touching the hand-off — but the enablement flags are not that kind of field. Both absent
+ * reads as both disabled, which resolves to `none`, so a mapper that drops them makes every Gerrit
+ * hand-off fail with "Could not start signing" rather than degrading the display. That is the
+ * intended failure: #2066 was a wrong agreement signed silently, and stopping is the safer end.
  *
  * Both display names are optional because the producer omits each independently: `projectName`
  * when the group maps to several projects with no foundation marker, `claGroupName` when the
@@ -203,7 +205,9 @@ export interface ClaGroupOption {
  * (#1250) rather than inventing a third shape.
  *
  * Not a bare array: `truncated` describes the result *set*, so it cannot ride inside one of
- * the results. The hand-off still consumes only the selected option's `claGroupId`.
+ * the results. What the hand-off consumes from the selected option is described on
+ * `ClaGroupOption` — it is no longer `claGroupId` alone, since the Gerrit route also reads the
+ * enablement flags.
  */
 export interface ClaGroupSearchResponse {
   /** Echo of the term actually searched (trimmed). */

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -167,14 +167,15 @@ export interface ClaGroupOrg {
 /**
  * A CLA Group the contributor can choose to sign against (Sign CLA hand-off, #1251).
  *
- * The hand-off needs `claGroupId`, plus `iclaEnabled` / `cclaEnabled` on the Gerrit route, where
- * they decide the contract type and whether the contributor is asked for it (#2066). Every other
- * field is here so the picker can show which group this is and why it matched. Consumers MUST
- * ignore unknown fields rather than validate exhaustively, so the search can keep enriching this
- * without touching the hand-off — but the enablement flags are not that kind of field. Both absent
- * reads as both disabled, which resolves to `none`, so a mapper that drops them makes every Gerrit
- * hand-off fail with "Could not start signing" rather than degrading the display. That is the
- * intended failure: #2066 was a wrong agreement signed silently, and stopping is the safer end.
+ * The hand-off needs `claGroupId`, `organizations` to pick the GitHub / Gerrit / GitLab route,
+ * plus `iclaEnabled` / `cclaEnabled` on the Gerrit route, where they decide the contract type and
+ * whether the contributor is asked for it (#2066). Every other field is here so the picker can
+ * show which group this is and why it matched. Consumers MUST ignore unknown fields rather than
+ * validate exhaustively, so the search can keep enriching this without touching the hand-off —
+ * but those three are not that kind of field. Both enablement flags absent reads as both
+ * disabled, which resolves to `none`, so a mapper that drops them makes every Gerrit hand-off
+ * fail with "Could not start signing" rather than degrading the display. That is the intended
+ * failure: #2066 was a wrong agreement signed silently, and stopping is the safer end.
  *
  * Both display names are optional because the producer omits each independently: `projectName`
  * when the group maps to several projects with no foundation marker, `claGroupName` when the

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -172,10 +172,10 @@ export interface ClaGroupOrg {
  * whether the contributor is asked for it (#2066). Every other field is here so the picker can
  * show which group this is and why it matched. Consumers MUST ignore unknown fields rather than
  * validate exhaustively, so the search can keep enriching this without touching the hand-off —
- * but those three are not that kind of field. Both enablement flags absent reads as both
- * disabled, which resolves to `none`, so a mapper that drops them makes every Gerrit hand-off
- * fail with "Could not start signing" rather than degrading the display. That is the intended
- * failure: #2066 was a wrong agreement signed silently, and stopping is the safer end.
+ * but those three are not that kind of field. When both enablement flags are absent, that reads
+ * as both disabled and resolves to `none`, so a mapper that drops them makes every Gerrit
+ * hand-off fail with "Could not start signing" rather than degrading the display. That is the
+ * intended failure: #2066 was a wrong agreement signed silently, and stopping is the safer end.
  *
  * Both display names are optional because the producer omits each independently: `projectName`
  * when the group maps to several projects with no foundation marker, `claGroupName` when the


### PR DESCRIPTION
## Summary

Follow-up to [#2075 (Gerrit contract-type picker before Console hand-off)](https://github.com/linuxfoundation/lfx-self-serve/pull/2075), addressing the minor and nit items from @dealako's review, plus one test-fixture nit from @luismoriguerra on [#2068 (keep long ECLA type pills inside the badge)](https://github.com/linuxfoundation/lfx-self-serve/pull/2068). Tests and documentation only — no behaviour change.

## What changed

**The teardown guard was bypassable.** The dialog harness returned `of()` for both `onClose` and `onDestroy`, which collapses the distance the fix in #2075 depends on: the two are one event apart in PrimeNG but a whole leave animation apart in time, and the scroll lock is dropped at the end of it. A step reopened from `onClose` — the bug — passed as readily as one that waits. The identity step's two events now come from separate `Subject`s so the order is assertable.

Re-entry is asserted by attempting a second Sign CLA in the gap rather than by reading `signDialogOpen`, since refusing a parallel hand-off is what the gate exists for.

**The neither-enabled case now asserts the message word for word.** The contributor is being turned away at the last step before a signature, so the message has to name the misconfiguration and who can fix it. A bare severity check passes on a generic failure that reads as a transient glitch worth retrying.

**Two interface docs were inaccurate.** `ClaGroupOption` claimed that dropping the enablement flags reinstates the silent default — it does not. Both absent resolves to `none`, so every Gerrit hand-off fails closed with "Could not start signing" instead. That distinction matters to a future mapper author, who would otherwise read the old wording as permission to omit the flags and expect a degraded-but-working hand-off. `ClaGroupSearchResponse` still said the hand-off consumes only `claGroupId`.

**The long-ECLA wrap test no longer uses a real org name.** Luis's audit on #2068 flagged `The Linux Foundation` in the badge-wrap fixture; it now uses a synthetic long employer name so the test stays representative without naming a real company.

## Test plan

- [x] `./check-headers.sh && yarn format:check && yarn lint:check && yarn check-types`
- [x] `yarn workspace @lfx-one/shared test` — 1,326 pass
- [x] `yarn workspace lfx-one-ui test` — 2,431 pass
- [x] Mutation-checked the new guard: reverting `afterDialogTornDown` from `onDestroy` to `onClose` fails it, along with two existing contract-type tests. Restored and re-verified.
- [x] Long-ECLA wrap spec passes with the synthetic employer name

No DEV leg: nothing here is reachable from the UI.

Refs #2066