### PR TITLE
fix(cla): keep an identity selectable until every enabled CLA type is held

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -852,6 +852,17 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     // The group they picked, not their whole list: the step grays out identities, and an
     // agreement on a different CLA group says nothing about this one.
     expect(identityStepData()?.claGroupAgreements).toEqual([alreadyHeld]);
+    expect(identityStepData()?.iclaEnabled).toBe(true);
+    expect(identityStepData()?.cclaEnabled).toBe(false);
+  });
+
+  it('forwards the chosen group enablement flags into the identity step', async () => {
+    const fixture = await setup({ iclaEnabled: true, cclaEnabled: true });
+
+    await sign(fixture);
+
+    expect(identityStepData()?.iclaEnabled).toBe(true);
+    expect(identityStepData()?.cclaEnabled).toBe(true);
   });
 
   it('leaves the identity step nothing to gray out when the group is new to them', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -24,6 +24,7 @@ import type {
   PrepareSignResponse,
   SignIdentityDialogData,
   SignIdentitySelectResult,
+  SignContractTypeDialogData,
   SignContractTypeSelectResult,
 } from '@lfx-one/shared/interfaces';
 import { BadgeComponent } from '@components/badge/badge.component';
@@ -575,7 +576,10 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
   /** Records dialog opens in order, so "which dialog, and was it opened at all" is assertable. */
   let opened: unknown[];
   /** Records what each dialog was opened with, so the identity step's inputs are assertable. */
-  let openedWith: { component: unknown; config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData } }[];
+  let openedWith: {
+    component: unknown;
+    config: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData | SignContractTypeDialogData };
+  }[];
   /**
    * Manual control of the identity step's teardown, under `stepIdentityTeardown`.
    *
@@ -634,7 +638,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
       cclaEnabled: options.cclaEnabled ?? false,
     };
 
-    open = vi.fn((component: unknown, config?: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData }) => {
+    open = vi.fn((component: unknown, config?: { header?: string; data?: SignIdentityDialogData | ClaGroupSelectDialogData | SignContractTypeDialogData }) => {
       opened.push(component);
       openedWith.push({ component, config: config ?? {} });
       if (component === SignIdentitySelectComponent) {
@@ -1251,6 +1255,12 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
     return data && 'variant' in data ? data : undefined;
   }
 
+  /** What the contract-type step was actually served on the last open. */
+  function contractTypeStepData(): SignContractTypeDialogData | undefined {
+    const data = openedWith.filter((entry) => entry.component === SignContractTypeSelectComponent).at(-1)?.config.data;
+    return data && 'heldKinds' in data ? data : undefined;
+  }
+
   it('keeps a group with no linked organization on the GitHub path', async () => {
     // The regression this whole change is at risk of. An empty organization list means nothing
     // is linked or nothing resolved, not "not GitHub" — and these groups are signable today, so
@@ -1340,6 +1350,55 @@ describe('ProfileClasComponent — Sign CLA hand-off and identity selection (#12
 
     expect(opened).toContain(SignContractTypeSelectComponent);
     expect(location.href).toContain('/#/cla/gerrit/project/cg-1/individual');
+  });
+
+  it('tells the contract-type step which type the Gerrit identity already holds', async () => {
+    // The step is only reached because one type is still unsigned. Without this it offers the
+    // type they hold as freely as the one they need, which is the re-sign the gate prevents —
+    // and dropping the wiring would otherwise leave every test on both sides of it green.
+    const gerritIcla: MyClaAgreement = {
+      id: 's1',
+      kind: 'ICLA',
+      claGroupName: 'Venus',
+      claGroupId: CLA_GROUP.claGroupId,
+      signedOn: '2022-01-01',
+      status: 'valid',
+      pdfAvailable: true,
+      signedVia: 'gerrit',
+      signedAs: 'jellis-lf',
+    };
+    // A different group, and a GitHub agreement on this one: neither says anything about what
+    // this Gerrit identity holds here, so a matcher pointed at the wrong thing fails here.
+    const otherGroup: MyClaAgreement = { ...gerritIcla, id: 's2', kind: 'ECLA', claGroupId: 'cg-other', pdfAvailable: false };
+    const viaGithub: MyClaAgreement = { ...gerritIcla, id: 's3', kind: 'ECLA', signedVia: 'github', signedAs: 'jellis', pdfAvailable: false };
+
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+      contractTypeClosesWith: { contractType: 'corporate' },
+      agreements: [gerritIcla, otherGroup, viaGithub],
+    });
+
+    await sign(fixture);
+
+    expect(contractTypeStepData()?.heldKinds).toEqual(['ICLA']);
+    expect(location.href).toContain('/#/cla/gerrit/project/cg-1/corporate');
+  });
+
+  it('leaves the contract-type step nothing to disable when the identity holds nothing', async () => {
+    const fixture = await setup({
+      organizations: [org('gerrit')],
+      iclaEnabled: true,
+      cclaEnabled: true,
+      accountClosesWith: { kind: 'gerrit' },
+      agreements: [],
+    });
+
+    await sign(fixture);
+
+    expect(contractTypeStepData()?.heldKinds).toEqual([]);
   });
 
   it('hands off at corporate when only CCLA is enabled', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -343,14 +343,16 @@ export class ProfileClasComponent {
     this.starting.set(false);
     this.signDialogOpen.set(true);
 
-    // What they already hold for *this* group, so the step can gray out the identity that signed
-    // it. Passed as agreements rather than a precomputed verdict because only the step knows
-    // which identities it ended up offering.
+    // What they already hold for *this* group, plus which types the group enables, so the step
+    // can gray out an identity with nothing left to sign. Passed as agreements rather than a
+    // precomputed verdict because only the step knows which identities it ended up offering.
     const claGroupAgreements = alreadySignedAgreementsForGroup(this.agreements(), option.claGroupId);
 
     const data: SignIdentityDialogData = {
       variant: effectiveVariant,
       accounts,
+      iclaEnabled: option.iclaEnabled === true,
+      cclaEnabled: option.cclaEnabled === true,
       ...(gerritUsername ? { gerritUsername } : {}),
       ...(claGroupAgreements.length > 0 ? { claGroupAgreements } : {}),
     };

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -23,6 +23,7 @@ import type {
   MyClaAgreement,
   MyClasState,
   PrepareSignResponse,
+  SignContractTypeDialogData,
   SignContractTypeSelectResult,
   SignIdentityDialogData,
   SignIdentitySelectResult,
@@ -36,6 +37,7 @@ import {
   downloadFromUrl,
   formatClaSignedOn,
   gerritSignUrl,
+  heldClaKindsForIdentity,
   isMyClasEmpty,
   resolveGerritContractType,
   signedAsLine,
@@ -443,15 +445,24 @@ export class ProfileClasComponent {
 
     this.signDialogOpen.set(true);
 
-    // No data: the step renders both cards unconditionally, and it is only reachable for a group
-    // that enables both. Passing the flags it would have to ignore invites a later caller to open
-    // it for a single-type group, which is the hand-off this branch exists to make without asking.
+    // The group's own flags are not passed: the step is only reachable for a group that enables
+    // both, so it would have to ignore them, and a later caller could read them as licence to
+    // open it for a single-type group — the hand-off this branch makes without asking.
+    //
+    // What it does get is the types this Gerrit identity already holds. The identity step passed
+    // them because one type is still unsigned, and without this the step would offer the type
+    // they hold as freely as the one they need, which is the re-sign that gate prevents.
+    const data: SignContractTypeDialogData = {
+      heldKinds: heldClaKindsForIdentity(alreadySignedAgreementsForGroup(this.agreements(), option.claGroupId), { platform: 'gerrit' }, []),
+    };
+
     const dialogRef = this.dialogService.open(SignContractTypeSelectComponent, {
       header: SIGN_CONTRACT_TYPE_COPY.header,
       width: '32rem',
       modal: true,
       closable: true,
       dismissableMask: true,
+      data,
     }) as DynamicDialogRef;
 
     this.whenDialogSettles<SignContractTypeSelectResult>(dialogRef, (result) => {

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.html
@@ -18,6 +18,8 @@ SPDX-License-Identifier: MIT
         control="contractType"
         [value]="individualValue"
         [label]="copy.individual.label"
+        [disabled]="individualHeld"
+        [disabledReason]="individualHeld ? copy.alreadyHeld : ''"
         describedBy="sign-contract-type-select-individual-description"
         testId="sign-contract-type-select-individual" />
       <p id="sign-contract-type-select-individual-description" class="pl-1 text-xs leading-relaxed text-slate-500">
@@ -31,6 +33,8 @@ SPDX-License-Identifier: MIT
         control="contractType"
         [value]="corporateValue"
         [label]="copy.corporate.label"
+        [disabled]="corporateHeld"
+        [disabledReason]="corporateHeld ? copy.alreadyHeld : ''"
         describedBy="sign-contract-type-select-corporate-description"
         testId="sign-contract-type-select-corporate" />
       <p id="sign-contract-type-select-corporate-description" class="pl-1 text-xs leading-relaxed text-slate-500">

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
@@ -5,7 +5,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { SIGN_CONTRACT_TYPE_COPY } from '@lfx-one/shared/constants';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import type { ClaKind } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SignContractTypeSelectComponent } from './sign-contract-type-select.component';
@@ -22,13 +23,18 @@ describe('SignContractTypeSelectComponent', () => {
   let close: ReturnType<typeof vi.fn>;
   let fixture: ComponentFixture<SignContractTypeSelectComponent>;
 
-  async function setup(): Promise<void> {
+  async function setup(heldKinds: readonly ClaKind[] = []): Promise<void> {
     TestBed.resetTestingModule();
     close = vi.fn();
 
     TestBed.configureTestingModule({
       imports: [SignContractTypeSelectComponent],
-      providers: [provideRouter([]), provideNoopAnimations(), { provide: DynamicDialogRef, useValue: { close } }],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: { heldKinds } } },
+      ],
     });
 
     fixture = TestBed.createComponent(SignContractTypeSelectComponent);
@@ -122,5 +128,49 @@ describe('SignContractTypeSelectComponent', () => {
     (fixture.componentInstance as any).onCancel();
 
     expect(close).toHaveBeenCalledWith(null);
+  });
+
+  describe('a type the identity already holds', () => {
+    // The identity step lets a contributor this far precisely because one type is still unsigned.
+    // Offering the type they already hold as freely as the one they need would hand back the
+    // redundant signing ceremony the identity gate exists to prevent.
+
+    it('offers a held ICLA as held, and leaves the corporate route open', async () => {
+      await setup(['ICLA']);
+
+      expect(query('sign-contract-type-select-individual')?.getAttribute('aria-disabled')).toBe('true');
+      expect(query('sign-contract-type-select-corporate')?.getAttribute('aria-disabled')).not.toBe('true');
+      expect(fixture.nativeElement.textContent).toContain(SIGN_CONTRACT_TYPE_COPY.alreadyHeld);
+    });
+
+    it('offers a held ECLA as held, and leaves the individual route open', async () => {
+      await setup(['ECLA']);
+
+      expect(query('sign-contract-type-select-corporate')?.getAttribute('aria-disabled')).toBe('true');
+      expect(query('sign-contract-type-select-individual')?.getAttribute('aria-disabled')).not.toBe('true');
+    });
+
+    it('refuses to close on the held type even if its card is reached', async () => {
+      await setup(['ICLA']);
+      await choose('sign-contract-type-select-individual');
+      continueToSign();
+
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    it('still closes on the type that is left to sign', async () => {
+      await setup(['ICLA']);
+      await choose('sign-contract-type-select-corporate');
+      continueToSign();
+
+      expect(close).toHaveBeenCalledWith({ contractType: 'corporate' });
+    });
+
+    it('disables neither card when the identity holds nothing', async () => {
+      await setup([]);
+
+      expect(query('sign-contract-type-select-individual')?.getAttribute('aria-disabled')).not.toBe('true');
+      expect(query('sign-contract-type-select-corporate')?.getAttribute('aria-disabled')).not.toBe('true');
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.spec.ts
@@ -18,6 +18,8 @@ import { SignContractTypeSelectComponent } from './sign-contract-type-select.com
  * segment the hand-off uses. The two are joined only by a template `[value]`, and getting them
  * the wrong way round would send a contributor who chose "Individual Contributor" to sign a
  * corporate agreement — so the choice is always made by clicking, never by writing to the form.
+ * The single exception is the held-type submit guard, which exists for the case where something
+ * other than a click supplied the value, and so cannot be reached by clicking.
  */
 describe('SignContractTypeSelectComponent', () => {
   let close: ReturnType<typeof vi.fn>;
@@ -55,6 +57,15 @@ describe('SignContractTypeSelectComponent', () => {
 
   function continueToSign(): void {
     (fixture.componentInstance as any).onContinue();
+  }
+
+  /**
+   * Writes the form the way nothing in the UI does — the deliberate exception to the rule above,
+   * used only to reach the submit path with the cards bypassed.
+   */
+  function preselect(contractType: 'individual' | 'corporate'): void {
+    (fixture.componentInstance as any).selectForm.controls.contractType.setValue(contractType);
+    fixture.detectChanges();
   }
 
   beforeEach(async () => {
@@ -150,9 +161,22 @@ describe('SignContractTypeSelectComponent', () => {
       expect(query('sign-contract-type-select-individual')?.getAttribute('aria-disabled')).not.toBe('true');
     });
 
-    it('refuses to close on the held type even if its card is reached', async () => {
+    it('refuses the click on the held card, so the form never takes that type', async () => {
       await setup(['ICLA']);
       await choose('sign-contract-type-select-individual');
+
+      expect((fixture.componentInstance as any).selectedType()).toBeNull();
+      continueToSign();
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    it('refuses to submit the held type even when the form is written another way', async () => {
+      // The one place the form is written directly, and only to prove the click is not the only
+      // thing standing between a held type and the hand-off. A preselection or a form patch
+      // reaches `onContinue` with the disabled card never involved, which is why the guard is on
+      // the submit path too rather than on the card alone.
+      await setup(['ICLA']);
+      preselect('individual');
       continueToSign();
 
       expect(close).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
@@ -5,8 +5,8 @@ import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/cor
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { GERRIT_CONTRACT_TYPE_CORPORATE, GERRIT_CONTRACT_TYPE_INDIVIDUAL, SIGN_CONTRACT_TYPE_COPY } from '@lfx-one/shared/constants';
-import type { GerritContractType, SignContractTypeSelectResult } from '@lfx-one/shared/interfaces';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import type { GerritContractType, SignContractTypeDialogData, SignContractTypeSelectResult } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
@@ -21,6 +21,11 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
  * type enabled never reaches here — the caller resolves that type and hands off without asking —
  * so a flag on this dialog could only ever say "both", and a dialog that could render one card is
  * one that could render none.
+ *
+ * A type the confirmed identity already holds is disabled rather than dropped. The identity step
+ * only lets them this far because one type is still unsigned, so removing the other would leave
+ * a step that asks a question with one answer, and never say why the other went. Both disabled
+ * cannot happen: that identity is grayed a step earlier.
  */
 @Component({
   selector: 'lfx-sign-contract-type-select',
@@ -30,10 +35,15 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
 })
 export class SignContractTypeSelectComponent {
   private readonly ref = inject(DynamicDialogRef);
+  private readonly config = inject<DynamicDialogConfig<SignContractTypeDialogData>>(DynamicDialogConfig);
 
   protected readonly copy = SIGN_CONTRACT_TYPE_COPY;
   protected readonly individualValue = GERRIT_CONTRACT_TYPE_INDIVIDUAL;
   protected readonly corporateValue = GERRIT_CONTRACT_TYPE_CORPORATE;
+
+  private readonly heldKinds = this.config.data?.heldKinds ?? [];
+  protected readonly individualHeld = this.heldKinds.includes('ICLA');
+  protected readonly corporateHeld = this.heldKinds.includes('ECLA');
 
   protected readonly selectForm = new FormGroup({
     contractType: new FormControl<GerritContractType | null>(null),

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-contract-type-select.component.ts
@@ -57,12 +57,22 @@ export class SignContractTypeSelectComponent {
 
   protected onContinue(): void {
     const contractType = this.selectedType();
-    if (!contractType) return;
+    if (!contractType || this.isHeld(contractType)) return;
 
     this.ref.close({ contractType } satisfies SignContractTypeSelectResult);
   }
 
   protected onCancel(): void {
     this.ref.close(null);
+  }
+
+  /**
+   * Whether the confirmed identity already holds this type. The disabled card refuses the click,
+   * so reaching here means the control was written some other way — a preselection, a form patch
+   * — and closing on it would hand off the re-sign the step exists to prevent. The identity step
+   * re-checks its own verdict on submit for the same reason.
+   */
+  private isHeld(contractType: GerritContractType): boolean {
+    return contractType === this.individualValue ? this.individualHeld : this.corporateHeld;
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -283,16 +283,33 @@ describe('SignIdentitySelectComponent', () => {
   // --- Identities that already signed this CLA group (#1914) -----------------
 
   describe('already signed', () => {
-    function signedAs(signedAs: string, signedVia: 'github' | 'gerrit' = 'github'): MyClaAgreement[] {
+    function signedAs(signedAs: string, signedVia: 'github' | 'gerrit' = 'github', kind: MyClaAgreement['kind'] = 'ICLA'): MyClaAgreement[] {
       return [
-        { id: 's1', kind: 'ICLA', claGroupName: 'Venus', claGroupId: 'cg-1', signedOn: '2022-01-01', status: 'valid', pdfAvailable: true, signedVia, signedAs },
+        {
+          id: 's1',
+          kind,
+          claGroupName: 'Venus',
+          claGroupId: 'cg-1',
+          signedOn: '2022-01-01',
+          status: 'valid',
+          pdfAvailable: kind === 'ICLA',
+          signedVia,
+          signedAs,
+        },
       ];
     }
 
+    function signedBoth(handle: string, signedVia: 'github' | 'gerrit' = 'github'): MyClaAgreement[] {
+      return [...signedAs(handle, signedVia, 'ICLA'), { ...signedAs(handle, signedVia, 'ECLA')[0]!, id: 's2' }];
+    }
+
+    const ICLA_ONLY = { iclaEnabled: true, cclaEnabled: false };
+    const BOTH_TYPES = { iclaEnabled: true, cclaEnabled: true };
     const REASON = 'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.';
+    const BOTH_REASON = 'You already have an ICLA and an ECLA for this CLA group signed with this account. Choose another identity to sign again.';
 
     it('grays out the account that already signed, and only that account', async () => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
       expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
@@ -301,7 +318,7 @@ describe('SignIdentitySelectComponent', () => {
     it('grays the account the producer recorded by number rather than handle', async () => {
       // Agreements carry one identity string, which is the account number when no handle was
       // recorded. Matching only the handle would leave the account that signed selectable.
-      await setup({ claGroupAgreements: signedAs('12345') });
+      await setup({ claGroupAgreements: signedAs('12345'), ...ICLA_ONLY });
 
       expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
       expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
@@ -317,6 +334,7 @@ describe('SignIdentitySelectComponent', () => {
           { githubId: '12345', githubUsername: 'jellis' },
         ],
         claGroupAgreements: signedAs('12345'),
+        ...ICLA_ONLY,
       });
 
       expect(query('sign-identity-select-github-18281050')?.getAttribute('aria-disabled')).toBe('true');
@@ -324,7 +342,7 @@ describe('SignIdentitySelectComponent', () => {
     });
 
     it('says why, in the tooltip and to assistive tech', async () => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       const card = fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]'));
       expect(card.injector.get(Tooltip, null)?.content).toBe(REASON);
@@ -335,7 +353,7 @@ describe('SignIdentitySelectComponent', () => {
     });
 
     it('keeps the grayed card reachable, so the reason is not hover-only', async () => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       // Removing it from the tab order would leave a keyboard-only contributor with no way to
       // ask why the account is unavailable — the tooltip also answers to focus, not just hover.
@@ -348,7 +366,7 @@ describe('SignIdentitySelectComponent', () => {
       ['Enter', 'Enter'],
       ['Space', ' '],
     ])('refuses the %s key on the grayed card', async (_label, key) => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       // Keeping the card focusable put Enter/Space on a live path: the only thing that stops it
       // selecting the account is the card's own disabled guard, so assert the key leaves the
@@ -371,7 +389,7 @@ describe('SignIdentitySelectComponent', () => {
     });
 
     it('still selects a card that has not signed, from the keyboard', async () => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       // The mirror of the refusal above. Without it, deleting the card's (keydown) binding would
       // leave that test green — nothing else here proves a dispatched key reaches the handler.
@@ -385,7 +403,7 @@ describe('SignIdentitySelectComponent', () => {
     });
 
     it('refuses to submit it even if the card is reached another way', async () => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       // Clicking a grayed card is refused by the card itself, which leaves the control unwritten
       // and never reaches the guard this test is named for. Writing the control directly is the
@@ -399,7 +417,7 @@ describe('SignIdentitySelectComponent', () => {
     });
 
     it('still lets them sign with their other account', async () => {
-      await setup({ claGroupAgreements: signedAs('octocat') });
+      await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       await choose('sign-identity-select-github-67890');
       (fixture.componentInstance as any).onContinue();
@@ -408,7 +426,7 @@ describe('SignIdentitySelectComponent', () => {
     });
 
     it('grays out the Gerrit card when the group was signed under the LF identity', async () => {
-      await setup({ variant: 'github-or-gerrit', gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit') });
+      await setup({ variant: 'github-or-gerrit', gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit'), ...ICLA_ONLY });
 
       expect(query('sign-identity-select-gerrit')?.getAttribute('aria-disabled')).toBe('true');
       // A Gerrit signature says nothing about their GitHub accounts.
@@ -425,7 +443,7 @@ describe('SignIdentitySelectComponent', () => {
     it('tells them to choose another identity only when one is left to choose', async () => {
       // A Gerrit-only step offers exactly one card. Once it is grayed there is nothing else to
       // pick, so prescribing a way out would name the one thing they cannot do.
-      await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit') });
+      await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit'), ...ICLA_ONLY });
 
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-gerrit"]')).injector.get(Tooltip, null)?.content).toBe(
         'You already have an ICLA for this CLA group signed with this account.'
@@ -436,10 +454,39 @@ describe('SignIdentitySelectComponent', () => {
       // The most common dead-end this change set out to remove: one account, already signed,
       // nothing else on the step. The false branch of `anotherSelectable` has to be wired through
       // initAccounts, not only through the Gerrit call site.
-      await setup({ accounts: [OCTOCAT], claGroupAgreements: signedAs('octocat') });
+      await setup({ accounts: [OCTOCAT], claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
 
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(
         'You already have an ICLA for this CLA group signed with this account.'
+      );
+    });
+
+    it('leaves a dual-type GitHub identity selectable when only an ICLA is held', async () => {
+      await setup({ claGroupAgreements: signedAs('octocat'), ...BOTH_TYPES });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('false');
+      expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('leaves a dual-type Gerrit identity selectable when only an ICLA is held', async () => {
+      await setup({ variant: 'github-or-gerrit', gerritUsername: GERRIT_USER, claGroupAgreements: signedAs('jdoe', 'gerrit'), ...BOTH_TYPES });
+
+      expect(query('sign-identity-select-gerrit')?.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('grays a dual-type GitHub identity once both kinds are held, and names both in the reason', async () => {
+      await setup({ claGroupAgreements: signedBoth('octocat'), ...BOTH_TYPES });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
+      expect(query('sign-identity-select-github-67890')?.getAttribute('aria-disabled')).toBe('false');
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(BOTH_REASON);
+    });
+
+    it('still drops the other-identity sentence when both kinds are held and nothing else is selectable', async () => {
+      await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedBoth('jdoe', 'gerrit'), ...BOTH_TYPES });
+
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-gerrit"]')).injector.get(Tooltip, null)?.content).toBe(
+        'You already have an ICLA and an ECLA for this CLA group signed with this account.'
       );
     });
   });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -482,14 +482,26 @@ describe('SignIdentitySelectComponent', () => {
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(BOTH_REASON);
     });
 
-    it('names what the identity holds, not what the group enables', async () => {
-      // An identity can hold a type the group has since stopped offering. The block is owed to
-      // the ICLA alone, but the contributor holds both, and a reason drawn from the enabled flags
-      // would tell them they hold only the one — about their own agreements, which they can check.
+    it('names only the type the block is owed to when the group has dropped the other', async () => {
+      // An identity can hold a type the group has since stopped offering. The graying is owed to
+      // the ICLA alone, so naming the ECLA too would explain it with an agreement that has
+      // nothing to do with it — the group cannot be signed for one either way.
       await setup({ claGroupAgreements: signedBoth('octocat'), ...ICLA_ONLY });
 
       expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
-      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(BOTH_REASON);
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(REASON);
+    });
+
+    it('names the kind actually held when the group enables neither type', async () => {
+      // The kind-blind fallback blocks on the match alone, so there is no offered kind to narrow
+      // to. Naming nothing would leave the tooltip reading "an ICLA" by default — which for an
+      // ECLA holder is a statement about their agreements that is simply untrue.
+      await setup({ claGroupAgreements: signedAs('octocat', 'github', 'ECLA'), iclaEnabled: false, cclaEnabled: false });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(
+        'You already have an ECLA for this CLA group signed with this account. Choose another identity to sign again.'
+      );
     });
 
     it('still drops the other-identity sentence when both kinds are held and nothing else is selectable', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -482,6 +482,16 @@ describe('SignIdentitySelectComponent', () => {
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(BOTH_REASON);
     });
 
+    it('names what the identity holds, not what the group enables', async () => {
+      // An identity can hold a type the group has since stopped offering. The block is owed to
+      // the ICLA alone, but the contributor holds both, and a reason drawn from the enabled flags
+      // would tell them they hold only the one — about their own agreements, which they can check.
+      await setup({ claGroupAgreements: signedBoth('octocat'), ...ICLA_ONLY });
+
+      expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
+      expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(BOTH_REASON);
+    });
+
     it('still drops the other-identity sentence when both kinds are held and nothing else is selectable', async () => {
       await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedBoth('jdoe', 'gerrit'), ...BOTH_TYPES });
 

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -204,13 +204,29 @@ export class SignIdentitySelectComponent {
     // that happens to be all digits.
     const offeredHandles = accounts.map((account) => account.githubUsername);
 
-    // The gate says whether the card is blocked; the held set says what to call it. Asking the
-    // same matcher twice keeps the reason describing this identity rather than the group.
+    const enabledKinds: readonly ClaKind[] = [...(enabled.iclaEnabled ? (['ICLA'] as const) : []), ...(enabled.cclaEnabled ? (['ECLA'] as const) : [])];
+
+    /**
+     * The gate says whether the card is blocked; these say what to call it.
+     *
+     * Drawn from the gate's own matcher rather than from the enablement flags, so the reason
+     * describes this identity's agreements instead of standing on the gate's rule holding. Then
+     * narrowed to the types the group still offers, because those are the ones the block is owed
+     * to — an identity holding a type the group has since dropped is not blocked by that type,
+     * and naming it would explain the graying with an agreement that has nothing to do with it.
+     *
+     * The narrowing is dropped when the group offers nothing, which is the gate's kind-blind
+     * fallback: there the match itself is the whole reason, and an empty list would leave the
+     * tooltip naming a type by default rather than the one actually held.
+     */
     const blockFor = (identity: SignIdentityRef): IdentityBlock | undefined => {
       const agreement = alreadySignedAgreementForIdentity(agreements, identity, offeredHandles, enabled);
       if (!agreement) return undefined;
 
-      return { agreement, heldKinds: heldClaKindsForIdentity(agreements, identity, offeredHandles) };
+      const held = heldClaKindsForIdentity(agreements, identity, offeredHandles);
+      const offered = held.filter((kind) => enabledKinds.includes(kind));
+
+      return { agreement, heldKinds: offered.length > 0 ? offered : held };
     };
 
     const byGithubId = new Map<string, IdentityBlock>();

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -5,12 +5,32 @@ import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { GERRIT_IDENTITY_VALUE, SIGN_IDENTITY_COPY, SIGN_IDENTITY_PLATFORM_LABELS } from '@lfx-one/shared/constants';
-import type { ClaKind, GithubAccountChoice, MyClaAgreement, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
-import { alreadySignedAgreementForIdentity, alreadySignedIdentityTooltip } from '@lfx-one/shared/utils';
+import type {
+  ClaGroupEnablement,
+  ClaKind,
+  GithubAccountChoice,
+  MyClaAgreement,
+  SignIdentityDialogData,
+  SignIdentityRef,
+  SignIdentitySelectResult,
+} from '@lfx-one/shared/interfaces';
+import { alreadySignedAgreementForIdentity, alreadySignedIdentityTooltip, heldClaKindsForIdentity } from '@lfx-one/shared/utils';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
+
+/**
+ * Why one card cannot sign: the agreement that blocked it, and everything that identity holds.
+ *
+ * Two answers rather than one because the blocking agreement is a single record, while the
+ * reason shown has to name every type held — a card blocked for holding both would otherwise be
+ * explained by whichever of the two happened to be newest.
+ */
+interface IdentityBlock {
+  agreement: MyClaAgreement;
+  heldKinds: readonly ClaKind[];
+}
 
 /**
  * "Which identity are you signing as?" step, shown between the CLA-group picker and the Console
@@ -171,11 +191,11 @@ export class SignIdentitySelectComponent {
    * offered identity is still selectable. A Gerrit card counts as offered on the same test
    * `initGerritLabel` uses, so the two cannot disagree about whether it is on the step at all.
    */
-  private resolveAlreadySigned(): { byGithubId: Map<string, MyClaAgreement>; gerrit: MyClaAgreement | undefined; anotherSelectable: boolean } {
+  private resolveAlreadySigned(): { byGithubId: Map<string, IdentityBlock>; gerrit: IdentityBlock | undefined; anotherSelectable: boolean } {
     const agreements = this.config.data?.claGroupAgreements ?? [];
     const accounts = this.config.data?.accounts ?? [];
     const gerritOffered = !!this.config.data?.gerritUsername?.trim();
-    const enabled = {
+    const enabled: ClaGroupEnablement = {
       iclaEnabled: this.config.data?.iclaEnabled === true,
       cclaEnabled: this.config.data?.cclaEnabled === true,
     };
@@ -184,14 +204,22 @@ export class SignIdentitySelectComponent {
     // that happens to be all digits.
     const offeredHandles = accounts.map((account) => account.githubUsername);
 
-    const byGithubId = new Map<string, MyClaAgreement>();
+    // The gate says whether the card is blocked; the held set says what to call it. Asking the
+    // same matcher twice keeps the reason describing this identity rather than the group.
+    const blockFor = (identity: SignIdentityRef): IdentityBlock | undefined => {
+      const agreement = alreadySignedAgreementForIdentity(agreements, identity, offeredHandles, enabled);
+      if (!agreement) return undefined;
+
+      return { agreement, heldKinds: heldClaKindsForIdentity(agreements, identity, offeredHandles) };
+    };
+
+    const byGithubId = new Map<string, IdentityBlock>();
     for (const account of accounts) {
-      const identity = { platform: 'github', username: account.githubUsername, githubId: account.githubId } as const;
-      const held = alreadySignedAgreementForIdentity(agreements, identity, offeredHandles, enabled);
+      const held = blockFor({ platform: 'github', username: account.githubUsername, githubId: account.githubId });
       if (held) byGithubId.set(account.githubId, held);
     }
 
-    const gerrit = gerritOffered ? alreadySignedAgreementForIdentity(agreements, { platform: 'gerrit' }, offeredHandles, enabled) : undefined;
+    const gerrit = gerritOffered ? blockFor({ platform: 'gerrit' }) : undefined;
     const selectable = accounts.filter((account) => !byGithubId.has(account.githubId)).length + (gerritOffered && !gerrit ? 1 : 0);
 
     return { byGithubId, gerrit, anotherSelectable: selectable > 0 };
@@ -232,10 +260,8 @@ export class SignIdentitySelectComponent {
     return held ? this.identityTooltip(held) : undefined;
   }
 
-  private identityTooltip(held: MyClaAgreement): string {
-    const namesBoth = this.config.data?.iclaEnabled === true && this.config.data?.cclaEnabled === true;
-    const heldKinds: readonly ClaKind[] = namesBoth ? ['ICLA', 'ECLA'] : [held.kind];
-    return alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable, heldKinds);
+  private identityTooltip(held: IdentityBlock): string {
+    return alreadySignedIdentityTooltip(held.agreement, this.alreadySigned.anotherSelectable, held.heldKinds);
   }
 
   /** Suffixes the platform on a mixed list only; a single-source list needs no disambiguation. */

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { GERRIT_IDENTITY_VALUE, SIGN_IDENTITY_COPY, SIGN_IDENTITY_PLATFORM_LABELS } from '@lfx-one/shared/constants';
-import type { GithubAccountChoice, MyClaAgreement, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
+import type { ClaKind, GithubAccountChoice, MyClaAgreement, SignIdentityDialogData, SignIdentitySelectResult } from '@lfx-one/shared/interfaces';
 import { alreadySignedAgreementForIdentity, alreadySignedIdentityTooltip } from '@lfx-one/shared/utils';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -60,10 +60,12 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
  *
  * ## Identities that have already signed
  *
- * An identity already on an agreement for this CLA group is grayed out with the reason (#1914).
- * This is the step that refuses, rather than the CLA-group picker before it: a contributor with
- * two linked accounts who signed under one of them can still sign under the other, so refusing
- * the whole group would deny a signature they are entitled to give. The group is only tagged.
+ * An identity that already holds every contract type the CLA group enables is grayed out with
+ * the reason (#1914). This is the step that refuses, rather than the CLA-group picker before
+ * it: a contributor with two linked accounts who signed under one of them can still sign under
+ * the other, and a contributor who holds only an ICLA on a group that also offers an ECLA can
+ * still sign the ECLA under the same identity. Refusing the whole group would deny a signature
+ * they are entitled to give. The group is only tagged.
  *
  * Refusing here is a courtesy, not a guarantee — EasyCLA reuses an existing signature rather
  * than duplicating it, so what this prevents is a contributor being walked through a ceremony
@@ -98,8 +100,8 @@ export class SignIdentitySelectComponent {
   protected readonly copy = SIGN_IDENTITY_COPY[this.config.data?.variant ?? 'github'];
 
   /**
-   * Which of the offered identities already hold a CLA for this group, resolved in one pass
-   * before any copy is written. The refusal message names another identity only when one is
+   * Which of the offered identities have no enabled contract type left to sign, resolved in one
+   * pass before any copy is written. The refusal message names another identity only when one is
    * genuinely selectable, so how many are left has to be known before the tooltips exist — and
    * resolving it once keeps the two cards' verdicts from coming from separate evaluations.
    */
@@ -122,8 +124,8 @@ export class SignIdentitySelectComponent {
   protected readonly gerritLabel = signal<string | null>(this.initGerritLabel());
 
   /**
-   * Why the Gerrit card cannot sign, when the contributor already signed this group under their
-   * LF identity (#1914). Undefined ⇒ selectable.
+   * Why the Gerrit card cannot sign, when the contributor already holds every enabled type for
+   * this group under their LF identity (#1914). Undefined ⇒ selectable.
    */
   protected readonly gerritAlreadySignedTooltip = signal<string | undefined>(this.initGerritAlreadySignedTooltip());
 
@@ -158,7 +160,7 @@ export class SignIdentitySelectComponent {
     this.ref.close({ linkAccounts: true } satisfies SignIdentitySelectResult);
   }
 
-  /** Whether the chosen card is one the contributor has already signed this group with. */
+  /** Whether the chosen card is one with no enabled contract type left to sign. */
   private isAlreadySigned(identityValue: string): boolean {
     if (identityValue === GERRIT_IDENTITY_VALUE) return !!this.gerritAlreadySignedTooltip();
     return this.accounts().some((account) => account.githubId === identityValue && !!account.alreadySignedTooltip);
@@ -173,6 +175,10 @@ export class SignIdentitySelectComponent {
     const agreements = this.config.data?.claGroupAgreements ?? [];
     const accounts = this.config.data?.accounts ?? [];
     const gerritOffered = !!this.config.data?.gerritUsername?.trim();
+    const enabled = {
+      iclaEnabled: this.config.data?.iclaEnabled === true,
+      cclaEnabled: this.config.data?.cclaEnabled === true,
+    };
 
     // Every handle on the step, so the matcher can tell a recorded account number from a handle
     // that happens to be all digits.
@@ -181,11 +187,11 @@ export class SignIdentitySelectComponent {
     const byGithubId = new Map<string, MyClaAgreement>();
     for (const account of accounts) {
       const identity = { platform: 'github', username: account.githubUsername, githubId: account.githubId } as const;
-      const held = alreadySignedAgreementForIdentity(agreements, identity, offeredHandles);
+      const held = alreadySignedAgreementForIdentity(agreements, identity, offeredHandles, enabled);
       if (held) byGithubId.set(account.githubId, held);
     }
 
-    const gerrit = gerritOffered ? alreadySignedAgreementForIdentity(agreements, { platform: 'gerrit' }, offeredHandles) : undefined;
+    const gerrit = gerritOffered ? alreadySignedAgreementForIdentity(agreements, { platform: 'gerrit' }, offeredHandles, enabled) : undefined;
     const selectable = accounts.filter((account) => !byGithubId.has(account.githubId)).length + (gerritOffered && !gerrit ? 1 : 0);
 
     return { byGithubId, gerrit, anotherSelectable: selectable > 0 };
@@ -198,7 +204,7 @@ export class SignIdentitySelectComponent {
       return {
         ...account,
         label: account.githubUsername ? this.withPlatform(account.githubUsername, SIGN_IDENTITY_PLATFORM_LABELS.github) : `GitHub account ${account.githubId}`,
-        ...(held ? { alreadySignedTooltip: alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable) } : {}),
+        ...(held ? { alreadySignedTooltip: this.identityTooltip(held) } : {}),
       };
     });
   }
@@ -223,7 +229,13 @@ export class SignIdentitySelectComponent {
     if (!this.gerritLabel()) return undefined;
 
     const held = this.alreadySigned.gerrit;
-    return held ? alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable) : undefined;
+    return held ? this.identityTooltip(held) : undefined;
+  }
+
+  private identityTooltip(held: MyClaAgreement): string {
+    const namesBoth = this.config.data?.iclaEnabled === true && this.config.data?.cclaEnabled === true;
+    const heldKinds: readonly ClaKind[] = namesBoth ? ['ICLA', 'ECLA'] : [held.kind];
+    return alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable, heldKinds);
   }
 
   /** Suffixes the platform on a mixed list only; a single-source list needs no disambiguation. */

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.ts
@@ -21,16 +21,20 @@ import { ButtonComponent } from '@components/button/button.component';
 import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
 
 /**
- * Why one card cannot sign: the agreement that blocked it, and everything that identity holds.
+ * The agreement that blocks a card, carrying the types to name in the reason.
  *
- * Two answers rather than one because the blocking agreement is a single record, while the
- * reason shown has to name every type held — a card blocked for holding both would otherwise be
- * explained by whichever of the two happened to be newest.
+ * The kinds ride along rather than being re-derived at the tooltip, because a card blocked for
+ * holding both types has to name both, and the blocking agreement is one record — reading the
+ * kind off it would leave whichever happened to be newest standing for the pair.
+ *
+ * A local intersection rather than a `@lfx-one/shared` interface: this is the component's own
+ * view model, consumed by nothing else, so it is not part of any contract between the tiers. It
+ * is also the one form both repo rules allow — CLAUDE.md prohibits a local `interface Foo {}`
+ * inside `apps/lfx-one/`, while ESLint's `@typescript-eslint/consistent-type-definitions`
+ * rewrites a plain `type X = { … }` back into an interface on `--fix`. Same standoff as
+ * `PlatformResultRow` in the campaigns implementation tab.
  */
-interface IdentityBlock {
-  agreement: MyClaAgreement;
-  heldKinds: readonly ClaKind[];
-}
+type IdentityBlock = MyClaAgreement & { heldKinds: readonly ClaKind[] };
 
 /**
  * "Which identity are you signing as?" step, shown between the CLA-group picker and the Console
@@ -226,7 +230,7 @@ export class SignIdentitySelectComponent {
       const held = heldClaKindsForIdentity(agreements, identity, offeredHandles);
       const offered = held.filter((kind) => enabledKinds.includes(kind));
 
-      return { agreement, heldKinds: offered.length > 0 ? offered : held };
+      return { ...agreement, heldKinds: offered.length > 0 ? offered : held };
     };
 
     const byGithubId = new Map<string, IdentityBlock>();
@@ -277,7 +281,7 @@ export class SignIdentitySelectComponent {
   }
 
   private identityTooltip(held: IdentityBlock): string {
-    return alreadySignedIdentityTooltip(held.agreement, this.alreadySigned.anotherSelectable, held.heldKinds);
+    return alreadySignedIdentityTooltip(held, this.alreadySigned.anotherSelectable, held.heldKinds);
   }
 
   /** Suffixes the platform on a mixed list only; a single-source list needs no disambiguation. */

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-09-01
+last_updated: 2026-09-03
 intercom_collection: Account
 ---
 
@@ -78,7 +78,7 @@ You can start there. Select **Sign CLA**, search for the project, CLA group, or 
 
 ## Why does a search result say "Already signed as" when I search for a CLA to sign?
 
-In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. The result stays selectable: holding a CLA under one identity does not stop you signing under another, so it is the identity step that greys out the account already covered — and only when that account is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Results are matched per CLA group, not per project, so a project with more than one CLA group only tags the group you signed. An **Invalidated** CLA greys out nothing — that agreement no longer covers you, so you can sign again with the same identity. See [Why does a search result say "Already signed as"?](../my-clas/#why-does-a-search-result-say-already-signed-as).
+In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. The result stays selectable: holding a CLA under one identity does not stop you signing under another, and holding one contract type — an ICLA (Individual CLA) or an ECLA (Employee CLA) — does not stop you signing the other type with the same identity when the group offers both. The identity step greys out an account only when that identity already holds every contract type the group offers — and only when that account is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Results are matched per CLA group, not per project, so a project with more than one CLA group only tags the group you signed. An **Invalidated** CLA greys out nothing — that agreement no longer covers you, so you can sign again with the same identity. See [Why does a search result say "Already signed as"?](../my-clas/#why-does-a-search-result-say-already-signed-as).
 
 ## What do the CLA status labels mean?
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -4,7 +4,7 @@ description: View your signed Individual and Employee CLAs in LFX Self Serve, st
 audience: [all]
 product_area: Account
 tags: [account, cla, easycla, icla, ecla, ccla, identities, signing]
-last_updated: 2026-09-01
+last_updated: 2026-09-03
 intercom_collection: Account
 ---
 
@@ -121,21 +121,21 @@ If the search returns more matches than it can display, narrow the term — the 
 
 In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Already signed as** followed by the account it was signed under. Hover the result to see which agreement you hold — an ICLA (Individual CLA) or an ECLA (Employee CLA).
 
-The result stays selectable, because holding a CLA under one identity does not stop you signing under another. If you have two GitHub accounts linked to your profile and signed with one of them, you can still sign with the other.
+The result stays selectable, because holding a CLA under one identity does not stop you signing under another. If you have two GitHub accounts linked to your profile and signed with one of them, you can still sign with the other. Holding one contract type also does not stop you signing the other type with the same identity, when the CLA group offers both: an ICLA holder can still sign an ECLA under that identity, and the reverse.
 
-The tag names an account only when EasyCLA recorded one. Continue past the result and the identity step greys out the identity that signed — but only when the account on the agreement is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Where no account was recorded on a CLA signed through GitHub, or the CLA was signed through GitLab, the result is still tagged and every identity stays selectable. A CLA signed through Gerrit greys out your LF identity whether or not an account was recorded.
+The tag names an account only when EasyCLA recorded one. Continue past the result and the identity step greys out an identity only when that identity already holds every contract type the group offers — and only when the account on the agreement is one of the GitHub accounts linked to your profile, or the CLA was signed under your LF identity through Gerrit. Where no account was recorded on a CLA signed through GitHub, or the CLA was signed through GitLab, the result is still tagged and every identity stays selectable. A CLA signed through Gerrit greys out your LF identity only when that identity already holds every type the group offers, whether or not an account was recorded.
 
 Results are matched per **CLA group**, not per project. A project with more than one CLA group only tags the group you signed.
 
-How each status on an existing CLA affects the identity step, once that agreement matches an identity offered in the step:
+How each status on an existing CLA affects the identity step, once that agreement matches an identity offered in the step. A matching agreement only greys the identity when no enabled contract type remains unsigned for it:
 
-| Status on your existing CLA      | Identity greyed out? | What to do instead                                                                                                                         |
-| -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Valid**                        | Yes                  | Nothing — that identity is already covered                                                                                                 |
-| **Needs attention** (ECLA)       | Yes                  | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again |
-| **Revoked** (ECLA)               | Yes                  | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                |
-| **—** (no status recorded, ECLA) | Yes                  | The status could not be read, so the identity stays greyed out rather than offer you a signature that may do nothing                       |
-| **Invalidated**                  | No                   | That agreement no longer covers you, so you can sign again with the same identity                                                          |
+| Status on your existing CLA      | Counts as held? | What to do instead                                                                                                                                |
+| -------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Valid**                        | Yes             | If a type remains unsigned (for example an ECLA after an ICLA), continue with this identity. Otherwise nothing — that identity is already covered |
+| **Needs attention** (ECLA)       | Yes             | Signing again does not restore coverage. Use **Request approval** on the CLAs row to ask your employer's CLA managers to approve you again        |
+| **Revoked** (ECLA)               | Yes             | This is a sanctions-screening outcome and cannot be changed from Self Serve                                                                       |
+| **—** (no status recorded, ECLA) | Yes             | The status could not be read, so this agreement still counts as held rather than offer you a signature that may do nothing                        |
+| **Invalidated**                  | No              | That agreement no longer covers you, so you can sign again with the same identity                                                                 |
 
 ## How do I ask my CLA manager to approve or remove my ECLA?
 

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -71,6 +71,8 @@ export const SIGN_CONTRACT_TYPE_COPY = {
     label: 'Corporate Contributor',
     description: 'If you are making a contribution of content owned by your employer, you should proceed as a corporate contributor.',
   },
+  /** Why a card is disabled: the identity confirmed a step earlier already holds that type. */
+  alreadyHeld: 'You already have this agreement for this CLA group signed with this identity.',
 } as const;
 
 /**

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -202,6 +202,18 @@ export interface ClaGroupOption {
 }
 
 /**
+ * The contract types a CLA group offers, resolved to a definite answer per type.
+ *
+ * `ClaGroupOption` leaves both flags optional because the producer omits them for a group whose
+ * record it could not resolve. Anything reading them to decide something has to settle that
+ * first, so this is the settled form: absent has already been read as disabled.
+ */
+export interface ClaGroupEnablement {
+  iclaEnabled: boolean;
+  cclaEnabled: boolean;
+}
+
+/**
  * Response for `GET /api/me/clas/sign-options?q=` — mirrors the producer's `cla-search-list`
  * (#1250) rather than inventing a third shape.
  *

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -330,11 +330,15 @@ export interface SignIdentityDialogData {
   gerritUsername?: string;
   /**
    * What the contributor already holds for the CLA group they picked, so the step can gray out
-   * the identity that signed it (#1914). This is where the already-signed block lives: one
-   * contributor can hold several identities, so the group itself stays selectable and only the
-   * identity already on an agreement is refused.
+   * an identity that has no enabled contract type left to sign (#1914). This is where the
+   * already-signed block lives: one contributor can hold several identities, so the group itself
+   * stays selectable and only an identity that has already signed every enabled type is refused.
    */
   claGroupAgreements?: MyClaAgreement[];
+  /** Whether the chosen group accepts an ICLA — used with `cclaEnabled` by the already-signed gate. */
+  iclaEnabled?: boolean;
+  /** Whether the chosen group accepts a CCLA — used with `iclaEnabled` by the already-signed gate. */
+  cclaEnabled?: boolean;
 }
 
 /**

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -357,10 +357,22 @@ export type SignIdentitySelectResult = { kind: 'github'; githubId: string } | { 
 export type GerritContractType = 'individual' | 'corporate';
 
 /**
- * What the contract-type step closes with, or `null` for a dismissal (#2066).
+ * What the contract-type step is opened with (#2066).
  *
- * The step takes no input data: it opens only for a group with both types enabled, so there is
- * nothing about the group left for it to branch on.
+ * The step opens only for a group with both types enabled, so nothing about the *group* is left
+ * for it to branch on. What it does need is what the identity confirmed a step earlier already
+ * holds, so the type they cannot usefully sign again is offered as held rather than as a choice.
+ */
+export interface SignContractTypeDialogData {
+  /**
+   * Types this identity already holds for the group. At most one in practice: an identity holding
+   * both is grayed at the identity step, so it never reaches here.
+   */
+  heldKinds: readonly ClaKind[];
+}
+
+/**
+ * What the contract-type step closes with, or `null` for a dismissal (#2066).
  */
 export interface SignContractTypeSelectResult {
   contractType: GerritContractType;

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -439,9 +439,20 @@ describe('alreadySignedAgreementForIdentity', () => {
     expect(alreadySignedAgreementForIdentity(ecla, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, iclaOnly)).toBeUndefined();
   });
 
-  it('does not treat a neither-enabled group as already signed', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, neither)).toBeUndefined();
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered, neither)).toBeUndefined();
+  it('blocks on any match when the group enables neither type', () => {
+    // Two false flags are what a group whose CLA Group record could not be resolved arrives as,
+    // not a group with nothing to sign. Taken at face value the enabled set is empty, every
+    // identity passes the subset test, and the #1914 block is silently off for that group — so
+    // the kind-blind block stands in, which is what this gate did before it knew about kinds.
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, neither)?.id).toBe('s1');
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered, neither)?.id).toBe('s2');
+  });
+
+  it('still leaves an unsigned identity selectable when the group enables neither type', () => {
+    // The fallback widens which matches block, never what counts as a match. An identity with no
+    // agreement of its own must stay selectable, or an unresolvable group would strand everyone.
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work', githubId: '67890' }, offered, neither)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' }, offered, neither)).toBeUndefined();
   });
 
   it('reports a kind the group still offers, not a newer one it has since dropped', () => {

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -444,6 +444,18 @@ describe('alreadySignedAgreementForIdentity', () => {
     expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered, neither)).toBeUndefined();
   });
 
+  it('reports a kind the group still offers, not a newer one it has since dropped', () => {
+    // A group can stop offering a type the identity already signed. That agreement can be the
+    // newest match, and naming it would tell the contributor they hold an ECLA on a group that
+    // cannot be signed for one — while the block itself is owed to the ICLA.
+    const bothKinds = [
+      agreement({ id: 's2', claGroupId: 'cg-1', kind: 'ECLA', signedVia: 'github', signedAs: 'jellis', pdfAvailable: false }),
+      agreement({ id: 's1', claGroupId: 'cg-1', kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }),
+    ];
+
+    expect(alreadySignedAgreementForIdentity(bothKinds, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, iclaOnly)?.id).toBe('s1');
+  });
+
   it('still blocks a dual-type identity when the other kind is revoked', () => {
     const both = [
       agreement({ id: 's1', claGroupId: 'cg-1', kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }),

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -344,23 +344,27 @@ describe('alreadySignedAgreementForIdentity', () => {
 
   /** The handles the step is offering, which is how a recorded number is told from a handle. */
   const offered = ['jellis', 'jellis-work'];
+  const iclaOnly = { iclaEnabled: true, cclaEnabled: false } as const;
+  const cclaOnly = { iclaEnabled: false, cclaEnabled: true } as const;
+  const bothTypes = { iclaEnabled: true, cclaEnabled: true } as const;
+  const neither = { iclaEnabled: false, cclaEnabled: false } as const;
 
   it('matches a GitHub handle regardless of case', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered)?.id).toBe('s1');
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, iclaOnly)?.id).toBe('s1');
   });
 
   it('leaves the contributor a second GitHub account to sign with', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work', githubId: '67890' }, offered)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis-work', githubId: '67890' }, offered, iclaOnly)).toBeUndefined();
   });
 
   it('matches the Gerrit identity on the platform alone', () => {
-    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered)?.id).toBe('s2');
-    expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' }, offered)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered, iclaOnly)?.id).toBe('s2');
+    expect(alreadySignedAgreementForIdentity([held[0]!], { platform: 'gerrit' }, offered, iclaOnly)).toBeUndefined();
   });
 
   it('never blocks a GitHub card on an agreement with no recorded identity', () => {
     const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'github', signedAs: '   ' })];
-    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis', githubId: '12345' }, offered)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, iclaOnly)).toBeUndefined();
   });
 
   it('still blocks the Gerrit card on an agreement with no recorded identity', () => {
@@ -368,7 +372,7 @@ describe('alreadySignedAgreementForIdentity', () => {
     // accounts, so it matches none, while only one Gerrit card is ever offered and it is the
     // contributor's own LF identity — so the platform alone identifies it.
     const blank = [agreement({ claGroupId: 'cg-1', signedVia: 'gerrit', signedAs: undefined })];
-    expect(alreadySignedAgreementForIdentity(blank, { platform: 'gerrit' }, offered)?.claGroupId).toBe('cg-1');
+    expect(alreadySignedAgreementForIdentity(blank, { platform: 'gerrit' }, offered, iclaOnly)?.claGroupId).toBe('cg-1');
   });
 
   it('matches the account number when that is what the producer recorded', () => {
@@ -377,8 +381,10 @@ describe('alreadySignedAgreementForIdentity', () => {
     // that signed selectable, which is the redundant signature this is meant to prevent.
     const byNumber = [agreement({ id: 's3', claGroupId: 'cg-1', signedVia: 'github', signedAs: '12345' })];
 
-    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: '', githubId: '12345' }, ['', 'jellis'])?.id).toBe('s3');
-    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: 'jellis', githubId: '67890' }, ['', 'jellis'])).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: '', githubId: '12345' }, ['', 'jellis'], iclaOnly)?.id).toBe('s3');
+    expect(
+      alreadySignedAgreementForIdentity(byNumber, { platform: 'github', username: 'jellis', githubId: '67890' }, ['', 'jellis'], iclaOnly)
+    ).toBeUndefined();
   });
 
   it('reads a numeric identity as a handle when a card on the step carries it', () => {
@@ -389,13 +395,62 @@ describe('alreadySignedAgreementForIdentity', () => {
     const collides = [agreement({ id: 's4', claGroupId: 'cg-1', signedVia: 'github', signedAs: '12345' })];
     const bothOffered = ['12345', 'jellis'];
 
-    expect(alreadySignedAgreementForIdentity(collides, { platform: 'github', username: '12345', githubId: '18281050' }, bothOffered)?.id).toBe('s4');
-    expect(alreadySignedAgreementForIdentity(collides, { platform: 'github', username: 'jellis', githubId: '12345' }, bothOffered)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(collides, { platform: 'github', username: '12345', githubId: '18281050' }, bothOffered, iclaOnly)?.id).toBe('s4');
+    expect(alreadySignedAgreementForIdentity(collides, { platform: 'github', username: 'jellis', githubId: '12345' }, bothOffered, iclaOnly)).toBeUndefined();
   });
 
   it('does not block on an invalidated agreement', () => {
     const invalidated = [agreement({ claGroupId: 'cg-1', status: 'invalidated', signedVia: 'github', signedAs: 'jellis' })];
-    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis', githubId: '12345' }, offered)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(invalidated, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, iclaOnly)).toBeUndefined();
+  });
+
+  it('leaves a dual-type GitHub identity selectable when only an ICLA is held', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, bothTypes)).toBeUndefined();
+  });
+
+  it('leaves a dual-type Gerrit identity selectable when only an ICLA is held', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered, bothTypes)).toBeUndefined();
+  });
+
+  it('blocks a dual-type GitHub identity once both kinds are held', () => {
+    const both = [
+      agreement({ id: 's1', claGroupId: 'cg-1', kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }),
+      agreement({ id: 's2', claGroupId: 'cg-1', kind: 'ECLA', signedVia: 'github', signedAs: 'jellis', pdfAvailable: false }),
+    ];
+
+    expect(alreadySignedAgreementForIdentity(both, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, bothTypes)?.id).toBe('s1');
+  });
+
+  it('blocks a dual-type Gerrit identity once both kinds are held', () => {
+    const both = [
+      agreement({ id: 's1', claGroupId: 'cg-1', kind: 'ICLA', signedVia: 'gerrit', signedAs: 'jellis-lf' }),
+      agreement({ id: 's2', claGroupId: 'cg-1', kind: 'ECLA', signedVia: 'gerrit', signedAs: 'jellis-lf', pdfAvailable: false }),
+    ];
+
+    expect(alreadySignedAgreementForIdentity(both, { platform: 'gerrit' }, offered, bothTypes)?.id).toBe('s1');
+  });
+
+  it('does not block a CCLA-only group on an ICLA held under that identity', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, cclaOnly)).toBeUndefined();
+  });
+
+  it('does not block an ICLA-only group on an ECLA held under that identity', () => {
+    const ecla = [agreement({ claGroupId: 'cg-1', kind: 'ECLA', signedVia: 'github', signedAs: 'jellis', pdfAvailable: false })];
+    expect(alreadySignedAgreementForIdentity(ecla, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, iclaOnly)).toBeUndefined();
+  });
+
+  it('does not treat a neither-enabled group as already signed', () => {
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, neither)).toBeUndefined();
+    expect(alreadySignedAgreementForIdentity(held, { platform: 'gerrit' }, offered, neither)).toBeUndefined();
+  });
+
+  it('still blocks a dual-type identity when the other kind is revoked', () => {
+    const both = [
+      agreement({ id: 's1', claGroupId: 'cg-1', kind: 'ICLA', signedVia: 'github', signedAs: 'jellis' }),
+      agreement({ id: 's2', claGroupId: 'cg-1', kind: 'ECLA', status: 'revoked', signedVia: 'github', signedAs: 'jellis', pdfAvailable: false }),
+    ];
+
+    expect(alreadySignedAgreementForIdentity(both, { platform: 'github', username: 'jellis', githubId: '12345' }, offered, bothTypes)?.id).toBe('s1');
   });
 });
 
@@ -408,6 +463,18 @@ describe('alreadySignedIdentityTooltip', () => {
 
   it('states the position without prescribing a way out when nothing else is selectable', () => {
     expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), false)).toBe('You already have an ICLA for this CLA group signed with this account.');
+  });
+
+  it('names both kinds when the identity holds an ICLA and an ECLA', () => {
+    expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), true, ['ICLA', 'ECLA'])).toBe(
+      'You already have an ICLA and an ECLA for this CLA group signed with this account. Choose another identity to sign again.'
+    );
+  });
+
+  it('still drops the other-identity sentence when both kinds are held and nothing else is selectable', () => {
+    expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), false, ['ICLA', 'ECLA'])).toBe(
+      'You already have an ICLA and an ECLA for this CLA group signed with this account.'
+    );
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -398,20 +398,11 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  * identifies it — which does mean a Gerrit agreement with a blank handle still matches that
  * card, and then the enablement rule decides whether the match blocks.
  */
-export function alreadySignedAgreementForIdentity(
-  agreements: readonly MyClaAgreement[],
-  identity: SignIdentityRef,
-  offeredHandles: readonly string[],
-  enabled: { iclaEnabled: boolean; cclaEnabled: boolean }
-): MyClaAgreement | undefined {
-  const enabledKinds = new Set<ClaKind>();
-  if (enabled.iclaEnabled) enabledKinds.add('ICLA');
-  if (enabled.cclaEnabled) enabledKinds.add('ECLA');
-  if (enabledKinds.size === 0) return undefined;
-
+/** The agreements this identity holds for the group, newest first. Shared by the two readers below. */
+function agreementsMatchingIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef, offeredHandles: readonly string[]): MyClaAgreement[] {
   const handles = new Set(offeredHandles.map((handle) => handle.trim().toLowerCase()).filter(Boolean));
 
-  const matched = agreements.filter((agreement) => {
+  return agreements.filter((agreement) => {
     if (!ALREADY_SIGNED_CLA_STATUSES.has(agreement.status)) return false;
     if (identity.platform === 'gerrit') return agreement.signedVia === 'gerrit';
     if (agreement.signedVia !== 'github') return false;
@@ -424,6 +415,31 @@ export function alreadySignedAgreementForIdentity(
 
     return !handles.has(signedAs) && signedAs === identity.githubId.trim().toLowerCase();
   });
+}
+
+/**
+ * Which contract types this identity already holds for the group.
+ *
+ * The contract-type step reads this to offer a held type as held rather than as a choice. It
+ * shares the identity matcher with the gate above so the two cannot disagree about what is held —
+ * a step that offered a type the gate counted would let through the re-sign the gate prevents.
+ */
+export function heldClaKindsForIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef, offeredHandles: readonly string[]): ClaKind[] {
+  return [...new Set(agreementsMatchingIdentity(agreements, identity, offeredHandles).map((agreement) => agreement.kind))];
+}
+
+export function alreadySignedAgreementForIdentity(
+  agreements: readonly MyClaAgreement[],
+  identity: SignIdentityRef,
+  offeredHandles: readonly string[],
+  enabled: { iclaEnabled: boolean; cclaEnabled: boolean }
+): MyClaAgreement | undefined {
+  const enabledKinds = new Set<ClaKind>();
+  if (enabled.iclaEnabled) enabledKinds.add('ICLA');
+  if (enabled.cclaEnabled) enabledKinds.add('ECLA');
+  if (enabledKinds.size === 0) return undefined;
+
+  const matched = agreementsMatchingIdentity(agreements, identity, offeredHandles);
 
   const heldKinds = new Set(matched.map((agreement) => agreement.kind));
   for (const kind of enabledKinds) {

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -19,6 +19,7 @@ import { PROFILE_TABS } from '../constants/profile.constants';
 import { BadgeSeverity, TagSeverity } from '../interfaces/components.interface';
 import { ProfileTab } from '../interfaces';
 import type {
+  ClaGroupEnablement,
   ClaGroupOption,
   ClaGroupOptionView,
   ClaGroupOrg,
@@ -365,6 +366,36 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
   return `${signed ? `${held} ${signed}.` : held}${another}`;
 }
 
+/** The agreements this identity holds for the group, newest first. Shared by the two readers below. */
+function agreementsMatchingIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef, offeredHandles: readonly string[]): MyClaAgreement[] {
+  const handles = new Set(offeredHandles.map((handle) => handle.trim().toLowerCase()).filter(Boolean));
+
+  return agreements.filter((agreement) => {
+    if (!ALREADY_SIGNED_CLA_STATUSES.has(agreement.status)) return false;
+    if (identity.platform === 'gerrit') return agreement.signedVia === 'gerrit';
+    if (agreement.signedVia !== 'github') return false;
+
+    const signedAs = agreement.signedAs?.trim().toLowerCase();
+    if (!signedAs) return false;
+
+    const username = identity.username?.trim().toLowerCase();
+    if (username && signedAs === username) return true;
+
+    return !handles.has(signedAs) && signedAs === identity.githubId.trim().toLowerCase();
+  });
+}
+
+/**
+ * Which contract types this identity already holds for the group.
+ *
+ * The contract-type step reads this to offer a held type as held rather than as a choice. It
+ * shares the identity matcher with the gate below so the two cannot disagree about what is held —
+ * a step that offered a type the gate counted would let through the re-sign the gate prevents.
+ */
+export function heldClaKindsForIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef, offeredHandles: readonly string[]): ClaKind[] {
+  return [...new Set(agreementsMatchingIdentity(agreements, identity, offeredHandles).map((agreement) => agreement.kind))];
+}
+
 /**
  * The agreement that blocks this identity from signing again, if any — the check that actually
  * blocks (#1914).
@@ -372,8 +403,15 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  * Blocks when every contract type the group enables is already held under this identity
  * (`enabled ⊆ held`, and `enabled` is non-empty). A dual-type group therefore stays selectable
  * on that identity until it holds both an ICLA and an ECLA; a single-type group still blocks
- * once that one type is held. Neither-enabled is not a block — that failure belongs to the
- * Gerrit hand-off, not this gate.
+ * once that one type is held.
+ *
+ * A group that enables neither type is not a group offering nothing to sign; it is one whose CLA
+ * Group record the producer could not resolve, which arrives here as two false flags. Read
+ * literally that is an empty enabled set, and an empty set is a subset of nothing — so it would
+ * pass every identity through and retire this check for that group without saying so. Any match
+ * blocks instead, which is what this gate did before it knew about kinds. The Gerrit hand-off
+ * refuses such a group outright, so the fallback costs that route nothing, and it is the whole
+ * of the protection on the GitHub route, which never reads these flags at all.
  *
  * The producer records one identity string per agreement, derived as the GitHub handle when it
  * had one and the account number when it did not. So the GitHub branch compares against both
@@ -398,48 +436,19 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  * identifies it — which does mean a Gerrit agreement with a blank handle still matches that
  * card, and then the enablement rule decides whether the match blocks.
  */
-/** The agreements this identity holds for the group, newest first. Shared by the two readers below. */
-function agreementsMatchingIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef, offeredHandles: readonly string[]): MyClaAgreement[] {
-  const handles = new Set(offeredHandles.map((handle) => handle.trim().toLowerCase()).filter(Boolean));
-
-  return agreements.filter((agreement) => {
-    if (!ALREADY_SIGNED_CLA_STATUSES.has(agreement.status)) return false;
-    if (identity.platform === 'gerrit') return agreement.signedVia === 'gerrit';
-    if (agreement.signedVia !== 'github') return false;
-
-    const signedAs = agreement.signedAs?.trim().toLowerCase();
-    if (!signedAs) return false;
-
-    const username = identity.username?.trim().toLowerCase();
-    if (username && signedAs === username) return true;
-
-    return !handles.has(signedAs) && signedAs === identity.githubId.trim().toLowerCase();
-  });
-}
-
-/**
- * Which contract types this identity already holds for the group.
- *
- * The contract-type step reads this to offer a held type as held rather than as a choice. It
- * shares the identity matcher with the gate above so the two cannot disagree about what is held —
- * a step that offered a type the gate counted would let through the re-sign the gate prevents.
- */
-export function heldClaKindsForIdentity(agreements: readonly MyClaAgreement[], identity: SignIdentityRef, offeredHandles: readonly string[]): ClaKind[] {
-  return [...new Set(agreementsMatchingIdentity(agreements, identity, offeredHandles).map((agreement) => agreement.kind))];
-}
-
 export function alreadySignedAgreementForIdentity(
   agreements: readonly MyClaAgreement[],
   identity: SignIdentityRef,
   offeredHandles: readonly string[],
-  enabled: { iclaEnabled: boolean; cclaEnabled: boolean }
+  enabled: ClaGroupEnablement
 ): MyClaAgreement | undefined {
+  const matched = agreementsMatchingIdentity(agreements, identity, offeredHandles);
+  if (matched.length === 0) return undefined;
+
   const enabledKinds = new Set<ClaKind>();
   if (enabled.iclaEnabled) enabledKinds.add('ICLA');
   if (enabled.cclaEnabled) enabledKinds.add('ECLA');
-  if (enabledKinds.size === 0) return undefined;
-
-  const matched = agreementsMatchingIdentity(agreements, identity, offeredHandles);
+  if (enabledKinds.size === 0) return matched[0];
 
   const heldKinds = new Set(matched.map((agreement) => agreement.kind));
   for (const kind of enabledKinds) {

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -22,6 +22,7 @@ import type {
   ClaGroupOption,
   ClaGroupOptionView,
   ClaGroupOrg,
+  ClaKind,
   ClaSignedVia,
   ClaSignRoute,
   ClaStatus,
@@ -332,8 +333,7 @@ export function alreadySignedAgreementsForGroup(agreements: readonly MyClaAgreem
 
 /**
  * Tag on a Sign a CLA search result the contributor already holds a CLA for (#1914). Names the
- * identity, because that is what tells them which of their accounts is already covered and
- * therefore which one the next step will gray out.
+ * identity, because that is what tells them which of their accounts is already covered.
  */
 export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
   const identity = agreement.signedAs?.trim();
@@ -366,8 +366,14 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
 }
 
 /**
- * The agreement this one identity already signed for the group, if any — the check that
- * actually blocks (#1914).
+ * The agreement that blocks this identity from signing again, if any — the check that actually
+ * blocks (#1914).
+ *
+ * Blocks when every contract type the group enables is already held under this identity
+ * (`enabled ⊆ held`, and `enabled` is non-empty). A dual-type group therefore stays selectable
+ * on that identity until it holds both an ICLA and an ECLA; a single-type group still blocks
+ * once that one type is held. Neither-enabled is not a block — that failure belongs to the
+ * Gerrit hand-off, not this gate.
  *
  * The producer records one identity string per agreement, derived as the GitHub handle when it
  * had one and the account number when it did not. So the GitHub branch compares against both
@@ -389,16 +395,23 @@ export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaS
  *
  * The Gerrit branch cannot make that trade, because it has nothing to compare. Only one Gerrit
  * card is ever offered and it is the contributor's own LF identity, so the platform alone
- * identifies it — which does mean a Gerrit agreement with a blank handle still blocks that card.
+ * identifies it — which does mean a Gerrit agreement with a blank handle still matches that
+ * card, and then the enablement rule decides whether the match blocks.
  */
 export function alreadySignedAgreementForIdentity(
   agreements: readonly MyClaAgreement[],
   identity: SignIdentityRef,
-  offeredHandles: readonly string[]
+  offeredHandles: readonly string[],
+  enabled: { iclaEnabled: boolean; cclaEnabled: boolean }
 ): MyClaAgreement | undefined {
+  const enabledKinds = new Set<ClaKind>();
+  if (enabled.iclaEnabled) enabledKinds.add('ICLA');
+  if (enabled.cclaEnabled) enabledKinds.add('ECLA');
+  if (enabledKinds.size === 0) return undefined;
+
   const handles = new Set(offeredHandles.map((handle) => handle.trim().toLowerCase()).filter(Boolean));
 
-  return agreements.find((agreement) => {
+  const matched = agreements.filter((agreement) => {
     if (!ALREADY_SIGNED_CLA_STATUSES.has(agreement.status)) return false;
     if (identity.platform === 'gerrit') return agreement.signedVia === 'gerrit';
     if (agreement.signedVia !== 'github') return false;
@@ -411,6 +424,13 @@ export function alreadySignedAgreementForIdentity(
 
     return !handles.has(signedAs) && signedAs === identity.githubId.trim().toLowerCase();
   });
+
+  const heldKinds = new Set(matched.map((agreement) => agreement.kind));
+  for (const kind of enabledKinds) {
+    if (!heldKinds.has(kind)) return undefined;
+  }
+
+  return matched[0];
 }
 
 /**
@@ -420,9 +440,16 @@ export function alreadySignedAgreementForIdentity(
  * Gerrit-only step offers a single card, so once that card is grayed there is nothing left to
  * choose, and "choose another identity" would be the one instruction the contributor cannot
  * follow. Stating the position without prescribing a way out is the honest form there.
+ *
+ * When the card is grayed because both an ICLA and an ECLA are held, the reason names both.
+ * The `anotherSelectable` sentence is independent of that and stays conditional.
  */
-export function alreadySignedIdentityTooltip(agreement: MyClaAgreement, anotherSelectable: boolean): string {
-  const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
+export function alreadySignedIdentityTooltip(agreement: MyClaAgreement, anotherSelectable: boolean, heldKinds: readonly ClaKind[] = [agreement.kind]): string {
+  const hasIcla = heldKinds.includes('ICLA');
+  const hasEcla = heldKinds.includes('ECLA');
+  let kind = 'an ICLA';
+  if (hasIcla && hasEcla) kind = 'an ICLA and an ECLA';
+  else if (hasEcla) kind = 'an ECLA';
   const held = `You already have ${kind} for this CLA group signed with this account.`;
 
   return anotherSelectable ? `${held} Choose another identity to sign again.` : held;

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -401,17 +401,17 @@ export function heldClaKindsForIdentity(agreements: readonly MyClaAgreement[], i
  * blocks (#1914).
  *
  * Blocks when every contract type the group enables is already held under this identity
- * (`enabled ⊆ held`, and `enabled` is non-empty). A dual-type group therefore stays selectable
- * on that identity until it holds both an ICLA and an ECLA; a single-type group still blocks
- * once that one type is held.
+ * (`enabled ⊆ held`), and on any match at all when the group enables nothing. A dual-type group
+ * therefore stays selectable on that identity until it holds both an ICLA and an ECLA; a
+ * single-type group still blocks once that one type is held.
  *
- * A group that enables neither type is not a group offering nothing to sign; it is one whose CLA
- * Group record the producer could not resolve, which arrives here as two false flags. Read
- * literally that is an empty enabled set, and an empty set is a subset of nothing — so it would
- * pass every identity through and retire this check for that group without saying so. Any match
- * blocks instead, which is what this gate did before it knew about kinds. The Gerrit hand-off
- * refuses such a group outright, so the fallback costs that route nothing, and it is the whole
- * of the protection on the GitHub route, which never reads these flags at all.
+ * That second rule is why the subset test is not applied to an empty `enabled`. A group enabling
+ * neither type is not one with nothing to sign; it is one whose CLA Group record the producer
+ * could not resolve, which arrives here as two false flags. The empty set is a subset of every
+ * set, so the test would pass for every identity and retire this check for that group without
+ * saying so. The kind-blind block stands in — what this gate did before it knew about kinds. The
+ * Gerrit hand-off refuses such a group outright, so the fallback costs that route nothing, and
+ * it is the whole of the protection on the GitHub route, which never reads these flags at all.
  *
  * The producer records one identity string per agreement, derived as the GitHub handle when it
  * had one and the account number when it did not. So the GitHub branch compares against both

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -430,7 +430,11 @@ export function alreadySignedAgreementForIdentity(
     if (!heldKinds.has(kind)) return undefined;
   }
 
-  return matched[0];
+  // An identity can hold a kind the group no longer offers, and that agreement can be the newest
+  // one matched. Returning it would block on an enabled kind while naming a type this group
+  // cannot be signed for, so the reason is drawn from an enabled kind. Every enabled kind is
+  // held by this point, so this always finds one.
+  return matched.find((agreement) => enabledKinds.has(agreement.kind));
 }
 
 /**


### PR DESCRIPTION
## Summary
- The already-signed identity gate now blocks a GitHub or Gerrit identity only when every contract type the CLA group enables is already held under that identity.
- Holding an ICLA no longer greys the same identity on a group that still offers an ECLA, and the reverse. Single-type groups still grey once that type is held, so a contributor cannot re-sign something they already have.
- The Gerrit contract-type step disables a type the confirmed identity already holds, so opening the gate does not hand back the redundant signing ceremony it prevents.
- Help Center copy on the CLAs article and the Account FAQ now states the kind-aware rule.

## Gate

```
enabled = { ICLA if iclaEnabled, ECLA if cclaEnabled }
held    = kinds matching this identity (status set unchanged)
block   = enabled ⊆ held, when enabled is non-empty
          any match,      when enabled is empty
```

| Group | Held | Card |
| --- | --- | --- |
| Both enabled | ICLA only / ECLA only | selectable |
| Both enabled | both | greyed |
| ICLA-only | ICLA | greyed (#1914 kept) |
| CCLA-only | ECLA | greyed |
| ICLA-only | ECLA | selectable |
| Neither enabled | any match | greyed (kind-blind fallback) |

Where the block stands but the identity also holds a kind the group has since dropped, the reason names only a kind the group still offers — that is what the graying is owed to. Under the kind-blind fallback there is no offered kind to narrow to, so the reason names what is held.

Two false flags are not a group with nothing to sign — upstream leaves both false for a group whose CLA Group record it could not resolve, and the search still returns that result when a mapping row supplies its name. Read literally the enabled set is empty, every identity satisfies the subset test, and the #1914 block is off for that group without saying so. Any match blocks there instead, which is what the gate did before it knew about kinds. The Gerrit hand-off already refuses such a group with "Could not start signing", so the fallback costs that route nothing and is the whole of the protection on the GitHub route, which never reads these flags.

### Downstream of the gate

Letting a partial holder through the identity step means the next step must not offer them the type they already hold. On the Gerrit route that step is ours, so it disables the held card with a reason and leaves the other selectable — sharing the gate's identity matcher so the two cannot disagree. Both cards disabled is unreachable, since an identity holding every enabled type is greyed a step earlier.

The GitHub route has no such step: its contract type is chosen in the Contributor Console after hand-off.

## Related

- Refs #1914 — added the already-signed gate this corrects. That gate matched on identity alone, which is what made one contract type block the other.
- Refs #2066 / #2075 — the Gerrit contract-type picker. The gap was found reviewing that change: an ICLA holder never reached the new picker, because the identity step had already greyed their only card.

No closing keyword: neither issue is fixed by this, and there is no separate tracking issue.

## Test plan
- [ ] On a group with both ICLA and CCLA enabled, an identity that holds only an ICLA stays selectable (GitHub and Gerrit).
- [ ] On that same group, once the identity holds both an ICLA and an ECLA, the card is greyed and the tooltip names both kinds.
- [ ] On an ICLA-only group, an identity that already holds an ICLA is still greyed.
- [ ] A second linked GitHub account remains selectable when the first is greyed, and the tooltip still offers "choose another identity" only in that case.
- [ ] A group with neither type enabled still greys an identity that holds any agreement for it.
- [ ] On a dual-type Gerrit group, an ICLA holder reaches the contract-type step with Individual disabled and Corporate selectable.


