### PR TITLE
fix(meetings): keep edit page mounted on transient load errors (#2037)

### DIFF
--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -277,6 +277,21 @@ async function stubMeetingEditDetail(page: Page, meeting: ReturnType<typeof buil
 }
 
 /**
+ * Same route shapes as stubMeetingEditDetail, but the detail GET fulfills an error status —
+ * exercises meeting-manage's non-404 inline error state and 404 eject (GH-2037).
+ */
+async function stubMeetingEditDetailError(page: Page, status: number): Promise<void> {
+  await page.route('**/api/meetings*', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+  });
+  await page.route(`**/api/meetings/${MOCK_MEETING_UID}`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ message: 'stub detail failure' }) });
+  });
+}
+
+/**
  * Edit-page detail payload; `enriched: false` mirrors the v1-sync gap (empty slug/name, no
  * is_foundation) so the component's resolve-by-uid fallback runs (GH-1567).
  */
@@ -537,6 +552,78 @@ test.describe('Meeting edit deep-link resolves the meeting’s project context (
 
     await page.waitForTimeout(500);
     expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+});
+
+test.describe('Meeting edit load failure (GH-2037)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Same shape as the gh-1432 meeting block: ED persona skips the writerGuard entity probe,
+    // so the component's own detail-fetch error branch is what runs.
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await setProjectCookie(page, OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project');
+    await stubPersona(page, ['executive-director']);
+    await stubProjectApi(page);
+    await stubCommittees(page, buildCommittees());
+    await stubLensItems(page);
+  });
+
+  test('transient detail-load failure stays mounted with retry/back instead of ejecting (AC-1)', async ({ page }) => {
+    await stubMeetingEditDetailError(page, 500);
+
+    await gotoSpa(page, `/project/meetings/${MOCK_MEETING_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+
+    // Inline error state replaces the skeleton; no "not found" toast; URL stays on /edit.
+    await expect(page.getByTestId('meeting-manage-retry')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-manage-back')).toBeVisible();
+    await expect(page.getByTestId('meeting-manage-loading')).not.toBeVisible();
+    // Give a (never-fired) toast a render window — negative assertions pass instantly otherwise.
+    await page.waitForTimeout(500);
+    await expect(page.locator('.p-toast')).not.toBeVisible();
+    expect(page.url()).toContain(`/project/meetings/${MOCK_MEETING_UID}/edit`);
+  });
+
+  test('Retry after a transient failure re-fetches the meeting and renders the form (AC-1, AC-3)', async ({ page }) => {
+    await stubMeetingEditDetailError(page, 500);
+
+    await gotoSpa(page, `/project/meetings/${MOCK_MEETING_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('meeting-manage-retry')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // "Backend recovered": re-registering the detail route takes precedence over the error
+    // stub (Playwright matches in reverse registration order), so the retry fetch gets a 200.
+    await stubMeetingEditDetail(page, buildMeetingStub(true));
+    await page.getByTestId('meeting-manage-retry').click();
+
+    await expect(page.getByTestId('meeting-manage-stepper')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-manage-load-error')).not.toBeVisible();
+    expect(page.url()).toContain(`/project/meetings/${MOCK_MEETING_UID}/edit`);
+  });
+
+  test('a real 404 still ejects to the meetings list with the not-found toast (AC-2)', async ({ page }) => {
+    await stubMeetingEditDetailError(page, 404);
+
+    await gotoSpa(page, `/project/meetings/${MOCK_MEETING_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+
+    // Toast first: it fires synchronously with the eject and expires (default p-toast life)
+    // before a URL-first assertion would observe it.
+    await expect(page.locator('.p-toast')).toContainText('Meeting not found or you do not have permission to access it', {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page).toHaveURL(/\/meetings(\?|$)/, { timeout: ELEMENT_TIMEOUT });
   });
 });
 

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -289,6 +289,7 @@ async function stubMeetingEditDetailError(page: Page, status: number): Promise<v
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
   });
+  await page.route(`**/api/meetings/${MOCK_MEETING_UID}/attachments`, (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
   await page.route(`**/api/meetings/${MOCK_MEETING_UID}`, (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ message: 'stub detail failure' }) });
@@ -658,6 +659,26 @@ test.describe('Meeting edit load failure (GH-2037)', () => {
       timeout: PAGE_LOAD_TIMEOUT,
     });
     await expect(page).toHaveURL(/\/meetings(\?|$)/, { timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('non-ED writer persona: a transient probe failure redirects to the project overview (guard fail-closed)', async ({ page }) => {
+    // Documents the guard-level path the AC-1 tests can't reach: non-ED personas run the
+    // writerGuard entity probe before the component mounts, and a non-404 probe failure
+    // resolves no slug — the guard fails closed to /project/overview (no `_notice` toast)
+    // rather than authorizing against a possibly stale context (writer.guard.ts). The
+    // component's inline error state only renders for personas that bypass or pass the probe.
+    await setPersonaAndLensCookies(page, ['maintainer'], 'project');
+    await stubPersona(page, ['maintainer']);
+    await stubMeetingEditDetailError(page, 500);
+
+    await gotoSpa(page, `/project/meetings/${MOCK_MEETING_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+
+    await expect(page).toHaveURL(/\/project\/overview(\?|$)/, { timeout: PAGE_LOAD_TIMEOUT });
   });
 });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
@@ -35,7 +35,20 @@
       data-testid="meeting-manage-committee-context"></lfx-message>
   }
 
-  @if (meetingLoading()) {
+  @if (meetingLoadError()) {
+    <!-- Detail fetch failed with a non-404 error (GH-2037) — stay mounted with retry/back -->
+    <div class="flex flex-col gap-4" data-testid="meeting-manage-load-error">
+      <lfx-message
+        severity="error"
+        icon="fa-light fa-triangle-exclamation"
+        text="We couldn't load this meeting. Please try again, or go back to the meetings list."
+        data-testid="meeting-manage-load-error-message"></lfx-message>
+      <div class="flex gap-3">
+        <lfx-button label="Retry" icon="fa-light fa-rotate-right" (onClick)="retryMeetingLoad()" data-testid="meeting-manage-retry"> </lfx-button>
+        <lfx-button label="Back" [text]="true" (onClick)="navigateBack()" data-testid="meeting-manage-back"> </lfx-button>
+      </div>
+    </div>
+  } @else if (meetingLoading()) {
     <!-- Loading skeleton while meeting data is being fetched -->
     <div class="flex flex-col gap-6" data-testid="meeting-manage-loading">
       <!-- Stepper skeleton -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
@@ -36,7 +36,7 @@
   }
 
   @if (meetingLoadError()) {
-    <!-- Detail fetch failed with a non-404 error (GH-2037) — stay mounted with retry/back -->
+    <!-- Detail fetch failed with a retryable error (anything other than a 404/403 eject, GH-2037) — stay mounted with retry/back -->
     <div class="flex flex-col gap-4" data-testid="meeting-manage-load-error">
       <lfx-message
         severity="error"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
@@ -44,7 +44,8 @@
         text="We couldn't load this meeting. Please try again, or go back to the meetings list."
         data-testid="meeting-manage-load-error-message"></lfx-message>
       <div class="flex gap-3">
-        <lfx-button label="Retry" icon="fa-light fa-rotate-right" (onClick)="retryMeetingLoad()" data-testid="meeting-manage-retry"> </lfx-button>
+        <lfx-button label="Retry" icon="fa-light fa-rotate-right" severity="info" (onClick)="retryMeetingLoad()" data-testid="meeting-manage-retry">
+        </lfx-button>
         <lfx-button label="Back" [text]="true" (onClick)="navigateBack()" data-testid="meeting-manage-back"> </lfx-button>
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ApplicationRef, signal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, NavigationEnd, Router } from '@angular/router';
@@ -31,6 +31,8 @@ describe('MeetingManageComponent', () => {
 
   let getMeetingDetail: ReturnType<typeof vi.fn>;
   let getProject: ReturnType<typeof vi.fn>;
+  let messageAdd: ReturnType<typeof vi.fn>;
+  let navigate: ReturnType<typeof vi.fn>;
   let routerEvents$: BehaviorSubject<NavigationEnd>;
   let setProject: ReturnType<typeof vi.fn>;
 
@@ -71,6 +73,8 @@ describe('MeetingManageComponent', () => {
   beforeEach(() => {
     getMeetingDetail = vi.fn();
     getProject = vi.fn();
+    messageAdd = vi.fn();
+    navigate = vi.fn();
     setProject = vi.fn();
     routerEvents$ = new BehaviorSubject<NavigationEnd>(new NavigationEnd(0, '/project/meetings/x/edit', '/project/meetings/x/edit'));
 
@@ -83,7 +87,10 @@ describe('MeetingManageComponent', () => {
             url: '/project/meetings/x/edit',
             parseUrl: vi.fn().mockReturnValue({ queryParams: {} }),
             serializeUrl: vi.fn().mockReturnValue('/project/meetings/x/edit'),
-            navigate: vi.fn(),
+            navigate,
+            // evictOnWriteAccessLoss navigates via navigateByUrl when the loaded meeting's
+            // project resolves without write access (getProject → null in these tests).
+            navigateByUrl: vi.fn(),
             createUrlTree: vi.fn(),
           },
         },
@@ -123,7 +130,7 @@ describe('MeetingManageComponent', () => {
         // PrimeNG stepper binds @content.start animation listeners when the template is compiled —
         // required even without detectChanges(), since compilation alone wires the listener.
         provideNoopAnimations(),
-        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: MessageService, useValue: { add: messageAdd } },
       ],
     });
   });
@@ -177,6 +184,73 @@ describe('MeetingManageComponent', () => {
     await emitNavigationEnd();
     expect(skipCacheCalls().length).toBeGreaterThan(failedAttempts);
     expect(setProject).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG }, false);
+  });
+
+  // GH-2037: the edit-mode detail fetch is load-bearing (it pre-populates the form) — a
+  // transient failure stays mounted with the inline error + Retry; only a 404/403 ejects.
+  describe('edit-mode load failure (GH-2037)', () => {
+    const httpError = (status: number) => new HttpErrorResponse({ status });
+
+    it('stays mounted with the inline error state on a transient failure', async () => {
+      getMeetingDetail.mockReturnValue(throwError(() => httpError(500)));
+      getProject.mockReturnValue(of(null));
+      const fixture = await createComponent();
+      const component = fixture.componentInstance;
+
+      expect(component.meetingLoadError()).toBe(true);
+      // The error state is not "loading": the template's @if ordering already kept the skeleton
+      // hidden, and the computed now excludes the error state outright.
+      expect(component.meetingLoading()).toBe(false);
+      expect(navigate).not.toHaveBeenCalled();
+      expect(messageAdd).not.toHaveBeenCalled();
+    });
+
+    it('re-fetches the meeting and clears the error state on retryMeetingLoad', async () => {
+      let fail = true;
+      getMeetingDetail.mockImplementation(() => (fail ? throwError(() => httpError(500)) : of(enrichedMeeting())));
+      getProject.mockReturnValue(of(null));
+      const fixture = await createComponent();
+      const component = fixture.componentInstance;
+      expect(component.meetingLoadError()).toBe(true);
+      const callsBefore = getMeetingDetail.mock.calls.length;
+
+      fail = false;
+      component.retryMeetingLoad();
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(getMeetingDetail.mock.calls.length).toBeGreaterThan(callsBefore);
+      expect(component.meetingLoadError()).toBe(false);
+      expect(component.meeting()?.id).toBe(MEETING_UID);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('ejects with the not-found toast on a real 404', async () => {
+      getMeetingDetail.mockReturnValue(throwError(() => httpError(404)));
+      getProject.mockReturnValue(of(null));
+      const fixture = await createComponent();
+
+      expect(fixture.componentInstance.meetingLoadError()).toBe(false);
+      expect(messageAdd).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Meeting not found or you do not have permission to access it',
+      });
+      expect(navigate).toHaveBeenCalledWith(['/', 'meetings']);
+    });
+
+    it('ejects with the permission toast on a 403 — Retry cannot restore guard-owned access', async () => {
+      getMeetingDetail.mockReturnValue(throwError(() => httpError(403)));
+      getProject.mockReturnValue(of(null));
+      const fixture = await createComponent();
+
+      expect(fixture.componentInstance.meetingLoadError()).toBe(false);
+      expect(messageAdd).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Meeting not found or you do not have permission to access it',
+      });
+      expect(navigate).toHaveBeenCalledWith(['/', 'meetings']);
+    });
   });
 
   // GH-1673: prepareOwnerData / syncHydratedOwnerFromForm are private but carry the owner

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -148,8 +148,9 @@ export class MeetingManageComponent {
     toUpdate: [],
     toDelete: [],
   });
