### PR TITLE
fix(groups): resolve vanity slugs for authenticated group URLs

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -43,6 +43,7 @@ import { COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW, COMMITTEE_VALID_TABS, WG_ENGAGEMEN
 import {
   canManageCommitteeMembers,
   committeeRequiresOrganization,
+  committeeRouteIdMatches,
   findPendingInvitationForCommittee,
   invitationRequiresOrganization,
 } from '@lfx-one/shared/utils';
@@ -306,20 +307,25 @@ export class CommitteeViewComponent {
   // notified the wrapper, and meetingCoordinatorLoading stayed forced `true` forever for the new
   // committee (Copilot). A fresh object literal is always reference-distinct, so every emission below
   // reliably propagates, and meetingCoordinatorLoading/meetingCoordinator (further down) compare the
-  // tag against the LIVE committeeId() directly rather than needing a value-change to "release" them.
+  // loaded committee to the live route param (UID or vanity slug) rather than needing a value-change
+  // to "release" them.
   private readonly meetingCoordinatorState: Signal<{ committeeUid: string | null; loading: boolean; coordinator: boolean }> = this.initMeetingCoordinator();
   // True until meetingCoordinatorState has settled FOR THE CURRENT committee (the tag comparison
   // covers both "still mid-navigation, state belongs to the previous committee" and "fetch actually
   // in flight" — see the state signal's doc comment above).
   public readonly meetingCoordinatorLoading: Signal<boolean> = computed(() => {
     const state = this.meetingCoordinatorState();
-    return state.committeeUid !== this.committeeId() || state.loading;
+    const committee = this.committee();
+    // Route param may be a vanity slug while `state.committeeUid` / `committee.uid` are UUIDs
+    // (GH #2072). Compare the loaded committee to the route, then confirm the probe belongs to it.
+    return !committeeRouteIdMatches(this.committeeId(), committee) || state.committeeUid !== committee?.uid || state.loading;
   });
   // Only trusts the resolved grant once meetingCoordinatorState belongs to the CURRENT committee —
   // never leaks a stale previous committee's resolved value into eligible() below.
   public readonly meetingCoordinator: Signal<boolean> = computed(() => {
     const state = this.meetingCoordinatorState();
-    return state.committeeUid === this.committeeId() && state.coordinator;
+    const committee = this.committee();
+    return committeeRouteIdMatches(this.committeeId(), committee) && state.committeeUid === committee?.uid && state.coordinator;
   });
 
   // Single source of truth for "can this user read committee engagement data" (LFXV2-1705), shared
@@ -545,7 +551,7 @@ export class CommitteeViewComponent {
         if (!result?.organization) {
           return;
         }
-        if (this.committeeId() !== committee.uid) {
+        if (!committeeRouteIdMatches(this.committeeId(), committee)) {
           return;
         }
         organization = result.organization;
@@ -575,7 +581,7 @@ export class CommitteeViewComponent {
         if (!result?.organization) {
           return;
         }
-        if (this.committeeId() !== committee.uid) {
+        if (!committeeRouteIdMatches(this.committeeId(), committee)) {
           return;
         }
         organization = result.organization;
@@ -955,7 +961,9 @@ export class CommitteeViewComponent {
           // `this.committee()` holds the *previous* committee until this switchMap's read emits, so
           // navigating between groups (e.g. a parent/subgroup link) would otherwise misread a still-
           // loading different group as a silent refresh and skip the retry window (Cursor Bugbot).
-          const isInitialLoad = this.committee()?.uid !== committeeId;
+          // Vanity `/groups/<slug>` routes keep the slug in the param while `committee.uid` is the
+          // UUID — treat slug and UID as the same committee (GH #2072).
+          const isInitialLoad = !committeeRouteIdMatches(committeeId, this.committee());
 
           return this.readCommitteeToleratingPropagation(committeeId, isInitialLoad).pipe(
             finalize(() => {
@@ -1262,8 +1270,10 @@ export class CommitteeViewComponent {
       // on route.paramMap); `committee()` — and therefore `uid` below — only catches up once the
       // async committee fetch resolves. Comparing the two detects the in-between window where
       // engagement()/engagementLoading still reflect the PREVIOUS committee (Cursor Bugbot).
+      // Vanity URLs keep a slug in the route while `uid` is the UUID (GH #2072).
       routeCommitteeId: this.committeeId(),
       uid: this.committee()?.uid ?? null,
+      ssoGroupName: this.committee()?.sso_group_name ?? null,
       window: this.engagementWindow(),
       // FeatureFlagService.providerReady() — not initialized(), which only confirms user context was
       // applied to the LaunchDarkly client, not that the provider has actually streamed real flag
@@ -1303,6 +1313,7 @@ export class CommitteeViewComponent {
           (a, b) =>
             a.routeCommitteeId === b.routeCommitteeId &&
             a.uid === b.uid &&
+            a.ssoGroupName === b.ssoGroupName &&
             a.window === b.window &&
             a.flagResolved === b.flagResolved &&
             a.enabled === b.enabled &&
@@ -1310,7 +1321,7 @@ export class CommitteeViewComponent {
             a.notEligible === b.notEligible &&
             a.refresh === b.refresh
         ),
-        switchMap(({ routeCommitteeId, uid, window, flagResolved, enabled, roleLoading, notEligible }) => {
+        switchMap(({ routeCommitteeId, uid, ssoGroupName, window, flagResolved, enabled, roleLoading, notEligible }) => {
           // SSR (or an unreachable LaunchDarkly client that never initializes) fails closed to the
           // flag's default and stays that way forever — terminal immediately, no reason to wait.
           if (!isPlatformBrowser(this.platformId)) {
@@ -1335,7 +1346,8 @@ export class CommitteeViewComponent {
           // committee/window data with no loading indicator. Clear immediately (not EMPTY, which
           // would preserve it) and show the skeleton. Distinct from an ordinary same-committee
           // roleLoading refresh below, where the still-valid prior data should keep rendering.
-          if (routeCommitteeId !== uid) {
+          // Vanity slugs must not be treated as a different committee than the loaded UID (GH #2072).
+          if (!committeeRouteIdMatches(routeCommitteeId, { uid, sso_group_name: ssoGroupName ?? undefined })) {
             this.engagementLoading.set(true);
             return of(null);
           }

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -317,7 +317,7 @@ export class CommitteeViewComponent {
     const state = this.meetingCoordinatorState();
     const committee = this.committee();
     // Route param may be a vanity slug while `state.committeeUid` / `committee.uid` are UUIDs
-    // (GH #2072). Compare the loaded committee to the route, then confirm the probe belongs to it.
+    // (GH-2072). Compare the loaded committee to the route, then confirm the probe belongs to it.
     return !committeeRouteIdMatches(this.committeeId(), committee) || state.committeeUid !== committee?.uid || state.loading;
   });
   // Only trusts the resolved grant once meetingCoordinatorState belongs to the CURRENT committee —
@@ -962,7 +962,7 @@ export class CommitteeViewComponent {
           // navigating between groups (e.g. a parent/subgroup link) would otherwise misread a still-
           // loading different group as a silent refresh and skip the retry window (Cursor Bugbot).
           // Vanity `/groups/<slug>` routes keep the slug in the param while `committee.uid` is the
-          // UUID — treat slug and UID as the same committee (GH #2072).
+          // UUID — treat slug and UID as the same committee (GH-2072).
           const isInitialLoad = !committeeRouteIdMatches(committeeId, this.committee());
 
           return this.readCommitteeToleratingPropagation(committeeId, isInitialLoad).pipe(
@@ -1270,10 +1270,10 @@ export class CommitteeViewComponent {
       // on route.paramMap); `committee()` — and therefore `uid` below — only catches up once the
       // async committee fetch resolves. Comparing the two detects the in-between window where
       // engagement()/engagementLoading still reflect the PREVIOUS committee (Cursor Bugbot).
-      // Vanity URLs keep a slug in the route while `uid` is the UUID (GH #2072).
+      // Vanity URLs keep a slug in the route while `uid` is the UUID (GH-2072).
       routeCommitteeId: this.committeeId(),
       uid: this.committee()?.uid ?? null,
-      ssoGroupName: this.committee()?.sso_group_name ?? null,
+      ssoGroupName: this.committee()?.sso_group_name,
       window: this.engagementWindow(),
       // FeatureFlagService.providerReady() — not initialized(), which only confirms user context was
       // applied to the LaunchDarkly client, not that the provider has actually streamed real flag
@@ -1346,8 +1346,8 @@ export class CommitteeViewComponent {
           // committee/window data with no loading indicator. Clear immediately (not EMPTY, which
           // would preserve it) and show the skeleton. Distinct from an ordinary same-committee
           // roleLoading refresh below, where the still-valid prior data should keep rendering.
-          // Vanity slugs must not be treated as a different committee than the loaded UID (GH #2072).
-          if (!committeeRouteIdMatches(routeCommitteeId, { uid, sso_group_name: ssoGroupName ?? undefined })) {
+          // Vanity slugs must not be treated as a different committee than the loaded UID (GH-2072).
+          if (!committeeRouteIdMatches(routeCommitteeId, { uid, sso_group_name: ssoGroupName })) {
             this.engagementLoading.set(true);
             return of(null);
           }

--- a/apps/lfx-one/src/app/shared/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.spec.ts
@@ -1,0 +1,106 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { COMMITTEE_DETAIL_CACHE_TTL_MS } from '@lfx-one/shared/constants';
+import type { Committee, CommitteeMember } from '@lfx-one/shared/interfaces';
+import { of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CommitteeService } from './committee.service';
+
+// Pins the slug↔UID alias contract join/leave/update rely on (GH-2072): a vanity-route load
+// caches under the slug, writes evict by UID, and both keys must drop together.
+describe('CommitteeService detail cache aliases', () => {
+  const UID = '7cad5a8d-19d0-41a4-81a6-043453daf9ee';
+  const SLUG = 'cncf-toc';
+  const COMMITTEE = { uid: UID, sso_group_name: SLUG } as unknown as Committee;
+
+  let service: CommitteeService;
+  let http: {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    http = { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() };
+    http.get.mockReturnValue(of(COMMITTEE));
+    TestBed.configureTestingModule({ providers: [{ provide: HttpClient, useValue: http }] });
+    service = TestBed.inject(CommitteeService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('shares one request between a slug load and a later UID load within the TTL', () => {
+    service.getCommitteeDetail(SLUG).subscribe();
+    service.getCommitteeDetail(UID).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(http.get).toHaveBeenCalledWith(`/api/committees/${SLUG}`);
+  });
+
+  it('hits the slug alias when the next read uses a different case', () => {
+    service.getCommitteeDetail(SLUG).subscribe();
+    service.getCommitteeDetail('CNCF-TOC').subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the slug key when leaveCommittee writes by UID', () => {
+    http.delete.mockReturnValue(of(void 0));
+    service.getCommitteeDetail(SLUG).subscribe();
+    service.leaveCommittee(UID).subscribe();
+    service.getCommitteeDetail(SLUG).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the slug key when joinCommittee writes by UID', () => {
+    http.post.mockReturnValue(of({} as CommitteeMember));
+    service.getCommitteeDetail(SLUG).subscribe();
+    service.joinCommittee(UID).subscribe();
+    service.getCommitteeDetail(SLUG).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the slug key when updateCommittee writes by UID', () => {
+    http.put.mockReturnValue(of(COMMITTEE));
+    service.getCommitteeDetail(SLUG).subscribe();
+    service.updateCommittee(UID, { name: 'Renamed' } as Parameters<CommitteeService['updateCommittee']>[1]).subscribe();
+    service.getCommitteeDetail(SLUG).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('skipCache forces a fresh fetch within the TTL', () => {
+    service.getCommitteeDetail(SLUG).subscribe();
+    service.getCommitteeDetail(SLUG, { skipCache: true }).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches once the TTL has expired', () => {
+    vi.useFakeTimers();
+    service.getCommitteeDetail(SLUG).subscribe();
+    vi.setSystemTime(Date.now() + COMMITTEE_DETAIL_CACHE_TTL_MS);
+    service.getCommitteeDetail(SLUG).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts on error so the next caller retries instead of serving the failure', () => {
+    http.get.mockReturnValueOnce(throwError(() => new Error('boom')));
+    service.getCommitteeDetail(SLUG).subscribe({ error: vi.fn() });
+    service.getCommitteeDetail(SLUG).subscribe();
+
+    expect(http.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -129,23 +129,31 @@ export class CommitteeService {
    * enrichment) twice on every edit-page load. Probe-friendly: no `committee` signal
    * side-effect. Entries evict on error and on write (updateCommittee/updateCommitteePermissions/
    * deleteCommittee and the membership-changing writes: join/leave, member CRUD, application
-   * approve). Pass `skipCache` to force a fresh fetch when a caller needs enrichment that
-   * a cached payload may predate — including polls that wait for a just-written membership change
-   * to propagate (a cached pre-write payload would otherwise replay through the whole poll
-   * window). `skipCache` replaces the cache entry with the new `request$`
-   * rather than invalidating — callers already subscribed to the prior `shareReplay(1)`
+   * approve). Vanity `/groups/<slug>` loads cache under the route slug; writes key by UID —
+   * both keys (and a lowercased slug) alias the same entry so a UID eviction cannot leave a
+   * stale slug payload for the next refresh (GH-2072). Pass `skipCache` to force a fresh fetch
+   * when a caller needs enrichment that a cached payload may predate — including polls that wait
+   * for a just-written membership change to propagate (a cached pre-write payload would otherwise
+   * replay through the whole poll window). `skipCache` replaces the cache entry with the new
+   * `request$` rather than invalidating — callers already subscribed to the prior `shareReplay(1)`
    * observable continue to completion with the old payload, so racing `skipCache` callers can
    * still observe a stale result. Mirrors MeetingService.getMeetingDetail.
    */
   public getCommitteeDetail(id: string, options?: { skipCache?: boolean }): Observable<Committee> {
-    const cached = this.committeeDetailCache.get(id);
+    const cached = this.lookupCommitteeDetailCache(id);
     if (!options?.skipCache && cached && Date.now() - cached.cachedAt < COMMITTEE_DETAIL_CACHE_TTL_MS) {
       return cached.observable;
     }
     if (cached) {
-      this.committeeDetailCache.delete(id);
+      this.evictCommitteeDetailCache(id);
     }
-    const request$ = this.http.get<Committee>(`/api/committees/${id}`).pipe(tap({ error: () => this.committeeDetailCache.delete(id) }), shareReplay(1));
+    const request$ = this.http.get<Committee>(`/api/committees/${id}`).pipe(
+      tap({
+        next: (committee) => this.aliasCommitteeDetailCache(id, committee),
+        error: () => this.evictCommitteeDetailCache(id),
+      }),
+      shareReplay(1)
+    );
     this.pruneExpiredCommitteeDetailCache();
     this.committeeDetailCache.set(id, { observable: request$, cachedAt: Date.now() });
     return request$;
@@ -154,7 +162,7 @@ export class CommitteeService {
   public deleteCommittee(id: string): Observable<void> {
     return this.http.delete<void>(`/api/committees/${id}`).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(id))
+      tap(() => this.evictCommitteeDetailCache(id))
     );
   }
 
@@ -168,7 +176,7 @@ export class CommitteeService {
   public updateCommittee(id: string, committee: CommitteeUpdateData & Pick<CommitteeSettingsData, 'chat_webhook_url'>): Observable<Committee> {
     return this.http.put<Committee>(`/api/committees/${id}`, committee).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(id))
+      tap(() => this.evictCommitteeDetailCache(id))
     );
   }
 
@@ -176,7 +184,7 @@ export class CommitteeService {
   public updateCommitteePermissions(committeeId: string, writers: CommitteeUser[], auditors: CommitteeUser[]): Observable<Committee> {
     return this.http.put<Committee>(`/api/committees/${committeeId}`, { writers, auditors }).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
@@ -219,21 +227,21 @@ export class CommitteeService {
 
     return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData, { params }).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
   public updateCommitteeMember(committeeId: string, memberId: string, memberData: Partial<CreateCommitteeMemberRequest>): Observable<CommitteeMember> {
     return this.http.put<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`, memberData).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
   public deleteCommitteeMember(committeeId: string, memberId: string): Observable<void> {
     return this.http.delete<void>(`/api/committees/${committeeId}/members/${memberId}`).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
@@ -264,7 +272,7 @@ export class CommitteeService {
     const body = organization ? { organization } : {};
     return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, body).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
@@ -272,7 +280,7 @@ export class CommitteeService {
   public leaveCommittee(committeeId: string): Observable<void> {
     return this.http.delete<void>(`/api/committees/${committeeId}/leave`).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
@@ -291,7 +299,7 @@ export class CommitteeService {
   public approveApplication(committeeId: string, applicationId: string, body?: ApproveCommitteeJoinApplicationRequest): Observable<CommitteeMember> {
     return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/applications/${applicationId}/approve`, { notify: true, ...body }).pipe(
       take(1),
-      tap(() => this.committeeDetailCache.delete(committeeId))
+      tap(() => this.evictCommitteeDetailCache(committeeId))
     );
   }
 
@@ -408,6 +416,54 @@ export class CommitteeService {
       params = params.set('project_uid', projectUid);
     }
     return this.http.get<string[]>('/api/committees/my-committee-uids', { params }).pipe(catchError(() => of([])));
+  }
+
+  private lookupCommitteeDetailCache(id: string): { observable: Observable<Committee>; cachedAt: number } | undefined {
+    const exact = this.committeeDetailCache.get(id);
+    if (exact) {
+      return exact;
+    }
+    const lower = id.toLowerCase();
+    return lower === id ? undefined : this.committeeDetailCache.get(lower);
+  }
+
+  /**
+   * Points the UID and vanity slug at the same cache entry as `requestId` so a later write
+   * that only knows the UID still evicts the slug-keyed load (GH-2072).
+   */
+  private aliasCommitteeDetailCache(requestId: string, committee: Committee): void {
+    const entry = this.committeeDetailCache.get(requestId);
+    if (!entry) {
+      return;
+    }
+    this.committeeDetailCache.set(committee.uid, entry);
+    const slug = committee.sso_group_name?.trim();
+    if (!slug) {
+      return;
+    }
+    this.committeeDetailCache.set(slug, entry);
+    const lower = slug.toLowerCase();
+    if (lower !== slug) {
+      this.committeeDetailCache.set(lower, entry);
+    }
+  }
+
+  /**
+   * Drops every cache key that aliases the same in-flight/cached detail observable —
+   * the route slug and the UID must evict together so a write keyed by UID cannot leave a
+   * stale slug entry for the next refresh (GH-2072).
+   */
+  private evictCommitteeDetailCache(id: string): void {
+    const entry = this.lookupCommitteeDetailCache(id);
+    if (!entry) {
+      this.committeeDetailCache.delete(id);
+      return;
+    }
+    for (const [key, value] of this.committeeDetailCache) {
+      if (value.observable === entry.observable) {
+        this.committeeDetailCache.delete(key);
+      }
+    }
   }
 
   private pruneExpiredCommitteeDetailCache(): void {

--- a/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
@@ -15,6 +15,7 @@ const { getEffectiveEmailMock, committeeSvc } = vi.hoisted(() => ({
     // Stub remaining methods so the constructor doesn't fail.
     getCommittees: vi.fn(),
     getCommitteeById: vi.fn(),
+    resolveCommitteeUid: vi.fn((_req: unknown, id: string) => Promise.resolve(id)),
     getCommitteeSettings: vi.fn(),
     getPendingCommitteeInvites: vi.fn(),
     acceptPendingCommitteeInvitesAfterLfidAccept: vi.fn(),
@@ -242,5 +243,39 @@ describe('CommitteeController.getCommitteeCalendar', () => {
     expect(next).not.toHaveBeenCalled();
     expect(buildVCalendar).toHaveBeenCalledWith(expect.anything(), expect.any(String), undefined);
     expect(res.send).toHaveBeenCalled();
+  });
+});
+
+describe('CommitteeController.getCommitteeById — vanity slug resolution (GH #2072)', () => {
+  let controller: CommitteeController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new CommitteeController();
+    committeeSvc.resolveCommitteeUid.mockImplementation((_req: unknown, id: string) => Promise.resolve(id));
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_ID, category: 'Working Group' });
+  });
+
+  it('resolves the route param to a UID before fetching the committee', async () => {
+    committeeSvc.resolveCommitteeUid.mockResolvedValueOnce(COMMITTEE_ID);
+    const req = buildReq();
+    req.params.id = 'cncf-toc';
+    const res = { json: vi.fn() };
+    const next = vi.fn();
+
+    await controller.getCommitteeById(req, res as any, next);
+
+    expect(committeeSvc.resolveCommitteeUid).toHaveBeenCalledWith(
+      req,
+      'cncf-toc',
+      expect.objectContaining({ operation: 'get_committee_by_id', service: 'committee_controller' })
+    );
+    expect(committeeSvc.getCommitteeById).toHaveBeenCalledWith(
+      req,
+      COMMITTEE_ID,
+      expect.objectContaining({ includeMembership: true, includeProjectMetadata: true })
+    );
+    expect(res.json).toHaveBeenCalledWith({ uid: COMMITTEE_ID, category: 'Working Group' });
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
@@ -246,7 +246,7 @@ describe('CommitteeController.getCommitteeCalendar', () => {
   });
 });
 
-describe('CommitteeController.getCommitteeById — vanity slug resolution (GH #2072)', () => {
+describe('CommitteeController.getCommitteeById — vanity slug resolution (GH-2072)', () => {
   let controller: CommitteeController;
 
   beforeEach(() => {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -174,7 +174,7 @@ export class CommitteeController {
 
       // Vanity `/groups/<sso_group_name>` URLs land here with a slug, not a UID. Resolve first so
       // Heimdall's `committee:{uid}#viewer` check hits the object that actually has tuples
-      // (GH #2072). UUIDs pass through unchanged.
+      // (GH-2072). UUIDs pass through unchanged.
       const committeeUid = await this.committeeService.resolveCommitteeUid(req, id, {
         operation: 'get_committee_by_id',
         service: 'committee_controller',

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -172,6 +172,15 @@ export class CommitteeController {
         return;
       }
 
+      // Vanity `/groups/<sso_group_name>` URLs land here with a slug, not a UID. Resolve first so
+      // Heimdall's `committee:{uid}#viewer` check hits the object that actually has tuples
+      // (GH #2072). UUIDs pass through unchanged.
+      const committeeUid = await this.committeeService.resolveCommitteeUid(req, id, {
+        operation: 'get_committee_by_id',
+        service: 'committee_controller',
+        path: req.path,
+      });
+
       // Get the committee by ID — include caller membership so the UI can render
       // visitor / member / chair states without a second round-trip, enrich with
       // project metadata so the detail page's Parent Project link can resolve project_uid
@@ -179,7 +188,7 @@ export class CommitteeController {
       // so the members roster can label foundation-level managers correctly (LFXV2-2059),
       // and include mailing-list status (upstream does not reliably populate
       // has_mailing_list on this endpoint — LFXV2-2914).
-      const committee = await this.committeeService.getCommitteeById(req, id, {
+      const committee = await this.committeeService.getCommitteeById(req, committeeUid, {
         includeMembership: true,
         includeProjectMetadata: true,
         includeInheritedPermissions: true,
@@ -188,7 +197,7 @@ export class CommitteeController {
 
       // Log the success
       logger.success(req, 'get_committee_by_id', startTime, {
-        committee_id: id,
+        committee_id: committeeUid,
         committee_category: committee.category,
       });
 

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CHAIR_ROLES, UUID_REGEX } from '@lfx-one/shared/constants';
+import { CHAIR_ROLES } from '@lfx-one/shared/constants';
 import { CommitteeMemberVisibility, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   Committee,
@@ -50,23 +50,12 @@ export class PublicGroupsController {
       const m2mToken = await generateM2MToken(req);
       req.bearerToken = m2mToken;
 
-      let committeeUid = id;
-      if (!UUID_REGEX.test(id)) {
-        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          type: 'committee',
-          tags: `sso_group_name:${id.toLowerCase()}`,
-          page_size: 1,
-        });
-        if (resources.length === 0) {
-          throw new ResourceNotFoundError('Group', id, {
-            operation: 'get_public_group_by_id',
-            service: 'public_groups_controller',
-            path: `/groups/${id}`,
-          });
-        }
-        committeeUid = resources[0].data.uid;
-        logger.debug(req, 'get_public_group_by_id', 'Resolved group slug to UID', { slug: id, group_uid: committeeUid });
-      }
+      const committeeUid = await this.committeeService.resolveCommitteeUid(req, id, {
+        operation: 'get_public_group_by_id',
+        service: 'public_groups_controller',
+        path: `/groups/${id}`,
+        resourceType: 'Group',
+      });
 
       const committee = await this.committeeService.getCommitteeById(req, committeeUid);
 

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -40,11 +40,16 @@ vi.mock('@lfx-one/shared/enums', () => ({
   CommitteeMemberVisibility: { HIDDEN: 'hidden', BASIC_PROFILE: 'basic_profile' },
 }));
 vi.mock('@lfx-one/shared/utils', () => ({ invitationRequiresOrganization: vi.fn() }));
-vi.mock('@lfx-one/shared/constants', () => ({
-  SLACK_INCOMING_WEBHOOK_URL_PATTERN: /^https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]+$/,
-  CHAT_WEBHOOK_URL_MAX_LENGTH: 500,
-  UUID_REGEX: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-}));
+vi.mock('@lfx-one/shared/constants', async () => {
+  const regex = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/regex.constants')>(
+    '../../../../../packages/shared/src/constants/regex.constants'
+  );
+  return {
+    SLACK_INCOMING_WEBHOOK_URL_PATTERN: /^https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]+$/,
+    CHAT_WEBHOOK_URL_MAX_LENGTH: 500,
+    UUID_REGEX: regex.UUID_REGEX,
+  };
+});
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
     public proxyRequest = proxyRequest;
@@ -423,6 +428,7 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
     });
 
     it('resolves a vanity slug via sso_group_name tag lookup and lowercases the slug', async () => {
+      vi.mocked(logger.debug).mockClear();
       proxyRequest.mockResolvedValueOnce(pageOf([{ uid: COMMITTEE_UUID }]));
 
       const result = await service.resolveCommitteeUid(req, 'My-Group-Slug');
@@ -435,6 +441,12 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
         tags: 'sso_group_name:my-group-slug',
         page_size: 1,
       });
+      expect(logger.debug).toHaveBeenCalledWith(
+        req,
+        'resolve_committee_uid',
+        'Resolved slug to UID',
+        expect.objectContaining({ slug: 'My-Group-Slug', committee_uid: COMMITTEE_UUID })
+      );
     });
 
     it('throws ResourceNotFoundError when the slug matches no committee the caller can see', async () => {

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -43,6 +43,7 @@ vi.mock('@lfx-one/shared/utils', () => ({ invitationRequiresOrganization: vi.fn(
 vi.mock('@lfx-one/shared/constants', () => ({
   SLACK_INCOMING_WEBHOOK_URL_PATTERN: /^https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]+$/,
   CHAT_WEBHOOK_URL_MAX_LENGTH: 500,
+  UUID_REGEX: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
 }));
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
@@ -408,6 +409,57 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
 
       expect('chat_webhook_url' in result).toBe(false);
       expect(result.project_slug).toBe('test-project');
+    });
+  });
+
+  describe('resolveCommitteeUid', () => {
+    const COMMITTEE_UUID = '7cad5a8d-19d0-41a4-81a6-043453daf9ee';
+
+    it('returns a UUID unchanged without querying', async () => {
+      const result = await service.resolveCommitteeUid(req, COMMITTEE_UUID);
+
+      expect(result).toBe(COMMITTEE_UUID);
+      expect(proxyRequest).not.toHaveBeenCalled();
+    });
+
+    it('resolves a vanity slug via sso_group_name tag lookup and lowercases the slug', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: COMMITTEE_UUID }]));
+
+      const result = await service.resolveCommitteeUid(req, 'My-Group-Slug');
+
+      expect(result).toBe(COMMITTEE_UUID);
+      expect(proxyRequest).toHaveBeenCalledOnce();
+      expect(proxyRequest.mock.calls[0][2]).toBe('/query/resources');
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({
+        type: 'committee',
+        tags: 'sso_group_name:my-group-slug',
+        page_size: 1,
+      });
+    });
+
+    it('throws ResourceNotFoundError when the slug matches no committee the caller can see', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([]));
+
+      await expect(service.resolveCommitteeUid(req, 'missing-group')).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Committee with ID 'missing-group' not found",
+      });
+    });
+
+    it('uses resourceType Group when the public group path asks for it', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([]));
+
+      await expect(
+        service.resolveCommitteeUid(req, 'missing-group', {
+          operation: 'get_public_group_by_id',
+          service: 'public_groups_controller',
+          path: '/groups/missing-group',
+          resourceType: 'Group',
+        })
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Group with ID 'missing-group' not found",
+      });
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CHAT_WEBHOOK_URL_MAX_LENGTH, SLACK_INCOMING_WEBHOOK_URL_PATTERN } from '@lfx-one/shared/constants';
+import { CHAT_WEBHOOK_URL_MAX_LENGTH, SLACK_INCOMING_WEBHOOK_URL_PATTERN, UUID_REGEX } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole } from '@lfx-one/shared/enums';
 import {
   AcceptCommitteeInviteRequest,
@@ -316,6 +316,45 @@ export class CommitteeService {
     }
 
     return permitted.slice(0, pageSize).map((c) => this.stripChatWebhookUrl(c));
+  }
+
+  /**
+   * Resolves a committee route param to a UID. UUIDs pass through; anything else is treated as an
+   * `sso_group_name` vanity slug and looked up via query-service (same tag the public group page
+   * uses — GH #2072 / LFXV2-2012). Uses the caller's bearer token so FGA filtering applies: a
+   * project admin who is not a group member still sees committees they can view, and a private
+   * group they cannot view resolves as not found rather than leaking existence.
+   *
+   * Must run before proxying `GET /committees/{uid}` — Heimdall authorizes `committee:{id}#viewer`
+   * using the path capture, and every FGA tuple is keyed by UID, not slug.
+   */
+  public async resolveCommitteeUid(
+    req: Request,
+    id: string,
+    options: { operation?: string; service?: string; path?: string; resourceType?: string } = {}
+  ): Promise<string> {
+    const operation = options.operation ?? 'resolve_committee_uid';
+    const service = options.service ?? 'committee_service';
+    const resourceType = options.resourceType ?? 'Committee';
+    const path = options.path ?? `/committees/${id}`;
+
+    if (UUID_REGEX.test(id)) {
+      return id;
+    }
+
+    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+      type: 'committee',
+      tags: `sso_group_name:${id.toLowerCase()}`,
+      page_size: 1,
+    });
+
+    const committeeUid = resources[0]?.data?.uid;
+    if (!committeeUid) {
+      throw new ResourceNotFoundError(resourceType, id, { operation, service, path });
+    }
+
+    logger.debug(req, operation, 'Resolved group slug to UID', { slug: id, group_uid: committeeUid });
+    return committeeUid;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -321,12 +321,22 @@ export class CommitteeService {
   /**
    * Resolves a committee route param to a UID. UUIDs pass through; anything else is treated as an
    * `sso_group_name` vanity slug and looked up via query-service (same tag the public group page
-   * uses — GH #2072 / LFXV2-2012). Uses the caller's bearer token so FGA filtering applies: a
-   * project admin who is not a group member still sees committees they can view, and a private
-   * group they cannot view resolves as not found rather than leaking existence.
+   * uses — GH-2072 / LFXV2-2012).
+   *
+   * Authorization depends on the caller's `req.bearerToken`:
+   * - Authenticated `GET /api/committees/:id` keeps the user token, so query-service FGA filtering
+   *   applies. A project admin who is not a group member still sees committees they can view; a
+   *   private group they cannot view resolves as not found rather than leaking existence.
+   * - Public `GET /public/api/groups/:id` swaps in an M2M token before calling this; privacy is
+   *   enforced afterwards by rejecting `!committee.public`.
    *
    * Must run before proxying `GET /committees/{uid}` — Heimdall authorizes `committee:{id}#viewer`
    * using the path capture, and every FGA tuple is keyed by UID, not slug.
+   *
+   * @param options.operation Logger / error operation name (defaults to `resolve_committee_uid`)
+   * @param options.service Error `service` field (defaults to `committee_service`)
+   * @param options.path Error `path` field (defaults to `/committees/${id}`)
+   * @param options.resourceType Not-found resource label (defaults to `Committee`; public groups pass `Group`)
    */
   public async resolveCommitteeUid(
     req: Request,
@@ -353,7 +363,7 @@ export class CommitteeService {
       throw new ResourceNotFoundError(resourceType, id, { operation, service, path });
     }
 
-    logger.debug(req, operation, 'Resolved group slug to UID', { slug: id, group_uid: committeeUid });
+    logger.debug(req, operation, 'Resolved slug to UID', { slug: id, committee_uid: committeeUid });
     return committeeUid;
   }
 
@@ -1075,6 +1085,7 @@ export class CommitteeService {
         project_name?: string | null;
         project_slug?: string | null;
         is_foundation?: boolean | null;
+        sso_group_name?: string | null;
       }
     >();
 
@@ -1095,6 +1106,7 @@ export class CommitteeService {
             // consumers treat it as "no slug", never as an empty-string slug.
             project_slug: enrichedCommittee?.project_slug || null,
             is_foundation: enrichedCommittee?.is_foundation ?? null,
+            sso_group_name: committee.sso_group_name || null,
           });
         }
       }
@@ -1117,6 +1129,7 @@ export class CommitteeService {
         project_name: context?.project_name ?? null,
         project_slug: context?.project_slug ?? null,
         is_foundation: context?.is_foundation ?? null,
+        sso_group_name: context?.sso_group_name ?? null,
         category: context?.category ?? null,
         role: invite.role ?? null,
         invitee_email: invite.invitee_email,

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -138,6 +138,8 @@ export interface PendingInvitation {
   project_slug?: string | null;
   /** Whether the owning project is a foundation — enriched (optional); drives the `/foundation` vs `/project` tier prefix on the view link. Null/absent means tier unknown → callers keep the flat `/groups/:uid` fallback (GH-1566). */
   is_foundation?: boolean | null;
+  /** Vanity SSO group slug — enriched (optional); used to match `/groups/<slug>` invite banners (GH-2072). */
+  sso_group_name?: string | null;
   /** Committee category, for the My Groups class badge (optional) */
   category?: string | null;
   /** Suggested role on acceptance (from the invite) */

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -20,6 +20,7 @@ import {
   buildCommitteeCreateQueryParams,
   buildEngagementStatCards,
   canManageCommitteeMembers,
+  committeeRouteIdMatches,
   countVotingReps,
   groupCommitteesByFoundation,
   resolveCommitteeMemberPermission,
@@ -131,6 +132,29 @@ describe('buildCommitteeCreateQueryParams', () => {
 
   it('omits the project key when the committee has no project slug', () => {
     expect(buildCommitteeCreateQueryParams(committee({ uid: 'cmte-9' }))).toEqual({ committee_uid: 'cmte-9' });
+  });
+});
+
+describe('committeeRouteIdMatches', () => {
+  const uid = '7cad5a8d-19d0-41a4-81a6-043453daf9ee';
+
+  it('matches the committee UID', () => {
+    expect(committeeRouteIdMatches(uid, committee({ uid, sso_group_name: 'cncf-toc' }))).toBe(true);
+  });
+
+  it('matches a vanity sso_group_name slug case-insensitively', () => {
+    expect(committeeRouteIdMatches('CNCF-TOC', committee({ uid, sso_group_name: 'cncf-toc' }))).toBe(true);
+  });
+
+  it('does not match a different committee slug or UID', () => {
+    expect(committeeRouteIdMatches('other-group', committee({ uid, sso_group_name: 'cncf-toc' }))).toBe(false);
+    expect(committeeRouteIdMatches('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', committee({ uid, sso_group_name: 'cncf-toc' }))).toBe(false);
+  });
+
+  it('is false when the route id or committee is missing', () => {
+    expect(committeeRouteIdMatches(null, committee({ uid }))).toBe(false);
+    expect(committeeRouteIdMatches(uid, null)).toBe(false);
+    expect(committeeRouteIdMatches('cncf-toc', committee({ uid }))).toBe(false);
   });
 });
 

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -88,6 +88,22 @@ export function getGroupCommands(committee: Pick<Committee, 'uid' | 'is_foundati
 }
 
 /**
+ * True when a `/groups/:id` (or lens-prefixed) route param names this committee — either by UID
+ * or by vanity `sso_group_name` slug (case-insensitive). Authenticated vanity URLs keep the slug
+ * in the route while the loaded payload carries the UID (GH #2072).
+ */
+export function committeeRouteIdMatches(routeId: string | null | undefined, committee: Pick<Committee, 'uid' | 'sso_group_name'> | null | undefined): boolean {
+  if (!routeId || !committee?.uid) {
+    return false;
+  }
+  if (committee.uid === routeId) {
+    return true;
+  }
+  const slug = committee.sso_group_name;
+  return !!slug && slug.toLowerCase() === routeId.toLowerCase();
+}
+
+/**
  * Build the query params used when navigating to create a vote or survey for a committee.
  * Always includes `committee_uid`; includes `project` only when the committee carries a project slug.
  */

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -90,9 +90,12 @@ export function getGroupCommands(committee: Pick<Committee, 'uid' | 'is_foundati
 /**
  * True when a `/groups/:id` (or lens-prefixed) route param names this committee — either by UID
  * or by vanity `sso_group_name` slug (case-insensitive). Authenticated vanity URLs keep the slug
- * in the route while the loaded payload carries the UID (GH #2072).
+ * in the route while the loaded payload carries the UID (GH-2072).
  */
-export function committeeRouteIdMatches(routeId: string | null | undefined, committee: Pick<Committee, 'uid' | 'sso_group_name'> | null | undefined): boolean {
+export function committeeRouteIdMatches(
+  routeId: string | null | undefined,
+  committee: (Pick<Committee, 'uid'> & { sso_group_name?: string | null }) | null | undefined
+): boolean {
   if (!routeId || !committee?.uid) {
     return false;
   }

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -290,8 +290,14 @@ describe('findPendingInvitationForCommittee', () => {
     expect(findPendingInvitationForCommittee(invites, new Set(), undefined)).toBeNull();
   });
 
-  it('excludes an invite already resolved this session', () => {
-    expect(findPendingInvitationForCommittee(invites, new Set(['i1']), 'c1')).toBeNull();
+  it('matches a vanity sso_group_name slug case-insensitively (GH-2072)', () => {
+    const invites = [invitation({ uid: 'i1', committee_uid: 'c1', sso_group_name: 'cncf-toc' })];
+    expect(findPendingInvitationForCommittee(invites, new Set(), 'CNCF-TOC')?.uid).toBe('i1');
+  });
+
+  it('does not match a slug against a different committee', () => {
+    const invites = [invitation({ uid: 'i1', committee_uid: 'c1', sso_group_name: 'cncf-toc' })];
+    expect(findPendingInvitationForCommittee(invites, new Set(), 'other-group')).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -5,6 +5,7 @@ import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_SEVERITY } from '../constant
 import { PendingActionItem } from '../interfaces/components.interface';
 import type { CommitteeOrganizationFormValue, CommitteeOrganizationReference, PendingInvitation } from '../interfaces/committee.interface';
 import type { WorkExperienceEntry } from '../interfaces/profile.interface';
+import { committeeRouteIdMatches } from './committee.utils';
 
 /**
  * Returns true when a committee requires organization on invite create/accept.
@@ -161,18 +162,23 @@ export function buildInvitationActions(invitations: PendingInvitation[]): Pendin
  *
  * Shared by the group-detail invite banner: it matches the shared invitation cache against the
  * committee being viewed, excluding any invite already accepted/declined this session (so the banner
- * disappears the moment the user acts, in sync with the other surfaces). Returns null when there is
- * no committee UID or no matching pending invite.
+ * disappears the moment the user acts, in sync with the other surfaces). `committeeId` may be a UID
+ * or a vanity `sso_group_name` slug (GH-2072). Returns null when there is no committee id or no
+ * matching pending invite.
  */
 export function findPendingInvitationForCommittee(
   invitations: PendingInvitation[],
   resolvedUids: ReadonlySet<string>,
-  committeeUid: string | null | undefined
+  committeeId: string | null | undefined
 ): PendingInvitation | null {
-  if (!committeeUid) {
+  if (!committeeId) {
     return null;
   }
-  return invitations.find((invite) => invite.committee_uid === committeeUid && !resolvedUids.has(invite.uid)) ?? null;
+  return (
+    invitations.find(
+      (invite) => !resolvedUids.has(invite.uid) && committeeRouteIdMatches(committeeId, { uid: invite.committee_uid, sso_group_name: invite.sso_group_name })
+    ) ?? null
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes authenticated `/groups/<sso_group_name>` links denying project admins who are not group members ([#2072](https://github.com/linuxfoundation/lfx-self-serve/issues/2072)).
- Resolves vanity slugs to a committee UID on `GET /api/committees/:id` before the Heimdall `committee:{uid}#viewer` check, reusing the same lookup the public group page already had.
- Treats slug and UID as the same committee in committee-view so engagement, join, and the access-retry window do not treat the loaded page as a navigation away.

## Test plan
- [ ] As a project admin who is **not** a member of the group, open `/groups/<sso_group_name>` and confirm the authenticated group page loads (no "Finalizing your access" → "We couldn't load this group").
- [ ] Confirm the same group still loads via `/foundation/groups/<uid>?project=<slug>` (or `/project/groups/<uid>?project=<slug>`).
- [ ] As an anonymous visitor, confirm a public group's vanity URL still loads.
- [ ] Open a group via UID (`/groups/<uid>`) and confirm that path is unchanged.

Fixes #2072


Made with [Cursor](https://cursor.com)