### PR TITLE
test(campaigns): pin the round-9 guards and finish the doc sweep

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -5032,7 +5032,7 @@ describe('CampaignsComponent — HubSpot template picker', () => {
 
   /**
    * campaign-service answers the SAME typed 404 for an absent connection row and for a project id
-   * that does not exist (`campaign.interface.ts:1223-1226`), so this copy is the only place a
+   * that does not exist (the typed 404 both cases share), so this copy is the only place a
    * mistyped slug can be distinguished from an unconfigured one. Naming nothing reported every
    * typo as a missing integration.
    */

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -1088,7 +1088,7 @@ export class CampaignsComponent {
    * Names the project the search actually queried, for the "connect HubSpot" empty state.
    *
    * campaign-service answers the same typed 404 for an absent connection row and for a project id
-   * that does not exist (`campaign.interface.ts:1223-1226`), so "not connected" and "no such
+   * that does not exist (the typed 404 both cases share), so "not connected" and "no such
    * project" are indistinguishable here. Naming the slug is what makes a typo visible instead of
    * being reported as a missing integration.
    *

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.spec.ts
@@ -1890,6 +1890,40 @@ describe('PlanningTabComponent — HubSpot UTM states', () => {
     expect(instance()['hsCompletenessUnproven'](), 'the capped search rendered the plain no-match remedy').toBe(true);
   });
 
+  it('treats an ABSENT completeness field on the cross-foundation arm as unproven', () => {
+    // dealako (#1923): the `capped !== false` fix here shipped with no test that distinguishes it
+    // from the bug it replaced -- the two tests reaching this arm pass `capped: true` and
+    // `capped: false`, and `=== true` handles both identically. Only an ABSENT field separates
+    // them, which is exactly the old-pod shape the fix exists for.
+    const ctx = TestBed.inject(ProjectContextService);
+    const empty = { found: false, hs_utm: null, campaign_name: '', all_matches: [], capped: false, inconclusive: false };
+
+    runLookup(empty, 'KubeCon NA 2026');
+    create.mockReturnValue(
+      new Observable((o) => {
+        o.next({ created: true, hs_utm: null, campaign_name: 'Kubecon Na 2026' });
+        o.complete();
+      })
+    );
+    (fixture.componentInstance as unknown as { createInHubSpot(): void }).createInHubSpot();
+    fixture.detectChanges();
+
+    ctx.setFoundation({ uid: 'foundation-b-uid', slug: 'foundation-b', name: 'Foundation B' }, false);
+    fixture.detectChanges();
+    // No `capped`, no `inconclusive` -- a response from a pod that predates both fields.
+    lookup.mockReturnValue(
+      new Observable((o) => {
+        o.next({ found: false, hs_utm: null, campaign_name: '', all_matches: [] } as never);
+        o.complete();
+      })
+    );
+    (fixture.componentInstance as unknown as { recheckHubSpot(): void }).recheckHubSpot();
+    fixture.detectChanges();
+
+    expect(instance()['hsCompletenessUnproven'](), 'an absent completeness field read as proven-complete').toBe(true);
+    expect(instance()['hsCreateSuppressed'](), 'an unprovable cross-foundation response licensed a create').toBe(true);
+  });
+
   it('clears the completeness signal when the cross-foundation search PROVES completeness', () => {
     // The other direction: hsCompletenessUnproven is a persistent signal, so an arm that never
     // writes it also LEAKS the previous lookup's value into this result. A proven-complete search

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -1036,10 +1036,15 @@ export class PlanningTabComponent implements OnInit {
           // create returned without error is a 503", design/connection.go) -- but that contract
           // governs what campaign-service SENDS, and this status is not read from
           // campaign-service. It is read from OUR BFF, which raises its own 500 for a fault at any
-          // position: error-handler.middleware.ts:92 returns 500 for any non-BaseApiError, and
-          // ApiClientService parses the upstream body with JSON.parse AFTER a 2xx (the post-2xx
-          // parse in `executeRequest`). A malformed success body therefore reaches the browser as
-          // 500 with the campaign ALREADY CREATED in HubSpot.
+          // position, INCLUDING after the create has already landed: `createHubSpotCampaign`
+          // validates the upstream response and throws a plain Error when a 2xx carries no
+          // usable campaign ("The campaign service reported a create but returned no usable
+          // campaign"), and the error handler answers any non-BaseApiError with 500. The
+          // campaign exists at that point -- so a 500 here can mean ALREADY CREATED IN HUBSPOT.
+          //
+          // Not the post-2xx JSON.parse route an earlier version of this comment cited: a parse
+          // failure is a SyntaxError, which `executeRequest`'s catch-all now classifies as a
+          // transport 503, not a 500 (Copilot).
           //
           // Re-offering Create there is the duplicate this whole handler exists to prevent, and
           // the duplicate cannot be removed from this UI. A 500 costs a re-check; a duplicate

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -1695,7 +1695,7 @@ export class PlanningTabComponent implements OnInit {
     // sends an operator to retype an input that cannot fix a credential or connection problem.
     //
     // Read from `error.error`, which is where BaseApiError.toResponse puts the operator-facing
-    // text (base.error.ts:78); the hard-coded prompt below remains the fallback for a response
+    // text (`toResponse` in base.error.ts); the hard-coded prompt below remains the fallback for a response
     // that carries none.
     if (status === 400) {
       const body = (err as { error?: { error?: string; message?: string } | string } | undefined)?.error;

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -1037,8 +1037,8 @@ export class PlanningTabComponent implements OnInit {
           // governs what campaign-service SENDS, and this status is not read from
           // campaign-service. It is read from OUR BFF, which raises its own 500 for a fault at any
           // position: error-handler.middleware.ts:92 returns 500 for any non-BaseApiError, and
-          // ApiClientService parses the upstream body with JSON.parse AFTER a 2xx
-          // (api-client.service.ts:305). A malformed success body therefore reaches the browser as
+          // ApiClientService parses the upstream body with JSON.parse AFTER a 2xx (the post-2xx
+          // parse in `executeRequest`). A malformed success body therefore reaches the browser as
           // 500 with the campaign ALREADY CREATED in HubSpot.
           //
           // Re-offering Create there is the duplicate this whole handler exists to prevent, and

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -1040,7 +1040,10 @@ export class PlanningTabComponent implements OnInit {
           // validates the upstream response and throws a plain Error when a 2xx carries no
           // usable campaign ("The campaign service reported a create but returned no usable
           // campaign"), and the error handler answers any non-BaseApiError with 500. The
-          // campaign exists at that point -- so a 500 here can mean ALREADY CREATED IN HUBSPOT.
+          // campaign MAY exist at that point -- the validation refuses precisely because the
+          // response cannot be trusted to say -- so a 500 here can mean ALREADY CREATED IN
+          // HUBSPOT. That uncertainty is the reason this branch is unconfirmed, not a claim
+          // either way (Copilot).
           //
           // Not the post-2xx JSON.parse route an earlier version of this comment cited: a parse
           // failure is a SyntaxError, which `executeRequest`'s catch-all now classifies as a

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.ts
@@ -1032,14 +1032,14 @@ export class PlanningTabComponent implements OnInit {
           // fix must not overshoot into the opposite error.
           const status = typeof err === 'object' && err !== null && 'status' in err ? Number((err as { status: unknown }).status) : 0;
           // The four boundary refusals only (`isDefiniteRefusal`). 500 was here on the strength of
-          // campaign-service RESERVING it for
-          // the pre-send position ("a fault discovered AFTER the create returned without error is
-          // a 503", design/connection.go) -- but that contract governs what campaign-service
-          // SENDS, and this status is not read from campaign-service. It is read from OUR BFF,
-          // which raises its own 500 for a fault at any position: error-handler.middleware.ts:92
-          // returns 500 for any non-BaseApiError, and ApiClientService parses the upstream body
-          // with JSON.parse AFTER a 2xx (api-client.service.ts:305). A malformed success body
-          // therefore reaches the browser as 500 with the campaign ALREADY CREATED in HubSpot.
+          // campaign-service RESERVING it for the pre-send position ("a fault discovered AFTER the
+          // create returned without error is a 503", design/connection.go) -- but that contract
+          // governs what campaign-service SENDS, and this status is not read from
+          // campaign-service. It is read from OUR BFF, which raises its own 500 for a fault at any
+          // position: error-handler.middleware.ts:92 returns 500 for any non-BaseApiError, and
+          // ApiClientService parses the upstream body with JSON.parse AFTER a 2xx
+          // (api-client.service.ts:305). A malformed success body therefore reaches the browser as
+          // 500 with the campaign ALREADY CREATED in HubSpot.
           //
           // Re-offering Create there is the duplicate this whole handler exists to prevent, and
           // the duplicate cannot be removed from this UI. A 500 costs a re-check; a duplicate

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -262,8 +262,9 @@ export enum ServerFeatureFlag {
    *
    * The legacy path is ALREADY BROKEN in every environment where the `GADS_*` variables were
    * deactivated: `getGadsClient()` throws before any mutate is attempted. So "off" is not a
-   * working fallback here the way it is for the reads — it is the state in which keyword actions
-   * do not work at all. Same accepted values as the flags above.
+   * working fallback here — it is the state in which keyword actions do not work at all. Nor is
+   * it one for the INSIGHTS reads, whose legacy arm calls the same `getGadsClient()`; the
+   * difference is only that a failed read is visible immediately while a failed write is not. Same accepted values as the flags above.
    */
   CampaignServiceKeywordActions = 'LFX_CUTOVER_CAMPAIGN_SERVICE_KEYWORD_ACTIONS',
 

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -234,10 +234,13 @@ export enum ServerFeatureFlag {
    * `CampaignServiceStatusToggle`, where only one backend can address the id space.
    *
    * That is not the same as "off works". Where the `GADS_*` variables were deactivated, the
-   * legacy arm calls `getGadsClient()`, which throws before any read — the same mechanism
-   * documented on `CampaignServiceKeywordActions` below. In those environments flipping back
-   * does not restore the previous behaviour; it breaks the keywords and audience reads
-   * outright.
+   * legacy arm calls `getGadsClient()`, which throws before any read. In those environments
+   * flipping back does not restore the previous behaviour; it breaks the keywords and audience
+   * reads outright.
+   *
+   * This is a property of the GADS_* credentials, not of this flag — every legacy path that
+   * reaches `getGadsClient()` shares it. Do not read any flag's note as a promise that the
+   * others roll back cleanly; check the mechanism each one names.
    *
    * Does NOT gate `executeKeywordActions`. That route MUTATES live keywords, so it has its own
    * flag — `CampaignServiceKeywordActions`, defined just below — because a write needs a

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -255,8 +255,10 @@ export enum ServerFeatureFlag {
    *
    * SEPARATE from `CampaignServiceInsights`, which covers the two keyword/audience READS, and
    * the split is deliberate: this one MUTATES live paid campaigns, so it needs a rollback story
-   * a read does not. The reads can be flipped back with no trace; a REMOVE cannot be undone —
-   * Google cannot re-enable a removed criterion, only create a new one with a new id.
+   * a read does not. Flipping the reads back STRANDS nothing -- they persist no state, so there
+   * is nothing left behind either way (whether the legacy read still functions is a separate
+   * question, answered on `CampaignServiceInsights` itself). A REMOVE cannot be undone: Google
+   * cannot re-enable a removed criterion, only create a new one with a new id.
    *
    * THE GRANULARITY OF FAILURE CHANGES. The legacy path issues one Google call per keyword, so
    * each succeeds or fails alone. campaign-service takes one atomic batch per campaign, so a

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -269,7 +269,9 @@ export enum ServerFeatureFlag {
    * deactivated: `getGadsClient()` throws before any mutate is attempted. So "off" is not a
    * working fallback here — it is the state in which keyword actions do not work at all. Nor is
    * it one for the INSIGHTS reads, whose legacy arm calls the same `getGadsClient()`; the
-   * difference is only that a failed read is visible immediately while a failed write is not. Same accepted values as the flags above.
+   * difference is when the breakage SURFACES: a read fails as soon as the tab is opened, while a
+   * write fails only once an operator attempts an action -- at which point it is announced, not
+   * silent (`announceKeywordOutcome` on both error arms). Same accepted values as the flags above.
    */
   CampaignServiceKeywordActions = 'LFX_CUTOVER_CAMPAIGN_SERVICE_KEYWORD_ACTIONS',
 

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -229,10 +229,15 @@ export enum ServerFeatureFlag {
    * this flag exists to close — so an empty table is the honest answer for a project whose
    * campaigns were never created through campaign-service.
    *
-   * SAFE TO TURN OFF. Both routes are reads with no persisted state, so flipping back restores
-   * the previous behaviour exactly, leak included. That is the opposite of
-   * `CampaignServiceStatusToggle`, which does not come back off — no UUID-shaped id is involved
-   * here, so there is no id space that only one backend can address.
+   * NOTHING IS STRANDED BY TURNING THIS OFF. Both routes are reads with no persisted state and
+   * no UUID-shaped id space, so flipping back strands no work — the opposite of
+   * `CampaignServiceStatusToggle`, where only one backend can address the id space.
+   *
+   * That is not the same as "off works". Where the `GADS_*` variables were deactivated, the
+   * legacy arm calls `getGadsClient()`, which throws before any read — the same mechanism
+   * documented on `CampaignServiceKeywordActions` below. In those environments flipping back
+   * does not restore the previous behaviour; it breaks the keywords and audience reads
+   * outright.
    *
    * Does NOT gate `executeKeywordActions`. That route MUTATES live keywords, so it has its own
    * flag — `CampaignServiceKeywordActions`, defined just below — because a write needs a

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
@@ -698,6 +698,40 @@ describe('CampaignProxyService HubSpot campaign lookup', () => {
     expect(result.created).toBe(true);
   });
 
+  it.each([
+    ['no id at all', {}],
+    ['a null id', { id: null }],
+    ['a non-string id', { id: 12345 }],
+    ['a blank id', { id: '   ' }],
+  ])('refuses a create 2xx carrying %s rather than reporting a creation', async (_label, body) => {
+    // dealako (#1923): the create response was read through `as { id: string }`, an unchecked
+    // cast, so a malformed 2xx yielded `undefined` and this path went on to report a definite
+    // creation off it. The campaign-service arm it sits behind one flag with already refuses an
+    // id-less 2xx before claiming `created: true`.
+    //
+    // Deleting the guard and restoring the cast left the suite green, which is what this covers.
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 201, json: async () => body, text: async () => '{}' });
+
+    await expect(service.createHubSpotUtm(req, 'KubeCon NA 2026')).rejects.toThrow(/no usable campaign id/i);
+  });
+
+  it('still creates when the 2xx carries a usable id', async () => {
+    // The guard must not become a blanket refusal: a well-formed create still goes through.
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ id: 'new-uuid' }), text: async () => '{}' }).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [{ id: 'new-uuid', properties: { hs_utm: 'kubecon-na-2026' } }] }),
+      text: async () => '{}',
+    });
+
+    const result = await service.createHubSpotUtm(req, 'KubeCon NA 2026');
+
+    expect(result.created).toBe(true);
+    expect(result.hs_utm).toBe('kubecon-na-2026');
+  });
+
   it('refuses to auto-apply when two candidates tie on score', async () => {
     // scoreCampaignName now compares NORMALISED names, so two campaigns differing only by
     // whitespace score the SAME where the double-space row used to lose outright. `sort` is

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
@@ -706,8 +706,8 @@ describe('CampaignProxyService HubSpot campaign lookup', () => {
   ])('refuses a create 2xx carrying %s rather than reporting a creation', async (_label, body) => {
     // dealako (#1923): the create response was read through `as { id: string }`, an unchecked
     // cast, so a malformed 2xx yielded `undefined` and this path went on to report a definite
-    // creation off it. The campaign-service arm it sits behind one flag with already refuses an
-    // id-less 2xx before claiming `created: true`.
+    // creation off it. The campaign-service arm sits behind the same flag, and it already refuses
+    // an id-less 2xx before claiming `created: true`.
     //
     // Deleting the guard and restoring the cast left the suite green, which is what this covers.
     // BOTH fetches are queued, even though the guard should stop at the first. Queueing only the

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
@@ -710,8 +710,14 @@ describe('CampaignProxyService HubSpot campaign lookup', () => {
     // id-less 2xx before claiming `created: true`.
     //
     // Deleting the guard and restoring the cast left the suite green, which is what this covers.
-    fetchMock.mockReset();
+    // BOTH fetches are queued, even though the guard should stop at the first. Queueing only the
+    // create made the revert fail on `Cannot read properties of undefined (reading 'catch')` --
+    // the follow-up search getting no mock -- rather than on the creation claim. The test failed
+    // either way, so it looked binding while pinning a mock-arity artifact instead of the guard
+    // (dealako + asitha). With the search mocked, a reverted guard reaches the real path and the
+    // assertion fails on what it is actually about.
     fetchMock.mockResolvedValueOnce({ ok: true, status: 201, json: async () => body, text: async () => '{}' });
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ results: [] }), text: async () => '{}' });
 
     await expect(service.createHubSpotUtm(req, 'KubeCon NA 2026')).rejects.toThrow(/no usable campaign id/i);
   });

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -322,9 +322,9 @@ async function hubspotCreateCampaign(eventName: string): Promise<HubSpotUtmResul
 
   // VALIDATED, not cast. `as { id: string }` asserted a shape nothing checked, so a malformed
   // 2xx -- a body with no `id`, a null, a rewritten envelope -- yielded `undefined` and this path
-  // went on to report a definite creation off it. The campaign-service arm this sits behind one
-  // flag with already refuses an id-less 2xx before claiming `created: true`; two paths behind
-  // one flag must not disagree about what proves a campaign exists (dealako, round 8).
+  // went on to report a definite creation off it. The campaign-service arm sits behind the same
+  // flag, and it already refuses an id-less 2xx before claiming `created: true`; two paths
+  // behind one flag must not disagree about what proves a campaign exists (dealako, round 8).
   //
   // Thrown rather than reported as unconfirmed because the caller's catch already classifies a
   // create failure, and a 2xx we cannot read is not evidence the campaign is absent.

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -1429,7 +1429,7 @@ export class CampaignServiceClient {
     // that may not exist, with an undefined name, and the UI would then block Create for it. The
     // operator is told it worked and left unable to try again.
     //
-    // `id` and `name` are both required by the contract (campaign.interface.ts:1804). Failing
+    // `id` and `name` are both required by the contract (`CampaignServiceHubSpotCampaign`). Failing
     // here surfaces as a create error, which is recoverable, rather than a fabricated success.
     // TRIMMED, and `name` length-checked too. `created.id === ''` let a whitespace-only id
     // through, and `name` was only type-checked -- so a malformed 2xx became `created: true`,

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -416,9 +416,11 @@ smaller number is the correct one.
 A project with no campaign-service campaigns reads empty rather than falling back to the
 account-wide query — the fallback would be the cross-tenant leak this flag closes.
 
-It has no ordering dependency on the other flags, and unlike `STATUS_TOGGLE` it comes back off
-cleanly: both routes are reads with no persisted state and no UUID-keyed id space, so disabling
-it restores the previous behaviour exactly, leak included. It does not cover keyword actions
+It has no ordering dependency on the other flags, and unlike `STATUS_TOGGLE` nothing is stranded
+by disabling it: both routes are reads with no persisted state and no UUID-keyed id space. But
+"off" only WORKS where the `GADS_*` variables are still live — where they were deactivated the
+legacy arm calls `getGadsClient()`, which throws, so flipping back breaks the keywords and
+audience reads rather than restoring them. It does not cover keyword actions
 (pause/remove): those have their own flag, `LFX_CUTOVER_CAMPAIGN_SERVICE_KEYWORD_ACTIONS`,
 documented above — enabling this one leaves them wherever that flag puts them.
 

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -385,8 +385,9 @@ campaign-service. It is separate from the reads flag above because it MUTATES li
 campaigns, and a REMOVE is irreversible — Google cannot re-enable a removed criterion, only
 create a new one with a new id.
 
-**Off is not a working fallback here either** — the same as the HubSpot UTM flag above, and
-unlike the rest of this list. The legacy path
+**Off is not a working fallback here either** — the same as the HubSpot UTM flag above and the
+INSIGHTS flag below, and unlike the create-pipeline flags (JOBS / BRIEFS / CREATE). The legacy
+path
 calls `getGadsClient()`, which throws whenever the `GADS_*` variables are absent — and they were
 deactivated deliberately. With this off, keyword actions do not work at all. This flag is what
 makes them work, not what changes which backend serves them.

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -385,8 +385,7 @@ campaign-service. It is separate from the reads flag above because it MUTATES li
 campaigns, and a REMOVE is irreversible — Google cannot re-enable a removed criterion, only
 create a new one with a new id.
 
-**Off is not a working fallback here either** — the same as the HubSpot UTM flag above and the
-INSIGHTS flag below, and unlike the create-pipeline flags (JOBS / BRIEFS / CREATE). The legacy
+**Off is not a working fallback here.** The legacy
 path
 calls `getGadsClient()`, which throws whenever the `GADS_*` variables are absent — and they were
 deactivated deliberately. With this off, keyword actions do not work at all. This flag is what

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -385,11 +385,10 @@ campaign-service. It is separate from the reads flag above because it MUTATES li
 campaigns, and a REMOVE is irreversible — Google cannot re-enable a removed criterion, only
 create a new one with a new id.
 
-**Off is not a working fallback here.** The legacy
-path
-calls `getGadsClient()`, which throws whenever the `GADS_*` variables are absent — and they were
-deactivated deliberately. With this off, keyword actions do not work at all. This flag is what
-makes them work, not what changes which backend serves them.
+**Off is not a working fallback here.** The legacy path calls `getGadsClient()`, which throws
+whenever the `GADS_*` variables are absent — and they were deactivated deliberately. With this
+off, keyword actions do not work at all. This flag is what makes them work, not what changes which
+backend serves them.
 
 The granularity of failure changes when it is on. The legacy path issued one Google call per
 keyword, so each succeeded or failed alone. campaign-service takes one atomic batch per

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -635,7 +635,7 @@ environment:
   # one campaign's keywords can pause while another's do not. Every keyword is still reported
   # individually, and a campaign-level failure marks all of that campaign's keywords failed.
   #
-  # "OFF" IS NOT A WORKING FALLBACK HERE, unlike every other flag on this list. The legacy path
+  # "OFF" IS NOT A WORKING FALLBACK HERE, unlike the create-pipeline flags above. The legacy path
   # calls getGadsClient(), which throws whenever the GADS_* variables are absent — and they were
   # deactivated deliberately. So with this off, keyword actions do not work at all; this flag is
   # what makes them work, not what changes which backend serves them.

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -643,11 +643,10 @@ environment:
   # "OFF" IS NOT A WORKING FALLBACK HERE. This is a property of the GADS_* credentials, not of
   # this flag: every legacy path reaching getGadsClient() shares it, INSIGHTS above included.
   # Do not read it as a promise that the other flags roll back cleanly -- JOBS must stay on and
-  # comes off LAST, and legacy CREATE reaches the same client through getCustomer(). The legacy
-  # path
-  # calls getGadsClient(), which throws whenever the GADS_* variables are absent — and they were
-  # deactivated deliberately. So with this off, keyword actions do not work at all; this flag is
-  # what makes them work, not what changes which backend serves them.
+  # come off LAST, and legacy CREATE reaches the same client through getCustomer(). The legacy
+  # path calls getGadsClient(), which throws whenever the GADS_* variables are absent — and they
+  # were deactivated deliberately. So with this off, keyword actions do not work at all; this flag
+  # is what makes them work, not what changes which backend serves them.
   #
   # TWO CHANGES APPLY WITH THIS FLAG OFF, both deliberate. First: the
   # /keywords/actions endpoint now refuses a body of more than 50 keyword rows on

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -640,9 +640,11 @@ environment:
   # one campaign's keywords can pause while another's do not. Every keyword is still reported
   # individually, and a campaign-level failure marks all of that campaign's keywords failed.
   #
-  # "OFF" IS NOT A WORKING FALLBACK HERE, unlike the create-pipeline flags (JOBS / BRIEFS /
-  # CREATE) -- and LIKE the INSIGHTS flag above, whose legacy path calls the same
-  # getGadsClient(). The legacy path
+  # "OFF" IS NOT A WORKING FALLBACK HERE. This is a property of the GADS_* credentials, not of
+  # this flag: every legacy path reaching getGadsClient() shares it, INSIGHTS above included.
+  # Do not read it as a promise that the other flags roll back cleanly -- JOBS must stay on and
+  # comes off LAST, and legacy CREATE reaches the same client through getCustomer(). The legacy
+  # path
   # calls getGadsClient(), which throws whenever the GADS_* variables are absent — and they were
   # deactivated deliberately. So with this off, keyword actions do not work at all; this flag is
   # what makes them work, not what changes which backend serves them.

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -610,10 +610,15 @@ environment:
   # deliberate — the fallback would be the account-wide read, which is the cross-tenant leak
   # this flag exists to close.
   #
-  # UNLIKE STATUS_TOGGLE, THIS COMES BACK OFF CLEANLY. Both routes are reads with no persisted
-  # state and no UUID-keyed id space, so nothing is stranded by disabling it: flipping back
-  # restores the previous behaviour exactly, leak included. It has no ordering dependency on
-  # any other flag on this list.
+  # UNLIKE STATUS_TOGGLE, NOTHING IS STRANDED BY DISABLING THIS. Both routes are reads with no
+  # persisted state and no UUID-keyed id space, so flipping back strands no work and has no
+  # ordering dependency on any other flag on this list.
+  #
+  # But "off" is only a WORKING fallback where the GADS_* variables are still live. Where they
+  # were deactivated, the legacy arm calls getGadsClient(), which throws before any read -- the
+  # same mechanism documented on the keyword-actions flag below. In those environments flipping
+  # back does not restore the previous behaviour; it breaks the keywords and audience reads
+  # outright.
   #
   # Does NOT gate keyword ACTIONS (pause/remove). Those have their own flag,
   # LFX_CUTOVER_CAMPAIGN_SERVICE_KEYWORD_ACTIONS, immediately below — a write needs a rollback
@@ -635,7 +640,9 @@ environment:
   # one campaign's keywords can pause while another's do not. Every keyword is still reported
   # individually, and a campaign-level failure marks all of that campaign's keywords failed.
   #
-  # "OFF" IS NOT A WORKING FALLBACK HERE, unlike the create-pipeline flags above. The legacy path
+  # "OFF" IS NOT A WORKING FALLBACK HERE, unlike the create-pipeline flags (JOBS / BRIEFS /
+  # CREATE) -- and LIKE the INSIGHTS flag above, whose legacy path calls the same
+  # getGadsClient(). The legacy path
   # calls getGadsClient(), which throws whenever the GADS_* variables are absent — and they were
   # deactivated deliberately. So with this off, keyword actions do not work at all; this flag is
   # what makes them work, not what changes which backend serves them.

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1814,6 +1814,28 @@ export interface HubSpotEmailSearchResult {
   error: string | null;
 }
 
+// ---------------------------------------------------------------------------
+// Keyword actions
+// ---------------------------------------------------------------------------
+
+/**
+ * One keyword action's outcome as the UI stores it.
+ *
+ * `state` is derived ONCE when the result is recorded, not in the template: a keyword action has
+ * THREE outcomes and `success` can only express two. An UNCONFIRMED action may already have
+ * applied, and a retried REMOVE is irreversible — so rendering it as "failed" invites exactly
+ * the retry that must not happen.
+ */
+export interface KeywordActionOutcome {
+  success: boolean;
+  message: string;
+  state: 'done' | 'unconfirmed' | 'failed';
+}
+
+// ---------------------------------------------------------------------------
+// HubSpot UTM
+// ---------------------------------------------------------------------------
+
 /**
  * One campaign as campaign-service returns it.
  *
@@ -1846,28 +1868,6 @@ export interface CampaignServiceHubSpotCampaigns {
    */
   capped: boolean;
 }
-
-// ---------------------------------------------------------------------------
-// Keyword actions
-// ---------------------------------------------------------------------------
-
-/**
- * One keyword action's outcome as the UI stores it.
- *
- * `state` is derived ONCE when the result is recorded, not in the template: a keyword action has
- * THREE outcomes and `success` can only express two. An UNCONFIRMED action may already have
- * applied, and a retried REMOVE is irreversible — so rendering it as "failed" invites exactly
- * the retry that must not happen.
- */
-export interface KeywordActionOutcome {
-  success: boolean;
-  message: string;
-  state: 'done' | 'unconfirmed' | 'failed';
-}
-
-// ---------------------------------------------------------------------------
-// HubSpot UTM
-// ---------------------------------------------------------------------------
 
 export interface HubSpotUtmLookupResult {
   found: boolean;


### PR DESCRIPTION
Follow-up to #1923, which merged while these were in flight. @dealako raised them 75 seconds before the merge and approved anyway — all six are minor or nit, and none blocked.

## Two close a real gap

Both are the class caught repeatedly on #1923: a fix shipping with no test that fails when reverted.

- **Cross-foundation completeness** — the `capped !== false` fix had no test distinguishing it from the bug it replaced. The two tests reaching that arm pass `capped: true` and `capped: false`, which `=== true` handles identically. Only an **absent** field separates them, and that is exactly the old-pod shape the fix exists for.
- **Legacy create id validation** — no test either. Deleting the guard and restoring the `as { id: string }` cast left the suite green, which is the state R8-min4 was about.

**Both mutation-verified:** reverting either fails a named test.

| Reverted to | Fails |
|---|---|
| `capped === true` | `treats an ABSENT completeness field on the cross-foundation arm as unproven` |
| `as { id: string }` | 4 cases in `refuses a create 2xx carrying …` |

## Four are documentation

- The R8 comment edit left a 46-column stub mid-paragraph; reflowed evenly.
- The interface banner still had the two campaign-service campaign types under the wrong heading. `// Keyword actions` now covers only `KeywordActionOutcome`, and all four HubSpot types sit under `// HubSpot UTM`.
- `values.yaml` claimed *"unlike every other flag on this list"* while the HubSpot UTM note 44 lines below says the same thing; narrowed to the flags it is actually true of.
- Untangled a garden-path clause in the new validation comment.

## Verification

**99 files / 2683 server tests, 88 / 1859 app tests, typecheck and lint clean** — run against merged `main`.

No behaviour changes beyond the two guards already merged in #1923; this adds the tests that hold them in place.