### PR TITLE
perf(projects): batch project enrichment via getProjectsByIds

### DIFF
--- a/apps/lfx-one/src/server/services/create-picker.service.ts
+++ b/apps/lfx-one/src/server/services/create-picker.service.ts
@@ -170,9 +170,9 @@ export class CreatePickerService {
   }
 
   /**
-   * Resolves each committee's parent project via `ProjectService.getProjectsByIds` — a true
-   * single-request-per-chunk batch (`filters_or=uid:X`), not `enrichWithProjectData`'s N
-   * individual per-project lookups. Committees whose project can't be resolved are omitted
+   * Resolves each committee's parent project via `ProjectService.getProjectsByIds` — the same
+   * batched `filters_or=uid:X` lookup `enrichWithProjectData` uses, minus its payload-fallback
+   * merge: committees whose project can't be resolved are omitted
    * entirely rather than emitted with blank `projectSlug`/`projectName`: a picked row with an
    * empty project slug would navigate with `?project=` empty, which `writerGuard` cannot resolve —
    * exactly the post-selection dead end this picker is supposed to make impossible.

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -1595,3 +1595,118 @@ describe('ProjectService — getHealthMetricsDaily', () => {
     expect(execute.mock.calls[0][0]).toContain('AVG(HEALTH_SCORE_V2)');
   });
 });
+
+describe('ProjectService — enrichWithProjectData', () => {
+  let service: ProjectService;
+
+  // Membership-funded + Active + not an Internal Allocation, per the real computeIsFoundation.
+  function foundationProject(uid: string, overrides: Partial<Project> = {}): Project {
+    return {
+      uid,
+      slug: uid,
+      name: `name-${uid}`,
+      stage: 'Active',
+      legal_entity_type: '',
+      funding: 'Funded' as ProjectFunding,
+      funding_model: ['Membership'],
+      ...overrides,
+    } as Project;
+  }
+  // Missing the Membership funding model — the real computeIsFoundation returns false.
+  function childProject(uid: string, parentUid: string, overrides: Partial<Project> = {}): Project {
+    return {
+      uid,
+      slug: uid,
+      name: `name-${uid}`,
+      stage: 'Active',
+      legal_entity_type: '',
+      funding: 'Funded' as ProjectFunding,
+      funding_model: [],
+      parent_uid: parentUid,
+      ...overrides,
+    } as Project;
+  }
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new ProjectService();
+  });
+
+  it('deduplicates project_uids into a single batched lookup', async () => {
+    const getProjectsByIds = vi.spyOn(service, 'getProjectsByIds').mockResolvedValue(new Map());
+
+    await service.enrichWithProjectData(req, [{ project_uid: 'a' }, { project_uid: 'a' }, { project_uid: 'b' }]);
+
+    expect(getProjectsByIds).toHaveBeenCalledTimes(1);
+    expect(getProjectsByIds).toHaveBeenCalledWith(req, ['a', 'b']);
+  });
+
+  it('prefers freshly fetched project fields over the item payload and computes is_foundation from the fresh project', async () => {
+    vi.spyOn(service, 'getProjectsByIds').mockResolvedValue(
+      new Map([
+        ['fdn', foundationProject('fdn', { name: 'Fresh Foundation', slug: 'fresh-fdn' })],
+        ['child', childProject('child', 'fdn', { name: 'Fresh Child', slug: 'fresh-child' })],
+      ])
+    );
+
+    const result = await service.enrichWithProjectData(req, [
+      { project_uid: 'fdn', project_name: 'stale', project_slug: 'stale', is_foundation: false, parent_project_uid: '' },
+      { project_uid: 'child', project_name: 'stale', project_slug: 'stale', is_foundation: true, parent_project_uid: 'stale-parent' },
+    ]);
+
+    // Fresh fields win on every mapped column — including is_foundation flipping both ways
+    // (stale false -> computed true for the foundation; stale true -> computed false for the child).
+    expect(result).toEqual([
+      { project_uid: 'fdn', project_name: 'Fresh Foundation', project_slug: 'fresh-fdn', is_foundation: true, parent_project_uid: '' },
+      { project_uid: 'child', project_name: 'Fresh Child', project_slug: 'fresh-child', is_foundation: false, parent_project_uid: 'fdn' },
+    ]);
+  });
+
+  it('keeps payload fallbacks and leaves is_foundation undefined (not false) for unresolved projects', async () => {
+    vi.spyOn(service, 'getProjectsByIds').mockResolvedValue(new Map());
+
+    const result = await service.enrichWithProjectData(req, [
+      { project_uid: 'gone', project_name: 'Payload Name', project_slug: 'payload-slug', parent_project_uid: 'payload-parent' },
+      { project_uid: 'gone2', project_name: 'Tiered', project_slug: 'tiered', is_foundation: true, parent_project_uid: 'p' },
+    ]);
+
+    expect(result[0]).toEqual({
+      project_uid: 'gone',
+      project_name: 'Payload Name',
+      project_slug: 'payload-slug',
+      parent_project_uid: 'payload-parent',
+      is_foundation: undefined,
+    });
+    // The fail-soft contract: consumers treat undefined as "tier unknown" and fall back safely;
+    // a coerced false would mislabel a foundation-owned entity as project-owned.
+    expect(result[0].is_foundation).toBeUndefined();
+    // An item's own tier signal survives the ?? fallback untouched.
+    expect(result[1].is_foundation).toBe(true);
+  });
+
+  it('resolves the projects the batch returns and falls back per-row for the rest', async () => {
+    vi.spyOn(service, 'getProjectsByIds').mockResolvedValue(new Map([['ok', childProject('ok', 'fdn', { name: 'Resolved', slug: 'resolved' })]]));
+
+    const result = await service.enrichWithProjectData(req, [
+      { project_uid: 'ok', project_name: 'stale', project_slug: 'stale', parent_project_uid: 'stale' },
+      { project_uid: 'skipped', project_name: 'Kept', project_slug: 'kept', parent_project_uid: 'kept-parent' },
+    ]);
+
+    expect(result[0]).toMatchObject({ project_name: 'Resolved', project_slug: 'resolved', is_foundation: false, parent_project_uid: 'fdn' });
+    expect(result[1]).toMatchObject({ project_name: 'Kept', project_slug: 'kept', parent_project_uid: 'kept-parent' });
+    expect(result[1].is_foundation).toBeUndefined();
+  });
+
+  it('keeps item-level fields untouched when every batch fails', async () => {
+    // getProjectsByIds warn-and-skips failed batches internally, so a full query-service outage
+    // surfaces here as an empty map — the same net merge outcome as the old all-null per-item
+    // failures, with no exception escaping the enrichment.
+    vi.spyOn(service, 'getProjectsByIds').mockResolvedValue(new Map());
+
+    const result = await service.enrichWithProjectData(req, [
+      { project_uid: 'x', project_name: 'Last Known', project_slug: 'last-known', is_foundation: true, parent_project_uid: 'p' },
+    ]);
+
+    expect(result[0]).toMatchObject({ project_name: 'Last Known', project_slug: 'last-known', is_foundation: true, parent_project_uid: 'p' });
+  });
+});

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -6874,7 +6874,10 @@ export class ProjectService {
 
   /**
    * Enrich items that have a project_uid with project metadata (name, slug, is_foundation, parent_uid).
-   * Deduplicates project lookups across all items.
+   * Resolves every referenced project in one batched query-service lookup (`getProjectsByIds`,
+   * 100 uids per `filters_or` query, fail-soft per batch) instead of fanning out to per-project
+   * `getProjectById` calls — and ungated, so callers without a direct project viewer relation
+   * still resolve name/slug/tier/parent (near-live from the index rather than the live record).
    */
   public async enrichWithProjectData<T extends { project_uid: string }>(
     req: Request,
@@ -6887,16 +6890,7 @@ export class ProjectService {
       unique_projects: projectUids.length,
     });
 
