### PR TITLE
fix(impersonation): show a locate message when the target is missing

### DIFF
--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.spec.ts
@@ -1,0 +1,77 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { IMPERSONATION_TARGET_USER_NOT_FOUND_CODE, IMPERSONATION_USER_NOT_FOUND_MESSAGE } from '@lfx-one/shared/constants';
+import { ImpersonationService } from '@services/impersonation.service';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ImpersonationDialogComponent } from './impersonation-dialog.component';
+
+describe('ImpersonationDialogComponent', () => {
+  let fixture: ComponentFixture<ImpersonationDialogComponent>;
+  let startImpersonation: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    startImpersonation = vi.fn();
+    await TestBed.configureTestingModule({
+      imports: [ImpersonationDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close: vi.fn() } },
+        {
+          provide: ImpersonationService,
+          useValue: {
+            startImpersonation,
+            getRecentImpersonations: () => [],
+            addRecentImpersonation: vi.fn(),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImpersonationDialogComponent);
+    await fixture.whenStable();
+  });
+
+  async function submitAs(target: string, httpError: { error?: { error?: string; code?: string } }): Promise<void> {
+    startImpersonation.mockReturnValueOnce(throwError(() => httpError));
+    const component = fixture.componentInstance as unknown as {
+      targetUserForm: { controls: { targetUser: { setValue: (value: string) => void } } };
+      submit: () => void;
+    };
+    component.targetUserForm.controls.targetUser.setValue(target);
+    component.submit();
+    await fixture.whenStable();
+  }
+
+  it('shows the locate copy for TARGET_USER_NOT_FOUND instead of the raw token-exchange 400', async () => {
+    await submitAs('HWilson', {
+      error: {
+        code: IMPERSONATION_TARGET_USER_NOT_FOUND_CODE,
+        error: 'token exchange request failed: upstream returned status 400',
+      },
+    });
+
+    const alert = fixture.nativeElement.querySelector('[data-testid="impersonation-error"]');
+    expect(alert?.textContent).toContain(IMPERSONATION_USER_NOT_FOUND_MESSAGE);
+    expect(alert?.textContent).not.toContain('token exchange request failed');
+    expect(alert?.textContent).not.toContain('upstream returned status 400');
+  });
+
+  it('shows a generic fallback for other failures instead of upstream text', async () => {
+    await submitAs('jdoe', {
+      error: {
+        code: 'CTE_NATS_ERROR',
+        error: 'Impersonation token exchange failed: TIMEOUT',
+      },
+    });
+
+    const alert = fixture.nativeElement.querySelector('[data-testid="impersonation-error"]');
+    expect(alert?.textContent).toContain('We could not start impersonation. Please try again.');
+    expect(alert?.textContent).not.toContain('TIMEOUT');
+  });
+});

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
@@ -9,6 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { PersonaType, RecentImpersonation } from '@lfx-one/shared/interfaces';
+import { resolveImpersonationStartErrorMessage } from '@lfx-one/shared/utils';
 import { ImpersonationService } from '@services/impersonation.service';
 import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -86,7 +87,7 @@ export class ImpersonationDialogComponent {
           this.loading.set(false);
           this.targetUserForm.controls.targetUser.enable();
           this.targetUserForm.controls.personaContext.enable();
-          this.error.set(err.error?.error || 'Failed to start impersonation');
+          this.error.set(resolveImpersonationStartErrorMessage(err.error?.code));
         },
       });
   }

