### PR TITLE
fix(meetings): evict detail cache on cancelOccurrence + map 400 error

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component.ts
@@ -40,7 +40,7 @@ export class CancelOccurrenceConfirmationComponent {
         this.isCanceling.set(false);
         let errorMessage = 'Failed to cancel occurrence. Please try again.';
 
-        if (error.status === 400) {
+        if (error.status === 400 && (error.error?.error ?? '').includes('already cancelled')) {
           errorMessage = 'This occurrence has already been cancelled — please refresh the page.';
         } else if (error.status === 404) {
           errorMessage = 'Meeting occurrence not found.';

--- a/apps/lfx-one/src/app/modules/meetings/components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component.ts
@@ -40,7 +40,9 @@ export class CancelOccurrenceConfirmationComponent {
         this.isCanceling.set(false);
         let errorMessage = 'Failed to cancel occurrence. Please try again.';
 
-        if (error.status === 404) {
+        if (error.status === 400) {
+          errorMessage = 'This occurrence has already been cancelled — please refresh the page.';
+        } else if (error.status === 404) {
           errorMessage = 'Meeting occurrence not found.';
         } else if (error.status === 403) {
           errorMessage = 'You do not have permission to cancel this occurrence.';

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -336,7 +336,10 @@ export class MeetingService {
   }
 
   public cancelOccurrence(meetingId: string, occurrenceId: string): Observable<void> {
-    return this.http.delete<void>(`/api/meetings/${meetingId}/occurrences/${occurrenceId}`).pipe(take(1));
+    return this.http.delete<void>(`/api/meetings/${meetingId}/occurrences/${occurrenceId}`).pipe(
+      take(1),
+      tap(() => this.meetingDetailCache.delete(meetingId))
+    );
   }
 
   // ─── Meeting Attachment Methods ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes issue 1 of 2 from linuxfoundation/lfx-self-serve-ops#13: the "occurrence already cancelled" UX problem caused by a concurrent-session race condition amplified by stale caching.

## Root cause

Two independent caching gaps meant a successful `cancelOccurrence` left the occurrence still visible in the UI:

1. **Angular in-memory cache** — `MeetingService.cancelOccurrence` was not evicting the `meetingDetailCache` entry on success, unlike `updateMeeting` and `deleteMeeting` which both call `this.meetingDetailCache.delete(id)`. The occurrence remained visible in the same session until the TTL expired.
2. **Misleading error message** — When two concurrent sessions raced, the second got a correct `400 "occurrence for meeting is already cancelled"` from `itx-service-zoom`. The component mapped this to the generic "Failed to cancel occurrence. Please try again." — which encouraged further retries.

## Changes

### `apps/lfx-one/src/app/shared/services/meeting.service.ts`
- Add `tap(() => this.meetingDetailCache.delete(meetingId))` to the `cancelOccurrence` pipe on success, consistent with `updateMeeting` (line 315) and `deleteMeeting` (line 330).

### `apps/lfx-one/src/app/modules/meetings/components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component.ts`
- Add a `400` branch that maps to: _"This occurrence has already been cancelled — please refresh the page."_ instead of the generic retry prompt.

## Testing
- Cancel an occurrence: the occurrence disappears from the list immediately without a manual refresh.
- Simulate a concurrent cancel (e.g. two tabs): the second attempt shows the specific "already cancelled" message rather than the generic error.

Made with [Cursor](https://cursor.com)