### PR TITLE
feat(formation): canonical shared types for formations and checklist templates

### DIFF
--- a/packages/shared/src/constants/formation.constants.ts
+++ b/packages/shared/src/constants/formation.constants.ts
@@ -15,5 +15,4 @@ export const FORMATION_SUB_STAGE_LABELS = {
   exploratory: 'Formation · Exploratory',
   engaged: 'Formation · Engaged',
   on_hold: 'Formation · On Hold',
-  activating: 'Activating',
 } as const satisfies Record<FormationSubStage, string>;

--- a/packages/shared/src/constants/formation.constants.ts
+++ b/packages/shared/src/constants/formation.constants.ts
@@ -1,0 +1,19 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { FormationSubStage } from '../interfaces/formation.interface';
+
+/**
+ * Display labels for the canonical {@link FormationSubStage} union (GH-2163) — the Formations
+ * queue's stage column and stage-filter pills. This is the one label map for that union; it does
+ * not cover `ProjectStage`'s separate 5-value Formation taxonomy (which includes `Disengaged` and
+ * `Confidential`, neither a `FormationSubStage` member, and backs `isFormationStage`/
+ * `getFormationSubStageLabel` in `project.utils.ts`) — that map is project-domain data and is named
+ * distinctly to avoid colliding with this one.
+ */
+export const FORMATION_SUB_STAGE_LABELS = {
+  exploratory: 'Formation · Exploratory',
+  engaged: 'Formation · Engaged',
+  on_hold: 'Formation · On Hold',
+  activating: 'Activating',
+} as const satisfies Record<FormationSubStage, string>;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -101,3 +101,4 @@ export * from './brand-kit.constants';
 export * from './foundation-message.constants';
 export * from './social-listening.constants';
 export * from './id-migration.constants';
+export * from './formation.constants';

--- a/packages/shared/src/enums/formation.enum.spec.ts
+++ b/packages/shared/src/enums/formation.enum.spec.ts
@@ -14,6 +14,7 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { FORMATION_SUB_STAGE_LABELS } from '../constants/formation.constants';
 import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } from './formation.enum';
 import type { FormationTemplate } from '../interfaces/formation.interface';
 
