### PR TITLE
fix(sidebar): show Marketing OS on foundation lens

### DIFF
--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.spec.ts
@@ -1,0 +1,144 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MKTG_OS_AGENTS_ENABLED_FLAG, MKTG_OS_AGENTS_LABEL } from '@lfx-one/shared/constants';
+import { SidebarMenuItem } from '@lfx-one/shared/interfaces';
+import { AnalyticsService } from '@services/analytics.service';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { LensService } from '@services/lens.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { UserService } from '@services/user.service';
+import { WriterGrantsService } from '@services/writer-grants.service';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SidebarNavService } from './sidebar-nav.service';
+
+describe('SidebarNavService', () => {
+  const activeLens = signal<'me' | 'foundation' | 'project' | 'org'>('foundation');
+  const mktgOsEnabled = signal(false);
+  const hasFullFoundationAccess = signal(true);
+  const currentPersona = signal('executive-director');
+
+  const labels = (items: SidebarMenuItem[]): string[] => items.map((item) => item.label);
+
+  const findByLink = (items: SidebarMenuItem[], routerLink: string): SidebarMenuItem | undefined => items.find((item) => item.routerLink === routerLink);
+
+  beforeEach(() => {
+    activeLens.set('foundation');
+    mktgOsEnabled.set(false);
+    hasFullFoundationAccess.set(true);
+    currentPersona.set('executive-director');
+
+    TestBed.configureTestingModule({
+      providers: [
+        SidebarNavService,
+        {
+          provide: FeatureFlagService,
+          useValue: {
+            getBooleanFlag: vi.fn((key: string) => (key === MKTG_OS_AGENTS_ENABLED_FLAG ? mktgOsEnabled : signal(false))),
+          },
+        },
+        { provide: LensService, useValue: { activeLens } },
+        {
+          provide: PersonaService,
+          useValue: {
+            hasBoardRole: signal(false),
+            isRootWriter: hasFullFoundationAccess,
+            isLFStaff: signal(false),
+            canViewExecutiveDashboards: hasFullFoundationAccess,
+            currentPersona,
+            grantsByScope: signal(new Map()),
+            marketingGrantSlug: signal(null),
+            isMarketingAuditor: signal(false),
+            isCampaignManager: signal(false),
+            refreshEnrichedPersonas: vi.fn(() => of({})),
+          },
+        },
+        {
+          provide: ProjectContextService,
+          useValue: {
+            selectedFoundation: signal(null),
+            selectedProject: signal(null),
+            canWrite: signal(false),
+          },
+        },
+        { provide: UserService, useValue: { authenticated: signal(false) } },
+        { provide: WriterGrantsService, useValue: { hasWriterFoundation: signal(false) } },
+        {
+          provide: AnalyticsService,
+          useValue: { getFoundationProjectsDetailGrouped: vi.fn(() => of({ totalCount: 0 })) },
+        },
+      ],
+    });
+  });
+
+  it('hides Marketing OS on foundation lens when the flag is off', () => {
+    const items = TestBed.inject(SidebarNavService).sidebarItems();
+
+    expect(findByLink(items, '/foundation/mktg-os-agents')).toBeUndefined();
+    expect(findByLink(items, '/project/mktg-os-agents')).toBeUndefined();
+    expect(labels(items)).not.toContain(MKTG_OS_AGENTS_LABEL.nav);
+  });
+
+  it('inserts Marketing OS between Documents and Governance on foundation lens when the flag is on', () => {
+    mktgOsEnabled.set(true);
+
+    const items = TestBed.inject(SidebarNavService).sidebarItems();
+    const itemLabels = labels(items);
+    const documents = itemLabels.indexOf('Documents');
+    const marketingOs = itemLabels.indexOf(MKTG_OS_AGENTS_LABEL.nav);
+    const governance = itemLabels.indexOf('Governance');
+
+    expect(findByLink(items, '/foundation/mktg-os-agents')).toEqual(
+      expect.objectContaining({
+        label: MKTG_OS_AGENTS_LABEL.nav,
+        routerLink: '/foundation/mktg-os-agents',
+        testId: 'sidebar-foundation-mktg-os-agents',
+      })
+    );
+    expect(findByLink(items, '/project/mktg-os-agents')).toBeUndefined();
+    expect(documents).toBeGreaterThanOrEqual(0);
+    expect(marketingOs).toBe(documents + 1);
+    expect(governance).toBe(marketingOs + 1);
+  });
+
+  it('still shows Marketing OS for marketing-only foundation users when the flag is on', () => {
+    mktgOsEnabled.set(true);
+    hasFullFoundationAccess.set(false);
+    currentPersona.set('contributor');
+
+    const items = TestBed.inject(SidebarNavService).sidebarItems();
+
+    expect(findByLink(items, '/foundation/mktg-os-agents')).toEqual(
+      expect.objectContaining({
+        label: MKTG_OS_AGENTS_LABEL.nav,
+        routerLink: '/foundation/mktg-os-agents',
+      })
+    );
+    expect(labels(items)).not.toContain('Documents');
+    expect(labels(items)).not.toContain('Governance');
+  });
+
+  it('keeps the project-lens Marketing OS entry between Documents and Governance', () => {
+    activeLens.set('project');
+    mktgOsEnabled.set(true);
+
+    const items = TestBed.inject(SidebarNavService).sidebarItems();
+    const itemLabels = labels(items);
+
+    expect(findByLink(items, '/project/mktg-os-agents')).toEqual(
+      expect.objectContaining({
+        label: MKTG_OS_AGENTS_LABEL.nav,
+        routerLink: '/project/mktg-os-agents',
+        testId: 'sidebar-project-mktg-os-agents',
+      })
+    );
+    expect(findByLink(items, '/foundation/mktg-os-agents')).toBeUndefined();
+    expect(itemLabels.indexOf(MKTG_OS_AGENTS_LABEL.nav)).toBe(itemLabels.indexOf('Documents') + 1);
+    expect(itemLabels.indexOf('Governance')).toBe(itemLabels.indexOf(MKTG_OS_AGENTS_LABEL.nav) + 1);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.spec.ts
@@ -4,7 +4,7 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { MKTG_OS_AGENTS_ENABLED_FLAG, MKTG_OS_AGENTS_LABEL } from '@lfx-one/shared/constants';
-import { SidebarMenuItem } from '@lfx-one/shared/interfaces';
+import { Lens, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { AnalyticsService } from '@services/analytics.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { LensService } from '@services/lens.service';
@@ -18,7 +18,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SidebarNavService } from './sidebar-nav.service';
 
 describe('SidebarNavService', () => {
-  const activeLens = signal<'me' | 'foundation' | 'project' | 'org'>('foundation');
+  const activeLens = signal<Lens>('foundation');
   const mktgOsEnabled = signal(false);
   const hasFullFoundationAccess = signal(true);
   const currentPersona = signal('executive-director');
@@ -106,7 +106,7 @@ describe('SidebarNavService', () => {
     expect(governance).toBe(marketingOs + 1);
   });
 
-  it('still shows Marketing OS for marketing-only foundation users when the flag is on', () => {
+  it('still shows Marketing OS for users without full foundation sidebar access when the flag is on', () => {
     mktgOsEnabled.set(true);
     hasFullFoundationAccess.set(false);
     currentPersona.set('contributor');

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -47,7 +47,7 @@ export class SidebarNavService {
   private readonly isOrgLensEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ENABLED_FLAG, false);
   /** Dark-launch gate for the Akrites admin dashboard; hides the Security nav section when off. */
   private readonly isAkritesEnabled = this.featureFlagService.getBooleanFlag(AKRITES_ENABLED_FLAG, false);
-  /** Dark-launch gate for the Marketing OS marketplace; hides the Project Lens nav item when off. */
+  /** Dark-launch gate for the Marketing OS marketplace; hides the nav item on project and foundation lenses when off. */
   private readonly isMktgOsAgentsEnabled = this.featureFlagService.getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false);
   /** Dark-launch gate for the Org Lens ROI Metrics page; hides its org-lens nav entry when off. */
   private readonly isOrgLensRoiEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ROI_ENABLED_FLAG, false);
@@ -349,30 +349,35 @@ export class SidebarNavService {
           label: DOCUMENT_LABEL.plural,
           icon: 'fa-light fa-folder-open',
           routerLink: '/foundation/documents',
-        },
-        {
-          label: 'Governance',
-          isSection: true,
-          expanded: true,
-          items: [
-            {
-              label: VOTE_LABEL.plural,
-              icon: 'fa-light fa-check-to-slot',
-              routerLink: '/foundation/votes',
-            },
-            {
-              label: SURVEY_LABEL.plural,
-              icon: 'fa-light fa-clipboard-list',
-              routerLink: '/foundation/surveys',
-            },
-            {
-              label: 'Permissions',
-              icon: 'fa-light fa-shield',
-              routerLink: '/foundation/settings',
-            },
-          ],
         }
       );
+
+      if (this.isMktgOsAgentsEnabled()) {
+        items.push(this.foundationMktgOsAgentsNavItem);
+      }
+
+      items.push({
+        label: 'Governance',
+        isSection: true,
+        expanded: true,
+        items: [
+          {
+            label: VOTE_LABEL.plural,
+            icon: 'fa-light fa-check-to-slot',
+            routerLink: '/foundation/votes',
+          },
+          {
+            label: SURVEY_LABEL.plural,
+            icon: 'fa-light fa-clipboard-list',
+            routerLink: '/foundation/surveys',
+          },
+          {
+            label: 'Permissions',
+            icon: 'fa-light fa-shield',
+            routerLink: '/foundation/settings',
+          },
+        ],
+      });
 
       if (this.canSeeNewsletters()) {
         items.push({
@@ -413,6 +418,13 @@ export class SidebarNavService {
           items: metricsItems,
         });
       }
+    }
+
+    // Marketing-only FGA users never enter the full-access block above, so the Documents /
+    // Governance insertion point never runs. Still surface Marketing OS when the flag is on —
+    // `/foundation/mktg-os-agents` is already routed and guarded for this lens.
+    if (this.isMktgOsAgentsEnabled() && !this.hasFullFoundationAccess()) {
+      items.push(this.foundationMktgOsAgentsNavItem);
     }
 
     const marketingSection = this.marketingSectionItem();
@@ -507,12 +519,19 @@ export class SidebarNavService {
     },
   ];
 
-  // --- Project Lens — Mktg OS agents (dark-launched; inserted directly under Documents in sidebarItems()) ---
+  // --- Project / Foundation — Mktg OS agents (dark-launched; inserted directly under Documents) ---
   private readonly mktgOsAgentsNavItem: SidebarMenuItem = {
     label: MKTG_OS_AGENTS_LABEL.nav,
     icon: 'fa-light fa-robot',
     routerLink: '/project/mktg-os-agents',
     testId: 'sidebar-project-mktg-os-agents',
+  };
+
+  private readonly foundationMktgOsAgentsNavItem: SidebarMenuItem = {
+    label: MKTG_OS_AGENTS_LABEL.nav,
+    icon: 'fa-light fa-robot',
+    routerLink: '/foundation/mktg-os-agents',
+    testId: 'sidebar-foundation-mktg-os-agents',
   };
 
   // --- Project Lens — Governance section (always surfaced under the Project lens) ---

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -70,7 +70,7 @@ A user can carry both board and project roles simultaneously. In the sidebar len
 
 ## Foundation Lens
 
-Available to `board-member`, `executive-director`, and root writers.
+Available to board members, executive directors, root writers, LF Staff, foundation `writer` grant holders, and marketing FGA grant holders (`marketing_auditor` / `campaign_manager` when `marketing-ops-fga-enabled` is on — see `deriveAllowedLenses` in `lens.utils.ts`).
 
 | Sidebar item / section     | Route                          | Visible to                                                                                                                                                                                              |
 | -------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/architecture/frontend/persona-content-matrix.md
+++ b/docs/architecture/frontend/persona-content-matrix.md
@@ -81,6 +81,7 @@ Available to `board-member`, `executive-director`, and root writers.
 | Mailing Lists              | `/foundation/mailing-lists`    | All foundation users                                                                                                                                                                                    |
 | Committees                 | `/foundation/groups`           | All foundation users                                                                                                                                                                                    |
 | Documents                  | `/foundation/documents`        | All foundation users                                                                                                                                                                                    |
+| Marketing OS               | `/foundation/mktg-os-agents`   | `mktg-os-agents-enabled` LaunchDarkly flag (same gate as project lens). Inserted between Documents and Governance for full-access users; still shown to marketing-only FGA users when the flag is on    |
 | **Governance** section     |                                |                                                                                                                                                                                                         |
 | → Votes                    | `/foundation/votes`            | All foundation users                                                                                                                                                                                    |
 | → Surveys                  | `/foundation/surveys`          | All foundation users                                                                                                                                                                                    |
@@ -112,19 +113,20 @@ Available to `board-member`, `executive-director`, and root writers.
 
 Available to `contributor`, `maintainer`, and root writers.
 
-| Sidebar item / section     | Route                    | Visible to                                     |
-| -------------------------- | ------------------------ | ---------------------------------------------- |
-| Dashboard                  | `/project/overview`      | All project users                              |
-| Meetings                   | `/project/meetings`      | All project users                              |
-| Mailing Lists              | `/project/mailing-lists` | All project users                              |
-| Committees                 | `/project/groups`        | All project users                              |
-| Documents                  | `/project/documents`     | All project users                              |
-| **Governance** section     |                          |                                                |
-| → Votes                    | `/project/votes`         | All project users                              |
-| → Surveys                  | `/project/surveys`       | All project users                              |
-| → Permissions              | `/project/settings`      | All project users                              |
-| **Communications** section |                          | `canSeeNewsletters()` — ED **or** `canWrite()` |
-| → Newsletters              | `/project/newsletters`   | `canSeeNewsletters()`                          |
+| Sidebar item / section     | Route                     | Visible to                                                                            |
+| -------------------------- | ------------------------- | ------------------------------------------------------------------------------------- |
+| Dashboard                  | `/project/overview`       | All project users                                                                     |
+| Meetings                   | `/project/meetings`       | All project users                                                                     |
+| Mailing Lists              | `/project/mailing-lists`  | All project users                                                                     |
+| Committees                 | `/project/groups`         | All project users                                                                     |
+| Documents                  | `/project/documents`      | All project users                                                                     |
+| Marketing OS               | `/project/mktg-os-agents` | `mktg-os-agents-enabled` LaunchDarkly flag. Inserted between Documents and Governance |
+| **Governance** section     |                           |                                                                                       |
+| → Votes                    | `/project/votes`          | All project users                                                                     |
+| → Surveys                  | `/project/surveys`        | All project users                                                                     |
+| → Permissions              | `/project/settings`       | All project users                                                                     |
+| **Communications** section |                           | `canSeeNewsletters()` — ED **or** `canWrite()`                                        |
+| → Newsletters              | `/project/newsletters`    | `canSeeNewsletters()`                                                                 |
 
 ### Project lens by persona summary
 
@@ -170,6 +172,7 @@ Guards enforce access at the router level — regardless of whether a sidebar li
 | `newsletterAccessGuard`      | `/newsletters` (lens redirect), `/foundation/newsletters`, `/project/newsletters`       | `canSeeNewsletters()` — ED or `canWrite()`                                                                                                                                                                                                    |
 | `writerGuard`                | Create/edit routes for meetings, committees, mailing lists, surveys, votes (all lenses) | `executive-director` (fast path) or project `writer`; meetings routes also allow `meetingCoordinator` or `committee.writer` when `?committee_uid=` is set — see [Meetings write paths](#meetings-write-paths) below                           |
 | `orgLensEnabledGuard`        | `/org/*` (CanMatch — routes invisible when flag is off)                                 | Browser: `ORG_LENS_ENABLED_FLAG` must be `true`; redirects to `/` otherwise. SSR: always returns `true` — enforcement defers to browser after hydration                                                                                       |
+| `mktgOsAgentsEnabledGuard`   | `/project/mktg-os-agents`, `/foundation/mktg-os-agents` (CanMatch)                      | Browser: waits for LaunchDarkly READY, then `MKTG_OS_AGENTS_ENABLED_FLAG`; fail closed. Denied deep links go to `/{lens}/overview`. SSR: always returns `true` — enforcement defers to browser after hydration                                |
 
 Guards are defined in `apps/lfx-one/src/app/shared/guards/`.
 
@@ -213,5 +216,5 @@ Meeting create/edit is **manage/write permission**, not persona. A user with onl
 
 - [Lens & Persona System](./lens-system.md) — how lenses and personas are resolved and enforced
 - [Angular Patterns](./angular-patterns.md) — zoneless change detection and signals
-- [`main-layout.component.ts`](../../../apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts) — authoritative source for sidebar item definitions
+- [`sidebar-nav.service.ts`](../../../apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts) — authoritative source for sidebar item definitions
 - [`app.routes.ts`](../../../apps/lfx-one/src/app/app.routes.ts) — route guard wiring


### PR DESCRIPTION
## Summary
- Targeted users lost Marketing OS when they opened a foundation from the Projects tab. `#1943` gated both `/project/mktg-os-agents` and `/foundation/mktg-os-agents`, but the sidebar only inserted the item on project lens.
- Selecting a foundation (Open Secure AI Alliance) switches `activeLens` to `foundation`. `foundationLensItems()` never built the item, so the flag could be on and the nav still stayed hidden.
- Insert Marketing OS between Documents and Governance on foundation lens, linking to `/foundation/mktg-os-agents`. Marketing-only FGA users who skip the full foundation sidebar still get the item. Flag off stays hidden. Project-lens placement is unchanged.

## Test plan
- [ ] Sign in as a user targeted for `mktg-os-agents-enabled`
- [ ] Open the Projects tab and select a foundation (Open Secure AI Alliance)
- [ ] Confirm Marketing OS sits between Documents and Governance and opens `/foundation/mktg-os-agents`
- [ ] Open a child project and confirm the existing `/project/mktg-os-agents` item is still there
- [ ] Confirm a user without the flag still does not see the item on either lens

Closes #2171