### PR TITLE
fix(events): build certificate filename from event name and date

### DIFF
--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
@@ -102,7 +102,10 @@ export class EventsTableComponent {
           const fileName = headerFileName ?? `certificate-${eventId}.pdf`;
           const url = URL.createObjectURL(blob);
           downloadFromUrl(url, fileName);
-          URL.revokeObjectURL(url);
+          // Deferred: some browsers begin the download asynchronously, and revoking
+          // synchronously can invalidate the blob URL before it is consumed (see
+          // brand-kit-form.component.ts and mktg-agent-run.component.ts).
+          setTimeout(() => URL.revokeObjectURL(url), 0);
         },
         error: () => {
           this.messageService.add({

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
@@ -8,7 +8,7 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MY_EVENT_STATUS } from '@lfx-one/shared/constants';
 import { MyEventsResponse, PageChangeEvent, SortChangeEvent, TagSeverity } from '@lfx-one/shared/interfaces';
-import { parseContentDispositionFilename, sanitizeFilename } from '@lfx-one/shared/utils';
+import { downloadFromUrl, parseContentDispositionFilename } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { take } from 'rxjs/operators';
 
@@ -89,6 +89,8 @@ export class EventsTableComponent {
   }
 
   protected downloadCertificate(eventId: string): void {
+    // No catchError: this is a one-shot subscription (take(1)), and the subscribe `error`
+    // callback below already surfaces failures via the toast — a deliberate, equivalent trade-off.
     this.eventsService
       .getCertificate({ eventId })
       .pipe(take(1))
@@ -97,12 +99,9 @@ export class EventsTableComponent {
           const blob = response.body;
           if (!blob) return;
           const headerFileName = parseContentDispositionFilename(response.headers.get('Content-Disposition'));
-          const fileName = headerFileName ? sanitizeFilename(headerFileName) : `certificate-${eventId}.pdf`;
+          const fileName = headerFileName ?? `certificate-${eventId}.pdf`;
           const url = URL.createObjectURL(blob);
-          const anchor = document.createElement('a');
-          anchor.href = url;
-          anchor.download = fileName;
-          anchor.click();
+          downloadFromUrl(url, fileName);
           URL.revokeObjectURL(url);
         },
         error: () => {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
@@ -8,6 +8,7 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MY_EVENT_STATUS } from '@lfx-one/shared/constants';
 import { MyEventsResponse, PageChangeEvent, SortChangeEvent, TagSeverity } from '@lfx-one/shared/interfaces';
+import { parseContentDispositionFilename, sanitizeFilename } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { take } from 'rxjs/operators';
 
@@ -92,12 +93,15 @@ export class EventsTableComponent {
       .getCertificate({ eventId })
       .pipe(take(1))
       .subscribe({
-        next: (blob) => {
+        next: (response) => {
+          const blob = response.body;
           if (!blob) return;
+          const headerFileName = parseContentDispositionFilename(response.headers.get('Content-Disposition'));
+          const fileName = headerFileName ? sanitizeFilename(headerFileName) : `certificate-${eventId}.pdf`;
           const url = URL.createObjectURL(blob);
           const anchor = document.createElement('a');
           anchor.href = url;
-          anchor.download = `certificate-${eventId}.pdf`;
+          anchor.download = fileName;
           anchor.click();
           URL.revokeObjectURL(url);
         },

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -3,7 +3,7 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import {
   EventsResponse,
@@ -168,11 +168,11 @@ export class EventsService {
     return this.http.get<OrgEventsResponse>(`/api/orgs/${encodeURIComponent(accountId)}/lens/events`, { params: httpParams });
   }
 
-  public getCertificate(params: GetCertificateParams): Observable<Blob> {
+  public getCertificate(params: GetCertificateParams): Observable<HttpResponse<Blob>> {
     let httpParams = new HttpParams();
 
     if (params.eventId) httpParams = httpParams.set('eventId', params.eventId);
 
-    return this.http.get('/api/events/certificate', { params: httpParams, responseType: 'blob' });
+    return this.http.get('/api/events/certificate', { params: httpParams, responseType: 'blob', observe: 'response' });
   }
 }

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -6,6 +6,7 @@
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, ServiceValidationError } from '../errors';
+import { contentDispositionAttachment } from '../helpers/content-disposition.helper';
 import { logger } from '../services/logger.service';
 import { CertificateService } from '../services/certificate.service';
 import {
@@ -309,7 +310,7 @@ export class EventsController {
 
       const userName = getEffectiveName(req) || userEmail;
 
-      const pdfBuffer = await this.certificateService.generateCertificate(req, {
+      const { pdf, fileName } = await this.certificateService.generateCertificate(req, {
         eventId,
         userEmail,
         userName,
@@ -317,12 +318,10 @@ export class EventsController {
 
       logger.success(req, 'get_certificate', startTime, { event_id: eventId });
 
-      const safeEventId = String(eventId).replace(/[^a-zA-Z0-9_-]/g, '');
-
       res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `attachment; filename="certificate-${safeEventId}.pdf"`);
-      res.setHeader('Content-Length', pdfBuffer.length);
-      res.send(pdfBuffer);
+      res.setHeader('Content-Disposition', contentDispositionAttachment(fileName));
+      res.setHeader('Content-Length', pdf.length);
+      res.send(pdf);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors brand-kit.service.spec.ts: the `@lfx-one/shared/*` alias is wired into vitest.config.ts,
 // but the `utils` barrel transitively imports Angular-dependent modules that can't load in this
@@ -253,7 +253,12 @@ describe('CertificateService', () => {
   });
 
   describe('fileName', () => {
+    afterEach(() => vi.unstubAllEnvs());
+
     it('builds the download filename from the event name and start date', async () => {
+      // Pinned to UTC: the fixture's EVENT_START_DATE is 'Z'-anchored midnight, and the filename's
+      // date is now derived in local time (matching the PDF body) — see event.utils.ts.
+      vi.stubEnv('TZ', 'UTC');
       mockRow();
 
       const result = await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });

--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -23,7 +23,7 @@ vi.mock('@lfx-one/shared/utils', async () => {
   );
   // Vitest already wraps this return value in a Proxy that throws on any unstubbed export
   // ("No 'X' export is defined on the mock"), so a future second import fails loudly on its own.
-  return { isBackfillEventSource: eventUtils.isBackfillEventSource };
+  return { isBackfillEventSource: eventUtils.isBackfillEventSource, buildCertificateFileName: eventUtils.buildCertificateFileName };
 });
 vi.mock('./snowflake.service', () => ({
   SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },
@@ -249,6 +249,17 @@ describe('CertificateService', () => {
       expect(drawnLogo().path).toContain(CNCF_LOGO);
       expect(drawnTexts()).toContain('https://www.cncf.io/');
       expect(drawnTexts().some((t) => t.startsWith('Cloud Native Computing Foundation (CNCF) is pleased'))).toBe(true);
+    });
+  });
+
+  describe('fileName', () => {
+    it('builds the download filename from the event name and start date', async () => {
+      mockRow();
+
+      const result = await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      expect(result.fileName).toBe('certificate-of-attendance-test-event-2026-03-10.pdf');
+      expect(result.pdf).toBeInstanceOf(Buffer);
     });
   });
 

--- a/apps/lfx-one/src/server/services/certificate.service.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.ts
@@ -12,7 +12,7 @@ import { Request } from 'express';
 import { AuthorizationError, ResourceNotFoundError } from '../errors';
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
-import { PDFTemplateDetails, CertificateData, CertificateEventRow } from '@lfx-one/shared/interfaces';
+import { PDFTemplateDetails, CertificateData, CertificateEventRow, CertificateResult } from '@lfx-one/shared/interfaces';
 import {
   DEFAULT_LOGO_WIDTH,
   DEFAULT_TEMPLATE,
@@ -20,7 +20,7 @@ import {
   LF_OPEN_SOURCE_OVERRIDE_MATCH,
   PROJECT_TEMPLATES,
 } from '@lfx-one/shared/constants/pdf.constants';
-import { isBackfillEventSource } from '@lfx-one/shared/utils';
+import { buildCertificateFileName, isBackfillEventSource } from '@lfx-one/shared/utils';
 
 // In production, import.meta.url points to the server bundle (dist/lfx-one/server/server.mjs)
 // and pdf-templates are copied there by the build script.
@@ -45,7 +45,7 @@ export class CertificateService {
     this.snowflakeService = SnowflakeService.getInstance();
   }
 
-  public async generateCertificate(req: Request, data: CertificateData): Promise<Buffer> {
+  public async generateCertificate(req: Request, data: CertificateData): Promise<CertificateResult> {
     logger.debug(req, 'generate_certificate', 'Fetching event data for certificate', {
       event_id: data.eventId,
     });
@@ -82,7 +82,9 @@ export class CertificateService {
       project_id: eventRow.PROJECT_ID,
     });
 
-    return this.buildPdf(data.userName, eventRow, template);
+    const pdf = await this.buildPdf(data.userName, eventRow, template);
+    const fileName = buildCertificateFileName(eventRow.EVENT_NAME, eventRow.EVENT_START_DATE, data.eventId);
+    return { pdf, fileName };
   }
 
   /**

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -324,6 +324,12 @@ export interface CertificateData {
   userName: string;
 }
 
+/** Result of generating a Certificate of Attendance PDF: the buffer plus its download filename. */
+export interface CertificateResult {
+  pdf: Buffer;
+  fileName: string;
+}
+
 /**
  * Raw row returned from ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS for visa letter requests
  */

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -324,9 +324,13 @@ export interface CertificateData {
   userName: string;
 }
 
-/** Result of generating a Certificate of Attendance PDF: the buffer plus its download filename. */
+/**
+ * Result of generating a Certificate of Attendance PDF: the buffer plus its download filename.
+ * Typed as `Uint8Array` (which `Buffer` structurally satisfies) so this browser-consumed shared
+ * package doesn't couple its type surface to Node's `Buffer` global.
+ */
 export interface CertificateResult {
-  pdf: Buffer;
+  pdf: Uint8Array;
   fileName: string;
 }
 

--- a/packages/shared/src/utils/event.utils.spec.ts
+++ b/packages/shared/src/utils/event.utils.spec.ts
@@ -120,4 +120,30 @@ describe('buildCertificateFileName', () => {
     const name = buildCertificateFileName(longName, '2025-11-10T00:00:00.000Z', 'evt-12');
     expect(name.endsWith('-2025-11-10.pdf')).toBe(true);
   });
+
+  it('preserves combining marks in scripts that require them (e.g. Devanagari) instead of dropping them', () => {
+    // हिन्दी is base consonants + combining vowel signs/virama — a \p{L}-only filter reduces it
+    // to the unreadable "ह-न-द" and can collide distinct names on the same date.
+    expect(buildCertificateFileName('हिन्दी', null, 'evt-16')).toBe('certificate-of-attendance-हिन्दी.pdf');
+  });
+
+  it('never leaves an unpaired surrogate after truncating an astral-character event name', () => {
+    vi.stubEnv('TZ', 'UTC');
+    // U+10400 is an astral letter, i.e. a surrogate pair — a naive UTF-16 code-unit slice can
+    // split the pair and leave a lone high surrogate, which makes encodeURIComponent() throw
+    // downstream in contentDispositionAttachment().
+    const astralName = '𐐀'.repeat(200);
+    const name = buildCertificateFileName(astralName, '2025-06-01T00:00:00.000Z', 'evt-15');
+    expect(() => encodeURIComponent(name)).not.toThrow();
+  });
+
+  it('keeps the date suffix intact for a long name whose diacritics expand under NFD normalization', () => {
+    vi.stubEnv('TZ', 'UTC');
+    // sanitizeFilename() NFD-normalizes the whole string, which expands each precomposed 'é'
+    // into 'e' + a combining acute — budgeting the name against the pre-expansion length let a
+    // long accented name grow past the overall cap and crowd the date out of the final trim.
+    const accentedName = 'é'.repeat(100);
+    const name = buildCertificateFileName(accentedName, '2025-06-01T00:00:00.000Z', 'evt-14');
+    expect(name.endsWith('-2025-06-01.pdf')).toBe(true);
+  });
 });

--- a/packages/shared/src/utils/event.utils.spec.ts
+++ b/packages/shared/src/utils/event.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { isBackfillEventSource } from './event.utils';
+import { buildCertificateFileName, isBackfillEventSource } from './event.utils';
 
 describe('isBackfillEventSource', () => {
   it('matches the canonical value', () => {
@@ -37,5 +37,55 @@ describe('isBackfillEventSource', () => {
 
   it.each([[null], [undefined]])('rejects %p without throwing', (source) => {
     expect(isBackfillEventSource(source)).toBe(false);
+  });
+});
+
+describe('buildCertificateFileName', () => {
+  it('slugifies the event name and appends the UTC start date', () => {
+    expect(buildCertificateFileName('KubeCon + CloudNativeCon NA 2025', '2025-11-10T00:00:00.000Z', 'evt-1')).toBe(
+      'certificate-of-attendance-kubecon-cloudnativecon-na-2025-2025-11-10.pdf'
+    );
+  });
+
+  it('handles a Snowflake-formatted timestamp (space-separated, no offset)', () => {
+    expect(buildCertificateFileName('Open Source Summit', '2025-11-10 08:00:00', 'evt-2')).toBe('certificate-of-attendance-open-source-summit-2025-11-10.pdf');
+  });
+
+  it('handles a Date instance', () => {
+    expect(buildCertificateFileName('Open Source Summit', new Date('2025-11-10T00:00:00.000Z'), 'evt-3')).toBe(
+      'certificate-of-attendance-open-source-summit-2025-11-10.pdf'
+    );
+  });
+
+  it('drops punctuation from the event name into hyphens rather than mangling the slug', () => {
+    expect(buildCertificateFileName("O'Reilly's Conf: AI & ML!", '2025-06-01T00:00:00.000Z', 'evt-4')).toBe(
+      'certificate-of-attendance-o-reilly-s-conf-ai-ml-2025-06-01.pdf'
+    );
+  });
+
+  it('slugifies a non-ASCII event name into a safe, readable name rather than rejecting it', () => {
+    const name = buildCertificateFileName('Kubernetes 会議 2025', '2025-06-01T00:00:00.000Z', 'evt-5');
+    expect(name.startsWith('certificate-of-attendance-')).toBe(true);
+    expect(name.endsWith('-2025-06-01.pdf')).toBe(true);
+  });
+
+  it('omits the date segment when the start date is missing', () => {
+    expect(buildCertificateFileName('Open Source Summit', null, 'evt-6')).toBe('certificate-of-attendance-open-source-summit.pdf');
+  });
+
+  it('omits the date segment when the start date is unparseable', () => {
+    expect(buildCertificateFileName('Open Source Summit', 'not-a-date', 'evt-7')).toBe('certificate-of-attendance-open-source-summit.pdf');
+  });
+
+  it('omits the name segment when the event name is missing', () => {
+    expect(buildCertificateFileName(null, '2025-11-10T00:00:00.000Z', 'evt-8')).toBe('certificate-of-attendance-2025-11-10.pdf');
+  });
+
+  it('falls back to the sanitized event id when both name and date are unavailable', () => {
+    expect(buildCertificateFileName(null, null, 'evt-9')).toBe('certificate-of-attendance-evt-9.pdf');
+  });
+
+  it('falls back to the event id when the name slugifies to nothing (e.g. punctuation-only)', () => {
+    expect(buildCertificateFileName('!!!', null, 'evt-10')).toBe('certificate-of-attendance-evt-10.pdf');
   });
 });

--- a/packages/shared/src/utils/event.utils.spec.ts
+++ b/packages/shared/src/utils/event.utils.spec.ts
@@ -74,8 +74,15 @@ describe('buildCertificateFileName', () => {
   it('slugifies a non-ASCII event name into a safe, readable name rather than rejecting it', () => {
     vi.stubEnv('TZ', 'UTC');
     const name = buildCertificateFileName('Kubernetes 会議 2025', '2025-06-01T00:00:00.000Z', 'evt-5');
-    expect(name.startsWith('certificate-of-attendance-')).toBe(true);
-    expect(name.endsWith('-2025-06-01.pdf')).toBe(true);
+    expect(name).toBe('certificate-of-attendance-kubernetes-会議-2025-2025-06-01.pdf');
+  });
+
+  it('keeps an all-non-ASCII event name as its own segment rather than collapsing to an empty slug', () => {
+    vi.stubEnv('TZ', 'UTC');
+    // A purely non-Latin name has nothing an ASCII-only slugger would keep; two such events on
+    // the same date must not collide on the same filename.
+    const name = buildCertificateFileName('会議', '2025-06-01T00:00:00.000Z', 'evt-13');
+    expect(name).toBe('certificate-of-attendance-会議-2025-06-01.pdf');
   });
 
   it('omits the date segment when the start date is missing', () => {

--- a/packages/shared/src/utils/event.utils.spec.ts
+++ b/packages/shared/src/utils/event.utils.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { buildCertificateFileName, isBackfillEventSource } from './event.utils';
 
@@ -41,29 +41,38 @@ describe('isBackfillEventSource', () => {
 });
 
 describe('buildCertificateFileName', () => {
-  it('slugifies the event name and appends the UTC start date', () => {
+  // Pinned to UTC so a 'Z'-anchored input's local-calendar-date rendering (matching
+  // CertificateService's PDF body date) is deterministic regardless of the machine's TZ.
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('slugifies the event name and appends the start date', () => {
+    vi.stubEnv('TZ', 'UTC');
     expect(buildCertificateFileName('KubeCon + CloudNativeCon NA 2025', '2025-11-10T00:00:00.000Z', 'evt-1')).toBe(
       'certificate-of-attendance-kubecon-cloudnativecon-na-2025-2025-11-10.pdf'
     );
   });
 
-  it('handles a Snowflake-formatted timestamp (space-separated, no offset)', () => {
+  it('handles a Snowflake-formatted timestamp (space-separated, no offset), parsed in local time', () => {
+    vi.stubEnv('TZ', 'UTC');
     expect(buildCertificateFileName('Open Source Summit', '2025-11-10 08:00:00', 'evt-2')).toBe('certificate-of-attendance-open-source-summit-2025-11-10.pdf');
   });
 
   it('handles a Date instance', () => {
+    vi.stubEnv('TZ', 'UTC');
     expect(buildCertificateFileName('Open Source Summit', new Date('2025-11-10T00:00:00.000Z'), 'evt-3')).toBe(
       'certificate-of-attendance-open-source-summit-2025-11-10.pdf'
     );
   });
 
   it('drops punctuation from the event name into hyphens rather than mangling the slug', () => {
+    vi.stubEnv('TZ', 'UTC');
     expect(buildCertificateFileName("O'Reilly's Conf: AI & ML!", '2025-06-01T00:00:00.000Z', 'evt-4')).toBe(
       'certificate-of-attendance-o-reilly-s-conf-ai-ml-2025-06-01.pdf'
     );
   });
 
   it('slugifies a non-ASCII event name into a safe, readable name rather than rejecting it', () => {
+    vi.stubEnv('TZ', 'UTC');
     const name = buildCertificateFileName('Kubernetes 会議 2025', '2025-06-01T00:00:00.000Z', 'evt-5');
     expect(name.startsWith('certificate-of-attendance-')).toBe(true);
     expect(name.endsWith('-2025-06-01.pdf')).toBe(true);
@@ -78,6 +87,7 @@ describe('buildCertificateFileName', () => {
   });
 
   it('omits the name segment when the event name is missing', () => {
+    vi.stubEnv('TZ', 'UTC');
     expect(buildCertificateFileName(null, '2025-11-10T00:00:00.000Z', 'evt-8')).toBe('certificate-of-attendance-2025-11-10.pdf');
   });
 
@@ -87,5 +97,20 @@ describe('buildCertificateFileName', () => {
 
   it('falls back to the event id when the name slugifies to nothing (e.g. punctuation-only)', () => {
     expect(buildCertificateFileName('!!!', null, 'evt-10')).toBe('certificate-of-attendance-evt-10.pdf');
+  });
+
+  it('renders the date in local time, matching the PDF body rather than the UTC date', () => {
+    vi.stubEnv('TZ', 'America/Los_Angeles');
+    // Still Nov 9 in America/Los_Angeles (UTC-8 in November) — the local calendar date, not the UTC one.
+    expect(buildCertificateFileName('Open Source Summit', '2025-11-10T05:00:00.000Z', 'evt-11')).toBe(
+      'certificate-of-attendance-open-source-summit-2025-11-09.pdf'
+    );
+  });
+
+  it('truncates a very long event name so the date discriminator is never dropped by the overall filename cap', () => {
+    vi.stubEnv('TZ', 'UTC');
+    const longName = 'A'.repeat(200);
+    const name = buildCertificateFileName(longName, '2025-11-10T00:00:00.000Z', 'evt-12');
+    expect(name.endsWith('-2025-11-10.pdf')).toBe(true);
   });
 });

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -28,23 +28,42 @@ export function isBackfillEventSource(source: string | null | undefined): boolea
   return source?.replace(/^[ \t\n\r]+|[ \t\n\r]+$/g, '').toLowerCase() === EVENT_SOURCE_BACKFILL;
 }
 
-/** Certificate filename length budget for the slugified event name, leaving room for the fixed prefix, date suffix, and extension. */
-const MAX_NAME_SLUG_LENGTH = 100;
+/** Overall certificate filename length budget, matching the `sanitizeFilename()` call below. */
+const MAX_FILENAME_LENGTH = 150;
+const CERTIFICATE_PREFIX = 'certificate-of-attendance';
+const CERTIFICATE_EXTENSION = '.pdf';
 
 /**
- * Unicode-aware slug for the certificate filename: keeps letters/digits from any script
- * (unlike the ASCII-only `slugify()` in string.utils.ts), so an all-non-Latin event name still
- * yields a distinct, readable segment instead of collapsing to '' and colliding with other
- * events on the same date. `sanitizeFilename()` still runs over the final result.
+ * Unicode-aware slug for the certificate filename: keeps letters, digits, and combining marks
+ * from any script (unlike the ASCII-only `slugify()` in string.utils.ts). Marks matter for
+ * scripts like Devanagari, where they're required characters, not decoration — dropping them
+ * (as a `\p{L}`/`\p{N}`-only filter would) reduces e.g. "हिन्दी" to the unreadable "ह-न-द" and can
+ * collide distinct names. `sanitizeFilename()` still runs over the final joined result.
  */
 function slugifyEventName(text: string): string {
   const slug = text
     .normalize('NFKC')
     .toLocaleLowerCase()
-    .replace(/[^\p{L}\p{N}]+/gu, '-');
+    .replace(/[^\p{L}\p{N}\p{M}]+/gu, '-');
   const start = slug.startsWith('-') ? 1 : 0;
   const end = slug.endsWith('-') ? slug.length - 1 : slug.length;
   return slug.slice(start, end);
+}
+
+/**
+ * Truncate `text` to at most `maxLength` UTF-16 code units without splitting a surrogate pair.
+ * Iterating by `for...of` walks whole code points, so an astral character (e.g. `𐐀`, itself a
+ * surrogate pair) is either kept whole or dropped entirely — never left as an unpaired trailing
+ * high surrogate, which would otherwise make `encodeURIComponent` throw downstream.
+ */
+function truncateByCodePoint(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  let result = '';
+  for (const codePoint of text) {
+    if (result.length + codePoint.length > maxLength) break;
+    result += codePoint;
+  }
+  return result;
 }
 
 /**
@@ -68,13 +87,20 @@ function toDateStamp(value: Date | string | null | undefined): string {
  * discriminator.
  */
 export function buildCertificateFileName(eventName: string | null | undefined, startDate: Date | string | null | undefined, eventId: string): string {
-  const nameSlug = eventName ? slugifyEventName(eventName).slice(0, MAX_NAME_SLUG_LENGTH) : '';
   const dateStamp = toDateStamp(startDate);
 
-  const parts = ['certificate-of-attendance'];
+  // Budget the name slug against the *NFD-normalized* form — the same normalization
+  // `sanitizeFilename()` applies below — so a decomposable character (e.g. "é" → "e" + "´")
+  // can't grow past this count later and crowd the date suffix out of sanitizeFilename's own
+  // trailing truncation.
+  const suffix = dateStamp ? `-${dateStamp}` : '';
+  const nameBudget = Math.max(0, MAX_FILENAME_LENGTH - CERTIFICATE_PREFIX.length - 1 - suffix.length - CERTIFICATE_EXTENSION.length);
+  const nameSlug = eventName ? truncateByCodePoint(slugifyEventName(eventName).normalize('NFD'), nameBudget) : '';
+
+  const parts = [CERTIFICATE_PREFIX];
   if (nameSlug) parts.push(nameSlug);
   if (dateStamp) parts.push(dateStamp);
   if (!nameSlug && !dateStamp) parts.push(eventId);
 
-  return sanitizeFilename(`${parts.join('-')}.pdf`, 150);
+  return sanitizeFilename(`${parts.join('-')}${CERTIFICATE_EXTENSION}`, MAX_FILENAME_LENGTH);
 }

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -3,7 +3,6 @@
 
 import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
 import { sanitizeFilename } from './file.utils';
-import { slugify } from './string.utils';
 
 /**
  * True when an event registration row came from the CSV backfill import.
@@ -33,6 +32,22 @@ export function isBackfillEventSource(source: string | null | undefined): boolea
 const MAX_NAME_SLUG_LENGTH = 100;
 
 /**
+ * Unicode-aware slug for the certificate filename: keeps letters/digits from any script
+ * (unlike the ASCII-only `slugify()` in string.utils.ts), so an all-non-Latin event name still
+ * yields a distinct, readable segment instead of collapsing to '' and colliding with other
+ * events on the same date. `sanitizeFilename()` still runs over the final result.
+ */
+function slugifyEventName(text: string): string {
+  const slug = text
+    .normalize('NFKC')
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-');
+  const start = slug.startsWith('-') ? 1 : 0;
+  const end = slug.endsWith('-') ? slug.length - 1 : slug.length;
+  return slug.slice(start, end);
+}
+
+/**
  * Local calendar-date `YYYY-MM-DD` for a timestamp, matching the date `CertificateService` prints
  * in the PDF body (also derived from local `Date` getters) so the filename and the certificate
  * text never disagree. Returns '' when missing/unparseable.
@@ -53,7 +68,7 @@ function toDateStamp(value: Date | string | null | undefined): string {
  * discriminator.
  */
 export function buildCertificateFileName(eventName: string | null | undefined, startDate: Date | string | null | undefined, eventId: string): string {
-  const nameSlug = eventName ? slugify(eventName).slice(0, MAX_NAME_SLUG_LENGTH) : '';
+  const nameSlug = eventName ? slugifyEventName(eventName).slice(0, MAX_NAME_SLUG_LENGTH) : '';
   const dateStamp = toDateStamp(startDate);
 
   const parts = ['certificate-of-attendance'];

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -4,7 +4,6 @@
 import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
 import { sanitizeFilename } from './file.utils';
 import { slugify } from './string.utils';
-import { normalizeSnowflakeTimestamp } from './date-time.utils';
 
 /**
  * True when an event registration row came from the CSV backfill import.
@@ -30,12 +29,21 @@ export function isBackfillEventSource(source: string | null | undefined): boolea
   return source?.replace(/^[ \t\n\r]+|[ \t\n\r]+$/g, '').toLowerCase() === EVENT_SOURCE_BACKFILL;
 }
 
-/** UTC `YYYY-MM-DD` for a Snowflake-or-ISO timestamp, or '' when missing/unparseable. */
-function toUtcDateStamp(value: Date | string | null | undefined): string {
+/** Certificate filename length budget for the slugified event name, leaving room for the fixed prefix, date suffix, and extension. */
+const MAX_NAME_SLUG_LENGTH = 100;
+
+/**
+ * Local calendar-date `YYYY-MM-DD` for a timestamp, matching the date `CertificateService` prints
+ * in the PDF body (also derived from local `Date` getters) so the filename and the certificate
+ * text never disagree. Returns '' when missing/unparseable.
+ */
+function toDateStamp(value: Date | string | null | undefined): string {
   if (!value) return '';
-  const normalized = typeof value === 'string' ? normalizeSnowflakeTimestamp(value) : value;
-  const date = new Date(normalized);
-  return isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return '';
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
 }
 
 /**
@@ -45,8 +53,8 @@ function toUtcDateStamp(value: Date | string | null | undefined): string {
  * discriminator.
  */
 export function buildCertificateFileName(eventName: string | null | undefined, startDate: Date | string | null | undefined, eventId: string): string {
-  const nameSlug = eventName ? slugify(eventName) : '';
-  const dateStamp = toUtcDateStamp(startDate);
+  const nameSlug = eventName ? slugify(eventName).slice(0, MAX_NAME_SLUG_LENGTH) : '';
+  const dateStamp = toDateStamp(startDate);
 
   const parts = ['certificate-of-attendance'];
   if (nameSlug) parts.push(nameSlug);

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
+import { sanitizeFilename } from './file.utils';
+import { slugify } from './string.utils';
+import { normalizeSnowflakeTimestamp } from './date-time.utils';
 
 /**
  * True when an event registration row came from the CSV backfill import.
@@ -25,4 +28,30 @@ import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
  */
 export function isBackfillEventSource(source: string | null | undefined): boolean {
   return source?.replace(/^[ \t\n\r]+|[ \t\n\r]+$/g, '').toLowerCase() === EVENT_SOURCE_BACKFILL;
+}
+
+/** UTC `YYYY-MM-DD` for a Snowflake-or-ISO timestamp, or '' when missing/unparseable. */
+function toUtcDateStamp(value: Date | string | null | undefined): string {
+  if (!value) return '';
+  const normalized = typeof value === 'string' ? normalizeSnowflakeTimestamp(value) : value;
+  const date = new Date(normalized);
+  return isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
+}
+
+/**
+ * Build the download filename for a Certificate of Attendance PDF, e.g.
+ * "certificate-of-attendance-kubecon-cloudnativecon-na-2025-2025-11-10.pdf". Falls back to
+ * `eventId` when the event name and start date are both unavailable, so the file always has a
+ * discriminator.
+ */
+export function buildCertificateFileName(eventName: string | null | undefined, startDate: Date | string | null | undefined, eventId: string): string {
+  const nameSlug = eventName ? slugify(eventName) : '';
+  const dateStamp = toUtcDateStamp(startDate);
+
+  const parts = ['certificate-of-attendance'];
+  if (nameSlug) parts.push(nameSlug);
+  if (dateStamp) parts.push(dateStamp);
+  if (!nameSlug && !dateStamp) parts.push(eventId);
+
+  return sanitizeFilename(`${parts.join('-')}.pdf`, 150);
 }

--- a/packages/shared/src/utils/file.utils.spec.ts
+++ b/packages/shared/src/utils/file.utils.spec.ts
@@ -1,0 +1,40 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { parseContentDispositionFilename } from './file.utils';
+
+describe('parseContentDispositionFilename', () => {
+  it('reads the quoted ASCII fallback form', () => {
+    expect(parseContentDispositionFilename('attachment; filename="certificate.pdf"')).toBe('certificate.pdf');
+  });
+
+  it('reads the RFC 5987 filename* form, percent-decoded', () => {
+    expect(parseContentDispositionFilename("attachment; filename*=UTF-8''certificate-of-attendance-%C3%A9v%C3%A9nement.pdf")).toBe(
+      'certificate-of-attendance-événement.pdf'
+    );
+  });
+
+  it('prefers filename* over the quoted fallback when both are present', () => {
+    const header = 'attachment; filename="certificate.pdf"; filename*=UTF-8\'\'certificate-of-attendance.pdf';
+    expect(parseContentDispositionFilename(header)).toBe('certificate-of-attendance.pdf');
+  });
+
+  it('falls back to the quoted form when filename* is malformed percent-encoding', () => {
+    const header = 'attachment; filename="certificate.pdf"; filename*=UTF-8\'\'%E0%A4%A';
+    expect(parseContentDispositionFilename(header)).toBe('certificate.pdf');
+  });
+
+  it('reads an unquoted filename', () => {
+    expect(parseContentDispositionFilename('attachment; filename=certificate.pdf')).toBe('certificate.pdf');
+  });
+
+  it.each([[null], [undefined], ['']])('returns null for %p', (header) => {
+    expect(parseContentDispositionFilename(header)).toBeNull();
+  });
+
+  it('returns null when the header has no filename', () => {
+    expect(parseContentDispositionFilename('attachment')).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/file.utils.ts
+++ b/packages/shared/src/utils/file.utils.ts
@@ -306,6 +306,27 @@ export function rowsToCsv(rows: ReadonlyArray<ReadonlyArray<string | number>>): 
   return rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n');
 }
 
+/**
+ * Extract the filename from a `Content-Disposition` header, preferring the RFC 5987
+ * `filename*=UTF-8''…` form over the quoted ASCII fallback (the pair emitted by
+ * `contentDispositionAttachment` on the server). Returns `null` when neither form is present.
+ */
+export function parseContentDispositionFilename(header: string | null | undefined): string | null {
+  if (!header) return null;
+
+  const starMatch = header.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
+  if (starMatch) {
+    try {
+      return decodeURIComponent(starMatch[1].trim());
+    } catch {
+      // Malformed percent-encoding — fall through to the ASCII fallback below.
+    }
+  }
+
+  const quotedMatch = header.match(/filename\s*=\s*"([^"]*)"/i) ?? header.match(/filename\s*=\s*([^;]+)/i);
+  return quotedMatch ? quotedMatch[1].trim() : null;
+}
+
 /** Trigger a browser file download from a URL via `<a download>` (no new tab). No-op during SSR. */
 export function downloadFromUrl(url: string, filename?: string): void {
   if (typeof document === 'undefined') {


### PR DESCRIPTION
## Summary

- Replace the opaque `certificate-<eventId>.pdf` download name with a human-readable filename built from the event name and start date (e.g. `certificate-of-attendance-kubecon-cloudnativecon-na-2025-2025-11-10.pdf`)
- Build the filename once, server-side, in `CertificateService`, using the event data it already fetches — no new query
- Emit it via the existing `contentDispositionAttachment()` RFC 5987 helper instead of a hand-rolled header, so the server and the direct-download endpoint agree
- Client reads the filename from `Content-Disposition` instead of hardcoding `certificate-${eventId}.pdf`, falling back to the id-based name if the header is ever missing
- Add `parseContentDispositionFilename()` as the read-side counterpart to the existing `contentDispositionAttachment()` helper
- Degrade gracefully: missing/unparseable event name or start date drops that segment rather than emitting `undefined`; both missing falls back to the sanitized event id
- Date is derived in local time (matching the date already printed in the PDF body) rather than UTC, so the filename and the certificate text never disagree
- Cap the slugified name segment so a very long event name can never crowd out the date discriminator

Fixes #2205