@@ -32,6 +33,12 @@ describe('FormationOwnerTeam', () => {
 describe('FormationActionType', () => {
   it('is exhaustive against the five action kinds, including status_only', () => {
     expect(Object.values(FormationActionType).sort()).toEqual(['link', 'manual', 'provisionable', 'request', 'status_only']);
+  });
+});
+
+describe('FORMATION_SUB_STAGE_LABELS', () => {
+  it('covers exactly the three canonical sub-stages, with no activating member (GH-2163 amendment)', () => {
+    expect(Object.keys(FORMATION_SUB_STAGE_LABELS).sort()).toEqual(['engaged', 'exploratory', 'on_hold']);
   });
 });
 

--- a/packages/shared/src/enums/formation.enum.spec.ts
+++ b/packages/shared/src/enums/formation.enum.spec.ts
@@ -1,0 +1,64 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Structural invariants for the canonical formation types (GH-2163): the three seeded-template
+// vocabularies are exhaustive against their expected member sets, and a minimal template literal
+// round-trips the shape #1959's real seeded template must produce.
+//
+// "Sub-items nest one level only" (`FormationTemplateSubItem` has no `sub_items` of its own) is a
+// type-only invariant with no runtime trace, so it isn't asserted here: this package's `test`
+// script is a plain `vitest run` (esbuild transpile, no type-checking) and its `check-types`
+// script (`tsc --noEmit`) excludes `*.spec.ts` — neither gate command would actually catch a
+// violation, so a `@ts-expect-error` here would look enforced without being enforced. The
+// interface's own doc comment is this invariant's only guard.
+
+import { describe, expect, it } from 'vitest';
+
+import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } from './formation.enum';
+import type { FormationTemplate } from '../interfaces/formation.interface';
+
+describe('FormationTemplateSectionKey', () => {
+  it('is exhaustive against the two-section seeded template taxonomy', () => {
+    expect(Object.values(FormationTemplateSectionKey).sort()).toEqual(['community_and_launch', 'legal_and_entity']);
+  });
+});
+
+describe('FormationOwnerTeam', () => {
+  it('is exhaustive against the seven-team template vocabulary, deliberately with no PMO member', () => {
+    expect(Object.values(FormationOwnerTeam).sort()).toEqual(['brand_counsel', 'community', 'formation', 'it', 'marketing', 'product', 'product_ops']);
+  });
+});
+
+describe('FormationActionType', () => {
+  it('is exhaustive against the five action kinds, including status_only', () => {
+    expect(Object.values(FormationActionType).sort()).toEqual(['link', 'manual', 'provisionable', 'request', 'status_only']);
+  });
+});
+
+describe('FormationTemplate shape', () => {
+  it('accepts a minimal template with one section, one item, and one sub-item', () => {
+    const template = {
+      uid: 'formation-template-test',
+      version: 1,
+      name: 'Test template',
+      sections: [
+        {
+          key: FormationTemplateSectionKey.COMMUNITY_AND_LAUNCH,
+          title: 'Community and launch',
+          items: [
+            {
+              key: 'launch-chat-workspace',
+              title: 'Chat workspace',
+              is_gating: false,
+              owner_team: FormationOwnerTeam.IT,
+              action: FormationActionType.REQUEST,
+              sub_items: [{ key: 'launch-chat-workspace-create', title: 'Create workspace', owner_team: FormationOwnerTeam.IT }],
+            },
+          ],
+        },
+      ],
+    } satisfies FormationTemplate;
+
+    expect(template.sections[0].items[0].sub_items).toHaveLength(1);
+  });
+});

--- a/packages/shared/src/enums/formation.enum.ts
+++ b/packages/shared/src/enums/formation.enum.ts
@@ -1,0 +1,54 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Which section of the seeded formation checklist template a template item belongs to (GH-2163).
+ * Renamed from GH-1959's original `FormationTemplateSection` so it stops colliding with the
+ * structural interface of the same name in `formation.interface.ts` — that interface's `key`
+ * field is typed with this enum (`FormationTemplateSection['key']`). Only legal/entity items may
+ * gate the formation's transition to Active (not all of them do — see
+ * `FormationTemplateItem.is_gating`); community and launch items never gate.
+ */
+export enum FormationTemplateSectionKey {
+  LEGAL_AND_ENTITY = 'legal_and_entity',
+  COMMUNITY_AND_LAUNCH = 'community_and_launch',
+}
+
+/**
+ * Team responsible for completing a formation checklist template item. Values are stable
+ * identifiers, not display labels — once the formation service (#1957) persists these, a wording
+ * change (e.g. "Product Ops" -> "Program Ops") must stay a display-layer edit, not a data
+ * migration. Scoped to the *template* (`FormationTemplateItem.owner_team` /
+ * `FormationTemplateSubItem.owner_team`) — the runtime `FormationItem.owner_team` stays a plain
+ * string until #1957 confirms its live vocabulary (see that field's doc comment).
+ *
+ * Deliberately has no PMO member — PMO/umbrella onboarding is out of scope for this template
+ * (GH-1959).
+ */
+export enum FormationOwnerTeam {
+  FORMATION = 'formation',
+  BRAND_COUNSEL = 'brand_counsel',
+  COMMUNITY = 'community',
+  IT = 'it',
+  MARKETING = 'marketing',
+  PRODUCT_OPS = 'product_ops',
+  PRODUCT = 'product',
+}
+
+/**
+ * How a formation checklist item is completed. Carries GH-1958's `STATUS_ONLY` in addition to
+ * GH-1959's original four members — `status_only` rows never expose how the underlying tooling
+ * was set up (manual vs automated), only Done/pending plus an optional link.
+ */
+export enum FormationActionType {
+  /** The owning team checks this off by hand once the real-world work is done. */
+  MANUAL = 'manual',
+  /** Completing the item means following a link (e.g. signing a DocuSign envelope). */
+  LINK = 'link',
+  /** LFX can create/configure the resource itself — no other team needs to be asked. */
+  PROVISIONABLE = 'provisionable',
+  /** Completing the item means filing a request with another team (e.g. IT) and waiting on it. */
+  REQUEST = 'request',
+  /** Status-only row — Done/pending plus an optional link, no visibility into how it was set up. */
+  STATUS_ONLY = 'status_only',
+}

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -15,3 +15,4 @@ export * from './project-funding.enum';
 export * from './project-stage.enum';
 export * from './search.enum';
 export * from './crowdfunding.enum';
