### PR TITLE
fix(cla): show invalidated and revoked dates on my clas

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -185,6 +185,35 @@ describe('ProfileClasComponent', () => {
     expect(note?.textContent?.trim()).toBe('No longer matches the approval criteria.');
   });
 
+  it('shows Invalidated · date and Revoked · date under the pill when recorded', async () => {
+    await render([
+      agreement({ id: 's-inv', kind: 'ICLA', status: 'invalidated', pdfAvailable: false, invalidatedAt: '2026-06-03' }),
+      agreement({ id: 's-rev', kind: 'ECLA', status: 'revoked', pdfAvailable: false, companyName: 'Acme', flaggedAt: '2026-08-01' }),
+    ]);
+
+    expect(statusTag('s-inv').value()).toBe('Invalidated');
+    expect(fixture.nativeElement.querySelector('[data-testid="agreement-status-note-s-inv"]')?.textContent?.trim()).toBe('Invalidated · Jun 3, 2026');
+    expect(statusTag('s-rev').value()).toBe('Revoked');
+    expect(fixture.nativeElement.querySelector('[data-testid="agreement-status-note-s-rev"]')?.textContent?.trim()).toBe('Revoked · Aug 1, 2026');
+  });
+
+  it('leaves Invalidated and Revoked undated when the producer sent no date', async () => {
+    await render([
+      agreement({ id: 's-inv', status: 'invalidated', pdfAvailable: false }),
+      agreement({ id: 's-rev', kind: 'ECLA', status: 'revoked', pdfAvailable: false, companyName: 'Acme' }),
+    ]);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="agreement-status-note-s-inv"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="agreement-status-note-s-rev"]')).toBeNull();
+  });
+
+  it('does not invent an Invalidated date from signedOn', async () => {
+    await render([agreement({ id: 's-inv', status: 'invalidated', pdfAvailable: false, signedOn: '2022-01-01T18:40:42Z', invalidatedAt: 'not-a-date' })]);
+
+    expect(statusTag('s-inv').value()).toBe('Invalidated');
+    expect(fixture.nativeElement.querySelector('[data-testid="agreement-status-note-s-inv"]')).toBeNull();
+  });
+
   it('renders unknown as plain-text em dash, not a tag and not the list-miss sentence', async () => {
     await render([
       agreement({ id: 's-unknown', kind: 'ECLA', status: 'unknown', statusReason: 'unknown', pdfAvailable: false, companyName: 'Acme' }),

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -663,7 +663,8 @@ export class ProfileClasComponent {
    * `{Label} · {date}` when the producer recorded a parseable date (#1913);
    * a completed Approved List miss takes the mockup sentence. Other rows
    * have no note — including undated Invalidated/Revoked, where a missing
-   * date must not be invented.
+   * date must not be invented. Revoked reads `flaggedAt` even when
+   * `invalidatedAt` is also present (sanctions override Invalidated).
    */
   private statusNote(agreement: MyClaAgreement): string | undefined {
     const dateIso = agreement.status === 'revoked' ? agreement.flaggedAt : agreement.invalidatedAt;

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -32,6 +32,7 @@ import type {
 import {
   alreadySignedAgreementsForGroup,
   claSignRoute,
+  claStatusDateNote,
   claStatusLabel,
   claStatusSeverity,
   downloadFromUrl,
@@ -658,10 +659,16 @@ export class ProfileClasComponent {
   }
 
   /**
-   * Explanatory note beneath the status pill. Only a completed Approved List
-   * miss (`not_on_approval_list`) gets copy; unknown and omitted reasons do not.
+   * Explanatory note beneath the status pill. Invalidated / Revoked take
+   * `{Label} · {date}` when the producer recorded a parseable date (#1913);
+   * a completed Approved List miss takes the mockup sentence. Other rows
+   * have no note — including undated Invalidated/Revoked, where a missing
+   * date must not be invented.
    */
   private statusNote(agreement: MyClaAgreement): string | undefined {
+    const dateIso = agreement.status === 'revoked' ? agreement.flaggedAt : agreement.invalidatedAt;
+    const dated = claStatusDateNote(agreement.status, dateIso);
+    if (dated) return dated;
     if (agreement.kind === 'ICLA' || agreement.statusReason !== 'not_on_approval_list') {
       return undefined;
     }

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -273,6 +273,8 @@ describe('toMyClaAgreement', () => {
     expect(revoked.status).toBe('revoked');
   });
 
+  // A sanctioned ECLA that was also invalidated still carries both dates: the
+  // producer copies invalidatedAt before the sanctions override to revoked.
   it('copies invalidatedAt and flaggedAt from the producer and omits blanks', () => {
     const dated = toMyClaAgreement(
       ecla({ status: 'revoked', approved: true, valid: false, flaggedAt: '2026-08-01T12:00:00Z', invalidatedAt: '  2026-06-03T12:00:00Z  ' })

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -273,6 +273,29 @@ describe('toMyClaAgreement', () => {
     expect(revoked.status).toBe('revoked');
   });
 
+  it('copies invalidatedAt and flaggedAt from the producer and omits blanks', () => {
+    const dated = toMyClaAgreement(
+      ecla({ status: 'revoked', approved: true, valid: false, flaggedAt: '2026-08-01T12:00:00Z', invalidatedAt: '  2026-06-03T12:00:00Z  ' })
+    );
+    expect(dated.flaggedAt).toBe('2026-08-01T12:00:00Z');
+    expect(dated.invalidatedAt).toBe('2026-06-03T12:00:00Z');
+
+    const omitted = toMyClaAgreement(ecla({ status: 'invalidated', approved: false, valid: false }));
+    expect(omitted.invalidatedAt).toBeUndefined();
+    expect(omitted.flaggedAt).toBeUndefined();
+
+    const blank = toMyClaAgreement(ecla({ status: 'invalidated', approved: false, valid: false, invalidatedAt: '   ', flaggedAt: '' }));
+    expect(blank.invalidatedAt).toBeUndefined();
+    expect(blank.flaggedAt).toBeUndefined();
+  });
+
+  it('does not invent an Invalidated or Revoked date from signedOn', () => {
+    const row = toMyClaAgreement(ecla({ status: 'invalidated', approved: false, valid: false, signedOn: '2022-01-01T18:40:42Z' }));
+    expect(row.signedOn).toBe('2022-01-01T18:40:42Z');
+    expect(row.invalidatedAt).toBeUndefined();
+    expect(row.flaggedAt).toBeUndefined();
+  });
+
   it('pins claGroupId from the producer and omits a blank value', () => {
     expect(toMyClaAgreement(ecla()).claGroupId).toBe('cg-2');
     expect(toMyClaAgreement(ecla({ claGroupID: '  ' })).claGroupId).toBeUndefined();

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -353,6 +353,8 @@ export function toMyClaAgreement(cla: EasyClaMyCla): MyClaAgreement {
     signedAs: cla.signedAs?.trim() || undefined,
     status,
     statusReason,
+    invalidatedAt: cla.invalidatedAt?.trim() || undefined,
+    flaggedAt: cla.flaggedAt?.trim() || undefined,
     documentVersion,
     pdfAvailable: isIcla && cla.pdfAvailable === true,
   };

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -64,8 +64,10 @@ export interface EasyClaMyCla {
   status: 'valid' | 'needs_attention' | 'revoked' | 'invalidated' | 'unknown';
   statusReason?: 'not_on_approval_list' | 'unknown';
   /**
-   * Stored `date_invalidated`. Omitted on rows invalidated before the field existed,
-   * and on every non-invalidated row.
+   * Stored `date_invalidated`. Omitted when the producer sent none (rows
+   * invalidated before the field existed, or never invalidated). Independent of
+   * `status`: a sanctioned ECLA is `revoked` and can still carry this date,
+   * because EasyCLA copies it before the sanctions override.
    */
   invalidatedAt?: string;
   /**

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -63,6 +63,16 @@ export interface EasyClaMyCla {
   valid?: boolean;
   status: 'valid' | 'needs_attention' | 'revoked' | 'invalidated' | 'unknown';
   statusReason?: 'not_on_approval_list' | 'unknown';
+  /**
+   * Stored `date_invalidated`. Omitted on rows invalidated before the field existed,
+   * and on every non-invalidated row.
+   */
+  invalidatedAt?: string;
+  /**
+   * Employer's stored `sanctioned_date` (first live detection, then stable).
+   * Present only when `status` is `revoked` and a stored date exists.
+   */
+  flaggedAt?: string;
   documentMajorVersion?: number;
   documentMinorVersion?: number;
   /** True when the record is a signed ICLA eligible for PDF retrieval. */

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-09-03
+last_updated: 2026-09-04
 intercom_collection: Account
 ---
 
@@ -82,7 +82,7 @@ In the **Sign a CLA** dialog, a result you already hold a CLA for is tagged **Al
 
 ## What do the CLA status labels mean?
 
-**Valid** means the agreement covers your contributions. **Needs attention** means an Employee CLA no longer covers you, usually because you have dropped off your employer's **Approved List**. **Invalidated** means the agreement is no longer in force — someone removed you from an Approved List, a maintainer invalidated your ICLA, or the CLA group was deleted. **Revoked** is reserved for a sanctions-screening outcome against your employer and cannot be changed from Self Serve. See [What do the status labels mean?](../my-clas/#what-do-the-status-labels-mean).
+**Valid** means the agreement covers your contributions. **Needs attention** means an Employee CLA no longer covers you, usually because you have dropped off your employer's **Approved List**. **Invalidated** means the agreement is no longer in force — someone removed you from an Approved List, a maintainer invalidated your ICLA, or the CLA group was deleted. **Revoked** is reserved for a sanctions-screening outcome against your employer and cannot be changed from Self Serve. **Invalidated** and **Revoked** also show a date under the label when EasyCLA recorded one; if there is no date, the label stands alone. See [What do the status labels mean?](../my-clas/#what-do-the-status-labels-mean).
 
 ## Which account was my CLA signed under?
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -4,7 +4,7 @@ description: View your signed Individual and Employee CLAs in LFX Self Serve, st
 audience: [all]
 product_area: Account
 tags: [account, cla, easycla, icla, ecla, ccla, identities, signing]
-last_updated: 2026-09-03
+last_updated: 2026-09-04
 intercom_collection: Account
 ---
 
@@ -68,7 +68,11 @@ The **Status** column on the CLAs tab tells you whether an agreement still cover
 | **Invalidated**     | The agreement is no longer in force. A CLA manager removed you from your employer's **Approved List**, a project maintainer invalidated your ICLA, or the CLA group was deleted. | ICLA, ECLA |
 | **Revoked**         | Your employer was flagged by sanctions screening. This is set by EasyCLA, cannot be changed from Self Serve, and leaves no actions on the row.                                   | ECLA only  |
 
-When an ECLA needs attention because you are no longer on the Approved List, the row adds a line under the status: _No longer matches \<company\>'s approval criteria._
+Some statuses add a second line under the label.
+
+When an Employee CLA (ECLA) needs attention because you are no longer on the Approved List, that line reads _No longer matches \<company\>'s approval criteria._
+
+When the status is **Invalidated** or **Revoked**, the second line is the date EasyCLA recorded for that change — written as _Invalidated · Sep 1, 2026_ or _Revoked · Sep 1, 2026_, in the same calendar-day format as the **Signed** column — or the label stands alone if EasyCLA has no date. Older invalidated agreements often have no date, because EasyCLA started storing it later.
 
 **Invalidated and Revoked are not the same thing**, and the tab keeps them visibly apart on purpose. **Revoked** is only ever a sanctions-screening outcome. Being removed from an Approved List — including at your own request — or having a maintainer invalidate your ICLA shows as **Invalidated**, so that an ordinary administrative change is never presented as a screening result.
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -103,6 +103,19 @@ export interface MyClaAgreement {
   signedAs?: string;
   status: ClaStatus;
   statusReason?: ClaStatusReason;
+  /**
+   * Producer `invalidatedAt` — stored invalidation instant. Omitted when the
+   * producer sent none (legacy rows, or any non-invalidated status). Empty after
+   * trim is treated as omitted. The status note is `{Label} · {date}` only when
+   * this parses; a wrong date is worse than none.
+   */
+  invalidatedAt?: string;
+  /**
+   * Producer `flaggedAt` — employer's stored sanctioned_date. Omitted when the
+   * producer sent none. Empty after trim is treated as omitted. Feeds the
+   * Revoked date note the same way `invalidatedAt` feeds Invalidated.
+   */
+  flaggedAt?: string;
   /** Signed document version, when exposed upstream (display only). */
   documentVersion?: string;
   /** True only for ICLA — ECLAs have no signed PDF and never offer download. */

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -105,9 +105,11 @@ export interface MyClaAgreement {
   statusReason?: ClaStatusReason;
   /**
    * Producer `invalidatedAt` — stored invalidation instant. Omitted when the
-   * producer sent none (legacy rows, or any non-invalidated status). Empty after
-   * trim is treated as omitted. The status note is `{Label} · {date}` only when
-   * this parses; a wrong date is worse than none.
+   * producer sent none (legacy rows, or never invalidated). Empty after trim is
+   * treated as omitted. Independent of `status`: a revoked ECLA can still carry
+   * this date, because EasyCLA copies it before the sanctions override. The
+   * Invalidated status note is `{Label} · {date}` only when this parses; a
+   * wrong date is worse than none. Revoked notes read `flaggedAt` instead.
    */
   invalidatedAt?: string;
   /**

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -18,6 +18,7 @@ import {
   claGroupSecondaryName,
   claKindSeverity,
   claSignRoute,
+  claStatusDateNote,
   claStatusLabel,
   claStatusSeverity,
   formatClaSignedOn,
@@ -141,6 +142,27 @@ describe('claStatusLabel', () => {
     const statuses: ClaStatus[] = ['valid', 'needs_attention', 'revoked', 'invalidated', 'unknown', 'superseded'];
 
     expect(statuses.map(claStatusLabel).some((label) => /cancel/i.test(label))).toBe(false);
+  });
+});
+
+describe('claStatusDateNote', () => {
+  it('formats Invalidated and Revoked as "{Label} · {date}" when the date parses', () => {
+    expect(claStatusDateNote('invalidated', '2026-06-03T12:00:00Z', 'UTC')).toBe('Invalidated · Jun 3, 2026');
+    expect(claStatusDateNote('revoked', '2026-08-01T12:00:00Z', 'UTC')).toBe('Revoked · Aug 1, 2026');
+    expect(claStatusDateNote('invalidated', '2026-06-03', 'UTC')).toBe('Invalidated · Jun 3, 2026');
+  });
+
+  it('omits the note when the date is absent, blank, or unparseable', () => {
+    expect(claStatusDateNote('invalidated', undefined, 'UTC')).toBeUndefined();
+    expect(claStatusDateNote('revoked', '   ', 'UTC')).toBeUndefined();
+    expect(claStatusDateNote('invalidated', 'not-a-date', 'UTC')).toBeUndefined();
+    expect(claStatusDateNote('revoked', '2026-02-31', 'UTC')).toBeUndefined();
+  });
+
+  it('never dates a status that is not Invalidated or Revoked', () => {
+    expect(claStatusDateNote('valid', '2026-06-03T12:00:00Z', 'UTC')).toBeUndefined();
+    expect(claStatusDateNote('needs_attention', '2026-06-03T12:00:00Z', 'UTC')).toBeUndefined();
+    expect(claStatusDateNote('unknown', '2026-06-03T12:00:00Z', 'UTC')).toBeUndefined();
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -166,6 +166,20 @@ export function formatClaSignedOn(iso: string, timeZone?: string): string {
 }
 
 /**
+ * Note under an Invalidated / Revoked pill (#1913). `{Label} · {date}` when the
+ * producer recorded a parseable date; undefined when the date is absent or
+ * unparseable — a wrong date is worse than none. Other statuses never take this
+ * path (Needs attention owns the note slot with different copy).
+ */
+export function claStatusDateNote(status: ClaStatus, iso: string | undefined, timeZone?: string): string | undefined {
+  if (status !== 'invalidated' && status !== 'revoked') return undefined;
+  if (!iso?.trim()) return undefined;
+  const formatted = formatClaSignedOn(iso, timeZone);
+  if (formatted === '—') return undefined;
+  return `${claStatusLabel(status)} · ${formatted}`;
+}
+
+/**
  * Second line under the signed date (#1573). Undefined ⇒ the Signed cell is date-only.
  *
  * Every platform the producer names takes a suffix. `gerrit` reads wider than the Gerrit


### PR DESCRIPTION
EasyCLA already returns `invalidatedAt` and `flaggedAt` on My CLAs; the BFF dropped them, so Invalidated and Revoked rendered with no date. Copy both through and show `{Label} · {date}` under the pill when the date parses.

Closes #1913