### PR TITLE
feat(dashboards): hide health metrics summary tiles and flywheel card

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.html
@@ -40,35 +40,37 @@
       }
     </div>
 
-    <!-- Summary Metric Cards -->
+    <!-- Summary Metric Cards — hidden per #2167; data flow intentionally kept live for re-enable -->
     @if (hasFoundation()) {
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        @for (card of displayCards(); track card.config.key) {
-          <div class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-4" [attr.data-testid]="card.config.testId">
-            @if (loading()) {
-              <p-skeleton width="2.5rem" height="2.5rem" borderRadius="8px" />
-              <div class="flex flex-col gap-1 flex-1">
-                <p-skeleton width="4rem" height="1.5rem" />
-                <p-skeleton width="5rem" height="0.75rem" />
-              </div>
-            } @else {
-              <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg" [ngClass]="card.config.iconBgClass">
-                <i [class]="card.config.icon" [ngClass]="card.config.iconTextClass"></i>
-              </div>
-              <div class="flex flex-col">
-                <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
-                <div class="flex items-center gap-1">
-                  <span class="text-xs text-gray-500">{{ card.config.title }}</span>
-                  @if (card.changePercentage) {
-                    <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
-                      {{ card.changePercentage }}
-                    </span>
-                  }
+      <div class="hidden">
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          @for (card of displayCards(); track card.config.key) {
+            <div class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-4" [attr.data-testid]="card.config.testId">
+              @if (loading()) {
+                <p-skeleton width="2.5rem" height="2.5rem" borderRadius="8px" />
+                <div class="flex flex-col gap-1 flex-1">
+                  <p-skeleton width="4rem" height="1.5rem" />
+                  <p-skeleton width="5rem" height="0.75rem" />
                 </div>
-              </div>
-            }
-          </div>
-        }
+              } @else {
+                <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg" [ngClass]="card.config.iconBgClass">
+                  <i [class]="card.config.icon" [ngClass]="card.config.iconTextClass"></i>
+                </div>
+                <div class="flex flex-col">
+                  <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
+                  <div class="flex items-center gap-1">
+                    <span class="text-xs text-gray-500">{{ card.config.title }}</span>
+                    @if (card.changePercentage) {
+                      <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                        {{ card.changePercentage }}
+                      </span>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+          }
+        </div>
       </div>
     } @else {
       <div class="flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 p-12">
@@ -107,10 +109,12 @@
         <lfx-training-certification-card [range]="selectedRange()" (hasDataChange)="updateCardDataState('training', $event)" />
       </div>
 
-      <!-- Code Contribution & Flywheel Conversion Rate -->
-      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <!-- Code Contribution & Flywheel Conversion Rate (flywheel hidden per #2167; data flow intentionally kept live for re-enable) -->
+      <div class="grid grid-cols-1 gap-4">
         <lfx-code-contribution-card [range]="selectedRange()" (hasDataChange)="updateCardDataState('code-contribution', $event)" />
-        <lfx-flywheel-conversion-card [range]="selectedRange()" (hasDataChange)="updateCardDataState('flywheel', $event)" />
+        <div class="hidden">
+          <lfx-flywheel-conversion-card [range]="selectedRange()" (hasDataChange)="updateCardDataState('flywheel', $event)" />
+        </div>
       </div>
 
       <!-- Board Meeting Participation -->

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.ts
@@ -70,6 +70,9 @@ export class HealthMetricsComponent {
 
   protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
 
+  // 'flywheel' is excluded while its card is hidden (#2167): the empty-state gate below must
+  // resolve from visible cards only. The hidden card still emits hasDataChange, but writes for
+  // keys outside this list are ignored by allCardsEmpty().
   private readonly cardNames: readonly HealthMetricCardName[] = [
     'events',
     'nps',
@@ -78,14 +81,15 @@ export class HealthMetricsComponent {
     'participating-orgs',
     'training',
     'code-contribution',
-    'flywheel',
     'board-meeting',
   ];
 
   protected readonly allCardsEmpty = computed(() => {
     if (this.loading()) return false;
 
-    // Filter-independent totals: show cards even if the current period is empty.
+    // Filter-independent totals act as a data-availability probe: a foundation with any totals
+    // keeps the card layout even if the current period is empty. The tiles rendering these
+    // totals are hidden (#2167), but the probe intentionally still gates the empty state.
     const data = this.metricsData();
     const hasFoundationTotals =
       (data.totalValue?.totalValue ?? 0) > 0 || (data.totalProjects?.totalProjects ?? 0) > 0 || (data.totalMembers?.totalMembers ?? 0) > 0;
@@ -171,7 +175,7 @@ export class HealthMetricsComponent {
             totalValue: this.analyticsService.getFoundationValueConcentration(slug).pipe(catchError(() => of(null))),
             totalProjects: this.analyticsService.getFoundationTotalProjects(slug).pipe(catchError(() => of(null))),
             totalMembers: this.analyticsService.getFoundationTotalMembers(slug).pipe(catchError(() => of(null))),
-            flywheel: this.analyticsService.getFlywheelConversion(slug),
+            flywheel: this.analyticsService.getFlywheelConversion(slug).pipe(catchError(() => of(null))),
           })
         ),
         takeUntilDestroyed(this.destroyRef)

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -115,6 +115,8 @@ export const HEALTH_METRICS_SUMMARY_CARDS: readonly HealthMetricsSummaryCard[] =
   },
 ];
 
+// 'flywheel-conversion' is excluded while its card is hidden (#2167) so the
+// Status Overview strip only counts sections the user can actually see.
 export const HEALTH_METRICS_BODY_BLOCK_KEYS = [
   'participating-orgs',
   'nps',
@@ -123,7 +125,6 @@ export const HEALTH_METRICS_BODY_BLOCK_KEYS = [
   'events',
   'training-certification',
   'code-contribution',
-  'flywheel-conversion',
   'board-meeting',
 ] as const;
 


### PR DESCRIPTION
## Summary

Hides two sections of the Foundation **Health Metrics** page (`/foundation/health-metrics`) per product direction:

- The four summary tiles — **Total Value**, **Projects**, **Members**, **Flywheel** — under "Operational health metrics across your foundation."
- The **Flywheel Conversion Rate** card (conversion rate + previous period, Funnel Stages chart, insight banner).

## Approach: hide, not remove

This is a deliberate **CSS-level hide** (`<div class="hidden">` wrappers → `display: none`), not a code removal and not a feature flag. Components, data fetching, and the per-card `hasDataChange` reporting all stay live. Wrappers are used (rather than `hidden` on the elements) because the flywheel card's `:host` sets `display: block`, which could out-cascade a utility class on the host.

**Re-enable procedure** (three sites, each carrying a `#2167` comment): delete the two hidden wrappers in `health-metrics.component.html`, re-add `'flywheel'` to `cardNames` in `health-metrics.component.ts`, and re-add `'flywheel-conversion'` to `HEALTH_METRICS_BODY_BLOCK_KEYS` in `dashboard-metrics.constants.ts` (restoring the 2-column Code Contribution row is optional polish).

## Changes

- `health-metrics.component.html` — wrap the tiles grid and `<lfx-flywheel-conversion-card>` in hidden wrappers; the Code Contribution card takes a full-width row (was a 2-column split with the flywheel card).
- `dashboard-metrics.constants.ts` — drop `'flywheel-conversion'` from `HEALTH_METRICS_BODY_BLOCK_KEYS`, so the Status Overview strip reads **8** (not 9) "metrics tracked".
- `health-metrics.component.ts` (review findings from the pre-PR whole-branch review):
  - `'flywheel'` removed from `cardNames` so `allCardsEmpty()` resolves from the eight visible cards only — the hidden card is no longer load-bearing for the full-page empty state.
  - The flywheel `forkJoin` leg gets the `catchError(() => of(null))` its three siblings already had, so a failure from the now-invisible endpoint can't reject the whole join and skew the empty-state decision.
  - `hasFoundationTotals` comment rewritten: the totals are a hidden data-availability probe now (behavior intentionally unchanged — a foundation with any totals keeps the card layout).

## Intentionally out of scope

- **Server endpoints untouched** — `/api/analytics/flywheel-conversion` is shared with the ED marketing dashboard; the ED dashboard's separate flywheel drawer is unaffected.
- **No e2e lock on the hidden state** — the page sits behind the ED/LF-staff `dashboardAccessGuard`, so a hermetic spec would need a new persona-stubbed suite (à la `marketing-access.spec.ts`), disproportionate for a hide that's expected to be reversible. No existing spec asserts on the hidden test IDs (verified).
- **Known accepted quirk** — a foundation with totals but all visible cards empty shows per-card empty states rather than the full-page empty state; pre-existing `allCardsEmpty()` semantics, intentionally preserved.

## Validation

- `yarn lint`, `yarn build` (SSR bundle), `./check-headers.sh`, protected-files guard — all pass.
- Pre-PR whole-branch review (three-reviewer batch) completed; all Critical/Important findings fixed in d29665145 or documented above.

