### PR TITLE
fix(profile): let the profile shell own invalid_state/no_code toasts

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -208,7 +208,7 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
     ['invalid_state', 'Security validation failed. Please try again.'],
     ['no_code', 'Authorization did not complete. Please try again.'],
   ])('toasts, clears the URL, and clears the stash for %s', async (error, detail) => {
-    const { add, navigateByUrl } = await setup(error, { savedAt: Date.now(), userMetadata: { about_me: 'x' } });
+    const { add, navigateByUrl } = await setup(error, { savedAt: Date.now(), userMetadata: { bio: 'x' } });
 
     expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Authorization Error', detail }));
     expect(navigateByUrl).toHaveBeenCalledWith('/profile', { replaceUrl: true });

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -138,8 +138,13 @@ describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-
  * specific message (not the old generic "Authorization failed. Please try again." for every code).
  */
 describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', () => {
-  async function setup(error: string): Promise<{ add: ReturnType<typeof vi.fn> }> {
+  async function setup(error: string, pendingSave?: unknown): Promise<{ add: ReturnType<typeof vi.fn>; navigateByUrl: ReturnType<typeof vi.fn> }> {
+    if (pendingSave !== undefined) {
+      sessionStorage.setItem(PENDING_PROFILE_SAVE_KEY, JSON.stringify(pendingSave));
+    }
+
     const add = vi.fn();
+    const navigateByUrl = vi.fn();
     const userServiceMock = {
       user: signal({ user_id: 'u1' } as unknown as User),
       impersonating: signal(false),
@@ -157,7 +162,7 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
       providers: [
         { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: ActivatedRoute, useValue: { queryParams: of({ error }) } },
-        { provide: Router, useValue: { url: '/profile', navigateByUrl: vi.fn() } },
+        { provide: Router, useValue: { url: '/profile', navigateByUrl } },
         { provide: UserService, useValue: userServiceMock },
         { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
         { provide: MessageService, useValue: { add } },
@@ -169,8 +174,12 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
     fixture.detectChanges();
     await fixture.whenStable();
 
-    return { add };
+    return { add, navigateByUrl };
   }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
 
   it('toasts the specific message for a mapped Flow C error code', async () => {
     const { add } = await setup('user_mismatch');
@@ -190,6 +199,20 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
     const { add } = await setup('toString');
 
     expect(add).not.toHaveBeenCalled();
+  });
+
+  // Regression guard: invalid_state/no_code used to be excluded from PROFILE_AUTH_ERROR_MESSAGES
+  // so only ProfileIdentitiesComponent toasted them — producing no toast, a stuck ?error= param,
+  // and a leftover stash on every other /profile/* route. The layout now owns them too.
+  it.each([
+    ['invalid_state', 'Security validation failed. Please try again.'],
+    ['no_code', 'Authorization did not complete. Please try again.'],
+  ])('toasts, clears the URL, and clears the stash for %s', async (error, detail) => {
+    const { add, navigateByUrl } = await setup(error, { savedAt: Date.now(), userMetadata: { about_me: 'x' } });
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Authorization Error', detail }));
+    expect(navigateByUrl).toHaveBeenCalledWith('/profile', { replaceUrl: true });
+    expect(sessionStorage.getItem(PENDING_PROFILE_SAVE_KEY)).toBeNull();
   });
 });
 

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -167,8 +167,8 @@ export class ProfileLayoutComponent {
       const errorCode = params['error'];
       if (typeof errorCode === 'string' && Object.hasOwn(PROFILE_AUTH_ERROR_MESSAGES, errorCode)) {
         const authErrorMessage = PROFILE_AUTH_ERROR_MESSAGES[errorCode];
-        // Clear any stash from the redirect that failed — otherwise it outlives this failed
-        // attempt and gets replayed by the next unrelated Flow C success (see handleProfileAuthReturn).
+        // Clear any stash so it can't be replayed by a later unrelated Flow C success. Unconditional
+        // by design: an identity-link failure shares these codes too, and a stash still here is orphaned.
         if (isPlatformBrowser(this.platformId)) {
           sessionStorage.removeItem(ProfileLayoutComponent.formStateKey);
         }

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
@@ -60,9 +60,17 @@ describe('ProfileIdentitiesComponent — Flow C vs identity-link error ownership
     expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Social authentication failed. Please try again.' }));
   });
 
-  it('toasts the specific message for no_code', async () => {
+  // invalid_state/no_code moved into PROFILE_AUTH_ERROR_MESSAGES (owned by the layout) so a
+  // failure toasts on every /profile/* route, not just this tab — this component must now skip
+  // them the same as any other Flow C code.
+  it('does not toast invalid_state — the layout owns it', async () => {
+    const { add } = await setup({ error: 'invalid_state' });
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('does not toast no_code — the layout owns it', async () => {
     const { add } = await setup({ error: 'no_code' });
-    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Authorization did not complete. Please try again.' }));
+    expect(add).not.toHaveBeenCalled();
   });
 
   it('falls back to the generic message for an unmapped code', async () => {

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -94,8 +94,8 @@ export class ProfileIdentitiesComponent implements OnInit {
       this.clearQueryParams();
     } else if (typeof params['error'] === 'string' && params['error']) {
       const errorCode = params['error'];
-      // Flow C (/passwordless/callback) codes are owned by ProfileLayoutComponent, which is
-      // alive on this route and already toasts them — skip here to avoid a double toast.
+      // Codes in PROFILE_AUTH_ERROR_MESSAGES (including invalid_state/no_code, shared with the
+      // identity-link callback) are owned by ProfileLayoutComponent — skip here to avoid a double toast.
       // hasOwn guard: errorCode is unvalidated user input — an inherited Object.prototype key
       // (e.g. 'toString') would otherwise resolve as a truthy hit in either map below.
       if (Object.hasOwn(PROFILE_AUTH_ERROR_MESSAGES, errorCode)) return;

--- a/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
@@ -147,7 +147,7 @@ function buildReq(overrides: Record<string, unknown> = {}): any {
 }
 
 function buildRes(): any {
-  return { status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn() };
+  return { status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn(), redirect: vi.fn() };
 }
 
 describe('ProfileController.uploadProfilePicture', () => {
@@ -414,5 +414,31 @@ describe('ProfileController.sendPasswordResetEmail', () => {
     });
     expect(emailVerificationSvc.sendPasswordResetLink).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProfileController.startProfileAuth — returnTo allowlist', () => {
+  let controller: ProfileController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    profileAuthSvc.isProfileAuthConfigured.mockReturnValue(false);
+    controller = new ProfileController();
+  });
+
+  it('falls back to /profile for the dead /settings entry — the profile shell never mounts there', async () => {
+    const res = buildRes();
+
+    await controller.startProfileAuth(buildReq({ query: { returnTo: '/settings' } }), res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/profile?error=profile_auth_not_configured');
+  });
+
+  it('keeps /profile/settings as an allowed returnTo', async () => {
+    const res = buildRes();
+
+    await controller.startProfileAuth(buildReq({ query: { returnTo: '/profile/settings' } }), res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/profile/settings?error=profile_auth_not_configured');
   });
 });

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -101,7 +101,6 @@ export class ProfileController {
     PROFILE_PASSWORD_PATH,
     '/profile/linux-email',
     PROFILE_SETTINGS_PATH,
-    '/settings',
   ]);
 
   private auth0Service: Auth0Service = new Auth0Service();

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -203,9 +203,10 @@ export const ACCOUNT_SETTINGS_SECTIONS = {
  * Error codes from the Flow C profile-auth (`/passwordless/callback`) round trip,
  * owned by ProfileLayoutComponent — it's alive on every /profile/* route, so it
  * handles these once regardless of which tab triggered the flow. `invalid_state`
- * and `no_code` are emitted by both this callback and the identity-link callback
- * and can't be disambiguated from the code alone, so they live only in
- * IDENTITY_LINK_ERROR_MESSAGES below to avoid a double toast.
+ * and `no_code` are also emitted by the identity-link callback below, but their
+ * wording is flow-agnostic and ProfileIdentitiesComponent's own hasOwn guard on
+ * this map already skips them, so keeping them here (rather than duplicated in
+ * both maps) is safe against a double toast.
  */
 export const PROFILE_AUTH_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   profile_auth_not_configured: 'Authorization is not available right now. Please try again later.',
@@ -213,20 +214,20 @@ export const PROFILE_AUTH_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   token_exchange_failed: 'Authorization failed. Please try again.',
   login_session_invalid: 'Your session has expired. Please sign in again.',
   user_mismatch: 'You authorized a different account. Please sign in as yourself and try again.',
+  invalid_state: 'Security validation failed. Please try again.',
+  no_code: 'Authorization did not complete. Please try again.',
 };
 
 /**
  * Error codes from the identity-link (social auth) callback, owned by
- * ProfileIdentitiesComponent. See the note on PROFILE_AUTH_ERROR_MESSAGES above
- * for why invalid_state / no_code live here rather than in that map.
+ * ProfileIdentitiesComponent. `invalid_state` / `no_code` live in
+ * PROFILE_AUTH_ERROR_MESSAGES above instead — see the note there.
  */
 export const IDENTITY_LINK_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   social_auth_failed: 'Social authentication failed. Please try again.',
-  invalid_state: 'Security validation failed. Please try again.',
   link_failed: 'Failed to link identity. Please try again.',
   social_verification_failed: 'Identity verification failed. Please try again.',
   invalid_provider: 'Invalid identity provider specified.',
   no_management_token: 'Authorization expired. Please try again.',
   no_identity_token: 'No identity token received. Please try again.',
-  no_code: 'Authorization did not complete. Please try again.',
 };


### PR DESCRIPTION
## Summary

- `invalid_state` and `no_code` were only handled by the Identities tab's error map, so a Flow C (profile re-auth) failure on any other `/profile/*` route produced no toast, left `?error=` stuck in the URL, and left a pending-save stash behind
- Move both codes into `PROFILE_AUTH_ERROR_MESSAGES`, owned by the profile shell that's alive on every `/profile/*` route — the Identities component's existing ownership guard now skips them automatically, so there's no double-toast
- Remove the unreachable `/settings` entry from the profile-auth `returnTo` allowlist; nothing ever sends `returnTo=/settings`, and a value outside the allowlist already falls back safely to `/profile`

Fixes #2180