--- a/apps/lfx-one/src/server/services/impersonation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.spec.ts
@@ -50,9 +50,18 @@ describe('ImpersonationService.exchangeToken', () => {
       await service.exchangeToken(req, 'HWilson');
     } catch (error) {
       expect(error).toBeInstanceOf(MicroserviceError);
-      expect((error as MicroserviceError).errorBody).toEqual({
+      const microserviceError = error as MicroserviceError;
+      expect(microserviceError.errorBody).toEqual({
         target_user: 'HWilson',
-        error: 'token exchange request failed: upstream returned status 400',
+        upstreamError: 'token exchange request failed: upstream returned status 400',
+      });
+      const response = microserviceError.toResponse();
+      expect(response['upstreamCode']).toBeUndefined();
+      expect(JSON.stringify(response)).not.toContain('token exchange request failed');
+      expect(JSON.stringify(response)).not.toContain('upstream returned status 400');
+      expect(microserviceError.getLogContext()['error_body']).toEqual({
+        target_user: 'HWilson',
+        upstreamError: 'token exchange request failed: upstream returned status 400',
       });
     }
   });

--- a/apps/lfx-one/src/server/services/impersonation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.spec.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { IMPERSONATION_TARGET_USER_NOT_FOUND_CODE, IMPERSONATION_USER_NOT_FOUND_MESSAGE } from '@lfx-one/shared/constants';
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { natsRequest, logger } = vi.hoisted(() => ({
+  natsRequest: vi.fn(),
+  logger: { warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('./nats.service', () => ({
+  NatsService: vi.fn().mockImplementation(() => ({
+    getCodec: () => ({
+      encode: (v: string) => v,
+      decode: (v: unknown) => v as string,
+    }),
+    request: natsRequest,
+  })),
+}));
+
+vi.mock('./logger.service', () => ({ logger }));
+
+import { MicroserviceError } from '../errors';
+import { ImpersonationService } from './impersonation.service';
+
+const req = { bearerToken: 'subject-token' } as unknown as Request;
+
+describe('ImpersonationService.exchangeToken', () => {
+  let service: ImpersonationService;
+
+  beforeEach(() => {
+    natsRequest.mockReset();
+    service = new ImpersonationService();
+  });
+
+  it('maps the auth-service 400 wrap to TARGET_USER_NOT_FOUND and keeps the raw string off the public message', async () => {
+    natsRequest.mockResolvedValue({
+      data: JSON.stringify({ success: false, error: 'token exchange request failed: upstream returned status 400' }),
+    });
+
+    await expect(service.exchangeToken(req, 'HWilson')).rejects.toMatchObject({
+      statusCode: 404,
+      code: IMPERSONATION_TARGET_USER_NOT_FOUND_CODE,
+      message: IMPERSONATION_USER_NOT_FOUND_MESSAGE,
+    });
+
+    try {
+      await service.exchangeToken(req, 'HWilson');
+    } catch (error) {
+      expect(error).toBeInstanceOf(MicroserviceError);
+      expect((error as MicroserviceError).errorBody).toEqual({
+        target_user: 'HWilson',
+        error: 'token exchange request failed: upstream returned status 400',
+      });
+    }
+  });
+
+  it('maps a NATS transport failure to CTE_NATS_ERROR 502', async () => {
+    natsRequest.mockRejectedValue(new Error('TIMEOUT'));
+
+    await expect(service.exchangeToken(req, 'jdoe')).rejects.toMatchObject({
+      statusCode: 502,
+      code: 'CTE_NATS_ERROR',
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -50,7 +50,7 @@ export class ImpersonationService {
         throw new MicroserviceError(classified.message, classified.statusCode, classified.code, {
           operation: 'cte_token_exchange',
           service: 'auth-service',
-          errorBody: { target_user: targetUser, error: errorMessage },
+          errorBody: { target_user: targetUser, upstreamError: errorMessage },
         });
       }
 

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -12,6 +12,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { ImpersonationStatusResponse, ImpersonationUser, Impersonator, LfxAccessTokenClaims, M2MTokenResponse, PersonaType } from '@lfx-one/shared/interfaces';
+import { classifyImpersonationExchangeFailure } from '@lfx-one/shared/utils/impersonation.utils';
 import { Request, Response } from 'express';
 
 import { MicroserviceError } from '../errors';
@@ -45,10 +46,11 @@ export class ImpersonationService {
 
       if (!result.success) {
         const errorMessage = result.error || 'Impersonation token exchange failed';
-        throw new MicroserviceError(errorMessage, 400, 'CTE_EXCHANGE_FAILED', {
+        const classified = classifyImpersonationExchangeFailure(errorMessage);
+        throw new MicroserviceError(classified.message, classified.statusCode, classified.code, {
           operation: 'cte_token_exchange',
           service: 'auth-service',
-          errorBody: { target_user: targetUser },
+          errorBody: { target_user: targetUser, error: errorMessage },
         });
       }
 

--- a/apps/lfx-one/vitest.config.ts
+++ b/apps/lfx-one/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       // A deep source import the package's `exports` map doesn't publish; it resolves through
       // the tsconfig `@lfx-one/shared/*` path alias at build time. Mirrored here for specs.
       '@lfx-one/shared/constants/pdf.constants': fileURLToPath(new URL('../../packages/shared/src/constants/pdf.constants.ts', import.meta.url)),
+      '@lfx-one/shared/utils/impersonation.utils': fileURLToPath(new URL('../../packages/shared/src/utils/impersonation.utils.ts', import.meta.url)),
       '@lfx-one/shared': fileURLToPath(new URL('../../packages/shared/src', import.meta.url)),
     },
   },

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -94,9 +94,14 @@ The CTE is performed by the **lfx-v2-auth-service** via NATS request-reply on su
 // NATS response (success)
 { success: true, data: { access_token: "<target user's JWT>" } }
 
-// NATS response (failure)
+// NATS response (failure — documented Auth0 deny)
 { success: false, error: "target_user_not_found: Target user 'jdoe' not found" }
+
+// NATS response (failure — current auth-service wrap when Auth0 returns HTTP 400)
+{ success: false, error: "token exchange request failed: upstream returned status 400" }
 ```
+
+`exchangeToken()` classifies those lookup-shaped strings as HTTP 404 `TARGET_USER_NOT_FOUND` with user-facing copy. Other `success: false` errors stay 400 `CTE_EXCHANGE_FAILED` with a generic message. Raw upstream text is kept on `errorBody` for logs only. The impersonation dialog maps `TARGET_USER_NOT_FOUND` to the locate copy and never renders the upstream string.
 
 Profile enrichment (fetching the target user's name and picture) also uses NATS via the `lfx.auth-service.user_metadata.read` subject — no direct Auth0 Management API calls are made from the UI server.
 

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -101,7 +101,7 @@ The CTE is performed by the **lfx-v2-auth-service** via NATS request-reply on su
 { success: false, error: "token exchange request failed: upstream returned status 400" }
 ```
 
-`exchangeToken()` classifies those lookup-shaped strings as HTTP 404 `TARGET_USER_NOT_FOUND` with user-facing copy. Other `success: false` errors stay 400 `CTE_EXCHANGE_FAILED` with a generic message. Raw upstream text is kept on `errorBody` for logs only. The impersonation dialog maps `TARGET_USER_NOT_FOUND` to the locate copy and never renders the upstream string.
+`exchangeToken()` classifies those lookup-shaped strings as HTTP 404 `TARGET_USER_NOT_FOUND` with user-facing copy. Other `success: false` errors stay 400 `CTE_EXCHANGE_FAILED` with a generic message. Raw upstream text is kept on `errorBody.upstreamError` for logs (`getLogContext`). `toResponse()` does not forward that key, so it never becomes `upstreamCode`. The impersonation dialog maps `TARGET_USER_NOT_FOUND` to the locate copy and never renders the upstream string.
 
 Profile enrichment (fetching the target user's name and picture) also uses NATS via the `lfx.auth-service.user_metadata.read` subject — no direct Auth0 Management API calls are made from the UI server.
 

--- a/packages/shared/src/constants/impersonation.constants.ts
+++ b/packages/shared/src/constants/impersonation.constants.ts
@@ -3,3 +3,11 @@
 
 export const RECENT_IMPERSONATIONS_STORAGE_KEY = 'lfx:recent-impersonations';
 export const MAX_RECENT_IMPERSONATIONS = 5;
+
+/** Error code for a CTE / auth-service rejection that we treat as "target not found". */
+export const IMPERSONATION_TARGET_USER_NOT_FOUND_CODE = 'TARGET_USER_NOT_FOUND';
+
+export const IMPERSONATION_USER_NOT_FOUND_MESSAGE =
+  'We were unable to locate the user to impersonate. Please double-check the username or email address and try again.';
+
+export const IMPERSONATION_START_FAILED_MESSAGE = 'We could not start impersonation. Please try again.';

--- a/packages/shared/src/utils/impersonation.utils.spec.ts
+++ b/packages/shared/src/utils/impersonation.utils.spec.ts
@@ -1,0 +1,62 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyImpersonationExchangeFailure, isImpersonationTargetLookupFailure, resolveImpersonationStartErrorMessage } from './impersonation.utils';
+
+describe('isImpersonationTargetLookupFailure', () => {
+  it('matches the Auth0 CTE deny prefix from the documented NATS contract', () => {
+    expect(isImpersonationTargetLookupFailure("target_user_not_found: Target user 'HWilson' not found")).toBe(true);
+  });
+
+  it('matches the auth-service wrap for an Auth0 400 (current production string)', () => {
+    expect(isImpersonationTargetLookupFailure('token exchange request failed: upstream returned status 400')).toBe(true);
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(isImpersonationTargetLookupFailure('  TARGET_USER_NOT_FOUND: missing  ')).toBe(true);
+    expect(isImpersonationTargetLookupFailure('Token Exchange Request Failed: Upstream Returned Status 400')).toBe(true);
+  });
+
+  it('does not treat Management API lookup failures as a not-found', () => {
+    expect(isImpersonationTargetLookupFailure('target_user_lookup_failed: Failed to look up target user: timeout')).toBe(false);
+  });
+
+  it('does not match unrelated exchange or transport failures', () => {
+    expect(isImpersonationTargetLookupFailure('impersonation flow unavailable')).toBe(false);
+    expect(isImpersonationTargetLookupFailure('token exchange request failed: upstream returned status 500')).toBe(false);
+    expect(isImpersonationTargetLookupFailure('')).toBe(false);
+  });
+});
+
+describe('classifyImpersonationExchangeFailure', () => {
+  it('maps a lookup miss to 404 TARGET_USER_NOT_FOUND and the locate copy', () => {
+    expect(classifyImpersonationExchangeFailure('token exchange request failed: upstream returned status 400')).toEqual({
+      statusCode: 404,
+      code: 'TARGET_USER_NOT_FOUND',
+      message: 'We were unable to locate the user to impersonate. Please double-check the username or email address and try again.',
+    });
+  });
+
+  it('maps other exchange failures to 400 CTE_EXCHANGE_FAILED and the generic copy', () => {
+    expect(classifyImpersonationExchangeFailure('impersonation flow unavailable')).toEqual({
+      statusCode: 400,
+      code: 'CTE_EXCHANGE_FAILED',
+      message: 'We could not start impersonation. Please try again.',
+    });
+  });
+});
+
+describe('resolveImpersonationStartErrorMessage', () => {
+  it('returns the locate copy for TARGET_USER_NOT_FOUND', () => {
+    expect(resolveImpersonationStartErrorMessage('TARGET_USER_NOT_FOUND')).toBe(
+      'We were unable to locate the user to impersonate. Please double-check the username or email address and try again.'
+    );
+  });
+
+  it('never surfaces a raw upstream string for unknown or missing codes', () => {
+    expect(resolveImpersonationStartErrorMessage('CTE_EXCHANGE_FAILED')).toBe('We could not start impersonation. Please try again.');
+    expect(resolveImpersonationStartErrorMessage(undefined)).toBe('We could not start impersonation. Please try again.');
+  });
+});

--- a/packages/shared/src/utils/impersonation.utils.ts
+++ b/packages/shared/src/utils/impersonation.utils.ts
@@ -21,7 +21,7 @@ export function isImpersonationTargetLookupFailure(upstreamError: string): boole
 
 /**
  * Maps a failed CTE NATS `result.error` string to the public API error shape.
- * Raw upstream text stays on the server (`errorBody`); it is never the user message.
+ * Raw upstream text stays on the server under a log-only `errorBody` key; it is never the user message.
  */
 export function classifyImpersonationExchangeFailure(upstreamError: string): { statusCode: number; code: string; message: string } {
   if (isImpersonationTargetLookupFailure(upstreamError)) {

--- a/packages/shared/src/utils/impersonation.utils.ts
+++ b/packages/shared/src/utils/impersonation.utils.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import {
+  IMPERSONATION_START_FAILED_MESSAGE,
+  IMPERSONATION_TARGET_USER_NOT_FOUND_CODE,
+  IMPERSONATION_USER_NOT_FOUND_MESSAGE,
+} from '../constants/impersonation.constants';
+
+/**
+ * True when the auth-service / Auth0 CTE failure is a target-identity miss.
+ *
+ * Auth0 denies with `target_user_not_found`. The auth-service HTTP client
+ * currently swallows that body and returns
+ * `token exchange request failed: upstream returned status 400` instead.
+ */
+export function isImpersonationTargetLookupFailure(upstreamError: string): boolean {
+  const normalized = upstreamError.trim().toLowerCase();
+  return normalized.startsWith('target_user_not_found') || normalized.includes('upstream returned status 400');
+}
+
+/**
+ * Maps a failed CTE NATS `result.error` string to the public API error shape.
+ * Raw upstream text stays on the server (`errorBody`); it is never the user message.
+ */
+export function classifyImpersonationExchangeFailure(upstreamError: string): { statusCode: number; code: string; message: string } {
+  if (isImpersonationTargetLookupFailure(upstreamError)) {
+    return {
+      statusCode: 404,
+      code: IMPERSONATION_TARGET_USER_NOT_FOUND_CODE,
+      message: IMPERSONATION_USER_NOT_FOUND_MESSAGE,
+    };
+  }
+
+  return {
+    statusCode: 400,
+    code: 'CTE_EXCHANGE_FAILED',
+    message: IMPERSONATION_START_FAILED_MESSAGE,
+  };
+}
+
+/** Dialog-safe copy for POST /api/impersonate failures. Never returns upstream text. */
+export function resolveImpersonationStartErrorMessage(code: string | undefined): string {
+  if (code === IMPERSONATION_TARGET_USER_NOT_FOUND_CODE) {
+    return IMPERSONATION_USER_NOT_FOUND_MESSAGE;
+  }
+
+  return IMPERSONATION_START_FAILED_MESSAGE;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -41,6 +41,7 @@ export * from './insights.utils';
 export * from './pagination.utils';
 export * from './project-counts.utils';
 export * from './identity.utils';
+export * from './impersonation.utils';
 export * from './org-leaderboard-detail.utils';
 export * from './enrollment.utils';
 export * from './org-selector.utils';


### PR DESCRIPTION
## Summary
- Classify CTE lookup-shaped failures (`target_user_not_found` and the auth-service 400 wrap) as `TARGET_USER_NOT_FOUND` instead of dumping the raw token-exchange string
- Impersonation dialog maps that code to a locate message and uses a generic fallback for every other error

## Test plan
- [ ] Open Impersonate User as someone with `can_impersonate`
- [ ] Submit an unknown username and confirm the locate copy, not `token exchange request failed: upstream returned status 400`
- [ ] Submit an unknown email and confirm the same
- [ ] Confirm a real user still starts impersonation as before

Closes #2160

Made with [Cursor](https://cursor.com)