-    const projects: (Project | null)[] = [];
-    const batchSize = 25;
-
-    for (let i = 0; i < projectUids.length; i += batchSize) {
-      const batch = projectUids.slice(i, i + batchSize);
-      const results = await Promise.all(batch.map(async (uid) => this.getProjectById(req, uid, false).catch(() => null)));
-      projects.push(...results);
-    }
-
-    const projectMap = new Map(projects.filter((p): p is Project => p !== null).map((p) => [p.uid, p]));
+    const projectMap = await this.getProjectsByIds(req, projectUids);
 
     logger.debug(req, 'enrich_with_project_data', 'Project enrichment complete', {
       resolved: projectMap.size,


### PR DESCRIPTION
## Summary

Project enrichment on list endpoints previously resolved every referenced project through individual `getProjectById` calls — 25 at a time, one request per project. This PR switches `enrichWithProjectData` to the existing `getProjectsByIds` batch path, resolving all referenced projects in one `filters_or=uid:X` query-service request per 100 uids, fail-soft per batch. The enrichment contract (payload fallbacks, `is_foundation` left undefined-not-false for unresolved projects) is unchanged, and the batched lookup is ungated, so callers without a direct project viewer relation still resolve name/slug/tier/parent.

Closes #1643

## Behavior changes

| Before | After |
|---|---|
| Listing screens showing many items (meetings, committees, and similar) triggered one backend project lookup per distinct project — a screen touching 40 projects meant 40 separate upstream calls, which was slow and rate-limit prone | All referenced projects are resolved in one batched lookup per 100 projects, so the same screens load faster and put far less load on upstream services — and users without direct project access still see project names, slugs, and tier info |

## Technical changes

`apps/lfx-one/src/server/services/project.service.ts` — Project enrichment

- Replaces the 25-at-a-time `Promise.all(getProjectById)` fan-out in `enrichWithProjectData` with a single `getProjectsByIds(req, projectUids)` call — one `filters_or=uid:X` query per 100 uids, fail-soft per batch
- Keeps the merge contract unchanged: freshly fetched fields win, per-item payload values remain the fallback, and `is_foundation` stays `undefined` (not `false`) for unresolved projects so consumers treat tier as unknown rather than mislabeling foundation-owned entities as project-owned
- The batched path is ungated (near-live from the index rather than the live record), so callers without a direct project viewer relation still resolve name/slug/tier/parent

`apps/lfx-one/src/server/services/project.service.spec.ts` — Tests

- Adds an `enrichWithProjectData` suite covering: uid dedup into a single batched lookup, fresh-field precedence over item payloads (including `is_foundation` flipping both ways), payload fallback with `is_foundation` left `undefined` for unresolved projects, per-row fallback when only some projects resolve, and untouched item fields when every batch fails

`apps/lfx-one/src/server/services/create-picker.service.ts` — Comment only

- Updates the committee project-resolution comment to reflect that `enrichWithProjectData` now shares the same batched `getProjectsByIds` lookup (no behavioral change)