### PR TITLE
fix(surveys): edit links open in the survey's project context (GH-1569)

### DIFF
--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -356,9 +356,11 @@ async function stubMailingListEditDetail(page: Page, list: ReturnType<typeof bui
 }
 
 /**
- * Survey detail payload for the edit page. `enriched: false` simulates the BFF project
- * enrichment having failed (project_slug/project_name/is_foundation absent) so the component's
- * resolve-by-uid fallback is exercised instead (GH-1569).
+ * Survey detail payload for the edit page, shaped as the BFF emits it post-GH-1569: project
+ * identity lives in committees[0] (as upstream sends it — the upstream detail schema has no
+ * top-level project_uid), `project_uid` top-level is the BFF's flattened stamp, and the slug/name/
+ * tier fields appear only when BFF enrichment succeeded. `enriched: false` simulates the
+ * enrichment having failed so the component's resolve-by-uid fallback is exercised instead (GH-1569).
  */
 function buildSurveyStub(enriched: boolean) {
   return {
@@ -367,7 +369,16 @@ function buildSurveyStub(enriched: boolean) {
     survey_status: 'draft',
     project_uid: MOCK_FOUNDATION_UID,
     ...(enriched ? { project_slug: MOCK_FOUNDATION_SLUG, project_name: 'Test Foundation', is_foundation: true } : {}),
-    committees: [],
+    committees: [
+      {
+        committee_uid: MOCK_COMMITTEE_UID,
+        committee_name: 'Governing Board',
+        project_uid: MOCK_FOUNDATION_UID,
+        project_name: 'Test Foundation',
+        total_recipients: 0,
+        total_responses: 0,
+      },
+    ],
     committee_category: '',
     is_nps_survey: false,
     is_project_survey: false,

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -21,6 +21,9 @@
  *   - The same for a context-less vote EDIT link (`/project/votes/:uid/edit`, GH-1568):
  *     context syncs from the loaded vote (enriched payload or uid fallback), and writerGuard
  *     authorizes against the vote's own project via its entity probe.
+ *   - The same for a context-less survey EDIT link (`/project/surveys/:uid/edit`, GH-1569):
+ *     context syncs from the loaded survey (enriched payload or uid fallback), and writerGuard
+ *     authorizes against the survey's own project via its entity probe.
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -46,6 +49,7 @@ const OTHER_PROJECT_UID = 'p0000000-0000-0000-0000-00000000d003';
 const MOCK_MEETING_UID = 'm0000000-0000-0000-0000-00000000d001';
 const MOCK_VOTE_UID = 'v0000000-0000-0000-0000-00000000d001';
 const MOCK_MAILING_LIST_UID = 'l1000000-0000-0000-0000-00000000d001';
+const MOCK_SURVEY_UID = 's0000000-0000-0000-0000-00000000d001';
 
 function buildProjectStub(uid: string, slug: string, name: string) {
   return {
@@ -348,6 +352,43 @@ async function stubMailingListEditDetail(page: Page, list: ReturnType<typeof bui
   await page.route(`**/api/mailing-lists/${MOCK_MAILING_LIST_UID}`, (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(list) });
+  });
+}
+
+/**
+ * Survey detail payload for the edit page. `enriched: false` simulates the BFF project
+ * enrichment having failed (project_slug/project_name/is_foundation absent) so the component's
+ * resolve-by-uid fallback is exercised instead (GH-1569).
+ */
+function buildSurveyStub(enriched: boolean) {
+  return {
+    uid: MOCK_SURVEY_UID,
+    survey_title: 'Test Foundation Satisfaction Survey',
+    survey_status: 'draft',
+    project_uid: MOCK_FOUNDATION_UID,
+    ...(enriched ? { project_slug: MOCK_FOUNDATION_SLUG, project_name: 'Test Foundation', is_foundation: true } : {}),
+    committees: [],
+    committee_category: '',
+    is_nps_survey: false,
+    is_project_survey: false,
+    total_responses: 0,
+    total_recipients: 0,
+    created_at: '2025-01-15T00:00:00Z',
+    last_modified_at: '2025-06-01T00:00:00Z',
+  };
+}
+
+async function stubSurveyEditDetail(page: Page, survey: ReturnType<typeof buildSurveyStub>): Promise<void> {
+  // Catch-all registered FIRST (Playwright matches routes in reverse registration order) so
+  // incidental list calls from the edit page don't escape to the real BFF. `*` doesn't cross
+  // `/`, so the detail route needs its own pattern.
+  await page.route('**/api/surveys*', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route(`**/api/surveys/${MOCK_SURVEY_UID}`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(survey) });
   });
 }
 
@@ -808,5 +849,106 @@ test.describe('Mailing list edit deep-link resolves the list’s project context
     // Context syncs from the loaded list and the route rewrites to its owning tier (GH-1567).
     await expect(page).toHaveURL(new RegExp(`/foundation/mailing-lists/${MOCK_MAILING_LIST_UID}$`), { timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+  });
+});
+
+test.describe('Survey edit deep-link resolves the survey’s project context (GH-1569)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mirror the issue: the user was last working in an unrelated PROJECT (cookie-restored),
+    // then opens a context-less edit link for a survey owned by Test Foundation.
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await setProjectCookie(page, OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project');
+    await stubPersona(page, ['executive-director']);
+    await stubProjectApi(page);
+    await stubCommittees(page, buildCommittees());
+    await stubLensItems(page);
+    await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+      })
+    );
+  });
+
+  test('edit link without ?project= switches context to the survey’s foundation (BFF-enriched payload)', async ({ page }) => {
+    await stubSurveyEditDetail(page, buildSurveyStub(true));
+
+    await gotoSpa(page, `/project/surveys/${MOCK_SURVEY_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // The sync derives context from the loaded survey (Test Foundation), replacing the
+    // cookie-restored Other Project — the selector follows the correction.
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+
+    // The context correction must NOT inject ?project= into the entity URL (syncUrl guard) —
+    // give any NavigationEnd-driven backfill a tick to (not) fire before asserting absence.
+    await page.waitForTimeout(500);
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+
+  test('writerGuard authorizes the edit page against the survey’s project, not the stale context (GH-1569)', async ({ page }) => {
+    // Non-ED persona: no synchronous fast path — the guard must probe the survey for its
+    // project slug. The stale cookie context (Other Project) is intentionally NOT writable:
+    // if the guard authorizes against it, the page redirects to /project/overview?_notice=...
+    await setPersonaAndLensCookies(page, ['maintainer'], 'project');
+    await stubPersona(page, ['maintainer']);
+    await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project'), writer: false }),
+      })
+    );
+    await stubSurveyEditDetail(page, buildSurveyStub(true));
+
+    await gotoSpa(page, `/project/surveys/${MOCK_SURVEY_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Still on the edit page (no access-denied redirect), and the context follows the survey.
+    expect(page.url()).toContain(`/surveys/${MOCK_SURVEY_UID}/edit`);
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('edit link without ?project= falls back to resolving the project by uid when enrichment is absent', async ({ page }) => {
+    // Enrichment-failed payload: project_uid only. The component fallback fetches the project
+    // by uid — this route satisfies computeIsFoundation (Funded + Membership + Active), so the
+    // resolved context lands in the foundation slot just like the enriched path.
+    await stubSurveyEditDetail(page, buildSurveyStub(false));
+    await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...buildProjectStub(MOCK_FOUNDATION_UID, MOCK_FOUNDATION_SLUG, 'Test Foundation'),
+          funding: 'Funded',
+          funding_model: ['Membership'],
+          legal_entity_type: 'Series LLC',
+        }),
+      })
+    );
+
+    await gotoSpa(page, `/project/surveys/${MOCK_SURVEY_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+
+    await page.waitForTimeout(500);
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
   });
 });

--- a/apps/lfx-one/e2e/survey-edit-url.spec.ts
+++ b/apps/lfx-one/e2e/survey-edit-url.spec.ts
@@ -1,0 +1,340 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Survey edit-URL canonicalization — GH-1569.
+ *
+ * Coverage:
+ *   - The surveys table's per-row edit button derives its destination from the SURVEY's owning
+ *     tier (`is_foundation`) and project slug, not the viewer's transient active lens — the
+ *     pre-fix bug sent flat `/surveys/:uid/edit` links through `lensRedirectGuard`, which
+ *     prefixed them with whatever lens the viewer happened to be in:
+ *       foundation-owned survey → `/foundation/surveys/:uid/edit?project=<slug>`
+ *       project-owned survey    → `/project/surveys/:uid/edit?project=<slug>`
+ *       unenriched payload      → flat `/surveys/:uid/edit`, which `lensRedirectGuard`
+ *                                 prefixes by the active lens (documented fallback)
+ *   - The enriched cases seed the OPPOSITE lens/context from the survey's owning tier, so a pass
+ *     proves the URL follows the entity, not the viewer; the fallback case seeds the MATCHING
+ *     lens, since the lens-driven prefix is exactly the behavior under test there.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD
+ */
+
+import type { PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
+import { LENS_COOKIE_KEY, PERSONA_COOKIE_KEY, SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+
+const MOCK_FOUNDATION_SLUG = 'test-foundation';
+const MOCK_FOUNDATION_UID = 'f0000000-0000-0000-0000-00000000d001';
+const OTHER_FOUNDATION_SLUG = 'other-foundation';
+const OTHER_FOUNDATION_UID = 'f0000000-0000-0000-0000-00000000d002';
+const OTHER_PROJECT_SLUG = 'other-project';
+const OTHER_PROJECT_UID = 'p0000000-0000-0000-0000-00000000d003';
+const MOCK_SURVEY_UID = 's1000000-0000-0000-0000-00000000d001';
+
+function buildProjectStub(uid: string, slug: string, name: string) {
+  return {
+    uid,
+    slug,
+    name,
+    description: `${name} for survey edit-url specs`,
+    public: true,
+    parent_uid: '',
+    stage: 'Active',
+    category: 'project',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '',
+    updated_at: new Date().toISOString(),
+    mailing_list_count: 0,
+    writer: true,
+  };
+}
+
+/**
+ * Surveys-table row / edit-page detail payload. The list shape mirrors the BFF `getSurveys`
+ * response post-GH-1569 (project_uid flattened from committees[0], project fields enriched);
+ * omitting `projectSlug`/`isFoundation` mirrors an enrichment failure, where the row must fall
+ * back to the flat path.
+ */
+function buildSurveyStub(owner: { projectUid: string; projectSlug?: string; projectName?: string; isFoundation?: boolean }) {
+  return {
+    uid: MOCK_SURVEY_UID,
+    survey_title: 'Canonical Url Satisfaction Survey',
+    survey_status: 'draft',
+    project_uid: owner.projectUid,
+    ...(owner.projectSlug !== undefined ? { project_slug: owner.projectSlug } : {}),
+    ...(owner.projectName !== undefined ? { project_name: owner.projectName } : {}),
+    ...(owner.isFoundation !== undefined ? { is_foundation: owner.isFoundation } : {}),
+    committees: [],
+    committee_category: '',
+    is_nps_survey: false,
+    is_project_survey: false,
+    total_responses: 0,
+    total_recipients: 0,
+    survey_cutoff_date: '2027-01-01T00:00:00Z',
+    created_at: '2025-01-15T00:00:00Z',
+    last_modified_at: '2025-06-01T00:00:00Z',
+  };
+}
+
+async function stubPersona(page: Page, personas: string[]): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ personas, personaProjects: {}, projects: [], organizations: [], isRootWriter: true }),
+    })
+  );
+}
+
+async function stubProjectApi(page: Page): Promise<void> {
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildProjectStub(MOCK_FOUNDATION_UID, MOCK_FOUNDATION_SLUG, 'Test Foundation')),
+    })
+  );
+  await page.route(`**/api/projects/${OTHER_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildProjectStub(OTHER_FOUNDATION_UID, OTHER_FOUNDATION_SLUG, 'Other Foundation')),
+    })
+  );
+  await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+    })
+  );
+  await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
+}
+
+async function stubCommittees(page: Page): Promise<void> {
+  await page.route('**/api/committees/my-committee-uids*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/committees*', (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname !== '/api/committees') {
+      return route.fallback();
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+}
+
+/**
+ * Stubs the navigation lens-items feed so NavigationService.applyDefaultSelection can't
+ * override the stubbed context with the test account's real projects mid-test. Items cover
+ * every cookie-seeded context these specs use so the "preserve existing selection" guard
+ * keeps it instead of picking a default.
+ */
+async function stubLensItems(page: Page): Promise<void> {
+  await page.route('**/api/nav/lens-items*', (route) => {
+    const url = new URL(route.request().url());
+    const isFoundation = url.searchParams.get('lens') !== 'project';
+    const items = isFoundation
+      ? [
+          { uid: MOCK_FOUNDATION_UID, slug: MOCK_FOUNDATION_SLUG, name: 'Test Foundation', logoUrl: null, isFoundation: true },
+          { uid: OTHER_FOUNDATION_UID, slug: OTHER_FOUNDATION_SLUG, name: 'Other Foundation', logoUrl: null, isFoundation: true },
+        ]
+      : [{ uid: OTHER_PROJECT_UID, slug: OTHER_PROJECT_SLUG, name: 'Other Project', logoUrl: null, isFoundation: false }];
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items, next_page_token: null, upstream_failed: false, lens: isFoundation ? 'foundation' : 'project' }),
+    });
+  });
+}
+
+/**
+ * Stubs the surveys list (one row, params ignored) and the edit-page detail fetch. The
+ * catch-all is registered FIRST (Playwright matches in reverse registration order); `*` does
+ * not cross `/`, so the detail route needs its own pattern.
+ */
+async function stubSurveys(page: Page, survey: ReturnType<typeof buildSurveyStub>): Promise<void> {
+  await page.route('**/api/surveys*', (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (route.request().method() !== 'GET' || pathname !== '/api/surveys') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([survey]) });
+  });
+  await page.route(`**/api/surveys/${MOCK_SURVEY_UID}`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(survey) });
+  });
+}
+
+async function setPersonaAndLensCookies(page: Page, personas: string[], lens: 'foundation' | 'project'): Promise<void> {
+  const state: PersistedPersonaState = {
+    primary: personas[0] as PersonaType,
+    all: personas as PersonaType[],
+  };
+  await page.context().addCookies([
+    { name: PERSONA_COOKIE_KEY, value: encodeURIComponent(JSON.stringify(state)), domain: 'localhost', path: '/', sameSite: 'Lax' },
+    { name: LENS_COOKIE_KEY, value: lens, domain: 'localhost', path: '/', sameSite: 'Lax' },
+  ]);
+}
+
+async function setFoundationCookie(page: Page, uid: string, slug: string, name: string): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: SELECTED_FOUNDATION_COOKIE_KEY,
+      value: encodeURIComponent(JSON.stringify({ uid, slug, name })),
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function setProjectCookie(page: Page, uid: string, slug: string, name: string): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: SELECTED_PROJECT_COOKIE_KEY,
+      value: encodeURIComponent(JSON.stringify({ uid, slug, name })),
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+// Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
+// storageState, broken Auth0 login helper) still fail loudly when creds ARE configured.
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+/**
+ * Client-side (SPA) navigation for routes whose data is fully stubbed via page.route — a full
+ * `page.goto()` of an entity URL SSRs the route on the Express server, where server-side
+ * fetches bypass `page.route` stubs and hit the real BFF. Booting on `/` first and navigating
+ * via pushState + popstate keeps the router client-side, where every fetch is intercepted.
+ */
+async function gotoSpa(page: Page, path: string, seedContext: { uid: string; slug: string; name: string; foundation: boolean }): Promise<void> {
+  skipWhenAuthMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  // Wait for the app shell so the router is ready to process the synthetic popstate.
+  await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  // The '/' boot SSRs with the real backend persona data and can Set-Cookie a real selection
+  // (e.g. the test account's ASWF), racing the stubbed context these specs assert on. Re-assert
+  // the intended cookie post-boot so the client-side navigation starts from a clean slate.
+  if (seedContext.foundation) {
+    await setFoundationCookie(page, seedContext.uid, seedContext.slug, seedContext.name);
+  } else {
+    await setProjectCookie(page, seedContext.uid, seedContext.slug, seedContext.name);
+  }
+  await page.evaluate((url) => {
+    window.history.pushState({}, '', url);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+}
+
+test.describe('Survey edit URL derives from the survey’s owning tier (GH-1569)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubPersona(page, ['executive-director']);
+    await stubProjectApi(page);
+    await stubCommittees(page);
+    await stubLensItems(page);
+  });
+
+  test('foundation-owned survey: edit click-through lands on /foundation/... with ?project= (viewer in project lens)', async ({ page }) => {
+    // Seed the OPPOSITE lens from the survey's tier: the pre-fix bug prefixed the flat edit
+    // link with this transient project lens, landing on the wrong tier.
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await stubSurveys(
+      page,
+      buildSurveyStub({ projectUid: MOCK_FOUNDATION_UID, projectSlug: MOCK_FOUNDATION_SLUG, projectName: 'Test Foundation', isFoundation: true })
+    );
+
+    await gotoSpa(page, '/surveys', {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`).click();
+
+    await expect(page).toHaveURL(new RegExp(`/foundation/surveys/${MOCK_SURVEY_UID}/edit\\?project=${MOCK_FOUNDATION_SLUG}$`), {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  test('project-owned survey: edit click-through lands on /project/... with ?project= (viewer in foundation lens)', async ({ page }) => {
+    await setPersonaAndLensCookies(page, ['executive-director'], 'foundation');
+    await stubSurveys(
+      page,
+      buildSurveyStub({ projectUid: OTHER_PROJECT_UID, projectSlug: OTHER_PROJECT_SLUG, projectName: 'Other Project', isFoundation: false })
+    );
+
+    await gotoSpa(page, '/surveys', {
+      uid: MOCK_FOUNDATION_UID,
+      slug: MOCK_FOUNDATION_SLUG,
+      name: 'Test Foundation',
+      foundation: true,
+    });
+    await expect(page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`).click();
+
+    await expect(page).toHaveURL(new RegExp(`/project/surveys/${MOCK_SURVEY_UID}/edit\\?project=${OTHER_PROJECT_SLUG}$`), {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  test('unenriched survey: edit click-through falls back to the flat path, redirected by the active lens', async ({ page }) => {
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await stubSurveys(page, buildSurveyStub({ projectUid: OTHER_PROJECT_UID }));
+    // The manage page's uid-fallback resolves the project by uid when the payload carries no
+    // usable slug — stub the uid-keyed project route so context sync completes post-navigation.
+    await page.route(`**/api/projects/${OTHER_PROJECT_UID}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+      })
+    );
+
+    await gotoSpa(page, '/surveys', {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`).click();
+
+    // The button navigates flat; lensRedirectGuard prefixes by the ACTIVE lens (project here).
+    // The flat hop itself is an atomic guard redirect — only the settled URL is observable.
+    await expect(page).toHaveURL(new RegExp(`/project/surveys/${MOCK_SURVEY_UID}/edit$`), { timeout: PAGE_LOAD_TIMEOUT });
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+    await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  });
+});

--- a/apps/lfx-one/e2e/survey-edit-url.spec.ts
+++ b/apps/lfx-one/e2e/survey-edit-url.spec.ts
@@ -37,6 +37,7 @@ const OTHER_FOUNDATION_UID = 'f0000000-0000-0000-0000-00000000d002';
 const OTHER_PROJECT_SLUG = 'other-project';
 const OTHER_PROJECT_UID = 'p0000000-0000-0000-0000-00000000d003';
 const MOCK_SURVEY_UID = 's1000000-0000-0000-0000-00000000d001';
+const MOCK_COMMITTEE_UID = 'c0000000-0000-0000-0000-00000000d001';
 
 function buildProjectStub(uid: string, slug: string, name: string) {
   return {
@@ -66,10 +67,11 @@ function buildProjectStub(uid: string, slug: string, name: string) {
 }
 
 /**
- * Surveys-table row / edit-page detail payload. The list shape mirrors the BFF `getSurveys`
- * response post-GH-1569 (project_uid flattened from committees[0], project fields enriched);
- * omitting `projectSlug`/`isFoundation` mirrors an enrichment failure, where the row must fall
- * back to the flat path.
+ * Surveys-table row / edit-page detail payload, shaped as the BFF emits it post-GH-1569: project
+ * identity lives in committees[0] (as upstream sends it), `project_uid` top-level is the BFF's
+ * flattened stamp, and `project_slug`/`project_name`/`is_foundation` appear only when the BFF
+ * enrichment succeeded. Omitting `projectSlug`/`isFoundation` mirrors an enrichment failure,
+ * where the row must fall back to the flat path.
  */
 function buildSurveyStub(owner: { projectUid: string; projectSlug?: string; projectName?: string; isFoundation?: boolean }) {
   return {
@@ -80,7 +82,16 @@ function buildSurveyStub(owner: { projectUid: string; projectSlug?: string; proj
     ...(owner.projectSlug !== undefined ? { project_slug: owner.projectSlug } : {}),
     ...(owner.projectName !== undefined ? { project_name: owner.projectName } : {}),
     ...(owner.isFoundation !== undefined ? { is_foundation: owner.isFoundation } : {}),
-    committees: [],
+    committees: [
+      {
+        committee_uid: MOCK_COMMITTEE_UID,
+        committee_name: 'Test Committee',
+        project_uid: owner.projectUid,
+        project_name: owner.projectName ?? '',
+        total_recipients: 0,
+        total_responses: 0,
+      },
+    ],
     committee_category: '',
     is_nps_survey: false,
     is_project_survey: false,
@@ -279,9 +290,12 @@ test.describe('Survey edit URL derives from the survey’s owning tier (GH-1569)
 
     await page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`).click();
 
-    await expect(page).toHaveURL(new RegExp(`/foundation/surveys/${MOCK_SURVEY_UID}/edit\\?project=${MOCK_FOUNDATION_SLUG}$`), {
-      timeout: PAGE_LOAD_TIMEOUT,
-    });
+    await expect(page).toHaveURL(
+      new RegExp(`/foundation/surveys/${MOCK_SURVEY_UID}/edit\\?project=${MOCK_FOUNDATION_SLUG}&committee_uid=${MOCK_COMMITTEE_UID}$`),
+      {
+        timeout: PAGE_LOAD_TIMEOUT,
+      }
+    );
     await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
   });
 
@@ -302,7 +316,7 @@ test.describe('Survey edit URL derives from the survey’s owning tier (GH-1569)
 
     await page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`).click();
 
-    await expect(page).toHaveURL(new RegExp(`/project/surveys/${MOCK_SURVEY_UID}/edit\\?project=${OTHER_PROJECT_SLUG}$`), {
+    await expect(page).toHaveURL(new RegExp(`/project/surveys/${MOCK_SURVEY_UID}/edit\\?project=${OTHER_PROJECT_SLUG}&committee_uid=${MOCK_COMMITTEE_UID}$`), {
       timeout: PAGE_LOAD_TIMEOUT,
     });
     await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
@@ -331,9 +345,10 @@ test.describe('Survey edit URL derives from the survey’s owning tier (GH-1569)
 
     await page.getByTestId(`surveys-edit-${MOCK_SURVEY_UID}`).click();
 
-    // The button navigates flat; lensRedirectGuard prefixes by the ACTIVE lens (project here).
-    // The flat hop itself is an atomic guard redirect — only the settled URL is observable.
-    await expect(page).toHaveURL(new RegExp(`/project/surveys/${MOCK_SURVEY_UID}/edit$`), { timeout: PAGE_LOAD_TIMEOUT });
+    // The button navigates flat (with only the row's committee scope); lensRedirectGuard prefixes
+    // by the ACTIVE lens (project here). The flat hop itself is an atomic guard redirect — only
+    // the settled URL is observable.
+    await expect(page).toHaveURL(new RegExp(`/project/surveys/${MOCK_SURVEY_UID}/edit\\?committee_uid=${MOCK_COMMITTEE_UID}$`), { timeout: PAGE_LOAD_TIMEOUT });
     expect(new URL(page.url()).searchParams.has('project')).toBe(false);
     await expect(page.getByTestId('survey-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
   });

--- a/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.html
@@ -7,7 +7,7 @@
       [surveys]="surveys()"
       [hasPMOAccess]="canEdit()"
       [loading]="loading()"
-      [editQueryParams]="editSurveyQueryParams()"
+      [committeeUid]="committee().uid"
       (viewResults)="viewSurveyResults($event)"
       (rowClick)="viewSurveyResults($event)">
       @if (canEdit()) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts
@@ -44,7 +44,6 @@ export class CommitteeSurveysComponent {
   // Data
   public surveys: Signal<Survey[]> = this.initSurveys();
   public createSurveyQueryParams: Signal<Record<string, string>> = this.initCreateSurveyQueryParams();
-  public editSurveyQueryParams: Signal<Record<string, string>> = this.createSurveyQueryParams;
 
   public viewSurveyResults(survey: Survey): void {
     this.selectedSurveyId.set(survey.uid);

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -196,7 +196,6 @@
                       [text]="true"
                       [routerLink]="survey.editCommands"
                       [queryParams]="survey.editQueryParams"
-                      (onClick)="$event.stopPropagation()"
                       [attr.data-testid]="'surveys-edit-' + rowId">
                     </lfx-button>
                     <lfx-button

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -194,8 +194,8 @@
                       severity="primary"
                       size="small"
                       [text]="true"
-                      [routerLink]="['/surveys', survey.uid, 'edit']"
-                      [queryParams]="editQueryParams()"
+                      [routerLink]="survey.editCommands"
+                      [queryParams]="survey.editQueryParams"
                       (onClick)="$event.stopPropagation()"
                       [attr.data-testid]="'surveys-edit-' + rowId">
                     </lfx-button>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -290,6 +290,9 @@ export class SurveysTableComponent {
   // === Private Helpers ===
   // Mirrors meeting-card's per-row params: the row's own project slug + committee scope, so the
   // edit page opens in the survey's project context even from a context-less list (GH-1569).
+  // Without a viewed-committee override (global list) the scope resolves to the primary committee,
+  // so a writer of a non-primary committee is fail-closed denied from the list and edits via their
+  // committee tab instead — iterating committees[] per row is follow-up work (GH-2190).
   private buildEditQueryParams(survey: Survey): Record<string, string> {
     const params: Record<string, string> = {};
     if (survey.project_slug) params['project'] = survey.project_slug;

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -14,8 +14,8 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { SURVEY_LABEL, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
-import { FilterPillOption, Survey } from '@lfx-one/shared/interfaces';
-import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { FilterPillOption, Survey, SurveyTableRow } from '@lfx-one/shared/interfaces';
+import { getEntityCommands, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { DueDateLabelColorPipe } from '@pipes/due-date-label-color.pipe';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { ScheduledSendAriaLabelPipe, ScheduledSendTooltipPipe } from '@pipes/scheduled-send-tooltip.pipe';
@@ -73,7 +73,9 @@ export class SurveysTableComponent {
   public readonly showFoundationFilter = input<boolean>(false);
   public readonly showProjectFilter = input<boolean>(false);
   public readonly isMeLens = input<boolean>(false);
-  public readonly editQueryParams = input<Record<string, string>>({});
+  // Viewed-committee override (committee tab): rows stamp committees[0] by default, but a
+  // committee writer's guard fallback must probe the committee they're actually viewing (GH-1569).
+  public readonly committeeUid = input<string>('');
 
   // === Outputs ===
   public readonly viewResults = output<Survey>();
@@ -101,7 +103,7 @@ export class SurveysTableComponent {
   private readonly typeFilter: Signal<string | null> = this.initTypeFilter();
   protected readonly groupOptions: Signal<{ label: string; value: string | null }[]> = this.initGroupOptions();
   protected readonly typeOptions: Signal<{ label: string; value: string | null }[]> = this.initTypeOptions();
-  protected readonly filteredSurveys: Signal<(Survey & { displayStatus: SurveyStatus })[]> = this.initFilteredSurveys();
+  protected readonly filteredSurveys: Signal<SurveyTableRow[]> = this.initFilteredSurveys();
   protected readonly isFiltered = computed(
     () => this.searchTerm() !== '' || this.statusTab() !== 'all' || this.groupFilter() !== null || this.typeFilter() !== null
   );
@@ -243,13 +245,18 @@ export class SurveysTableComponent {
     });
   }
 
-  private initFilteredSurveys(): Signal<(Survey & { displayStatus: SurveyStatus })[]> {
+  private initFilteredSurveys(): Signal<SurveyTableRow[]> {
     return computed(() => {
       // Precompute displayStatus once per row so the template, filter, and sort
       // all agree on cutoff/case-normalized status (matches what the badge pipe shows).
+      // Also stamp the per-row edit link: canonical commands derive from the SURVEY's owning
+      // tier (is_foundation), not the viewer's active lens; unenriched rows (undefined tier)
+      // fall back to the flat path, which lensRedirectGuard prefixes (GH-1569).
       let filtered = this.surveys().map((survey) => ({
         ...survey,
         displayStatus: getSurveyDisplayStatus(survey),
+        editCommands: getEntityCommands('surveys', survey.uid, survey.is_foundation, 'edit') ?? ['/surveys', survey.uid, 'edit'],
+        editQueryParams: this.buildEditQueryParams(survey),
       }));
 
       const searchTerm = this.searchTerm()?.toLowerCase() || '';
@@ -281,7 +288,17 @@ export class SurveysTableComponent {
   }
 
   // === Private Helpers ===
-  private sortSurveys<T extends Survey & { displayStatus: SurveyStatus }>(surveys: T[]): T[] {
+  // Mirrors meeting-card's per-row params: the row's own project slug + committee scope, so the
+  // edit page opens in the survey's project context even from a context-less list (GH-1569).
+  private buildEditQueryParams(survey: Survey): Record<string, string> {
+    const params: Record<string, string> = {};
+    if (survey.project_slug) params['project'] = survey.project_slug;
+    const committeeUid = this.committeeUid() || survey.committees?.[0]?.committee_uid;
+    if (committeeUid) params['committee_uid'] = committeeUid;
+    return params;
+  }
+
+  private sortSurveys<T extends SurveyTableRow>(surveys: T[]): T[] {
     const statusPriority: Record<string, number> = {
       [SurveyStatus.OPEN]: 1,
       [SurveyStatus.DRAFT]: 2,

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -105,16 +105,27 @@ export class SurveyManageComponent {
   public constructor() {
     // Sync context from the loaded survey itself — an edit deep link can arrive with no
     // `?project=` under a stale cookie-restored context (GH-1569). Mirrors meeting-manage (gh-1432).
-    syncEntityProjectContext(this.surveyEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    // canonicalizeRoute rewrites a wrong-tier URL (/project/* vs /foundation/*) to the survey's own
+    // tier so copied wizard links reflect ownership — mirrors vote-manage/mailing-list-manage.
+    syncEntityProjectContext(this.surveyEntityContext, this.projectContextService, this.router, this.destroyRef, {
+      preferEntityKind: true,
+      canonicalizeRoute: true,
+    });
     // Unenriched-payload fallback (project_uid but no project_slug): resolve the project by uid;
     // freshFetch re-reads the detail uncached as a last resort for a committee writer whose
     // relation-gated project lookup resolves null (the enrichment needs no project relation).
     syncEntityProjectContextFallback(this.surveyEntityContext, this.projectService, this.projectContextService, this.router, this.destroyRef, {
       entityKind: 'survey',
+      canonicalizeRoute: true,
       freshFetch: (uid) =>
-        this.surveyService
-          .getSurvey(uid, undefined, { skipCache: true })
-          .pipe(map((survey) => ({ project_uid: survey.project_uid ?? '', project_slug: survey.project_slug, project_name: survey.project_name, is_foundation: survey.is_foundation ?? null }))),
+        this.surveyService.getSurvey(uid, undefined, { skipCache: true }).pipe(
+          map((survey) => ({
+            project_uid: survey.project_uid ?? '',
+            project_slug: survey.project_slug,
+            project_name: survey.project_name,
+            is_foundation: survey.is_foundation ?? null,
+          }))
+        ),
     });
     this.initCommitteeContext();
     evictOnWriteAccessLoss();

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -30,13 +30,14 @@ import { ProjectService } from '@services/project.service';
 import { SurveyService } from '@services/survey.service';
 import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
+import { resolveEntityWriteSlug } from '@shared/utils/write-access.util';
 import { MessageComponent } from '@components/message/message.component';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { trimmedRequired } from '@lfx-one/shared/validators';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, Observable, of, switchMap, take } from 'rxjs';
 
 import { SurveyAudienceTypeComponent } from '../components/survey-audience-type/survey-audience-type.component';
 import { SurveyEmailDraftComponent } from '../components/survey-email-draft/survey-email-draft.component';
@@ -90,10 +91,13 @@ export class SurveyManageComponent {
 
   // Complex computed/toSignal signals
   public readonly isEditMode: Signal<boolean> = this.initIsEditMode();
-  public readonly survey: Signal<Survey | null> = this.initSurvey();
+  private readonly survey: Signal<Survey | null> = this.initSurvey();
   // Survey → EntityWithProject adapter so the active project context syncs from the loaded
   // survey, not a stale cookie-restored context (GH-1569).
   private readonly surveyEntityContext: Signal<EntityWithProject | null> = this.initSurveyEntityContext();
+  // URL-stamped committee scope for the access predicate — mirrors writerGuard's committee leg.
+  private readonly committeeUidFromUrl = this.route.snapshot.queryParamMap.get('committee_uid');
+  private readonly writeAccess: Signal<boolean> = this.initWriteAccess();
   public readonly formValue: Signal<Record<string, unknown>> = this.initFormValue();
   public readonly canGoPrevious: Signal<boolean> = this.initCanGoPrevious();
   public readonly canGoNext: Signal<boolean> = this.initCanGoNext();
@@ -128,7 +132,9 @@ export class SurveyManageComponent {
         ),
     });
     this.initCommitteeContext();
-    evictOnWriteAccessLoss();
+    // Pass the guard-mirroring predicate — the default canWrite is project-writer-only and would
+    // evict guard-admitted committee writers the moment the context syncs to the survey's project.
+    evictOnWriteAccessLoss(this.writeAccess);
   }
 
   public nextStep(): void {
@@ -489,6 +495,105 @@ Thank you,
         project_name: survey.project_name,
         is_foundation: survey.is_foundation ?? null,
       };
+    });
+  }
+
+  /**
+   * Access predicate mirroring writerGuard's surveys standard — project writer on the survey's OWN
+   * project (never the boot context), or committee writer via the survey's own committees /
+   * ?committee_uid=; pending legs stay provisionally true so a resolving leg can't evict a
+   * guard-admitted committee writer mid-edit. Mirrors vote-manage's initWriteAccess (GH-1568).
+   */
+  private initWriteAccess(): Signal<boolean> {
+    const editSurveyId = this.route.snapshot.paramMap.get('id');
+    const projectKey$: Observable<string | null | undefined> = editSurveyId
+      ? toObservable(this.survey).pipe(
+          map((survey) => {
+            if (!survey) {
+              // Pending — in edit mode the authorization target comes from the survey itself.
+              return undefined;
+            }
+            // Mirror writerGuard's resolution order; the active-context fallback covers a survey
+            // carrying neither slug nor uid (the manage component owns that error path). The
+            // project_uid ?? '' mapping mirrors the guard probe — Survey.project_uid is typed
+            // optional and resolveEntityWriteSlug's || treats '' as absent.
+            return resolveEntityWriteSlug(
+              { project_slug: survey.project_slug, project_uid: survey.project_uid ?? '' },
+              this.projectContextService.activeContext()?.slug ?? null
+            );
+          })
+        )
+      : toObservable(this.projectContextService.activeContext).pipe(map((ctx) => ctx?.slug ?? null));
+
+    const projectAccess = toSignal(
+      projectKey$.pipe(
+        filter((key): key is string | null => key !== undefined),
+        distinctUntilChanged(),
+        switchMap((key) => {
+          if (!key) {
+            return of(false);
+          }
+          // writerGuard admits no coordinator-style role for surveys — project.writer only.
+          return this.projectService.getProject(key, false).pipe(
+            map((project) => project?.writer === true),
+            catchError(() => of(false))
+          );
+        })
+      )
+      // No initialValue: undefined doubles as the leg's pending state (see the doc above).
+    );
+    // Edit mode mirrors writerGuard's surveys probe selection: the URL ?committee_uid= wins only
+    // when the survey's own committees[] contains it, else the primary committee; a committee-less
+    // survey falls back to the URL param. Hoisted: toObservable needs the injection context, so it
+    // can't be created lazily inside the switchMap below.
+    const editCommitteeUid$: Observable<string | null | undefined> = toObservable(this.survey).pipe(
+      map((survey) => {
+        if (!survey) {
+          return undefined;
+        }
+        const url = this.committeeUidFromUrl;
+        const entityUid = url && survey.committees?.some((c) => c.committee_uid === url) ? url : survey.committees?.[0]?.committee_uid;
+        return entityUid ?? url;
+      })
+    );
+    // Gated on the project leg resolving false: a granted project leg makes the committee fetch
+    // moot, and while it's pending this leg stays pending too. undefined stays pending; null resolves immediately.
+    const committeeUid$: Observable<string | null | undefined> = toObservable(projectAccess).pipe(
+      filter((project): project is boolean => project !== undefined),
+      distinctUntilChanged(),
+      switchMap((project) => {
+        if (project) {
+          // Project leg granted — resolve the committee leg without firing the HTTP probe.
+          return of<string | null>(null);
+        }
+        return editSurveyId ? editCommitteeUid$ : of(this.committeeUidFromUrl);
+      })
+    );
+    const committeeAccess = toSignal(
+      committeeUid$.pipe(
+        filter((uid): uid is string | null => uid !== undefined),
+        distinctUntilChanged(),
+        switchMap((uid) =>
+          uid
+            ? this.committeeService.fetchCommittee(uid).pipe(
+                map((committee) => committee?.writer === true),
+                catchError(() => of(false))
+              )
+            : of(false)
+        )
+      )
+      // No initialValue: undefined doubles as the leg's pending state (see the doc above).
+    );
+    return computed(() => {
+      const project = projectAccess();
+      const committee = committeeAccess();
+      if (project === true || committee === true) {
+        return true;
+      }
+      if (project === undefined || committee === undefined) {
+        return true; // provisional — a pending leg can still grant access
+      }
+      return false;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal, signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import {
   SCHEDULE_SURVEY_CONFIRMATION,
@@ -14,17 +14,29 @@ import {
   SURVEY_LABEL,
   SURVEY_MANAGE_TOTAL_STEPS,
 } from '@lfx-one/shared/constants';
-import { Committee, CommitteeReference, CreateSurveyRequest, SurveyDistributionMethod, SurveyReminderType } from '@lfx-one/shared/interfaces';
+import {
+  Committee,
+  CommitteeReference,
+  CreateSurveyRequest,
+  EntityWithProject,
+  ProjectContext,
+  Survey,
+  SurveyDistributionMethod,
+  SurveyReminderType,
+} from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
 import { SurveyService } from '@services/survey.service';
+import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 import { MessageComponent } from '@components/message/message.component';
-import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
+import { computeIsFoundation, markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { trimmedRequired } from '@lfx-one/shared/validators';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, merge, of, switchMap, take } from 'rxjs';
 
 import { SurveyAudienceTypeComponent } from '../components/survey-audience-type/survey-audience-type.component';
 import { SurveyEmailDraftComponent } from '../components/survey-email-draft/survey-email-draft.component';
@@ -56,6 +68,9 @@ export class SurveyManageComponent {
   private readonly messageService = inject(MessageService);
   private readonly committeeService = inject(CommitteeService);
   private readonly surveyService = inject(SurveyService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly projectService = inject(ProjectService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
@@ -75,6 +90,10 @@ export class SurveyManageComponent {
 
   // Complex computed/toSignal signals
   public readonly isEditMode: Signal<boolean> = this.initIsEditMode();
+  public readonly survey: Signal<Survey | null> = this.initSurvey();
+  // Survey → EntityWithProject adapter so the active project context syncs from the loaded
+  // survey, not a stale cookie-restored context (GH-1569).
+  private readonly surveyEntityContext: Signal<EntityWithProject | null> = this.initSurveyEntityContext();
   public readonly formValue: Signal<Record<string, unknown>> = this.initFormValue();
   public readonly canGoPrevious: Signal<boolean> = this.initCanGoPrevious();
   public readonly canGoNext: Signal<boolean> = this.initCanGoNext();
@@ -84,6 +103,10 @@ export class SurveyManageComponent {
   public readonly submitButtonLabel: Signal<string> = this.initSubmitButtonLabel();
 
   public constructor() {
+    // Sync context from the loaded survey itself — an edit deep link can arrive with no
+    // `?project=` under a stale cookie-restored context (GH-1569). Mirrors meeting-manage (gh-1432).
+    syncEntityProjectContext(this.surveyEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    this.initSurveyContextFallback();
     this.initCommitteeContext();
     evictOnWriteAccessLoss();
   }
@@ -92,7 +115,8 @@ export class SurveyManageComponent {
     const next = this.currentStep() + 1;
     if (next <= this.totalSteps && this.canNavigateToStep(next)) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: next } });
+        // Merge so the entity's `?project=` (context sync key) and `committee_uid` survive step changes (GH-1569).
+        this.router.navigate([], { queryParams: { step: next }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(next);
       }
@@ -103,7 +127,7 @@ export class SurveyManageComponent {
     const previous = this.currentStep() - 1;
     if (previous >= 1) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: previous } });
+        this.router.navigate([], { queryParams: { step: previous }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(previous);
       }
@@ -113,7 +137,7 @@ export class SurveyManageComponent {
   public goToStep(step: number | undefined): void {
     if (step !== undefined && step >= 1 && step <= this.totalSteps) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step } });
+        this.router.navigate([], { queryParams: { step }, queryParamsHandling: 'merge' });
       } else {
         if (step <= this.currentStep() || this.canNavigateToStep(step)) {
           this.internalStep.set(step);
@@ -391,6 +415,97 @@ Thank you,
       }
     }
     return true;
+  }
+
+  /**
+   * Edit-mode entity fetch: loads the survey being edited so the project-context sync and the
+   * writerGuard probe derive from the entity itself, not a stale cookie-restored context
+   * (GH-1569). Shares the guard probe's short-TTL cached request via SurveyService.getSurvey.
+   * No form pre-population here — that's the edit-flow completion ticket.
+   */
+  private initSurvey(): Signal<Survey | null> {
+    return toSignal(
+      toObservable(this.surveyId).pipe(
+        switchMap((id) => {
+          if (!id) {
+            return of(null);
+          }
+          return this.surveyService.getSurvey(id).pipe(
+            catchError(() => {
+              this.messageService.add({
+                severity: 'error',
+                summary: 'Error',
+                detail: `${this.surveyLabel.singular} not found`,
+              });
+              this.router.navigate(['/surveys']);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  /**
+   * Adapts the loaded survey to {@link EntityWithProject}; a falsy `project_slug` (absent or
+   * empty) reads as "unenriched" to both the sync and the uid fallback below.
+   */
+  private initSurveyEntityContext(): Signal<EntityWithProject | null> {
+    return computed(() => {
+      const survey = this.survey();
+      if (!survey) {
+        return null;
+      }
+      return {
+        uid: survey.uid,
+        project_uid: survey.project_uid ?? '',
+        project_slug: survey.project_slug,
+        project_name: survey.project_name,
+        is_foundation: survey.is_foundation ?? null,
+      };
+    });
+  }
+
+  /**
+   * Unenriched-payload fallback (project_uid but no usable project_slug): resolve the project by
+   * uid and set context from it; NavigationEnd re-applies it, mirroring syncEntityProjectContext
+   * (GH-1569). `getProject(uid, false)` — `current: false` so the fetch doesn't clobber
+   * ProjectService's shared state; a null result leaves the (stale) context untouched rather
+   * than erroring the page.
+   */
+  private initSurveyContextFallback(): void {
+    const unresolvedEntity$ = toObservable(this.surveyEntityContext).pipe(
+      distinctUntilChanged((a, b) => a?.uid === b?.uid && a?.project_uid === b?.project_uid)
+    );
+    const navigationReapply$ = this.router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      map(() => this.surveyEntityContext())
+    );
+    merge(unresolvedEntity$, navigationReapply$)
+      .pipe(
+        filter((entity): entity is EntityWithProject => !!entity?.project_uid && !entity.project_slug),
+        switchMap((entity) =>
+          this.projectService.getProject(entity.project_uid, false).pipe(
+            map((project) => {
+              if (!project) {
+                return null;
+              }
+              const context: ProjectContext = { uid: project.uid, name: project.name, slug: project.slug };
+              return { context, isFoundation: computeIsFoundation(project) };
+            })
+          )
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((resolved) => {
+        if (!resolved) {
+          return;
+        }
+        // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
+        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
+        applyEntityProjectContext(this.projectContextService, resolved.context, resolved.isFoundation, syncUrl);
+      });
   }
 
   private isStepValid(step: number): boolean {

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -3,9 +3,9 @@
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, NavigationEnd, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import {
   SCHEDULE_SURVEY_CONFIRMATION,
@@ -20,7 +20,6 @@ import {
   CommitteeReference,
   CreateSurveyRequest,
   EntityWithProject,
-  ProjectContext,
   Survey,
   SurveyDistributionMethod,
   SurveyReminderType,
@@ -29,15 +28,15 @@ import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { SurveyService } from '@services/survey.service';
-import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 import { MessageComponent } from '@components/message/message.component';
-import { computeIsFoundation, markFormControlsAsTouched } from '@lfx-one/shared/utils';
+import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { trimmedRequired } from '@lfx-one/shared/validators';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, combineLatest, distinctUntilChanged, filter, map, merge, of, switchMap, take } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, take } from 'rxjs';
 
 import { SurveyAudienceTypeComponent } from '../components/survey-audience-type/survey-audience-type.component';
 import { SurveyEmailDraftComponent } from '../components/survey-email-draft/survey-email-draft.component';
@@ -107,7 +106,16 @@ export class SurveyManageComponent {
     // Sync context from the loaded survey itself — an edit deep link can arrive with no
     // `?project=` under a stale cookie-restored context (GH-1569). Mirrors meeting-manage (gh-1432).
     syncEntityProjectContext(this.surveyEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
-    this.initSurveyContextFallback();
+    // Unenriched-payload fallback (project_uid but no project_slug): resolve the project by uid;
+    // freshFetch re-reads the detail uncached as a last resort for a committee writer whose
+    // relation-gated project lookup resolves null (the enrichment needs no project relation).
+    syncEntityProjectContextFallback(this.surveyEntityContext, this.projectService, this.projectContextService, this.router, this.destroyRef, {
+      entityKind: 'survey',
+      freshFetch: (uid) =>
+        this.surveyService
+          .getSurvey(uid, undefined, { skipCache: true })
+          .pipe(map((survey) => ({ project_uid: survey.project_uid ?? '', project_slug: survey.project_slug, project_name: survey.project_name, is_foundation: survey.is_foundation ?? null }))),
+    });
     this.initCommitteeContext();
     evictOnWriteAccessLoss();
   }
@@ -455,7 +463,7 @@ Thank you,
 
   /**
    * Adapts the loaded survey to {@link EntityWithProject}; a falsy `project_slug` (absent or
-   * empty) reads as "unenriched" to both the sync and the uid fallback below.
+   * empty) reads as "unenriched" to both the sync and the fallback helper.
    */
   private initSurveyEntityContext(): Signal<EntityWithProject | null> {
     return computed(() => {
@@ -471,47 +479,6 @@ Thank you,
         is_foundation: survey.is_foundation ?? null,
       };
     });
-  }
-
-  /**
-   * Unenriched-payload fallback (project_uid but no usable project_slug): resolve the project by
-   * uid and set context from it; NavigationEnd re-applies it, mirroring syncEntityProjectContext
-   * (GH-1569). `getProject(uid, false)` — `current: false` so the fetch doesn't clobber
-   * ProjectService's shared state; a null result leaves the (stale) context untouched rather
-   * than erroring the page.
-   */
-  private initSurveyContextFallback(): void {
-    const unresolvedEntity$ = toObservable(this.surveyEntityContext).pipe(
-      distinctUntilChanged((a, b) => a?.uid === b?.uid && a?.project_uid === b?.project_uid)
-    );
-    const navigationReapply$ = this.router.events.pipe(
-      filter((event) => event instanceof NavigationEnd),
-      map(() => this.surveyEntityContext())
-    );
-    merge(unresolvedEntity$, navigationReapply$)
-      .pipe(
-        filter((entity): entity is EntityWithProject => !!entity?.project_uid && !entity.project_slug),
-        switchMap((entity) =>
-          this.projectService.getProject(entity.project_uid, false).pipe(
-            map((project) => {
-              if (!project) {
-                return null;
-              }
-              const context: ProjectContext = { uid: project.uid, name: project.name, slug: project.slug };
-              return { context, isFoundation: computeIsFoundation(project) };
-            })
-          )
-        ),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe((resolved) => {
-        if (!resolved) {
-          return;
-        }
-        // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
-        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
-        applyEntityProjectContext(this.projectContextService, resolved.context, resolved.isFoundation, syncUrl);
-      });
   }
 
   private isStepValid(step: number): boolean {

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -431,13 +432,18 @@ Thank you,
             return of(null);
           }
           return this.surveyService.getSurvey(id).pipe(
-            catchError(() => {
-              this.messageService.add({
-                severity: 'error',
-                summary: 'Error',
-                detail: `${this.surveyLabel.singular} not found`,
-              });
-              this.router.navigate(['/surveys']);
+            catchError((error) => {
+              // Only a real 404 ejects — the fetch exists for context sync (no form pre-population
+              // yet), so a transient 5xx/network blip leaves the page mounted; the context simply
+              // stays uncorrected rather than mislabeling a server error as "not found".
+              if (error instanceof HttpErrorResponse && error.status === 404) {
+                this.messageService.add({
+                  severity: 'error',
+                  summary: 'Error',
+                  detail: `${this.surveyLabel.singular} not found`,
+                });
+                this.router.navigate(['/surveys']);
+              }
               return of(null);
             })
           );

--- a/apps/lfx-one/src/app/modules/surveys/surveys.routes.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys.routes.ts
@@ -22,6 +22,9 @@ export const SURVEY_ROUTES: Routes = [
     path: ':id/edit',
     loadComponent: () => import('./survey-manage/survey-manage.component').then((m) => m.SurveyManageComponent),
     canActivate: [authGuard, writerGuard],
-    data: { writeFeature: 'surveys' },
+    // entityScopedSlug: writerGuard resolves the authorization slug from the survey itself on
+    // this route. A route-data flag, not a path check, so a route rename/restructure
+    // can't silently revert the guard to stale-context authorization.
+    data: { writeFeature: 'surveys', entityScopedSlug: true },
   },
 ];

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -391,6 +391,82 @@ describe('writerGuard', () => {
     expect(getCommittee).not.toHaveBeenCalled();
   });
 
+  it('admits a committee writer via a URL committee_uid the survey’s own committees contain', async () => {
+    getSurvey.mockReturnValue(
+      of({
+        uid: SURVEY_UID,
+        project_uid: 's-uid',
+        project_slug: SURVEY_SLUG,
+        committees: [{ committee_uid: COMMITTEE_UID }, { committee_uid: 'other-committee' }],
+      } as unknown as Survey)
+    );
+    getProject.mockReturnValue(of({ uid: 's-uid', slug: SURVEY_SLUG, writer: false }));
+    getCommittee.mockReturnValue(of({ uid: COMMITTEE_UID, writer: true } as unknown as Committee));
+    const route = {
+      queryParamMap: convertToParamMap({ committee_uid: COMMITTEE_UID }),
+      paramMap: convertToParamMap({ id: SURVEY_UID }),
+      data: { writeFeature: 'surveys', entityScopedSlug: true },
+      parent: null,
+    } as unknown as ActivatedRouteSnapshot;
+
+    const result = await runGuard(route);
+
+    expect(result).toBe(true);
+    expect(getCommittee).toHaveBeenCalledWith(COMMITTEE_UID);
+  });
+
+  it('authorizes against the survey’s primary committee, not a URL committee_uid naming an unrelated one', async () => {
+    getSurvey.mockReturnValue(
+      of({ uid: SURVEY_UID, project_uid: 's-uid', project_slug: SURVEY_SLUG, committees: [{ committee_uid: 'survey-committee' }] } as unknown as Survey)
+    );
+    getProject.mockReturnValue(of({ uid: 's-uid', slug: SURVEY_SLUG, writer: false }));
+    getCommittee.mockReturnValue(of({ uid: 'survey-committee', writer: false } as unknown as Committee));
+    const route = {
+      queryParamMap: convertToParamMap({ committee_uid: 'attacker-committee' }),
+      paramMap: convertToParamMap({ id: SURVEY_UID }),
+      data: { writeFeature: 'surveys', entityScopedSlug: true },
+      parent: null,
+    } as unknown as ActivatedRouteSnapshot;
+
+    const result = await runGuard(route);
+
+    expect(getCommittee).toHaveBeenCalledWith('survey-committee');
+    expect(getCommittee).not.toHaveBeenCalledWith('attacker-committee');
+    expect(result).not.toBe(true);
+  });
+
+  it('authorizes against the survey’s primary committee when the URL omits committee_uid', async () => {
+    getSurvey.mockReturnValue(
+      of({ uid: SURVEY_UID, project_uid: 's-uid', project_slug: SURVEY_SLUG, committees: [{ committee_uid: 'survey-committee' }] } as unknown as Survey)
+    );
+    getProject.mockReturnValue(of({ uid: 's-uid', slug: SURVEY_SLUG, writer: false }));
+    getCommittee.mockReturnValue(of({ uid: 'survey-committee', writer: true } as unknown as Committee));
+
+    const result = await runGuard(surveyRoute());
+
+    expect(result).toBe(true);
+    expect(getCommittee).toHaveBeenCalledWith('survey-committee');
+  });
+
+  it('falls back to the URL committee_uid for a committee-less survey', async () => {
+    // Pins the documented deliberate path: a committee-less project survey has no entity committee
+    // to win, so the (attacker-controllable but backend-enforced) URL param is the only committee leg.
+    getSurvey.mockReturnValue(of({ uid: SURVEY_UID, project_uid: 's-uid', project_slug: SURVEY_SLUG, committees: [] } as unknown as Survey));
+    getProject.mockReturnValue(of({ uid: 's-uid', slug: SURVEY_SLUG, writer: false }));
+    getCommittee.mockReturnValue(of({ uid: COMMITTEE_UID, writer: true } as unknown as Committee));
+    const route = {
+      queryParamMap: convertToParamMap({ committee_uid: COMMITTEE_UID }),
+      paramMap: convertToParamMap({ id: SURVEY_UID }),
+      data: { writeFeature: 'surveys', entityScopedSlug: true },
+      parent: null,
+    } as unknown as ActivatedRouteSnapshot;
+
+    const result = await runGuard(route);
+
+    expect(result).toBe(true);
+    expect(getCommittee).toHaveBeenCalledWith(COMMITTEE_UID);
+  });
+
   it('fails closed when an entity-scoped route has no :id param', async () => {
     const route = {
       queryParamMap: convertToParamMap({}),

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -11,14 +11,15 @@ import { MeetingService } from '@shared/services/meeting.service';
 import { PersonaService } from '@shared/services/persona.service';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { ProjectService } from '@shared/services/project.service';
+import { SurveyService } from '@shared/services/survey.service';
 import { VoteService } from '@shared/services/vote.service';
-import { Committee, GroupsIOMailingList, Meeting, Vote } from '@lfx-one/shared/interfaces';
+import { Committee, GroupsIOMailingList, Meeting, Survey, Vote } from '@lfx-one/shared/interfaces';
 import { firstValueFrom, of, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { writerGuard } from './writer.guard';
 
-// Pins the fail-closed entity-scoped slug contract (GH-1579/GH-1566/GH-1567/GH-1568): only a 404 probe read
+// Pins the fail-closed entity-scoped slug contract (GH-1579/GH-1566/GH-1567/GH-1568/GH-1569): only a 404 probe read
 // falls back to the stale context — anything else resolves no slug. Also covers the ED fast path and non-entity-scoped features.
 describe('writerGuard', () => {
   const MEETING_UID = 'meeting-uid-1';
@@ -29,6 +30,8 @@ describe('writerGuard', () => {
   const VOTE_SLUG = 'vote-project';
   const MAILING_LIST_UID = 'mailing-list-uid-1';
   const MAILING_LIST_SLUG = 'mailing-list-project';
+  const SURVEY_UID = 'survey-uid-1';
+  const SURVEY_SLUG = 'survey-project';
   const STALE_SLUG = 'stale-project';
 
   let getMeetingDetail: ReturnType<typeof vi.fn>;
@@ -37,6 +40,7 @@ describe('writerGuard', () => {
   let fetchCommittee: ReturnType<typeof vi.fn>;
   let fetchVote: ReturnType<typeof vi.fn>;
   let getMailingList: ReturnType<typeof vi.fn>;
+  let getSurvey: ReturnType<typeof vi.fn>;
   let router: { parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
   let currentPersona: ReturnType<typeof signal<string>>;
 
@@ -74,6 +78,14 @@ describe('writerGuard', () => {
       parent: null,
     }) as unknown as ActivatedRouteSnapshot;
 
+  const surveyRoute = (): ActivatedRouteSnapshot =>
+    ({
+      queryParamMap: convertToParamMap({}),
+      paramMap: convertToParamMap({ id: SURVEY_UID }),
+      data: { writeFeature: 'surveys', entityScopedSlug: true },
+      parent: null,
+    }) as unknown as ActivatedRouteSnapshot;
+
   const runGuard = async (route: ActivatedRouteSnapshot = meetingRoute()) => {
     // The guard returns `true` synchronously for the ED fast path, an Observable otherwise —
     // never a bare UrlTree (redirects are always wrapped in `of(...)`).
@@ -88,6 +100,7 @@ describe('writerGuard', () => {
     fetchCommittee = vi.fn();
     fetchVote = vi.fn();
     getMailingList = vi.fn();
+    getSurvey = vi.fn();
     currentPersona = signal('maintainer');
     router = {
       parseUrl: vi.fn().mockImplementation((url: string) => ({ redirect: url }) as unknown as UrlTree),
@@ -102,6 +115,7 @@ describe('writerGuard', () => {
         { provide: CommitteeService, useValue: { getCommittee, fetchCommittee } },
         { provide: MailingListService, useValue: { getMailingList } },
         { provide: MeetingService, useValue: { getMeetingDetail } },
+        { provide: SurveyService, useValue: { getSurvey } },
         { provide: VoteService, useValue: { fetchVote } },
         { provide: Router, useValue: router },
       ],
@@ -328,6 +342,51 @@ describe('writerGuard', () => {
     expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
     expect(result).toEqual({ redirect: '/project/overview' });
     expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).not.toHaveBeenCalled();
+    expect(getCommittee).not.toHaveBeenCalled();
+  });
+
+  it('authorizes survey edit against the survey’s own project when the read succeeds', async () => {
+    getSurvey.mockReturnValue(of({ uid: SURVEY_UID, project_uid: 's-uid', project_slug: SURVEY_SLUG } as unknown as Survey));
+    getProject.mockReturnValue(of({ uid: 's-uid', slug: SURVEY_SLUG, writer: true }));
+
+    const result = await runGuard(surveyRoute());
+
+    expect(result).toBe(true);
+    expect(getSurvey).toHaveBeenCalledWith(SURVEY_UID);
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledWith(SURVEY_SLUG, false, { meetingCoordinator: false });
+  });
+
+  it('resolves the survey uid when the payload lacks an enriched slug, never the stale context', async () => {
+    // Survey.project_uid is typed optional — the probe maps absent to '' and
+    // resolveEntityWriteSlug treats '' as absent, so only a real uid reaches the lookup.
+    getSurvey.mockReturnValue(of({ uid: SURVEY_UID, project_uid: 's-uid' } as unknown as Survey));
+    getProject.mockReturnValue(of({ uid: 's-uid', slug: SURVEY_SLUG, writer: true }));
+
+    const result = await runGuard(surveyRoute());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('s-uid', false, { meetingCoordinator: false });
+  });
+
+  it('falls back to the active context only on a 404 survey read', async () => {
+    getSurvey.mockReturnValue(throwError(() => httpError(404)));
+    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
+
+    const result = await runGuard(surveyRoute());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
+  });
+
+  it('fails closed on a 500 survey read without probing the stale project', async () => {
+    getSurvey.mockReturnValue(throwError(() => httpError(500)));
+
+    const result = await runGuard(surveyRoute());
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
     expect(getProject).not.toHaveBeenCalled();
     expect(getCommittee).not.toHaveBeenCalled();
   });

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -28,7 +28,7 @@ import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '../utils/write-ac
  *    only for routes with `data.writeFeature === 'meetings'`.
  * 3. `committee.writer` — committee writer; accepted only when `writeFeature` is one of
  *    `'meetings'`, `'surveys'`, or `'votes'` and a committee uid is available — from the probed
- *    entity itself when its probe surfaces one (today only the votes probe carries
+ *    entity itself when its probe surfaces one (the votes and surveys probes carry
  *    `committee_uid`; the meetings probe falls through to the URL param), else from the
  *    `committee_uid` query param (create routes; attacker-controlled, which is why the entity
  *    value wins when present). The backend ruleset allows committee:uid#writer to create
@@ -91,7 +91,15 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     'mailing-lists': (id) => mailingListService.getMailingList(id),
     // Survey.project_uid is typed optional — map absent to '' so the probe satisfies the
     // registry's Pick<EntityWithProject> shape; resolveEntityWriteSlug treats '' as absent.
-    surveys: (id) => surveyService.getSurvey(id).pipe(map((survey) => ({ project_slug: survey.project_slug, project_uid: survey.project_uid ?? '' }))),
+    // Surface the primary committee's uid (same source the BFF flattens project_uid from) so the
+    // entity's own committee wins over the attacker-controlled ?committee_uid= URL param — mirrors
+    // the votes probe; a committee-less project survey falls back to the URL param.
+    surveys: (id) =>
+      surveyService
+        .getSurvey(id)
+        .pipe(
+          map((survey) => ({ project_slug: survey.project_slug, project_uid: survey.project_uid ?? '', committee_uid: survey.committees?.[0]?.committee_uid }))
+        ),
   };
   const resolveSlug = (): Observable<{ slug: string | null; entityCommitteeUid: string | null }> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
@@ -131,9 +139,9 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
 
       // Committee writers can create entities for their committee via ?committee_uid=. On
       // entity-scoped edit routes the probed entity's own committee wins when the probe carries
-      // one (only the votes probe returns committee_uid today) — a URL param naming an unrelated
-      // committee must not admit its writer, and an absent param must not deny the entity's real
-      // committee writer.
+      // one (the votes and surveys probes return committee_uid today) — a URL param naming an
+      // unrelated committee must not admit its writer, and an absent param must not deny the
+      // entity's real committee writer.
       const effectiveCommitteeUid = entityCommitteeUid ?? committeeUid;
       // getCommittee's tap() side effect is safe here: deny blocks navigation; allow overwrites.
       const checkCommittee = (): Observable<true | ReturnType<typeof deny>> =>

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -91,15 +91,19 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     'mailing-lists': (id) => mailingListService.getMailingList(id),
     // Survey.project_uid is typed optional — map absent to '' so the probe satisfies the
     // registry's Pick<EntityWithProject> shape; resolveEntityWriteSlug treats '' as absent.
-    // Surface the primary committee's uid (same source the BFF flattens project_uid from) so the
-    // entity's own committee wins over the attacker-controlled ?committee_uid= URL param — mirrors
-    // the votes probe; a committee-less project survey falls back to the URL param.
+    // Honor the URL ?committee_uid= only when the survey's own committee list contains it (the
+    // committee tab stamps the viewed committee, and a writer of any associated committee must be
+    // admitted); otherwise fall back to the primary committee so an attacker-controlled param naming
+    // an unrelated committee can't win — a committee-less project survey falls back to the URL param.
     surveys: (id) =>
-      surveyService
-        .getSurvey(id)
-        .pipe(
-          map((survey) => ({ project_slug: survey.project_slug, project_uid: survey.project_uid ?? '', committee_uid: survey.committees?.[0]?.committee_uid }))
-        ),
+      surveyService.getSurvey(id).pipe(
+        map((survey) => ({
+          project_slug: survey.project_slug,
+          project_uid: survey.project_uid || '',
+          committee_uid:
+            committeeUid && survey.committees?.some((c) => c.committee_uid === committeeUid) ? committeeUid : survey.committees?.[0]?.committee_uid,
+        }))
+      ),
   };
   const resolveSlug = (): Observable<{ slug: string | null; entityCommitteeUid: string | null }> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -13,6 +13,7 @@ import { MeetingService } from '../services/meeting.service';
 import { PersonaService } from '../services/persona.service';
 import { ProjectContextService } from '../services/project-context.service';
 import { ProjectService } from '../services/project.service';
+import { SurveyService } from '../services/survey.service';
 import { VoteService } from '../services/vote.service';
 import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '../utils/write-access.util';
 
@@ -33,7 +34,7 @@ import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '../utils/write-ac
  *    value wins when present). The backend ruleset allows committee:uid#writer to create
  *    resources associated with their committee.
  *
- * Slug resolution: on routes flagged `data.entityScopedSlug` (meeting/group/mailing-list/vote edit), resolves
+ * Slug resolution: on routes flagged `data.entityScopedSlug` (meeting/group/mailing-list/vote/survey edit), resolves
  * the slug from the entity itself first — the active context can belong to a different project
  * when the edit link carried no `?project=`. A non-404 failure on that read resolves no slug at all,
  * so the guard redirects instead of authorizing against a stale context; a flagged route with no
@@ -62,6 +63,7 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const committeeService = inject(CommitteeService);
   const mailingListService = inject(MailingListService);
   const meetingService = inject(MeetingService);
+  const surveyService = inject(SurveyService);
   const voteService = inject(VoteService);
   const router = inject(Router);
 
@@ -87,6 +89,9 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     committees: (id) => committeeService.fetchCommittee(id),
     votes: (id) => voteService.fetchVote(id),
     'mailing-lists': (id) => mailingListService.getMailingList(id),
+    // Survey.project_uid is typed optional — map absent to '' so the probe satisfies the
+    // registry's Pick<EntityWithProject> shape; resolveEntityWriteSlug treats '' as absent.
+    surveys: (id) => surveyService.getSurvey(id).pipe(map((survey) => ({ project_slug: survey.project_slug, project_uid: survey.project_uid ?? '' }))),
   };
   const resolveSlug = (): Observable<{ slug: string | null; entityCommitteeUid: string | null }> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -92,9 +92,12 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     // Survey.project_uid is typed optional — map absent to '' so the probe satisfies the
     // registry's Pick<EntityWithProject> shape; resolveEntityWriteSlug treats '' as absent.
     // Honor the URL ?committee_uid= only when the survey's own committee list contains it (the
-    // committee tab stamps the viewed committee, and a writer of any associated committee must be
-    // admitted); otherwise fall back to the primary committee so an attacker-controlled param naming
+    // committee tab stamps the viewed committee, so from that path a writer of any associated
+    // committee is admitted); otherwise fall back to the primary committee so an attacker-controlled param naming
     // an unrelated committee can't win — a committee-less project survey falls back to the URL param.
+    // Known gap: the global surveys list stamps only committees[0] on edit links, so a writer of a
+    // non-primary committee is fail-closed denied from the list and must edit via their committee
+    // tab (iterating committees[] per row is follow-up work — GH-2190).
     surveys: (id) =>
       surveyService.getSurvey(id).pipe(
         map((survey) => ({

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -64,12 +64,13 @@ export class SurveyService {
    * SurveyManageComponent's edit-mode fetch need the same payload within one navigation —
    * sharing the request avoids a duplicate fetch on every edit-page load (GH-1569).
    * Probe-friendly: no signal side-effects. Entries evict on error and on delete.
-   * Mirrors MailingListService.getMailingList.
+   * Mirrors MailingListService.getMailingList, including the skipCache escape hatch the
+   * entity-project-context fallback uses for its fresh-fetch retry.
    */
-  public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {
+  public getSurvey(surveyUid: string, projectId?: string, options?: { skipCache?: boolean }): Observable<Survey> {
     const cacheKey = `${surveyUid}:${projectId ?? ''}`;
     const cached = this.surveyDetailCache.get(cacheKey);
-    if (cached && Date.now() - cached.cachedAt < SURVEY_DETAIL_CACHE_TTL_MS) {
+    if (!options?.skipCache && cached && Date.now() - cached.cachedAt < SURVEY_DETAIL_CACHE_TTL_MS) {
       return cached.observable;
     }
     if (cached) {

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -3,14 +3,16 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { SURVEY_DETAIL_CACHE_TTL_MS } from '@lfx-one/shared/constants';
 import { CreateSurveyRequest, MySurveyResponse, Survey, SurveyResponsesPage } from '@lfx-one/shared/interfaces';
-import { catchError, Observable, of, take, throwError } from 'rxjs';
+import { catchError, Observable, of, shareReplay, take, tap, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class SurveyService {
   private readonly http = inject(HttpClient);
+  private readonly surveyDetailCache = new Map<string, { observable: Observable<Survey>; cachedAt: number }>();
 
   public getSurveys(params?: HttpParams): Observable<Survey[]> {
     return this.http.get<Survey[]>('/api/surveys', { params });
@@ -57,18 +59,39 @@ export class SurveyService {
     );
   }
 
+  /**
+   * Survey-detail fetch with a short-TTL shared cache: the writerGuard slug probe and
+   * SurveyManageComponent's edit-mode fetch need the same payload within one navigation —
+   * sharing the request avoids a duplicate fetch on every edit-page load (GH-1569).
+   * Probe-friendly: no signal side-effects. Entries evict on error and on delete.
+   * Mirrors MailingListService.getMailingList.
+   */
   public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {
+    const cacheKey = `${surveyUid}:${projectId ?? ''}`;
+    const cached = this.surveyDetailCache.get(cacheKey);
+    if (cached && Date.now() - cached.cachedAt < SURVEY_DETAIL_CACHE_TTL_MS) {
+      return cached.observable;
+    }
+    if (cached) {
+      this.surveyDetailCache.delete(cacheKey);
+    }
+
     let params = new HttpParams();
     if (projectId) {
       params = params.set('project_id', projectId);
     }
 
-    return this.http.get<Survey>(`/api/surveys/${surveyUid}`, { params }).pipe(
+    const request$ = this.http.get<Survey>(`/api/surveys/${surveyUid}`, { params }).pipe(
+      tap({ error: () => this.surveyDetailCache.delete(cacheKey) }),
       catchError((error) => {
         console.error(`Failed to load survey ${surveyUid}:`, error);
         return throwError(() => error);
-      })
+      }),
+      shareReplay(1)
     );
+    this.pruneExpiredSurveyDetailCache();
+    this.surveyDetailCache.set(cacheKey, { observable: request$, cachedAt: Date.now() });
+    return request$;
   }
 
   /**
@@ -107,10 +130,29 @@ export class SurveyService {
   public deleteSurvey(surveyUid: string): Observable<void> {
     return this.http.delete<void>(`/api/surveys/${surveyUid}`).pipe(
       take(1),
+      tap(() => this.evictSurveyDetailCache(surveyUid)),
       catchError((error) => {
         console.error(`Failed to delete survey ${surveyUid}:`, error);
         return throwError(() => error);
       })
     );
+  }
+
+  /** Drops every cached detail entry for a survey (cache keys carry the project_id variant suffix). */
+  private evictSurveyDetailCache(surveyUid: string): void {
+    for (const key of this.surveyDetailCache.keys()) {
+      if (key.startsWith(`${surveyUid}:`)) {
+        this.surveyDetailCache.delete(key);
+      }
+    }
+  }
+
+  private pruneExpiredSurveyDetailCache(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.surveyDetailCache) {
+      if (now - entry.cachedAt >= SURVEY_DETAIL_CACHE_TTL_MS) {
+        this.surveyDetailCache.delete(key);
+      }
+    }
   }
 }

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -175,7 +175,9 @@ export class SurveyController {
       }
 
       const projectId = req.query['project_id'] as string | undefined;
-      const survey = await this.surveyService.getSurveyById(req, uid, projectId);
+      // includeProject: the edit page's context sync and the writerGuard entity probe need the
+      // owning project's slug/tier on the detail payload (GH-1569).
+      const survey = await this.surveyService.getSurveyById(req, uid, projectId, true);
 
       logger.success(req, 'get_survey_by_id', startTime, {
         survey_uid: uid,

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -89,7 +89,7 @@ export class SurveyService {
     // per-row canonical edit links (GH-1569; mirrors the meetings list enrichment).
     const flattened = enriched.map((s) => ({
       ...s,
-      project_uid: s.project_uid ?? s.committees?.[0]?.project_uid ?? '',
+      project_uid: s.project_uid || s.committees?.[0]?.project_uid || '',
     }));
     return this.projectService.enrichWithProjectData(req, flattened) as Promise<Survey[]>;
   }
@@ -127,7 +127,7 @@ export class SurveyService {
     // committees[] — flatten the primary project uid and stamp it top-level so the enrichment
     // below, the writerGuard probe, and the manage page's resolve-by-uid fallback all receive a
     // real uid (GH-1569; mirrors the list path's flatten in getSurveys).
-    survey.project_uid ??= survey.committees?.[0]?.project_uid;
+    survey.project_uid = survey.project_uid || survey.committees?.[0]?.project_uid;
 
     if (includeProject) {
       const project = await fetchEntityProject(req, this.projectService, survey.project_uid, { operation: 'get_survey_by_id', survey_uid: survey.uid });

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -8,6 +8,7 @@ import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
+import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { validateAndSanitizeUrl } from '../helpers/url-validation';
@@ -83,14 +84,24 @@ export class SurveyService {
       responded_in_result: respondedInResult,
     });
 
-    return enriched;
+    // The survey index carries project identity only inside committees[] — flatten the primary
+    // project uid and enrich so list rows expose project_slug/project_name/is_foundation for
+    // per-row canonical edit links (GH-1569; mirrors the meetings list enrichment).
+    const flattened = enriched.map((s) => ({
+      ...s,
+      project_uid: s.project_uid ?? s.committees?.[0]?.project_uid ?? '',
+    }));
+    return this.projectService.enrichWithProjectData(req, flattened) as Promise<Survey[]>;
   }
 
   /**
    * Fetches a single survey by UID.
    * Passes project_uid (V2 UUID) directly to upstream — no SFID translation needed.
+   * `includeProject` opts into BFF project enrichment (project_slug/project_name/is_foundation)
+   * for the edit page's context sync and the writerGuard entity probe (GH-1569); the shared
+   * helper no-ops when the payload lacks project_uid and warn-and-continues on lookup failure.
    */
-  public async getSurveyById(req: Request, surveyUid: string, projectId?: string): Promise<Survey> {
+  public async getSurveyById(req: Request, surveyUid: string, projectId?: string, includeProject = false): Promise<Survey> {
     logger.debug(req, 'get_survey_by_id', 'Fetching survey by ID', {
       survey_uid: surveyUid,
       project_uid: projectId,
@@ -110,6 +121,13 @@ export class SurveyService {
         service: 'survey_service',
         path: `/surveys/${surveyUid}`,
       });
+    }
+
+    if (includeProject) {
+      const project = await fetchEntityProject(req, this.projectService, survey.project_uid, { operation: 'get_survey_by_id', survey_uid: survey.uid });
+      if (project) {
+        Object.assign(survey, toEntityProjectFields(project));
+      }
     }
 
     logger.debug(req, 'get_survey_by_id', 'Completed survey fetch', {

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -123,6 +123,12 @@ export class SurveyService {
       });
     }
 
+    // The upstream detail payload (SurveyScheduleResult) carries project identity only inside
+    // committees[] — flatten the primary project uid and stamp it top-level so the enrichment
+    // below, the writerGuard probe, and the manage page's resolve-by-uid fallback all receive a
+    // real uid (GH-1569; mirrors the list path's flatten in getSurveys).
+    survey.project_uid ??= survey.committees?.[0]?.project_uid;
+
     if (includeProject) {
       const project = await fetchEntityProject(req, this.projectService, survey.project_uid, { operation: 'get_survey_by_id', survey_uid: survey.uid });
       if (project) {

--- a/packages/shared/src/constants/survey.constants.ts
+++ b/packages/shared/src/constants/survey.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { SurveyResponseStatus, SurveyStatus } from '../enums/survey.enum';
-import { TagSeverity } from '../interfaces/components.interface';
+import type { TagSeverity } from '../interfaces/components.interface';
 import type { CombinedSurveyStatus } from '../interfaces/survey.interface';
 
 /**
@@ -307,3 +307,9 @@ export const SURVEY_TEMPLATE_OPTIONS = [
   { label: 'General Survey', value: '521721013' },
   { label: 'Board Survey (May 2024)', value: '514467737' },
 ] as const;
+
+/**
+ * Short TTL so the writerGuard probe and the manage-page edit fetch share one request; entries
+ * evict on error and on delete. Mirrors MAILING_LIST_DETAIL_CACHE_TTL_MS.
+ */
+export const SURVEY_DETAIL_CACHE_TTL_MS = 10 * 1000;

--- a/packages/shared/src/constants/survey.constants.ts
+++ b/packages/shared/src/constants/survey.constants.ts
@@ -310,6 +310,6 @@ export const SURVEY_TEMPLATE_OPTIONS = [
 
 /**
  * Short TTL so the writerGuard probe and the manage-page edit fetch share one request; entries
- * evict on error and on delete. Mirrors MAILING_LIST_DETAIL_CACHE_TTL_MS.
+ * evict on error and on delete. Mirrors MEETING_DETAIL_CACHE_TTL_MS.
  */
 export const SURVEY_DETAIL_CACHE_TTL_MS = 10 * 1000;

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CommitteeReference } from './committee.interface';
+import type { CommitteeReference } from './committee.interface';
+import type { SurveyStatus } from '../enums/survey.enum';
 
 /**
  * Minimal shape required to evaluate the effective survey status.
@@ -96,15 +97,15 @@ export interface Survey {
   is_project_survey: boolean;
   /** Associated committees */
   committees: SurveyCommittee[];
-  /** Primary project UID (flattened from committees for filtering) */
+  /** Primary project UID (list rows: flattened from committees[0] by the BFF; detail: from the upstream payload) */
   project_uid?: string;
-  /** Project display name (enriched for filtering) */
+  /** Project display name (BFF-enriched on list rows and the authenticated detail response) */
   project_name?: string;
-  /** Project URL slug (enriched for filtering) */
+  /** Project URL slug (BFF-enriched on list rows and the authenticated detail response) */
   project_slug?: string;
-  /** Whether the project is a foundation (top-level entity) */
+  /** Whether the owning project is a foundation (BFF-enriched; absent when the lookup fails — consumers treat undefined as "tier unknown") */
   is_foundation?: boolean;
-  /** Parent project UID (for subprojects under a foundation) */
+  /** Parent project UID (BFF-enriched on list rows for Me-lens foundation filtering; not set on the detail response) */
   parent_project_uid?: string;
   /** Committee category */
   committee_category: string;
@@ -133,6 +134,21 @@ export interface Survey {
   /** survey_response UID — present only in the Me lens; identifies the specific response record this row was built from (one row per survey × committee) */
   response_uid?: string;
 }
+
+/**
+ * Surveys-table row view model: a `Survey` stamped with its display status and per-row canonical
+ * edit link (GH-1569). `editCommands`/`editQueryParams` derive from the survey's owning tier, not
+ * the viewer's active lens; unenriched rows (undefined `is_foundation`) carry the flat path,
+ * which `lensRedirectGuard` prefixes.
+ */
+export type SurveyTableRow = Survey & {
+  /** Cutoff/case-normalized status the badge, filter, and sort all agree on */
+  displayStatus: SurveyStatus;
+  /** Canonical edit-link commands (e.g. ['/', 'foundation', 'surveys', uid, 'edit']) */
+  editCommands: string[];
+  /** Edit-link query params: the row's own project slug + committee scope */
+  editQueryParams: Record<string, string>;
+};
 
 /**
  * A single choice/free-text answer selected by the respondent for a question.

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -97,7 +97,7 @@ export interface Survey {
   is_project_survey: boolean;
   /** Associated committees */
   committees: SurveyCommittee[];
-  /** Primary project UID (list rows: flattened from committees[0] by the BFF; detail: from the upstream payload) */
+  /** Primary project UID (flattened from committees[0] and stamped by the BFF on both list rows and the detail response — upstream sends no top-level project_uid) */
   project_uid?: string;
   /** Project display name (BFF-enriched on list rows and the authenticated detail response) */
   project_name?: string;


### PR DESCRIPTION
## Summary

Survey edit links previously inherited the viewer's current project context: opening one from a different lens — or from a context-less deep link — could load the edit page under the wrong project and even authorize against it. This PR makes survey editing entity-scoped end to end: list rows derive their edit URL from the survey's owning tier, the manage page syncs the active project context from the loaded survey itself, and the writer guard authorizes against the survey's own project. Mirrors the meetings pattern from gh-1432.

Resolves #1569

## Behavior changes

### Edit links in the surveys list

| Before | After |
|---|---|
| The Edit action on every survey row pointed to the same generic edit address, prefixed by whichever view (foundation or project) the user happened to be browsing, and carried no information about which project or committee owned the survey. | Each row's Edit action points to the canonical address for that survey's owning organization (foundation vs. project) and carries the survey's own project and committee identifiers, regardless of the view the user is browsing from. |

### Landing on the edit page directly

| Before | After |
|---|---|
| Opening a survey edit link with no project information (a bookmark, a shared link) kept whichever project had been selected previously — often an unrelated one — and a momentary server hiccup could bounce the user to the surveys list with a misleading "survey not found" message. | The edit page reads the survey being edited and switches the active project to the survey's owner — even when a second lookup is needed to identify it — and only a genuine "not found" sends the user back to the list; temporary errors leave the page in place. |

### Edit permission check

| Before | After |
|---|---|
| The permission check for editing a survey ran against whichever project was currently selected, so a context-less edit link could be allowed or denied based on the wrong project. | The permission check runs against the project that actually owns the survey; if the survey can't be loaded because of a server error, access is denied rather than decided against a stale selection. |

## Technical changes

`apps/lfx-one/src/server/services/survey.service.ts, apps/lfx-one/src/server/controllers/survey.controller.ts` — BFF project enrichment
- List: flattens `project_uid` from `committees[0]` (the upstream index sends no top-level uid) and enriches every row with `project_slug` / `project_name` / `is_foundation` via `enrichWithProjectData`
- Detail: new `includeProject` opt-in on `getSurveyById` (wired in the controller) that flattens `project_uid ??= committees[0].project_uid` and stamps the same project fields via the shared `entity-project-enrichment` helper — no-op without a uid, warn-and-continue on lookup failure
- The flatten fixes the previously inert deep-link half: the detail payload now always carries a real `project_uid` for the guard probe and the manage page's resolve-by-uid fallback

`apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts, apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html` — Per-row canonical edit links
- Rows are stamped with `editCommands` derived from the survey's owning tier via `getEntityCommands` (`/foundation/...` vs `/project/...`); rows whose payload lacks tier data fall back to the flat path, which `lensRedirectGuard` prefixes
- `editQueryParams` are built per row from the survey's own `project_slug` plus committee scope — the new `committeeUid` input (the viewed committee) wins over `committees[0]`
- The Edit action binds the per-row link on the button's real-anchor `routerLink`; the explicit `stopPropagation` was dropped because PrimeNG's selectable row already skips clicks on anchors/buttons, and a consumer `stopPropagation` can starve the RouterLink listener

`apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.ts, apps/lfx-one/src/app/modules/committees/components/committee-surveys/committee-surveys.component.html` — Committee surveys tab
- Passes the viewed committee's `uid` to the table instead of the old shared `editSurveyQueryParams` signal (removed), so a committee writer's guard fallback probes the committee actually being viewed

`apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts` — Edit-page context sync
- Edit mode now fetches the survey being edited and adapts it to `EntityWithProject`, driving `syncEntityProjectContext` — a context-less deep link under a stale cookie-restored context corrects to the survey's project (mirrors meeting-manage, gh-1432)
- `syncEntityProjectContextFallback` resolves the project by uid when the payload is unenriched (uid but no slug), with an uncached fresh re-read as a last resort for committee writers whose relation-gated project lookup resolves null
- Step navigation merges query params so `?project=` and `committee_uid` survive step changes
- Only a real 404 ejects to `/surveys`; a transient 5xx/network error leaves the edit page mounted (the fetch exists for context sync, not form pre-population)

`apps/lfx-one/src/app/shared/guards/writer.guard.ts, apps/lfx-one/src/app/modules/surveys/surveys.routes.ts` — Entity-scoped authorization
- `surveys` added to the guard's entity-probe registry; the edit route opts in via `data.entityScopedSlug: true` (a route-data flag, so a rename can't silently revert to stale-context authorization)
- The probe maps absent `project_uid` to `''` (treated as absent); a 404 read falls back to the active context, any other failure resolves no slug and redirects to `/project/overview`

`apps/lfx-one/src/app/shared/services/survey.service.ts` — Shared short-TTL detail cache
- `getSurvey` gained a 10-second `shareReplay` cache (`SURVEY_DETAIL_CACHE_TTL_MS`) so the guard probe and the manage-page fetch share one request per navigation — no signal side-effects, probe-friendly
- `skipCache` escape hatch for the fallback's fresh fetch; entries evict on error, on an expiry sweep, and on delete (keys carry the `project_id` variant suffix)
- Mirrors `MailingListService.getMailingList`

`packages/shared/src/constants/survey.constants.ts, packages/shared/src/interfaces/survey.interface.ts` — Shared contracts
- New `SURVEY_DETAIL_CACHE_TTL_MS` constant and `SurveyTableRow` type (`Survey` + `displayStatus` + per-row edit link)
- `Survey` field docs updated: `project_uid` is flattened from `committees[0]` by the BFF on list and detail; enrichment fields documented as absent-on-failure so consumers treat `undefined` as "tier unknown"

`apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts` — Guard unit tests
- Survey probe coverage: enriched slug authorizes against the survey's project, a uid-only payload resolves by uid (never the stale context), a 404 falls back to the active context, and a 500 fails closed without probing the stale project

`apps/lfx-one/e2e/survey-edit-url.spec.ts, apps/lfx-one/e2e/project-context-deep-link.spec.ts` — E2E coverage
- Click-through: foundation-owned, project-owned, and unenriched rows land on the correct tier URL with `?project=` / `committee_uid` (seeding the opposite lens to reproduce the pre-fix bug)
- Deep-link: a context-less edit link under a cookie-restored foreign project corrects the context (enriched and uid-fallback paths) without backfilling `?project=` into the URL, and the guard authorizes against the survey's project rather than the stale context
- Stubs mirror the real BFF detail contract — project identity lives inside `committees[]`; slug/name/tier appear only when enrichment succeeded
