### PR TITLE
fix(server): name the setting when NATS_URL cannot be parsed

### DIFF
--- a/apps/lfx-one/src/server/services/nats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/nats.service.spec.ts
@@ -1,0 +1,56 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NatsService } from './nats.service';
+
+/**
+ * A malformed `NATS_URL` must fail with a message that names the setting.
+ *
+ * The constructor runs during module evaluation for EVERY SSR route -- it is reached through
+ * `Auth0Service` -> `ProfileController` -> `server.ts` -- so an unguarded `new URL()` throw takes
+ * the whole app down with a bare `TypeError: Invalid URL` and a stack trace naming internal file
+ * paths. That is what a single missing `nats://` scheme produced in local testing.
+ *
+ * The failure stays fatal on purpose: a BFF that cannot reach NATS cannot resolve a project slug,
+ * so every authorization check would deny and serving those pages would be worse than not
+ * starting. What changes is that the error says which variable is wrong.
+ */
+describe('NatsService — NATS_URL parsing', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ['a bare host:port with no scheme', '127.0.0.1:4223'],
+    ['an empty-ish value', '   '],
+    ['a value that is not a URL at all', 'not a url'],
+  ])('rejects %s with an error naming NATS_URL and the expected shape', (_label, value) => {
+    vi.stubEnv('NATS_URL', value);
+
+    // Not a bare TypeError: the message must be actionable, or an operator sees only
+    // "Invalid URL" on every route with no indication of which setting caused it.
+    expect(() => new NatsService()).toThrow(/NATS_URL/);
+    expect(() => new NatsService()).toThrow(/nats:\/\/host:4222/);
+  });
+
+  it('accepts a well-formed nats:// URL and keeps its host and port', () => {
+    vi.stubEnv('NATS_URL', 'nats://127.0.0.1:4223');
+
+    const service = new NatsService() as unknown as { natsHostname: string; natsPort: number };
+
+    expect(service.natsHostname).toBe('127.0.0.1');
+    expect(service.natsPort).toBe(4223);
+  });
+
+  it('defaults the port to 4222 when the URL omits one', () => {
+    // `parseInt('')` is NaN, so the `|| 4222` fallback is what supplies the default -- a guard
+    // that only a port-less URL reaches.
+    vi.stubEnv('NATS_URL', 'nats://lfx-platform-nats.lfx.svc.cluster.local');
+
+    const service = new NatsService() as unknown as { natsPort: number };
+
+    expect(service.natsPort).toBe(4222);
+  });
+});

--- a/apps/lfx-one/src/server/services/nats.service.ts
+++ b/apps/lfx-one/src/server/services/nats.service.ts
@@ -29,7 +29,21 @@ export class NatsService {
 
   public constructor() {
     const natsUrl = process.env['NATS_URL'] || NATS_CONFIG.DEFAULT_SERVER_URL;
-    const parsedUrl = new URL(natsUrl.replace(/^nats:/, 'http:'));
+    // PARSED DEFENSIVELY. `new URL()` throws a bare `TypeError: Invalid URL` on a malformed value,
+    // and this constructor runs inside `Auth0Service` -> `ProfileController` -> `server.ts`, i.e.
+    // during module evaluation for EVERY SSR route. An unguarded throw there takes the whole app
+    // down with a raw stack trace that names internal file paths, for what is only a config typo
+    // (a missing `nats://` scheme is enough to trigger it).
+    //
+    // Rethrown as a named error naming the variable and the expected shape: the failure is still
+    // fatal -- a BFF that cannot reach NATS cannot resolve a project slug, so serving pages that
+    // all fail authorization would be worse -- but it now says which setting is wrong.
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(natsUrl.replace(/^nats:/, 'http:'));
+    } catch {
+      throw new Error(`Invalid NATS_URL: expected a URL like "nats://host:4222", received "${natsUrl}"`);
+    }
     this.natsHostname = parsedUrl.hostname;
     this.natsPort = parseInt(parsedUrl.port, 10) || 4222;
     NatsService.instances.add(this);


### PR DESCRIPTION
Found while running the paid-campaign platform end-to-end against dev.

## The defect

`new URL()` in `NatsService`'s constructor was unguarded:

```ts
const parsedUrl = new URL(natsUrl.replace(/^nats:/, 'http:'));
```

A malformed `NATS_URL` throws a bare `TypeError: Invalid URL`. That constructor runs inside `Auth0Service → ProfileController → server.ts` during module evaluation for **every SSR route**, so a config typo takes the whole app down and answers every page with a raw stack trace naming internal file paths.

Omitting the `nats://` scheme is enough to trigger it — which is exactly how I hit it.

## The fix

The failure stays **fatal on purpose**: a BFF that cannot reach NATS cannot resolve a project slug, so every authorization check would deny and serving those pages would be worse than not starting. What changes is that the error names the variable and the shape it expected:

```
Invalid NATS_URL: expected a URL like "nats://host:4222", received "127.0.0.1:4223"
```

## Verification

Five new tests. **Mutation-verified** — reverting the guard fails three of them:

| Reverted to | Fails |
|---|---|
| unguarded `new URL(...)` | all three `rejects …` cases |

The other two pin the success path: a well-formed URL keeps its host and port, and a port-less URL still defaults to 4222 (the `\|\| 4222` fallback, which only a port-less URL reaches).

**100 files / 2688 server tests, typecheck and lint clean.**