-  // True only when the edit-mode detail fetch failed with a non-404 error (GH-2037) — the
-  // template swaps the skeleton for an inline error + Retry instead of ejecting the user.
+  // True only when the edit-mode detail fetch failed with a retryable error — anything other
+  // than a 404/403 eject (GH-2037). The template swaps the skeleton for an inline error + Retry
+  // instead of ejecting the user.
   public meetingLoadError = signal(false);
   // Retry trigger folded into the initializeMeeting pipeline — each next() re-invokes the fetch.
   // Declared before `meeting`: initializeMeeting() reads it during field initialization.
@@ -348,7 +349,7 @@ export class MeetingManageComponent {
     this.navigateBack();
   }
 
-  /** Re-runs the edit-mode detail fetch after a non-404 load failure (GH-2037). */
+  /** Re-runs the edit-mode detail fetch after a retryable load failure — anything other than a 404/403 eject (GH-2037). */
   public retryMeetingLoad(): void {
     this.meetingLoadError.set(false);
     this.retryMeetingLoad$.next();

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -156,7 +156,7 @@ export class MeetingManageComponent {
   private readonly retryMeetingLoad$ = new Subject<void>();
   // Initialize meeting data using toSignal
   public meeting = this.initializeMeeting();
-  public meetingLoading = computed(() => this.isEditMode() && this.meeting() === null);
+  public meetingLoading = computed(() => this.isEditMode() && this.meeting() === null && !this.meetingLoadError());
   // Meeting → EntityWithProject adapter so the active project context syncs from the loaded
   // meeting rather than the cookie-restored last-visited project.
   private readonly meetingEntityContext: Signal<EntityWithProject | null> = this.initializeMeetingEntityContext();
@@ -990,10 +990,12 @@ export class MeetingManageComponent {
             return this.meetingService.getMeeting(meetingId).pipe(
               catchError((error) => {
                 console.error('Error getting meeting:', error);
-                // Only a real 404 ejects (GH-2037) — this fetch is load-bearing (it pre-populates
+                // Only a 404/403 ejects (GH-2037) — this fetch is load-bearing (it pre-populates
                 // the form), so a transient 5xx/network blip stays mounted with an inline error
                 // state + manual Retry rather than mislabeling a server error as "not found".
-                if (error instanceof HttpErrorResponse && error.status === 404) {
+                // 403 joins the eject path because write access is guard-owned — a forbidden
+                // response here means access was lost mid-session, and Retry cannot restore it.
+                if (error instanceof HttpErrorResponse && (error.status === 404 || error.status === 403)) {
                   this.messageService.add({
                     severity: 'error',
                     summary: 'Error',

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, effect, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -69,6 +70,7 @@ import { StepperModule } from 'primeng/stepper';
 import {
   BehaviorSubject,
   catchError,
+  combineLatest,
   concat,
   distinctUntilChanged,
   filter,
@@ -82,6 +84,7 @@ import {
   of,
   pairwise,
   startWith,
+  Subject,
   switchMap,
   take,
   toArray,
@@ -150,6 +153,12 @@ export class MeetingManageComponent {
     toUpdate: [],
     toDelete: [],
   });
+  // True only when the edit-mode detail fetch failed with a non-404 error (GH-2037) — the
+  // template swaps the skeleton for an inline error + Retry instead of ejecting the user.
+  public meetingLoadError = signal(false);
+  // Retry trigger folded into the initializeMeeting pipeline — each next() re-invokes the fetch.
+  // Declared before `meeting`: initializeMeeting() reads it during field initialization.
+  private readonly retryMeetingLoad$ = new Subject<void>();
   // Initialize meeting data using toSignal
   public meeting = this.initializeMeeting();
   public meetingLoading = computed(() => this.isEditMode() && this.meeting() === null);
@@ -339,6 +348,22 @@ export class MeetingManageComponent {
 
   public onCancel(): void {
     this.navigateBack();
+  }
+
+  /** Re-runs the edit-mode detail fetch after a non-404 load failure (GH-2037). */
+  public retryMeetingLoad(): void {
+    this.meetingLoadError.set(false);
+    this.retryMeetingLoad$.next();
+  }
+
+  /** Navigates back to the committee meetings tab or the main meetings page. */
+  public navigateBack(): void {
+    const uid = this.committeeContext()?.uid ?? this.committeeUidFromUrl;
+    if (uid) {
+      this.router.navigate(['/groups', uid], { queryParams: { tab: 'meetings' } });
+    } else {
+      this.router.navigate(['/', 'meetings']);
+    }
   }
 
   public onSubmit(): void {
@@ -1042,21 +1067,29 @@ export class MeetingManageComponent {
 
   private initializeMeeting() {
     return toSignal(
-      this.route.paramMap.pipe(
-        switchMap((params) => {
+      combineLatest([this.route.paramMap, this.retryMeetingLoad$.pipe(startWith(undefined))]).pipe(
+        switchMap(([params]) => {
           const meetingId = params.get('id');
           if (meetingId) {
             this.mode.set('edit');
             this.meetingId.set(meetingId);
+            this.meetingLoadError.set(false);
             return this.meetingService.getMeeting(meetingId).pipe(
               catchError((error) => {
                 console.error('Error getting meeting:', error);
-                this.messageService.add({
-                  severity: 'error',
-                  summary: 'Error',
-                  detail: 'Meeting not found or you do not have permission to access it',
-                });
-                this.navigateBack();
+                // Only a real 404 ejects (GH-2037) — this fetch is load-bearing (it pre-populates
+                // the form), so a transient 5xx/network blip stays mounted with an inline error
+                // state + manual Retry rather than mislabeling a server error as "not found".
+                if (error instanceof HttpErrorResponse && error.status === 404) {
+                  this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'Meeting not found or you do not have permission to access it',
+                  });
+                  this.navigateBack();
+                } else {
+                  this.meetingLoadError.set(true);
+                }
                 return of(null);
               })
             );
@@ -1688,16 +1721,6 @@ export class MeetingManageComponent {
 
     // Update form validity
     currentForm.updateValueAndValidity();
-  }
-
-  /** Navigates back to the committee meetings tab or the main meetings page. */
-  private navigateBack(): void {
-    const uid = this.committeeContext()?.uid ?? this.committeeUidFromUrl;
-    if (uid) {
-      this.router.navigate(['/groups', uid], { queryParams: { tab: 'meetings' } });
-    } else {
-      this.router.navigate(['/', 'meetings']);
-    }
   }
 
   /** Reads committee_uid from queryParams and pre-populates the committees field (locked). */


### PR DESCRIPTION
## Summary

When editing a meeting, the page fetches the meeting's details up front to pre-populate the form. Any failure of that fetch — even a momentary server or network blip — was treated as "not found": the user was kicked back to the meetings list with a misleading toast. This PR narrows that eject to a genuine 404 and keeps the edit page mounted for everything else, with an inline error state and Retry / Back actions.

Resolves #2037

## Behavior changes

| Before | After |
|---|---|
| Any hiccup while loading a meeting for editing — a brief server error, a dropped connection — sent you back to the meetings list with a "Meeting not found or you do not have permission" message, even though the meeting existed and you had access. | A temporary load failure keeps you on the edit page with a clear "couldn't load this meeting" message and Retry / Back buttons. You are only sent back to the list when the meeting truly doesn't exist or you lack permission to see it. |

## Technical changes

`apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts` — Edit-mode load handling
- Splits the detail-fetch error path in `initializeMeeting` by status: a real 404 keeps the existing toast + eject to the meetings list; any other error sets a new `meetingLoadError` signal and stays mounted.
- Adds a `retryMeetingLoad$` Subject folded into the `initializeMeeting` pipeline via `combineLatest` + `startWith`, so each `next()` re-invokes the fetch; the error flag resets at the start of each attempt.
- Adds public `retryMeetingLoad()` (clears the error state, triggers the re-fetch) and promotes `navigateBack()` from private to public so the template's Back button can call it.

`apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html` — Inline error state
- New `@if (meetingLoadError())` branch ahead of the loading skeleton: an error message with Retry and Back buttons (`meeting-manage-load-error`, `-retry`, `-back` test ids).

`apps/lfx-one/e2e/project-context-deep-link.spec.ts` — E2E coverage
- Adds a `stubMeetingEditDetailError` helper that fulfills the detail GET with a configurable error status.
- New "Meeting edit load failure (GH-2037)" describe block: a transient 500 stays mounted with retry/back and no not-found toast; clicking Retry after the backend recovers re-fetches and renders the form; a real 404 still ejects to the meetings list with the not-found toast.
