### PR TITLE
test(votes): cover getVotes opt-out and vote-manage eviction route (#2084)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.spec.ts
@@ -214,5 +214,6 @@ describe('VoteManageComponent', () => {
     await TestBed.inject(ApplicationRef).whenStable();
 
     expect(router.navigateByUrl).toHaveBeenCalled();
+    expect(router.parseUrl).toHaveBeenCalledWith(expect.stringMatching(/^\/(project|foundation)\/overview$/));
   });
 });

--- a/apps/lfx-one/src/server/services/vote.service.spec.ts
+++ b/apps/lfx-one/src/server/services/vote.service.spec.ts
@@ -279,6 +279,18 @@ describe('VoteService upstream path encoding', () => {
       expect(result.data[0]).not.toHaveProperty('project_slug');
       expect(result.data[0]).not.toHaveProperty('is_foundation');
     });
+
+    it('skips project enrichment entirely when includeProject is false', async () => {
+      proxyRequest.mockResolvedValue({ resources: [{ data: indexRow }], page_token: undefined });
+
+      const result = await service.getVotes(req, {}, { includeProject: false });
+
+      expect(getProjectsByIds).not.toHaveBeenCalled();
+      expect(computeIsFoundation).not.toHaveBeenCalled();
+      expect(result.data[0]).not.toHaveProperty('project_slug');
+      expect(result.data[0]).not.toHaveProperty('is_foundation');
+      expect(result.data[0]).not.toHaveProperty('parent_project_uid');
+    });
   });
 
   describe('getMyVotes', () => {

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -42,7 +42,7 @@ export class VoteService {
 
   /**
    * Fetches a single page of votes using cursor-based pagination — callers paginate via the returned page_token.
-   * `includeProject` (default true) enriches rows with project slug/name/tier; opt out when the caller discards them.
+   * `includeProject` (default true) enriches rows with `project_name`, `project_slug`, `is_foundation` and `parent_project_uid`; opt out when the caller discards them.
    */
   public async getVotes(req: Request, query: Record<string, unknown> = {}, options: { includeProject?: boolean } = {}): Promise<PaginatedResponse<Vote>> {
     const { includeProject = true } = options;


### PR DESCRIPTION
## Summary

Follow-up test-hardening PR for the vote enrichment guard. It pins two behaviors that previously had no automated proof: the `getVotes` `includeProject: false` opt-out skipping project enrichment entirely, and the vote-manage write-access eviction landing on the project/foundation overview. No runtime behavior changes — one docblock correction included.

Resolves #2084

## Behavior changes

### Vote list project enrichment opt-out

| Before | After |
|---|---|
| Callers could ask for the vote list without project details, but no automated test proved the skip actually happened — a future change could quietly start fetching project data again, adding hidden load and leaking fields the caller asked to discard. | An automated test now proves that opting out performs zero project lookups and returns rows with none of the project fields attached, so any regression fails the build immediately. |

### Vote management write-access eviction

| Before | After |
|---|---|
| When a user's write access was revoked while managing a vote, the app redirected them away — but the test only checked that *some* navigation happened, not that it landed on the expected overview page. | The test now confirms the redirect goes specifically to the project (or foundation) overview page, catching any future change to the eviction destination. |

## Technical changes

`apps/lfx-one/src/server/services/vote.service.spec.ts` — Server vote service tests
- adds a `getVotes` spec proving `{ includeProject: false }` never calls `getProjectsByIds` or `computeIsFoundation`, and that returned rows carry no `project_slug`, `is_foundation`, or `parent_project_uid` — mutation-checked against a reverted gate

`apps/lfx-one/src/server/services/vote.service.ts` — Server vote service docblock
- corrects the `getVotes` docblock to name all four enriched fields (`project_name`, `project_slug`, `is_foundation`, `parent_project_uid`) instead of the previous vague "slug/name/tier"

`apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.spec.ts` — Vote manage component tests
- strengthens the write-access eviction spec to assert `router.parseUrl` is called with `/project/overview` or `/foundation/overview`, not just that `navigateByUrl` fired
