### PR TITLE
fix(search): rank project search by relevance, not alphabetically

### DIFF
--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.spec.ts
@@ -8,14 +8,16 @@ import { LensItem } from '@lfx-one/shared/interfaces';
 import { NavigationService } from '@services/navigation.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectSelectorComponent } from './project-selector.component';
 
 /**
  * Covers the ordering contract only. Curated mode is used as the harness because it sources items
  * from the `items` input rather than `NavigationService`, which keeps the assertion about *order*
- * free of upstream pagination — the browse-vs-search branch under test is shared by both modes.
+ * free of upstream pagination and debouncing — the browse-vs-search branch under test is shared by
+ * both modes. The nav-mode timing rule (order on the term the results were fetched for, not the
+ * term the user typed) is covered separately below.
  */
 describe('ProjectSelectorComponent ordering', () => {
   // Deliberately not alphabetical, and every entry matches "cloud" so the search assertion is
@@ -94,5 +96,127 @@ describe('ProjectSelectorComponent ordering', () => {
     await search('');
 
     expect(renderedSlugs()).toEqual(['alpha-cloud', 'mid-cloud', 'zeta-cloud']);
+  });
+});
+
+/**
+ * Nav-backed mode, where the typed term and the term the visible items were fetched for diverge
+ * across the search debounce and the request round-trip.
+ */
+describe('ProjectSelectorComponent nav-backed ordering', () => {
+  const foundations: LensItem[] = [
+    { uid: 'f2', slug: 'zeta-foundation', name: 'Zeta Foundation', logoUrl: null, isFoundation: true },
+    { uid: 'f1', slug: 'alpha-foundation', name: 'Alpha Foundation', logoUrl: null, isFoundation: true },
+  ];
+  const projects: LensItem[] = [
+    { uid: 'p2', slug: 'zeta-project', name: 'Zeta Project', logoUrl: null, isFoundation: false },
+    { uid: 'p1', slug: 'alpha-project', name: 'Alpha Project', logoUrl: null, isFoundation: false },
+  ];
+
+  let fixture: ComponentFixture<ProjectSelectorComponent>;
+  let resultsTerm: ReturnType<typeof signal<string>>;
+
+  // Nav mode (unlike curated) runs the sidebar-relative panel alignment on popover show, which
+  // reads `window.matchMedia` — absent in jsdom. Reporting no match takes the early return, so the
+  // geometry path stays out of an ordering test.
+  afterEach(() => vi.unstubAllGlobals());
+
+  async function build(hybrid: boolean): Promise<void> {
+    vi.stubGlobal('matchMedia', () => ({ matches: false }));
+    resultsTerm = signal('');
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ProjectSelectorComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: NavigationService,
+          useValue: {
+            items: (lens: string) => signal(lens === 'foundation' ? foundations : projects),
+            hasMore: () => signal(false),
+            loading: () => signal(false),
+            // Both lenses are searched with the same term and share this signal, mirroring the
+            // parallel dispatch the component performs in hybrid mode.
+            resultsTerm: () => resultsTerm,
+            setSearchTerm: () => undefined,
+            loadNextPage: () => undefined,
+          },
+        },
+        {
+          provide: PersonaService,
+          useValue: {
+            personaProjects: signal({}),
+            // Makes p1 a child of f1, so the All tab has something to nest while browsing.
+            detectedProjects: signal([{ projectUid: 'p1', parentProjectUid: 'f1', isFoundation: false }]),
+            allPersonas: signal([]),
+          },
+        },
+        { provide: ProjectContextService, useValue: { isFoundationContext: signal(false) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectSelectorComponent);
+    fixture.componentRef.setInput('lens', 'project');
+    fixture.componentRef.setInput('hybridMode', hybrid);
+    await fixture.whenStable();
+    (fixture.nativeElement.querySelector('[data-testid="project-selector"]') as HTMLButtonElement).click();
+    await fixture.whenStable();
+  }
+
+  function renderedSlugs(): string[] {
+    return Array.from(document.body.querySelectorAll('[data-testid^="lens-item-"]')).map((el) =>
+      (el.getAttribute('data-testid') ?? '').replace('lens-item-', '')
+    );
+  }
+
+  function nestedSlugs(): string[] {
+    return Array.from(document.body.querySelectorAll('[data-testid^="lens-item-"]'))
+      .filter((el) => el.parentElement?.classList.contains('pl-5'))
+      .map((el) => (el.getAttribute('data-testid') ?? '').replace('lens-item-', ''));
+  }
+
+  async function type(term: string): Promise<void> {
+    const input = document.body.querySelector('[data-testid="project-search-input"]') as HTMLInputElement;
+    input.value = term;
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+  }
+
+  it('keeps browse ordering until the search results actually arrive', async () => {
+    await build(false);
+
+    // Typed, but NavigationService has not come back yet — the list on screen is still the browse
+    // list, so re-ordering it now would reshuffle twice for one search.
+    await type('zeta');
+
+    expect(renderedSlugs()).toEqual(['alpha-project', 'zeta-project']);
+  });
+
+  it('switches to relevance ordering once the results reflect the search', async () => {
+    await build(false);
+    await type('zeta');
+
+    resultsTerm.set('zeta');
+    await fixture.whenStable();
+
+    expect(renderedSlugs()).toEqual(['zeta-project', 'alpha-project']);
+  });
+
+  it('nests projects under their parent foundation on the All tab while browsing', async () => {
+    await build(true);
+
+    expect(nestedSlugs()).toEqual(['alpha-project']);
+  });
+
+  it('flattens the All tab while searching so a match is not hidden under its parent', async () => {
+    await build(true);
+    await type('zeta');
+    resultsTerm.set('zeta');
+    await fixture.whenStable();
+
+    // Foundations still lead — the two lenses are separate queries with non-comparable scores —
+    // but each group keeps its own relevance order and nothing is nested out of view (GH-2030).
+    expect(nestedSlugs()).toEqual([]);
+    expect(renderedSlugs()).toEqual(['zeta-foundation', 'alpha-foundation', 'zeta-project', 'alpha-project']);
   });
 });

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.spec.ts
@@ -1,0 +1,98 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { LensItem } from '@lfx-one/shared/interfaces';
+import { NavigationService } from '@services/navigation.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ProjectSelectorComponent } from './project-selector.component';
+
+/**
+ * Covers the ordering contract only. Curated mode is used as the harness because it sources items
+ * from the `items` input rather than `NavigationService`, which keeps the assertion about *order*
+ * free of upstream pagination — the browse-vs-search branch under test is shared by both modes.
+ */
+describe('ProjectSelectorComponent ordering', () => {
+  // Deliberately not alphabetical, and every entry matches "cloud" so the search assertion is
+  // about ordering rather than filtering.
+  const items: LensItem[] = [
+    { uid: 'u1', slug: 'zeta-cloud', name: 'Zeta Cloud', logoUrl: null, isFoundation: false },
+    { uid: 'u2', slug: 'alpha-cloud', name: 'Alpha Cloud', logoUrl: null, isFoundation: false },
+    { uid: 'u3', slug: 'mid-cloud', name: 'Mid Cloud', logoUrl: null, isFoundation: false },
+  ];
+
+  let fixture: ComponentFixture<ProjectSelectorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectSelectorComponent],
+      providers: [
+        // The list renders inside a PrimeNG popover, which declares animation metadata.
+        provideNoopAnimations(),
+        // Curated mode short-circuits every NavigationService read, but the component still injects
+        // it — these stubs exist to satisfy the injector, not to be exercised.
+        {
+          provide: NavigationService,
+          useValue: {
+            items: () => signal<LensItem[]>([]),
+            hasMore: () => signal(false),
+            loading: () => signal(false),
+            setSearchTerm: () => undefined,
+            loadNextPage: () => undefined,
+          },
+        },
+        // No persona grants: every item lands in the same role tier, so browse order collapses to
+        // the alphabetical tie-break and the two orderings are cleanly distinguishable.
+        // `allPersonas` backs the role-badge fallback and is read for every rendered row.
+        { provide: PersonaService, useValue: { personaProjects: signal({}), detectedProjects: signal([]), allPersonas: signal([]) } },
+        { provide: ProjectContextService, useValue: { isFoundationContext: signal(false) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProjectSelectorComponent);
+    fixture.componentRef.setInput('lens', 'project');
+    fixture.componentRef.setInput('items', items);
+    await fixture.whenStable();
+
+    // The list lives inside a PrimeNG popover that renders lazily into document.body.
+    (fixture.nativeElement.querySelector('[data-testid="project-selector"]') as HTMLButtonElement).click();
+    await fixture.whenStable();
+  });
+
+  function renderedSlugs(): string[] {
+    return Array.from(document.body.querySelectorAll('[data-testid^="lens-item-"]')).map((el) =>
+      (el.getAttribute('data-testid') ?? '').replace('lens-item-', '')
+    );
+  }
+
+  async function search(term: string): Promise<void> {
+    const input = document.body.querySelector('[data-testid="project-search-input"]') as HTMLInputElement;
+    input.value = term;
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+  }
+
+  it('sorts alphabetically while browsing', () => {
+    expect(renderedSlugs()).toEqual(['alpha-cloud', 'mid-cloud', 'zeta-cloud']);
+  });
+
+  it('preserves the source order while searching', async () => {
+    // The source order is relevance for nav-backed search (`sort: 'best_match'`). Re-sorting
+    // alphabetically here would bury the closest match under every other match (GH-2030).
+    await search('cloud');
+
+    expect(renderedSlugs()).toEqual(['zeta-cloud', 'alpha-cloud', 'mid-cloud']);
+  });
+
+  it('returns to alphabetical order once the search is cleared', async () => {
+    await search('cloud');
+    await search('');
+
+    expect(renderedSlugs()).toEqual(['alpha-cloud', 'mid-cloud', 'zeta-cloud']);
+  });
+});

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -58,21 +58,15 @@ export class ProjectSelectorComponent {
   protected readonly activeTab = signal<SelectorTab>('all');
   protected readonly selectorTabs: readonly SelectorTab[] = ['all', 'foundations', 'projects'];
   protected readonly searchControl = new FormControl<string>('', { nonNullable: true });
+  /**
+   * The term currently typed into the selector, mirrored for every mode. Curated mode filters on it
+   * directly; nav mode routes it through `NavigationService` to drive the upstream query and reads
+   * the settled term back from there (see `isSearchResult`).
+   */
+  private readonly searchTerm = signal<string>('');
 
   /** True when a curated `items` list is supplied — switches sourcing/search/pagination to local mode. */
   protected readonly isCurated: Signal<boolean> = computed(() => this.items() !== null);
-  /**
-   * The term currently typed into the selector, mirrored for every mode. Curated mode filters on it
-   * directly; nav mode also routes it through `NavigationService` to drive the upstream query, and
-   * reads it back here only to know whether a search is active (see `isSearching`).
-   */
-  private readonly searchTerm = signal<string>('');
-  /**
-   * While searching, the upstream order is relevance (`sort: 'best_match'`) and must be preserved —
-   * re-sorting alphabetically would bury the closest match under every other match. Role-tier
-   * ordering only applies to the unfiltered browse list.
-   */
-  private readonly isSearching: Signal<boolean> = computed(() => this.searchTerm().trim().length > 0);
 
   // Sidebar panel pins fixed to the right of the rail; the curated (dialog) variant drops that
   // sidebar-only positioning so PrimeNG anchors the popover to its own trigger inside the dialog.
@@ -305,14 +299,14 @@ export class ProjectSelectorComponent {
     return computed(() => {
       const selectedUid = this.selectedProject()?.uid ?? null;
       if (!this.hybridMode()) {
-        return this.orderItems(this.rawProjectItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
+        return this.orderItems(this.rawProjectItems(), this.lens()).map((item) => this.toDisplayItem(item, false, selectedUid));
       }
       const tab = this.activeTab();
       if (tab === 'foundations') {
-        return this.orderItems(this.foundationItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
+        return this.orderItems(this.foundationItems(), 'foundation').map((item) => this.toDisplayItem(item, false, selectedUid));
       }
       if (tab === 'projects') {
-        return this.orderItems(this.rawProjectItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
+        return this.orderItems(this.rawProjectItems(), 'project').map((item) => this.toDisplayItem(item, false, selectedUid));
       }
       return this.buildAllTabItems(selectedUid);
     });
@@ -388,11 +382,25 @@ export class ProjectSelectorComponent {
   }
 
   /**
-   * Browse order: role tier first, then alphabetical. Search order: whatever the source already
-   * produced, which is relevance for nav-backed search and the curated list's own order otherwise.
+   * Whether the items currently held for `lens` are search results rather than the browse list.
+   *
+   * Curated mode filters locally, so the typed term is immediately true of what is on screen. Nav
+   * mode debounces and round-trips, so the typed term is true of what was *requested*; reading it
+   * here would restyle the still-visible browse list for ~300ms before the results replace it.
+   * `NavigationService.resultsTerm` is the term the held items were actually fetched for.
    */
-  private orderItems(items: LensItem[]): LensItem[] {
-    return this.isSearching() ? items : this.sortByRole(items);
+  private isSearchResult(lens: NavLens): boolean {
+    const term = this.isCurated() ? this.searchTerm() : this.navigationService.resultsTerm(lens)();
+    return term.trim().length > 0;
+  }
+
+  /**
+   * Browse order: role tier first, then alphabetical. Search order: whatever the source already
+   * produced, which is relevance for nav-backed search (`sort: 'best_match'`) and the curated
+   * list's own order otherwise. Re-sorting search results would bury the closest match.
+   */
+  private orderItems(items: LensItem[], lens: NavLens): LensItem[] {
+    return this.isSearchResult(lens) ? items : this.sortByRole(items);
   }
 
   private sortByRole(items: LensItem[]): LensItem[] {
@@ -403,8 +411,22 @@ export class ProjectSelectorComponent {
   }
 
   private buildAllTabItems(selectedUid: string | null): DisplayLensItem[] {
-    const sortedFoundations = this.orderItems(this.foundationItems());
-    const sortedProjects = this.orderItems(this.rawProjectItems());
+    const sortedFoundations = this.orderItems(this.foundationItems(), 'foundation');
+    const sortedProjects = this.orderItems(this.rawProjectItems(), 'project');
+
+    // Nesting is a browse affordance: it helps someone scanning a hierarchy they already know.
+    // Applied to search results it hides matches, because a strong project match is filed under
+    // whatever position its parent foundation happened to take — or, when the parent didn't match
+    // at all, it isn't filed anywhere and only the flat tail below saves it. During search the two
+    // groups are emitted flat, each in its own relevance order (GH-2030).
+    //
+    // Foundations still lead. The two lenses are separate upstream queries whose scores aren't
+    // comparable, so there is no meaningful way to interleave them; grouping is the honest
+    // presentation. Both groups are relevance-ordered internally, and the Foundations and Projects
+    // tabs give a single-group view when that matters.
+    if (this.isSearchResult('foundation') || this.isSearchResult('project')) {
+      return [...sortedFoundations, ...sortedProjects].map((item) => this.toDisplayItem(item, false, selectedUid));
+    }
 
     // Pre-group projects by parent foundation in a single pass so nesting is O(F + P), not O(F × P).
     const detectedProjects = this.personaService.detectedProjects();

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -61,8 +61,18 @@ export class ProjectSelectorComponent {
 
   /** True when a curated `items` list is supplied — switches sourcing/search/pagination to local mode. */
   protected readonly isCurated: Signal<boolean> = computed(() => this.items() !== null);
-  /** Curated-mode search term (nav mode routes search through NavigationService instead). */
-  private readonly localSearchTerm = signal<string>('');
+  /**
+   * The term currently typed into the selector, mirrored for every mode. Curated mode filters on it
+   * directly; nav mode also routes it through `NavigationService` to drive the upstream query, and
+   * reads it back here only to know whether a search is active (see `isSearching`).
+   */
+  private readonly searchTerm = signal<string>('');
+  /**
+   * While searching, the upstream order is relevance (`sort: 'best_match'`) and must be preserved —
+   * re-sorting alphabetically would bury the closest match under every other match. Role-tier
+   * ordering only applies to the unfiltered browse list.
+   */
+  private readonly isSearching: Signal<boolean> = computed(() => this.searchTerm().trim().length > 0);
 
   // Sidebar panel pins fixed to the right of the rail; the curated (dialog) variant drops that
   // sidebar-only positioning so PrimeNG anchors the popover to its own trigger inside the dialog.
@@ -90,8 +100,8 @@ export class ProjectSelectorComponent {
 
   public constructor() {
     this.searchControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((term) => {
+      this.searchTerm.set(term);
       if (this.isCurated()) {
-        this.localSearchTerm.set(term);
         return;
       }
       if (this.hybridMode()) {
@@ -121,8 +131,8 @@ export class ProjectSelectorComponent {
     this.isPanelOpen.set(false);
     this.activeTab.set('all');
     this.searchControl.setValue('', { emitEvent: false });
+    this.searchTerm.set('');
     if (this.isCurated()) {
-      this.localSearchTerm.set('');
       return;
     }
     if (this.hybridMode()) {
@@ -258,7 +268,7 @@ export class ProjectSelectorComponent {
 
   /** Curated-mode source: the `items` input filtered by kind (null = any) and the local search term. */
   private curatedItems(foundation: boolean | null): LensItem[] {
-    const term = this.localSearchTerm().trim().toLowerCase();
+    const term = this.searchTerm().trim().toLowerCase();
     return (this.items() ?? [])
       .filter((item) => foundation === null || item.isFoundation === foundation)
       .filter((item) => !term || (item.name ?? '').toLowerCase().includes(term) || (item.slug ?? '').toLowerCase().includes(term));
@@ -295,14 +305,14 @@ export class ProjectSelectorComponent {
     return computed(() => {
       const selectedUid = this.selectedProject()?.uid ?? null;
       if (!this.hybridMode()) {
-        return this.sortByRole(this.rawProjectItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
+        return this.orderItems(this.rawProjectItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
       }
       const tab = this.activeTab();
       if (tab === 'foundations') {
-        return this.sortByRole(this.foundationItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
+        return this.orderItems(this.foundationItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
       }
       if (tab === 'projects') {
-        return this.sortByRole(this.rawProjectItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
+        return this.orderItems(this.rawProjectItems()).map((item) => this.toDisplayItem(item, false, selectedUid));
       }
       return this.buildAllTabItems(selectedUid);
     });
@@ -377,6 +387,14 @@ export class ProjectSelectorComponent {
     return priority.length;
   }
 
+  /**
+   * Browse order: role tier first, then alphabetical. Search order: whatever the source already
+   * produced, which is relevance for nav-backed search and the curated list's own order otherwise.
+   */
+  private orderItems(items: LensItem[]): LensItem[] {
+    return this.isSearching() ? items : this.sortByRole(items);
+  }
+
   private sortByRole(items: LensItem[]): LensItem[] {
     return [...items].sort((a, b) => {
       const diff = this.roleIndex(a) - this.roleIndex(b);
@@ -385,8 +403,8 @@ export class ProjectSelectorComponent {
   }
 
   private buildAllTabItems(selectedUid: string | null): DisplayLensItem[] {
-    const sortedFoundations = this.sortByRole(this.foundationItems());
-    const sortedProjects = this.sortByRole(this.rawProjectItems());
+    const sortedFoundations = this.orderItems(this.foundationItems());
+    const sortedProjects = this.orderItems(this.rawProjectItems());
 
     // Pre-group projects by parent foundation in a single pass so nesting is O(F + P), not O(F × P).
     const detectedProjects = this.personaService.detectedProjects();

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -297,7 +297,11 @@ export class NavigationService {
       })
     );
 
-    const nextPage$ = loadMore$.pipe(switchMap((token) => this.fetchSinglePage(lens, searchTerm(), token, loading, false, generation(), generation, null)));
+    // Continue with the term the cursor belongs to, not the term being typed. `nextPageToken` is
+    // set by the page that also set `resultsTerm`, so the two always describe the same query;
+    // pairing the cursor with a newer `searchTerm` would append results from one query onto
+    // another. The newer term gets its own reset fetch once the debounce fires.
+    const nextPage$ = loadMore$.pipe(switchMap((token) => this.fetchSinglePage(lens, resultsTerm(), token, loading, false, generation(), generation, null)));
 
     return toSignal(
       merge(firstPage$, nextPage$).pipe(

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -105,6 +105,15 @@ export class NavigationService {
     this.getState(lens).searchTerm.set(term);
   }
 
+  /**
+   * The term the lens's current `items` were fetched for — not what the user has typed. Consumers
+   * deciding how to present the visible list (ordering, empty state) should read this, otherwise
+   * they act on a search whose results have not arrived yet.
+   */
+  public resultsTerm(lens: NavLens): Signal<string> {
+    return this.getState(lens).resultsTerm;
+  }
+
   public loadNextPage(lens: NavLens): void {
     const state = this.getState(lens);
     const token = state.nextPageToken();
@@ -225,6 +234,7 @@ export class NavigationService {
 
   private createLensState(lens: NavLens): LensState {
     const searchTerm = signal<string>('');
+    const resultsTerm = signal<string>('');
     const loading = signal<boolean>(false);
     const loaded = signal<boolean>(false);
     const nextPageToken = signal<string | null>(null);
@@ -233,11 +243,12 @@ export class NavigationService {
     const loadMore$ = new Subject<string>();
     const reload$ = new Subject<void>();
 
-    const items = this.initItems(lens, searchTerm, loading, loaded, nextPageToken, pendingDefaultSelection, generation, loadMore$, reload$);
+    const items = this.initItems(lens, searchTerm, resultsTerm, loading, loaded, nextPageToken, pendingDefaultSelection, generation, loadMore$, reload$);
     const hasMore = computed(() => nextPageToken() !== null);
 
     return {
       searchTerm,
+      resultsTerm,
       items,
       loading,
       loaded,
@@ -253,6 +264,7 @@ export class NavigationService {
   private initItems(
     lens: NavLens,
     searchTerm: WritableSignal<string>,
+    resultsTerm: WritableSignal<string>,
     loading: WritableSignal<boolean>,
     loaded: WritableSignal<boolean>,
     nextPageToken: WritableSignal<string | null>,
@@ -291,6 +303,7 @@ export class NavigationService {
       merge(firstPage$, nextPage$).pipe(
         // Drop responses from a superseded generation (e.g., a scroll fetch that lands after a new search reset).
         filter(({ generation: pageGen }) => pageGen === generation()),
+        tap(({ term }) => resultsTerm.set(term)),
         map(({ page }) => page),
         tap((page) => {
           nextPageToken.set(page.nextPageToken);
@@ -330,7 +343,7 @@ export class NavigationService {
       if (activeGeneration() === generation) loading.set(false);
     };
     return this.fetchPage(lens, term, pageToken, selectedUid).pipe(
-      map((response) => ({ page: this.toLensPage(response, reset), generation })),
+      map((response) => ({ page: this.toLensPage(response, reset), generation, term })),
       tap(clearLoadingIfActive),
       catchError(() => {
         // Reset failures emit an empty page so handleEmptyLensResponse can redirect; scroll-triggered failures stay silent.
@@ -339,6 +352,7 @@ export class NavigationService {
           return of({
             page: { items: [], nextPageToken: null, upstreamFailed: true, reset: true },
             generation,
+            term,
           });
         }
         return EMPTY;

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -342,6 +342,33 @@ describe('ProjectService — create picker methods', () => {
     });
   });
 
+  describe('searchProjects', () => {
+    it('requests relevance ordering so the closest name match is not buried alphabetically', async () => {
+      // Without an explicit sort the query service defaults to name_asc, and OpenSearch drops
+      // scoring whenever a non-_score sort is present — the caller then gets the alphabetically
+      // first page of matches rather than the best ones (GH-2030).
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'cncf', slug: 'cncf' }]));
+
+      const result = await service.searchProjects(req, 'Cloud Native');
+
+      expect(result.map((p) => p.uid)).toEqual(['cncf']);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', name: 'Cloud Native', sort: 'best_match' });
+    });
+
+    it('excludes the ROOT pseudo-project from results', async () => {
+      proxyRequest.mockResolvedValueOnce(
+        pageOf([
+          { uid: 'root-uid', slug: 'root' },
+          { uid: 'real', slug: 'real' },
+        ])
+      );
+
+      const result = await service.searchProjects(req, 'anything');
+
+      expect(result.map((p) => p.slug)).toEqual(['real']);
+    });
+  });
+
   describe('searchCreatableProjects', () => {
     it('queries name=<term> with a small page size and filters to writer-permitted matches', async () => {
       proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'match-1', slug: 'match-1' }]));
@@ -350,7 +377,21 @@ describe('ProjectService — create picker methods', () => {
       const result = await service.searchCreatableProjects(req, 'kubernetes');
 
       expect(result.map((p) => p.uid)).toEqual(['match-1']);
-      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', name: 'kubernetes', page_size: 20 });
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', name: 'kubernetes', sort: 'best_match', page_size: 20 });
+    });
+
+    it('sorts by relevance on every page, not just the first', async () => {
+      // This method truncates to pageSize and gives up after the page cap, so a later page that
+      // silently fell back to the default name_asc would reorder results mid-scan (GH-2030).
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'visible-only', slug: 'visible-only' }], 'token-2'));
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'match-2', slug: 'match-2' }]));
+      addAccessToResources.mockImplementation((_req: Request, projects: Project[]) =>
+        Promise.resolve(projects.map((p) => ({ ...p, writer: p.uid === 'match-2' })))
+      );
+
+      await service.searchCreatableProjects(req, 'kubernetes');
+
+      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ sort: 'best_match', page_token: 'token-2' });
     });
 
     it('continues to the next page when the first page has no writer-permitted matches', async () => {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -378,11 +378,16 @@ export class ProjectService {
 
   /**
    * Search projects by name
+   *
+   * `sort: 'best_match'` is required for relevance ordering. The query service defaults `sort` to
+   * `name_asc`, and OpenSearch discards scoring whenever an explicit non-`_score` sort is present —
+   * so without this the caller gets the alphabetically-first page of matches, not the closest ones.
    */
   public async searchProjects(req: Request, searchQuery: string): Promise<Project[]> {
     const params = {
       type: 'project',
       name: searchQuery,
+      sort: 'best_match',
     };
 
     const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', params);
@@ -487,6 +492,11 @@ export class ProjectService {
         {
           type: 'project',
           name: searchQuery,
+          // Relevance ordering matters more here than anywhere else: this method truncates to
+          // `pageSize` and gives up after `SEARCH_PAGE_LIMIT` pages, so whatever upstream puts
+          // first is what the user sees. Under the default `name_asc` that is the alphabetically
+          // earliest matches, which buries the project the user is actually typing.
+          sort: 'best_match',
           page_size: pageSize,
           ...(pageToken && { page_token: pageToken }),
         }

--- a/docs/architecture/backend/pagination.md
+++ b/docs/architecture/backend/pagination.md
@@ -9,19 +9,26 @@ The application uses cursor-based pagination (via `page_token`) rather than offs
 
 ## Query Service API Parameters
 
-| Parameter    | Type       | Description                                                        |
-| ------------ | ---------- | ------------------------------------------------------------------ |
-| `page_token` | `string`   | Opaque cursor from a previous response. Omit for the first page.   |
-| `page_size`  | `number`   | Items per page (default: 50, range: 1–1000)                        |
-| `name`       | `string`   | Typeahead search (multi_match with bool_prefix)                    |
-| `filters`    | `string[]` | Field filtering (`field:value`, auto-prefixed with `data.`)        |
-| `tags`       | `string`   | Exact tag matching                                                 |
-| `tags_all`   | `string`   | Multiple tag matching (AND logic)                                  |
-| `type`       | `string`   | Resource type filter                                               |
-| `parent`     | `string`   | Parent resource filter                                             |
-| `sort`       | `string`   | Sort order: `name_asc`, `name_desc`, `updated_asc`, `updated_desc` |
+| Parameter    | Type       | Description                                                                                           |
+| ------------ | ---------- | ----------------------------------------------------------------------------------------------------- |
+| `page_token` | `string`   | Opaque cursor from a previous response. Omit for the first page.                                      |
+| `page_size`  | `number`   | Items per page (default: 50, range: 1–1000)                                                           |
+| `name`       | `string`   | Typeahead search (multi_match with bool_prefix); every term must match, last term matches as a prefix |
+| `filters`    | `string[]` | Field filtering (`field:value`, auto-prefixed with `data.`)                                           |
+| `tags`       | `string`   | Exact tag matching                                                                                    |
+| `tags_all`   | `string`   | Multiple tag matching (AND logic)                                                                     |
+| `type`       | `string`   | Resource type filter                                                                                  |
+| `parent`     | `string`   | Parent resource filter                                                                                |
+| `sort`       | `string`   | Sort order: `name_asc` (default), `name_desc`, `updated_asc`, `updated_desc`, `best_match`            |
 
 > **Note**: Use `page_size` (not `limit`) for consistency with the query service API.
+
+> **Always pass `sort: 'best_match'` alongside `name`.** `sort` defaults to `name_asc`, and
+> OpenSearch discards relevance scoring whenever an explicit non-`_score` sort is present. A search
+> that omits `sort` therefore returns the alphabetically-first page of matches rather than the
+> closest ones, and the match the user is typing can land on any page. This matters most for
+> endpoints that truncate or cap their page scan, where upstream order decides what the user ever
+> sees.
 
 ## Backend Interfaces
 

--- a/docs/architecture/backend/pagination.md
+++ b/docs/architecture/backend/pagination.md
@@ -9,26 +9,31 @@ The application uses cursor-based pagination (via `page_token`) rather than offs
 
 ## Query Service API Parameters
 
-| Parameter    | Type       | Description                                                                                           |
-| ------------ | ---------- | ----------------------------------------------------------------------------------------------------- |
-| `page_token` | `string`   | Opaque cursor from a previous response. Omit for the first page.                                      |
-| `page_size`  | `number`   | Items per page (default: 50, range: 1–1000)                                                           |
-| `name`       | `string`   | Typeahead search (multi_match with bool_prefix); every term must match, last term matches as a prefix |
-| `filters`    | `string[]` | Field filtering (`field:value`, auto-prefixed with `data.`)                                           |
-| `tags`       | `string`   | Exact tag matching                                                                                    |
-| `tags_all`   | `string`   | Multiple tag matching (AND logic)                                                                     |
-| `type`       | `string`   | Resource type filter                                                                                  |
-| `parent`     | `string`   | Parent resource filter                                                                                |
-| `sort`       | `string`   | Sort order: `name_asc` (default), `name_desc`, `updated_asc`, `updated_desc`, `best_match`            |
+| Parameter    | Type       | Description                                                                                |
+| ------------ | ---------- | ------------------------------------------------------------------------------------------ |
+| `page_token` | `string`   | Opaque cursor from a previous response. Omit for the first page.                           |
+| `page_size`  | `number`   | Items per page (default: 50, range: 1–1000)                                                |
+| `name`       | `string`   | Typeahead search (multi_match with bool_prefix); the last term matches as a prefix         |
+| `filters`    | `string[]` | Field filtering (`field:value`, auto-prefixed with `data.`)                                |
+| `tags`       | `string`   | Exact tag matching                                                                         |
+| `tags_all`   | `string`   | Multiple tag matching (AND logic)                                                          |
+| `type`       | `string`   | Resource type filter                                                                       |
+| `parent`     | `string`   | Parent resource filter                                                                     |
+| `sort`       | `string`   | Sort order: `name_asc` (default), `name_desc`, `updated_asc`, `updated_desc`, `best_match` |
 
 > **Note**: Use `page_size` (not `limit`) for consistency with the query service API.
 
-> **Always pass `sort: 'best_match'` alongside `name`.** `sort` defaults to `name_asc`, and
-> OpenSearch discards relevance scoring whenever an explicit non-`_score` sort is present. A search
-> that omits `sort` therefore returns the alphabetically-first page of matches rather than the
-> closest ones, and the match the user is typing can land on any page. This matters most for
-> endpoints that truncate or cap their page scan, where upstream order decides what the user ever
-> sees.
+**Always pass `sort: 'best_match'` alongside `name`.** `sort` defaults to `name_asc`, and
+OpenSearch discards relevance scoring whenever an explicit non-`_score` sort is present. A search
+that omits `sort` therefore returns the alphabetically-first page of matches rather than the
+closest ones, and the match the user is typing can land on any page. This matters most for
+endpoints that truncate or cap their page scan, where upstream order decides what the user ever
+sees.
+
+Terms are OR-ed upstream today, so each added word matches _more_ documents rather than fewer.
+[linuxfoundation/lfx-v2-query-service#70](https://github.com/linuxfoundation/lfx-v2-query-service/pull/70)
+switches this to AND; update this note once it deploys. Relevance ordering is what keeps the
+closest match on top either way, which is why `best_match` matters independently of that change.
 
 ## Backend Interfaces
 

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -219,13 +219,18 @@ const binds = [email];
 
 When calling the query service, use the correct parameter names:
 
-| Parameter    | Purpose                    | Note                                                         |
-| ------------ | -------------------------- | ------------------------------------------------------------ |
-| `page_size`  | Number of results per page | NOT `limit`                                                  |
-| `page_token` | Cursor for pagination      | Opaque string from previous response                         |
-| `name`       | Typeahead search           | Uses `multi_match` with `bool_prefix`                        |
-| `filters`    | Field filtering            | Format: `field:value`, auto-prefixed with `data.`            |
-| `sort`       | Sort order                 | Enum: `name_asc`, `name_desc`, `updated_asc`, `updated_desc` |
+| Parameter    | Purpose                    | Note                                                                                          |
+| ------------ | -------------------------- | --------------------------------------------------------------------------------------------- |
+| `page_size`  | Number of results per page | NOT `limit`                                                                                   |
+| `page_token` | Cursor for pagination      | Opaque string from previous response                                                          |
+| `name`       | Typeahead search           | Uses `multi_match` with `bool_prefix`; every term must match                                  |
+| `filters`    | Field filtering            | Format: `field:value`, auto-prefixed with `data.`                                             |
+| `sort`       | Sort order                 | Enum: `name_asc` (upstream default), `name_desc`, `updated_asc`, `updated_desc`, `best_match` |
+
+`best_match` opts into upstream `_score` ordering and is meaningful only alongside `name`. Pass it
+whenever you pass `name`: the upstream default is `name_asc`, and OpenSearch discards relevance
+scoring whenever an explicit non-`_score` sort is present, so omitting it returns the
+alphabetically-first page of matches rather than the closest ones.
 
 **Violation:**
 

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -223,7 +223,7 @@ When calling the query service, use the correct parameter names:
 | ------------ | -------------------------- | --------------------------------------------------------------------------------------------- |
 | `page_size`  | Number of results per page | NOT `limit`                                                                                   |
 | `page_token` | Cursor for pagination      | Opaque string from previous response                                                          |
-| `name`       | Typeahead search           | Uses `multi_match` with `bool_prefix`; every term must match                                  |
+| `name`       | Typeahead search           | Uses `multi_match` with `bool_prefix`                                                         |
 | `filters`    | Field filtering            | Format: `field:value`, auto-prefixed with `data.`                                             |
 | `sort`       | Sort order                 | Enum: `name_asc` (upstream default), `name_desc`, `updated_asc`, `updated_desc`, `best_match` |
 

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -35,6 +35,8 @@ export interface LensPage {
 export interface TaggedLensPage {
   page: LensPage;
   generation: number;
+  /** The search term this page was fetched for, so consumers can tell what the current items represent. */
+  term: string;
 }
 
 export interface GetLensItemsParams {
@@ -61,6 +63,12 @@ export interface LensItemsQuery {
 /** Internal per-lens reactive state container used by NavigationService. */
 export interface LensState {
   searchTerm: WritableSignal<string>;
+  /**
+   * The term the currently-held `items` were actually fetched for. Trails `searchTerm` by the
+   * search debounce plus request latency, so consumers that need to know what the visible list
+   * represents — rather than what the user has typed — must read this one.
+   */
+  resultsTerm: WritableSignal<string>;
   items: Signal<LensItem[]>;
   loading: WritableSignal<boolean>;
   loaded: WritableSignal<boolean>;


### PR DESCRIPTION
Closes #2030

## Problem

Searching for a project returned too many results, and the set *grew* with
each extra word typed. The project the user was looking for was frequently
absent from the visible list entirely.

Three independent layers each discarded relevance, and all three had to be
fixed for the search to behave:

1. **Upstream (query-service).** The `name` search runs a `multi_match` of
   type `bool_prefix`, which defaults to `OR`. Every additional word matched
   *more* documents, so `Cloud Native Computing` returned a superset of
   `Cloud Native`. Fixed upstream — see External references.
2. **BFF (this repo).** `sort` defaults to `name_asc` upstream, and OpenSearch
   discards relevance scoring entirely whenever an explicit non-`_score` sort
   is present. `searchProjects` and `searchCreatableProjects` passed `name`
   without `sort`, so they received the *alphabetically first* page of matches
   rather than the closest ones. `searchCreatableProjects` caps its page scan,
   so the intended project could be filtered out before the user ever saw it.
3. **Frontend (this repo).** `ProjectSelectorComponent` re-sorted whatever
   arrived by role tier and then alphabetically, which threw away any ordering
   the first two layers produced.

## Changes

**Backend** — `searchProjects` and `searchCreatableProjects` now send
`sort: 'best_match'`, on every page rather than just the first. The two other
query-service name-search callers (`navigation.service.ts`,
`org-navigation.service.ts`) already did; this brings the remaining two in line.

**Frontend** — the selector preserves source order while showing search
results and keeps role-tier ordering only for the unfiltered browse list.

Two follow-ups from local review, both about that fix actually reaching the user:

- The hybrid **All** tab — the sidebar's default view — rebuilt every result
  set foundation-first with projects nested under their parents. Applied to
  search results that hides matches: a strong project match was filed under
  wherever its parent foundation happened to rank, or, when the parent didn't
  match, escaped nesting only via the flat tail. The two groups are now emitted
  flat while searching, each in its own relevance order. Foundations still lead,
  because the two lenses are separate upstream queries whose scores aren't
  comparable — the Foundations and Projects tabs give a single-group view.
- Ordering keyed off the term the user had *typed*, which leads the term the
  visible items were *fetched for* by the 300ms search debounce plus request
  latency, so the browse list was restyled once before results arrived and
  again when they landed. `NavigationService` now tracks `resultsTerm` per
  lens and the selector orders on that, so each search reshuffles once.

**Docs** — `best_match` was missing from the query-service `sort` enum in
`docs/architecture/backend/pagination.md` and `docs/reviews/shared-and-sql-checklist.md`.
Both omissions predate this branch, but they contradicted shipped code and
this change makes `best_match` a contract these call sites depend on.

## Testing

- `project.service.spec.ts` asserts `sort: 'best_match'` on both entry points
  and on subsequent pages, not just the first.
- New `project-selector.component.spec.ts` covers the ordering contract:
  alphabetical while browsing, source order preserved while searching, back to
  alphabetical once cleared, All-tab nesting only while browsing, and the
  browse-until-results-arrive timing rule.
- Full suite green: 1865 app + 99 server + 59 shared. `yarn build`,
  `lint:check`, `format:check`, `check-types`, and `check-headers.sh` all pass.

## External references

Upstream `operator: "and"` fix: linuxfoundation/lfx-v2-query-service#70

The OR behavior was confirmed empirically against a local OpenSearch instance
loaded with the platform's actual index mapping — with the default operator an
added term widened the result set, and with `operator: and` it narrowed it.

Layers 2 and 3 are independently useful and safe to merge before the upstream
change lands: relevance ordering of an over-broad result set still surfaces the
closest match first. Result-set size only tightens once #70 deploys.

Made with [Cursor](https://cursor.com)