+export * from './formation.enum';

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -1,0 +1,201 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } from '../enums/formation.enum';
+
+/**
+ * Formation domain types (GH-2163, epic #1965). Mirrors the object shapes planned for
+ * `lfx-v2-formation-service` (#1957) — `formation`, `formation_item`, `activity`,
+ * `formation_template` — scoped to Epic 1: no `request` object/SLA tracking (that richer model
+ * is #1957/Epic 2), no invites, no Confidential read-guard switch, no application-flow state
+ * (`draft`/`submitted`/`withdrawn`) — intake is Epic 2, see #1957.
+ *
+ * Canonical shared shape reconciling GH-1958 (naming/structure) and GH-1959 (template sub-items,
+ * owner-team/action-type vocabularies) — see the GH-2163 issue for the full derivation.
+ *
+ * TODO(#1957): every runtime interface here is shaped to match the real service's eventual
+ * response bodies as closely as fixtures allow, so wiring the real service is a data-source swap
+ * in `formation.service.ts`, not a type change. See `formation-backend.helper.ts` for the swap
+ * point.
+ */
+
+/**
+ * Formations queue display taxonomy (queue filters, sub-stage pill) — formations already in
+ * flight only. No `proposed`/`withdrawn` here: those were Accept/Decline-era states (Epic 2,
+ * #1962).
+ */
+export type FormationSubStage = 'exploratory' | 'engaged' | 'on_hold' | 'activating';
+
+/** What kind of record is in formation — drives the queue's Type column and indentation. */
+export type FormationEntityType = 'foundation' | 'subproject' | 'project';
+
+export interface FormationLead {
+  username: string;
+  name: string;
+}
+
+export interface Formation {
+  uid: string;
+  parent_project_uid: string;
+  parent_project_slug: string;
+  parent_project_name: string;
+  /** Present only for a `subproject` — the foundation/project this formation nests under, for the queue's indented display. */
+  parent_formation_name?: string;
+  entity_type: FormationEntityType;
+  template_uid: string;
+  template_version: number;
+  sub_stage: FormationSubStage;
+  /** ISO date. Null until a gating item sets it. */
+  announcement_date: string | null;
+  /** Derived: every gating item `done` (and at least one gating item exists). TODO(#1957): backend-derived once real; see `deriveFormationReadinessSummary`, which computes this identically. */
+  is_activating: boolean;
+  gating_items_open: number;
+  gating_items_total: number;
+  /** First not-done gating item's title, precomputed for the queue's "Blocking" column. */
+  blocking_item_title: string | null;
+  subtitle: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** 5-state taxonomy confirmed against the design mockup — includes `waiting_on_partner`, distinct from `in_progress`. */
+export type FormationItemStatus = 'not_started' | 'in_progress' | 'waiting_on_partner' | 'done' | 'skipped';
+
+/**
+ * One row's action affordance. `request` is a real, working Epic-1 action (fixture-only: files a
+ * lightweight request and flips the item to `waiting_on_partner`, no SLA/target-team object — that
+ * richer `request` type is #1957/Epic 2). `status_only` items never expose how the underlying
+ * tooling was set up (manual vs automated) — only Done/pending + an optional link.
+ */
+export type FormationItemAction = 'manual' | 'link' | 'provisionable' | 'request' | 'status_only';
+
+export interface FormationSubItem {
+  uid: string;
+  title: string;
+  status: FormationItemStatus;
+}
+
+export interface FormationItem {
+  uid: string;
+  formation_uid: string;
+  template_item_key: string;
+  section_key: string;
+  section_title: string;
+  title: string;
+  status: FormationItemStatus;
+  /** Only gating items count toward `is_activating` and show the "Gates Active" chip. */
+  is_gating: boolean;
+  /** TODO(#1957): narrow once the real service confirms its owner-team vocabulary — fixture values today include labels (e.g. `'PMO'`) outside {@link FormationOwnerTeam}'s curated set. */
+  owner_team: string | null;
+  owner: FormationLead | null;
+  due_date: string | null;
+  action: FormationItemAction;
+  /** For `link`/`status_only` rows that open something external. */
+  action_href: string | null;
+  detail: string | null;
+  notes: string | null;
+  links: FormationItemLink[];
+  sub_items: FormationSubItem[];
+  /** Required and logged when a gating item is skipped. */
+  skip_reason: string | null;
+  /**
+   * Per-item `gate_writer` permission — response-only, enrichment output. TODO(#1957): fabricated
+   * today by `FormationItemAccessService.canComplete` from a real LF-staff check; swap for a real
+   * `checkSingleAccess(req, { resource: 'formation_item', id, access: 'gate_writer' })` call once
+   * the relation ships.
+   */
+  can_complete: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FormationItemLink {
+  label: string;
+  href: string;
+}
+
+export type FormationActivityType =
+  | 'item_completed'
+  | 'item_skipped'
+  | 'item_reopened'
+  | 'item_requested'
+  | 'note_added'
+  | 'assignee_changed'
+  | 'due_date_changed';
+
+export interface FormationActivity {
+  uid: string;
+  formation_uid: string;
+  /** Always item-scoped today — every {@link FormationActivityType} is an item-level action. */
+  formation_item_uid: string | null;
+  type: FormationActivityType;
+  actor: FormationLead;
+  message: string;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+/**
+ * A sub-step of a formation checklist template item (e.g. the chat workspace's IT setup steps).
+ * Nests one level only — a `FormationTemplateSubItem` has no `sub_items` of its own.
+ */
+export interface FormationTemplateSubItem {
+  key: string;
+  title: string;
+  owner_team: FormationOwnerTeam;
+}
+
+/**
+ * Structure only for Epic 1 — no template editor (#1994/Epic 2). One seeded template (#1959)
+ * applied automatically when a formation is created.
+ */
+export interface FormationTemplate {
+  uid: string;
+  /**
+   * Bump whenever items/gates/sections change. Persisted formations (#1957) reference
+   * (uid, version) to reconstruct the exact checklist they were created against, so a content
+   * edit without a version bump makes two different checklists indistinguishable.
+   */
+  version: number;
+  name: string;
+  sections: FormationTemplateSection[];
+}
+
+export interface FormationTemplateSection {
+  key: FormationTemplateSectionKey;
+  title: string;
+  items: FormationTemplateItem[];
+}
+
+export interface FormationTemplateItem {
+  key: string;
+  title: string;
+  /** True only on legal/entity items that gate the formation's transition to Active. */
+  is_gating: boolean;
+  owner_team: FormationOwnerTeam;
+  /** `'status_only'` IS the status-only signal — there is no separate boolean to keep in sync with it. */
+  action: FormationActionType;
+  sub_items?: FormationTemplateSubItem[];
+}
+
+/** Response body for `GET /api/projects/:slug/formation`. */
+export interface FormationChecklistResponse {
+  formation: Formation;
+  template: FormationTemplate | null;
+  items: FormationItem[];
+  data_source: 'fixture' | 'live';
+}
+
+/** Per-`sub_stage` counts for the queue's filter pills. */
+export type FormationQueueTiles = Record<FormationSubStage, number> & {
+  total: number;
+  foundations: number;
+  subprojects: number;
+};
+
+/** Response body for `GET /api/formations`. */
+export interface FormationsQueueResponse {
+  tiles: FormationQueueTiles;
+  rows: Formation[];
+  data_source: 'fixture' | 'live';
+}

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -22,14 +22,23 @@ import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } 
 /**
  * Formations queue display taxonomy (queue filters, sub-stage pill) — formations already in
  * flight only. No `proposed`/`withdrawn` here: those were Accept/Decline-era states (Epic 2,
- * #1962).
+ * #1962). No `activating` member: activating is derived readiness (see {@link Formation.is_activating}),
+ * rendered as a separate "Gates cleared" badge (#1958) — never in the Stage column, which would
+ * wrongly imply the project is about to flip (Active is set by the formation team in the admin
+ * tool, normally on the announcement date).
  */
-export type FormationSubStage = 'exploratory' | 'engaged' | 'on_hold' | 'activating';
+export type FormationSubStage = 'exploratory' | 'engaged' | 'on_hold';
 
-/** What kind of record is in formation — drives the queue's Type column and indentation. */
-export type FormationEntityType = 'foundation' | 'subproject' | 'project';
+/**
+ * What kind of record is in formation — drives the queue's Type column and indentation.
+ * TODO(#1958): this is a display taxonomy that should be derived (`is_foundation` on the project,
+ * plus "parent is not the root" for a child project) rather than stored; `child_project` is kept
+ * as a stored value for now because the canonical `Formation` has neither signal yet.
+ */
+export type FormationEntityType = 'foundation' | 'child_project' | 'project';
 
-export interface FormationLead {
+/** A plain user reference — not an Epic 2 "formation lead" record (#1992), which doesn't exist in Epic 1. */
+export interface FormationUser {
   username: string;
   name: string;
 }
@@ -39,7 +48,7 @@ export interface Formation {
   parent_project_uid: string;
   parent_project_slug: string;
   parent_project_name: string;
-  /** Present only for a `subproject` — the foundation/project this formation nests under, for the queue's indented display. */
+  /** Present only for a `child_project` — the foundation/project this formation nests under, for the queue's indented display. */
   parent_formation_name?: string;
   entity_type: FormationEntityType;
   template_uid: string;
@@ -47,7 +56,10 @@ export interface Formation {
   sub_stage: FormationSubStage;
   /** ISO date. Null until a gating item sets it. */
   announcement_date: string | null;
-  /** Derived: every gating item `done` (and at least one gating item exists). TODO(#1957): backend-derived once real; see `deriveFormationReadinessSummary`, which computes this identically. */
+  /**
+   * Derived: every gating item `done` (and at least one gating item exists). An `awaiting_acceptance`
+   * gating item does not count as `done`, so it keeps this false. TODO(#1957): backend-derived once real.
+   */
   is_activating: boolean;
   gating_items_open: number;
   gating_items_total: number;
@@ -58,14 +70,24 @@ export interface Formation {
   updated_at: string;
 }
 
-/** 5-state taxonomy confirmed against the design mockup — includes `waiting_on_partner`, distinct from `in_progress`. */
-export type FormationItemStatus = 'not_started' | 'in_progress' | 'waiting_on_partner' | 'done' | 'skipped';
+/**
+ * `blocked` is the stored value for an item stuck on something external — the UI may word it
+ * "waiting on partner", but that's copy, not a stored state. `awaiting_acceptance` is a 4 Sep
+ * product decision: an assignee marking their item complete doesn't close it — it stays on their
+ * Pending Actions until the formation team accepts it (`in_progress` understates that, `done`
+ * overstates it and would let it count toward readiness). TODO(#1957): `awaiting_acceptance` is
+ * provisional — the architecture lead hasn't reviewed the name.
+ *
+ * Only `done` counts toward readiness — wherever `is_activating` or a gating count is derived,
+ * `awaiting_acceptance` must not count as complete.
+ */
+export type FormationItemStatus = 'not_started' | 'in_progress' | 'blocked' | 'awaiting_acceptance' | 'done' | 'skipped';
 
 /**
  * One row's action affordance. `request` is a real, working Epic-1 action (fixture-only: files a
- * lightweight request and flips the item to `waiting_on_partner`, no SLA/target-team object — that
- * richer `request` type is #1957/Epic 2). `status_only` items never expose how the underlying
- * tooling was set up (manual vs automated) — only Done/pending + an optional link.
+ * lightweight request and flips the item to `blocked`, no SLA/target-team object — that richer
+ * `request` type is #1957/Epic 2). `status_only` items never expose how the underlying tooling was
+ * set up (manual vs automated) — only Done/pending + an optional link.
  */
 export type FormationItemAction = 'manual' | 'link' | 'provisionable' | 'request' | 'status_only';
 
@@ -83,11 +105,15 @@ export interface FormationItem {
   section_title: string;
   title: string;
   status: FormationItemStatus;
-  /** Only gating items count toward `is_activating` and show the "Gates Active" chip. */
+  /**
+   * Only gating items count toward `is_activating` and show the "Required for Active" chip — the
+   * agreed 4 Sep vocabulary (#1958) for the chip, the readiness strip, the Me-lens marker and the
+   * item-assigned email. "Gates cleared" survives only as the formation-level queue badge.
+   */
   is_gating: boolean;
   /** TODO(#1957): narrow once the real service confirms its owner-team vocabulary — fixture values today include labels (e.g. `'PMO'`) outside {@link FormationOwnerTeam}'s curated set. */
   owner_team: string | null;
-  owner: FormationLead | null;
+  owner: FormationUser | null;
   due_date: string | null;
   action: FormationItemAction;
   /** For `link`/`status_only` rows that open something external. */
@@ -99,10 +125,11 @@ export interface FormationItem {
   /** Required and logged when a gating item is skipped. */
   skip_reason: string | null;
   /**
-   * Per-item `gate_writer` permission — response-only, enrichment output. TODO(#1957): fabricated
-   * today by `FormationItemAccessService.canComplete` from a real LF-staff check; swap for a real
-   * `checkSingleAccess(req, { resource: 'formation_item', id, access: 'gate_writer' })` call once
-   * the relation ships.
+   * Whether the caller may complete this row — response-only, enrichment output. There is no
+   * `gate_writer` relation: gating is a property of the item, not the person. The guard is the
+   * project write permission plus this item's `is_gating` flag, checked service-side.
+   * TODO(#1957): fabricated today by `FormationItemAccessService.canComplete`; swap for the real
+   * service-side check once it ships.
    */
   can_complete: boolean;
   created_at: string;
@@ -129,7 +156,7 @@ export interface FormationActivity {
   /** Always item-scoped today — every {@link FormationActivityType} is an item-level action. */
   formation_item_uid: string | null;
   type: FormationActivityType;
-  actor: FormationLead;
+  actor: FormationUser;
   message: string;
   metadata: Record<string, unknown> | null;
   created_at: string;
@@ -190,7 +217,7 @@ export interface FormationChecklistResponse {
 export type FormationQueueTiles = Record<FormationSubStage, number> & {
   total: number;
   foundations: number;
-  subprojects: number;
+  child_projects: number;
 };
 
 /** Response body for `GET /api/formations`. */

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -137,6 +137,9 @@ export * from './public-group.interface';
 // Lens interfaces
 export * from './lens.interface';
 
+// Formation interfaces
+export * from './formation.interface';
+
 // Navigation interfaces
 export * from './navigation.interface';
 


### PR DESCRIPTION
## Summary

Lands the canonical `packages/shared/src/interfaces/formation.interface.ts` and a new
`packages/shared/src/enums/formation.enum.ts` on `main`, resolving the add/add conflict where
#2033 and #2035 each independently create `formation.interface.ts` from scratch.

- **#2033 wins on naming and structure** — `uid`, snake_case, nested `sections[].items[]`.
- **#2035's sub-item concept and curated vocabularies survive** — `FormationTemplateItem.sub_items?`
  is new (#2033 had no equivalent), and `FormationOwnerTeam` / `FormationActionType` /
  `FormationTemplateSectionKey` (renamed from #2035's `FormationTemplateSection`, which collided
  with #2033's structural interface of the same name) are TS enums per #2035's convention.
- `FormationActionType` gains `STATUS_ONLY`, which only #2033 needed.
- `owner_team` is split: enum on the template item/sub-item, `string | null` (TODO(#1957) to
  narrow) on the runtime `FormationItem` — #2033's fixtures use display labels (incl. `'PMO'`,
  deliberately absent from the enum) there today.
- `Formation.state` / `FormationState` dropped — banned application-flow values, and dead in all
  11 of #2033's fixture sites.
- **Follow-up commit:** a canonical `FORMATION_SUB_STAGE_LABELS` map
  (`packages/shared/src/constants/formation.constants.ts`), keyed by `FormationSubStage`. #2019 and
  #2033 each independently export a constant with this same name — a duplicate-export build break
  invisible until both land, same class of defect as the original add/add. The two turned out to
  key genuinely different enums (#2019's is `ProjectStage`-keyed, covers 5 stages including
  Disengaged/Confidential, and backs `isFormationStage`/`getFormationSubStageLabel`), so this isn't
  one map declared twice — it's a name collision between two different maps. #2033's
  `FormationSubStage`-keyed map (the queue's heavier-consumer shape) is canonical here, verbatim
  including its `'Formation · '` prefix; #2019 renames its own map on its rebase.
- Types and constants only. No components, services, fixtures, or template content.
- **Follow-up commit:** six amendments aligning the landed types with 4 Sep architecture-review and
  product decisions, before any of #2019/#2033/#2035 consumes them:
  - `FormationItemStatus`: drop `waiting_on_partner` (a UI wording of `blocked`, not a stored
    value), add `blocked` and `awaiting_acceptance` (an assignee-completed item stays on Pending
    Actions until the formation team accepts it — `in_progress` understates it, `done` overstates
    it and would count it toward readiness). Only `done` counts toward readiness;
    `awaiting_acceptance` is `TODO(#1957)`-flagged as a provisional name.
  - `FormationSubStage` drops `activating` — derived readiness (`Formation.is_activating`), not a
    PCC sub-stage; rendered as a separate "Gates cleared" badge (#1958), never the Stage column.
  - `can_complete` field stays; its comment no longer describes a `gate_writer` relation that will
    never exist — gating is a property of the item (`is_gating`), guarded by project write
    permission, `TODO(#1957)` for the real service-side check.
  - `FormationEntityType`: `'subproject'` → `'child_project'` (user-facing term), documented as a
    display taxonomy to derive later (`TODO(#1958)`) rather than store — the canonical `Formation`
    has neither `is_foundation` nor a parent-is-root signal yet, so deriving now would mean adding
    fields, not removing one. `FormationQueueTiles.subprojects` renamed to `child_projects` to match.
  - `is_gating` doc: "Gates Active" → **"Required for Active"**, the agreed 4 Sep vocabulary for
    the chip, readiness strip, Me-lens marker and item-assigned email.
  - `FormationLead` → `FormationUser` — it backs a plain user reference (`FormationItem.owner`,
    `FormationActivity.actor`), not the Epic 2 "formation lead" record (#1992).
  - Added a runtime regression guard on `FORMATION_SUB_STAGE_LABELS`' key set in
    `formation.enum.spec.ts` (no `activating`).
  - Every consumer of these six lives on #2033 (`feat/GH-1958-formation-checklist-queue`) —
    inventoried read-only, not touched here; #2035 has zero references to any of them. See the
    consumer inventory in the GH-2163 issue thread for the exact list #2033's rebase must absorb,
    including the three duplicated `status !== 'done' && status !== 'skipped'` predicates that
    already exclude `awaiting_acceptance` for free, and the three exhaustive
    `Record<FormationItemStatus, …>` constant maps that do not.

Verified round-trip against #2035's real 17-item seeded template (2 sections, 4 gating items, 4
chat-workspace sub-items) — every field maps with no information loss; #2035 gains two new
required fields on rebase (`FormationTemplate.name`, `FormationTemplateSection.title`), which its
flat shape never carried.

Blocks: #2019, #2033, #2035 (and #1993, #1956 later). Full derivation and decisions:
`~/lfx/formation-integration-conflict-report.md` (2026-09-03 section) and the GH-2163 issue.

Closes #2163

## Test plan

- [x] `./check-headers.sh && yarn lint && yarn format && yarn test && yarn build` — all pass
- [x] New `formation.enum.spec.ts`: enum exhaustiveness for all three vocabularies (real,
      runtime-enforced) + a minimal template literal round-trips the canonical shape
- [x] Confirmed the "sub-items nest one level only" invariant is real TS structure but not
      gate-enforced (this package's `test` is plain `vitest run`, no type-checking; `check-types`
      excludes `*.spec.ts`) — documented in the spec file rather than left as an inert
      `@ts-expect-error`
- [x] Merge dry-run (`git merge-tree --write-tree`) against scratch copies of #2033 and #2035
      with their local `formation.interface.ts`/`formation.enum.ts` deleted (simulating the
      post-merge rebase): clean merge, no `add/add` conflict, in both cases
- [x] `FORMATION_SUB_STAGE_LABELS`: confirmed `formation.constants.ts` is a genuinely new path on
      `main` but an existing one on #2033 — so, unlike the interface/enum files, this one cannot
      resolve to a clean automatic merge; #2033's rebase must hand-resolve the add/add by keeping
      this canonical label block and re-adding its own remaining unique constants (severity maps,
      queue tiles, row-action configs) into the same file. Simulated that resolution by hand in a
      scratch worktree and confirmed the merged file references only types already present in the
      canonical `formation.interface.ts`/`formation-checklist.interface.ts`/`components.interface.ts`
      — not full-build-verified there (the disposable worktree has no installed `node_modules`)
- [x] Amendments commit: `./check-headers.sh && yarn lint && yarn format && yarn test && yarn build`
      — all pass (`@lfx-one/shared` 60/60 files, `lfx-one-ui` 92/92 + 83/83 files); `grep` confirms
      `waiting_on_partner`, `'activating'`, `'subproject'`, and `FormationLead` are gone from
      `packages/shared`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdGb7zS2HyLZtgFAxokw71

