### PR TITLE
feat(formation): add action_link to the template item

### DIFF
--- a/packages/shared/src/enums/formation.enum.spec.ts
+++ b/packages/shared/src/enums/formation.enum.spec.ts
@@ -107,6 +107,10 @@ describe('FormationTemplate shape', () => {
       ],
     } satisfies FormationTemplate;
 
+    // JSON.stringify/parse of a plain string cannot itself fail — this doesn't gate a regression
+    // today. It documents the actual transport boundary `action_link` crosses (an HTTP JSON
+    // payload from #1957) and guards against a future step (e.g. accidental URL-encoding) that
+    // would otherwise mangle the `{{project.uid}}` placeholder silently.
     const roundTripped = JSON.parse(JSON.stringify(template)) as FormationTemplate;
     const [manualItem, linkItem, noLinkItem] = roundTripped.sections[0].items;
 

--- a/packages/shared/src/enums/formation.enum.spec.ts
+++ b/packages/shared/src/enums/formation.enum.spec.ts
@@ -68,4 +68,51 @@ describe('FormationTemplate shape', () => {
 
     expect(template.sections[0].items[0].sub_items).toHaveLength(1);
   });
+
+  it('round-trips action_link through serialize/parse, including an unmangled {{project.uid}} placeholder', () => {
+    const template = {
+      uid: 'formation-template-test',
+      version: 1,
+      name: 'Test template',
+      sections: [
+        {
+          key: FormationTemplateSectionKey.LEGAL_AND_ENTITY,
+          title: 'Legal and entity',
+          items: [
+            {
+              key: 'register-domain',
+              title: 'Register domain',
+              is_gating: false,
+              owner_team: FormationOwnerTeam.IT,
+              action: FormationActionType.MANUAL,
+              action_link: '/project/{{project.uid}}/committees/new',
+            },
+            {
+              key: 'contribution-agreement',
+              title: 'Contribution agreement',
+              is_gating: true,
+              owner_team: FormationOwnerTeam.FORMATION,
+              action: FormationActionType.LINK,
+              action_link: 'https://example.com/docusign/envelope',
+            },
+            {
+              key: 'charter-agreed',
+              title: 'Charter agreed',
+              is_gating: true,
+              owner_team: FormationOwnerTeam.FORMATION,
+              action: FormationActionType.MANUAL,
+            },
+          ],
+        },
+      ],
+    } satisfies FormationTemplate;
+
+    const roundTripped = JSON.parse(JSON.stringify(template)) as FormationTemplate;
+    const [manualItem, linkItem, noLinkItem] = roundTripped.sections[0].items;
+
+    expect(manualItem.action_link).toBe('/project/{{project.uid}}/committees/new');
+    expect(manualItem.action_link).toContain('{{project.uid}}');
+    expect(linkItem.action_link).toBe('https://example.com/docusign/envelope');
+    expect(noLinkItem).not.toHaveProperty('action_link');
+  });
 });

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -120,7 +120,10 @@ export interface FormationItem {
    * Resolved destination for the row's action — the expansion output of the template's
    * {@link FormationTemplateItem.action_link}, substituted once and stored static. Any action
    * kind may have one: a `manual` row still says where the work is done. May be an in-app
-   * relative path or an absolute external URL; `null` when the row has no destination.
+   * relative path or an absolute external URL; `null` when the row has no destination. Service-
+   * supplied and untrusted: a consumer binding this into `[href]` must scheme-validate an
+   * absolute value first (see `isValidUrl` in `packages/shared/src/utils/url.utils.ts`) and route
+   * a relative value through the router rather than a raw anchor.
    */
   action_href: string | null;
   detail: string | null;

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -116,7 +116,12 @@ export interface FormationItem {
   owner: FormationUser | null;
   due_date: string | null;
   action: FormationItemAction;
-  /** For `link`/`status_only` rows that open something external. */
+  /**
+   * Resolved destination for the row's action — the expansion output of the template's
+   * {@link FormationTemplateItem.action_link}, substituted once and stored static. Any action
+   * kind may have one: a `manual` row still says where the work is done. May be an in-app
+   * relative path or an absolute external URL; `null` when the row has no destination.
+   */
   action_href: string | null;
   detail: string | null;
   notes: string | null;
@@ -202,6 +207,16 @@ export interface FormationTemplateItem {
   owner_team: FormationOwnerTeam;
   /** `'status_only'` IS the status-only signal — there is no separate boolean to keep in sync with it. */
   action: FormationActionType;
+  /**
+   * Optional template-defined destination for the row's action. Resolved ONCE at expansion with
+   * `{{project.uid}}` / `{{project.slug}}` substitution and stored static on the resulting
+   * {@link FormationItem.action_href} — the runtime field is the resolved value, this one is the
+   * unresolved template. In-app relative paths (`/project/{{project.uid}}/committees/new`) or
+   * absolute external URLs. Absent means the row's action has no destination.
+   * TODO(#1957): the formation service owns the substitution; nothing in this repo resolves
+   * `{{…}}` today.
+   */
+  action_link?: string;
   sub_items?: FormationTemplateSubItem[];
 }
 


### PR DESCRIPTION
Closes #2212

## What

Adds optional `action_link` to `FormationTemplateItem` per Epic 1 architecture review §6: template-defined destination for a row's action, resolved once at expansion with `{{project.uid}}` / `{{project.slug}}` substitution and stored static. In-app relative paths (e.g. `/project/{{project.uid}}/committees/new`) or absolute external URLs.

Types + doc contract + test only — no UI, no service code, no template content edits (that's #1959, which depends on this PR).

Also widens `FormationItem.action_href`'s doc comment, which previously said it was only "for `link`/`status_only` rows that open something external" — both halves were wrong: a `manual` row can have a destination too, and the value may be an in-app relative path, not only external. The comment now also states the field is service-supplied and untrusted: a consumer binding it into `[href]` must scheme-validate an absolute value (see `isValidUrl` in `packages/shared/src/utils/url.utils.ts`) and route a relative value through the router rather than a raw anchor.

## `FormationTemplateSubItem` verdict: no `action_link`

Decided, not skipped:

1. There's nowhere for it to land — runtime `FormationSubItem` is `{ uid, title, status }`, no `action_href` counterpart.
2. The real seeded template's only sub-items (the `chat_workspace` item's 4 IT setup steps, on the unmerged `#1959` branch) are plain checkbox steps under one `request` parent — the parent row is the affordance.
3. No sub-item carries an `action` at all, so "the destination for the row's action" has no subject on a sub-item.

If a sub-item later needs its own destination, that's a shape change (needs `action` + a runtime `action_href` first), not a field add.

## Consumers needing follow-up (not in this PR)

- `formation-checklist-row.component.ts` (unmerged `feat/GH-1958-formation-checklist-queue`): computes `safeActionHref` via `isValidUrl(href)`, which requires `new URL()` to parse with `http:`/`https:` + a hostname — **a relative in-app path is rejected and silently dropped**. Rendering an in-app `action_link` needs a relative-path branch (`routerLink`) alongside the existing absolute-URL guard.
- `formation-fixture.helper.ts` (same branch): currently synthesizes `action_href` for `link`/`status_only` rows; should instead read the template's `action_link`.
- `formation-template.constants.ts` (unmerged `feat/issue-1959`): the real 17-item seeded template — needs `action_link` set on rows with a destination. This PR unblocks that work.

## Testing

Extended the existing round-trip test in `formation.enum.spec.ts` (new `it`, existing test/assertions untouched) with items carrying `action_link`, including one with an unmangled `{{project.uid}}` placeholder through `JSON.parse(JSON.stringify(...))`.

`./check-headers.sh && yarn lint && yarn format && yarn test && yarn build` all pass. `/lfx-self-serve-pr-readiness` verdict: READY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQ7qX74j5eeSTNwNCMDyzg