### PR TITLE
feat: add committee charter card

### DIFF
--- a/apps/lfx-one/e2e/committee-about-tab.spec.ts
+++ b/apps/lfx-one/e2e/committee-about-tab.spec.ts
@@ -137,6 +137,102 @@ test.describe('Group About tab (LFXV2-1713)', () => {
     await expect(page.getByRole('dialog')).toContainText('Edit Description');
   });
 
+  // These two exercise the actual editCharterRequested -> openEditCharter -> saveCharter wiring
+  // through committee-view (unit-tested in isolation on the card and the dialog separately, but
+  // not through this binding -- the PUT payload, the post-save refresh, and the no-op guard on an
+  // unchanged value all live in committee-view, which has no spec file of its own; see
+  // committee-view.component.ts:554-564's no-op guard comment).
+  test('admin (canEdit): adding a charter PUTs { charter: { url } }, refreshes, and shows the link with attribution', async ({ page }) => {
+    const charterUrl = 'https://example.org/e2e-charter.pdf';
+    let committeeState = baseCommittee({ my_role: 'Chair', writer: true });
+    await mockCommitteeApis(page, { committee: committeeState });
+
+    // Override the plain GET-only route registered above: PUT mutates the closed-over state and
+    // returns it, the subsequent GET (fired by saveCharter's refreshCommittee()) reads it back --
+    // mirrors the org-profile.spec.ts "S3: edit + save" stubbed-PUT pattern.
+    let putBody: unknown = null;
+    await page.route(`**/api/committees/${COMMITTEE_UID}`, (route) => {
+      const method = route.request().method();
+      if (method === 'PUT') {
+        putBody = route.request().postDataJSON();
+        committeeState = {
+          ...committeeState,
+          charter: { url: charterUrl, version: 1, updated_at: '2026-09-07T00:00:00Z', updated_by: { name: 'E2E Tester', username: 'e2e-tester', email: 'e2e@example.org' } },
+        };
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeState) });
+      }
+      if (method === 'GET') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeState) });
+      }
+      return route.fallback();
+    });
+
+    await gotoCommitteeTab(page);
+    await expect(page.getByTestId('committee-about')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('committee-about-charter-empty')).toBeVisible();
+
+    await page.getByTestId('committee-about-edit-charter-btn').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Add Charter');
+
+    await page.locator('[data-test="committee-view-charter-input"]').fill(charterUrl);
+    await page.getByTestId('charter-dialog-save').click();
+
+    await expect(dialog).toHaveCount(0);
+    await expect(page.locator('.p-toast')).toContainText('Charter updated');
+    await expect.poll(() => putBody).toEqual({ charter: { url: charterUrl } });
+
+    const link = page.getByTestId('committee-about-charter-link');
+    await expect(link).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(link).toHaveAttribute('href', charterUrl);
+    await expect(page.getByTestId('committee-about-charter-updated-by')).toContainText('Last updated by E2E Tester');
+  });
+
+  test('admin (canEdit): saving the charter dialog dirty-but-unchanged is a no-op -- no PUT, no toast', async ({ page }) => {
+    const existingUrl = 'https://example.org/existing-charter.pdf';
+    await mockCommitteeApis(page, {
+      committee: baseCommittee({
+        my_role: 'Chair',
+        writer: true,
+        charter: { url: existingUrl, version: 3, updated_at: '2026-08-01T00:00:00Z', updated_by: { name: 'Prior Editor', username: 'prior', email: 'prior@example.org' } },
+      }),
+    });
+
+    let putCalled = false;
+    await page.route(`**/api/committees/${COMMITTEE_UID}`, (route) => {
+      if (route.request().method() === 'PUT') {
+        putCalled = true;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      }
+      return route.fallback();
+    });
+
+    await gotoCommitteeTab(page);
+    await expect(page.getByTestId('committee-about-charter-link')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('committee-about-edit-charter-btn').click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Edit Charter');
+
+    const input = page.locator('[data-test="committee-view-charter-input"]');
+    await expect(input).toHaveValue(existingUrl);
+    // Dirty the control without changing its final value -- FormControl.dirty latches true on
+    // any edit and never resets on its own, independent of whether the value ends up matching
+    // the original. This is exactly the case saveCharter()'s no-op guard exists for.
+    await input.fill(`${existingUrl}/`);
+    await input.fill(existingUrl);
+    await expect(page.getByTestId('charter-dialog-save')).toBeEnabled();
+
+    await page.getByTestId('charter-dialog-save').click();
+    await expect(dialog).toHaveCount(0);
+
+    await page.waitForTimeout(300);
+    expect(putCalled).toBe(false);
+    await expect(page.locator('.p-toast')).not.toBeVisible();
+  });
+
   test('?tab=about deep-links directly into the About tab', async ({ page }) => {
     await mockCommitteeApis(page, { committee: baseCommittee({ my_role: null, writer: false }) });
     await gotoCommitteeTab(page, '?tab=about');

--- a/apps/lfx-one/e2e/committee-about-tab.spec.ts
+++ b/apps/lfx-one/e2e/committee-about-tab.spec.ts
@@ -161,7 +161,7 @@ test.describe('Group About tab (LFXV2-1713)', () => {
             url: charterUrl,
             version: 1,
             updated_at: '2026-09-07T00:00:00Z',
-            updated_by: { name: 'E2E Tester', username: 'e2e-tester', email: 'e2e@example.org' },
+            updated_by: { name: 'E2E Tester', username: 'e2e-tester' },
           },
         };
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeState) });
@@ -204,7 +204,7 @@ test.describe('Group About tab (LFXV2-1713)', () => {
           url: existingUrl,
           version: 3,
           updated_at: '2026-08-01T00:00:00Z',
-          updated_by: { name: 'Prior Editor', username: 'prior', email: 'prior@example.org' },
+          updated_by: { name: 'Prior Editor', username: 'prior' },
         },
       }),
     });

--- a/apps/lfx-one/e2e/committee-about-tab.spec.ts
+++ b/apps/lfx-one/e2e/committee-about-tab.spec.ts
@@ -157,7 +157,12 @@ test.describe('Group About tab (LFXV2-1713)', () => {
         putBody = route.request().postDataJSON();
         committeeState = {
           ...committeeState,
-          charter: { url: charterUrl, version: 1, updated_at: '2026-09-07T00:00:00Z', updated_by: { name: 'E2E Tester', username: 'e2e-tester', email: 'e2e@example.org' } },
+          charter: {
+            url: charterUrl,
+            version: 1,
+            updated_at: '2026-09-07T00:00:00Z',
+            updated_by: { name: 'E2E Tester', username: 'e2e-tester', email: 'e2e@example.org' },
+          },
         };
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeState) });
       }
@@ -195,7 +200,12 @@ test.describe('Group About tab (LFXV2-1713)', () => {
       committee: baseCommittee({
         my_role: 'Chair',
         writer: true,
-        charter: { url: existingUrl, version: 3, updated_at: '2026-08-01T00:00:00Z', updated_by: { name: 'Prior Editor', username: 'prior', email: 'prior@example.org' } },
+        charter: {
+          url: existingUrl,
+          version: 3,
+          updated_at: '2026-08-01T00:00:00Z',
+          updated_by: { name: 'Prior Editor', username: 'prior', email: 'prior@example.org' },
+        },
       }),
     });
 

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -423,6 +423,7 @@
             [meetingsLoading]="meetingsLoading()"
             (joinRequested)="handleJoinRequest()"
             (editDescriptionRequested)="openEditDescription()"
+            (editCharterRequested)="openEditCharter()"
             (parentProjectNavigationRequested)="navigateToParentProject()"
             (parentGroupNavigationRequested)="navigateToParentGroup()"
             (subGroupNavigationRequested)="navigateToSubGroup($event)" />

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -556,6 +556,12 @@ export class CommitteeViewComponent {
     if (!committee) {
       return;
     }
+    // Guard against stamping a removal when there was nothing to remove: an empty save against a
+    // charter that was never set would otherwise still write `{ url: '' }`, flipping the About
+    // card from "never set" to "set, then removed" for no reason.
+    if (url === (committee.charter?.url ?? '')) {
+      return;
+    }
     this.committeeService.updateCommittee(committee.uid, { charter: { url } }).subscribe({
       next: () => {
         this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Charter updated' });

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -62,6 +62,7 @@ import { CategoryAvatarColorPipe } from '@pipes/category-avatar-color.pipe';
 import { InitialsPipe } from '@pipes/initials.pipe';
 import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
 import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
+import { CharterDialogComponent } from '../components/charter-dialog/charter-dialog.component';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
 import { MessageService } from 'primeng/api';
 import {
@@ -530,6 +531,38 @@ export class CommitteeViewComponent {
       },
       error: (err: HttpErrorResponse) => {
         this.messageService.add({ severity: 'error', summary: 'Error', detail: getHttpErrorDetail(err, 'Failed to update description. Please try again.') });
+      },
+    });
+  }
+
+  public openEditCharter(): void {
+    const ref = this.dialogService.open(CharterDialogComponent, {
+      header: this.committee()?.charter?.url ? 'Edit Charter' : 'Add Charter',
+      width: '560px',
+      modal: true,
+      closable: true,
+      draggable: false,
+      data: { url: this.committee()?.charter?.url || '' },
+    });
+    ref?.onClose.pipe(take(1)).subscribe((newUrl: string | undefined) => {
+      if (newUrl !== undefined) {
+        this.saveCharter(newUrl);
+      }
+    });
+  }
+
+  public saveCharter(url: string): void {
+    const committee = this.committee();
+    if (!committee) {
+      return;
+    }
+    this.committeeService.updateCommittee(committee.uid, { charter: { url } }).subscribe({
+      next: () => {
+        this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Charter updated' });
+        this.refreshCommittee();
+      },
+      error: (err: HttpErrorResponse) => {
+        this.messageService.add({ severity: 'error', summary: 'Error', detail: getHttpErrorDetail(err, 'Failed to update charter. Please try again.') });
       },
     });
   }

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
@@ -1,0 +1,19 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div data-testid="committee-charter-edit-dialog">
+  <lfx-input-text
+    [form]="charterForm"
+    control="url"
+    type="url"
+    placeholder="https://example.org/charter.pdf"
+    styleClass="!w-full"
+    dataTest="committee-view-charter-input"></lfx-input-text>
+  @if (charterForm.get('url')?.invalid && charterForm.get('url')?.dirty) {
+    <p class="text-xs text-red-600 mt-1" data-testid="committee-charter-url-error">Enter a valid http(s) URL, or leave blank to remove the charter.</p>
+  }
+  <div class="flex justify-end gap-2 mt-4">
+    <lfx-button label="Cancel" severity="secondary" [outlined]="true" size="small" (onClick)="cancel()"></lfx-button>
+    <lfx-button label="Save" severity="info" size="small" (onClick)="save()" [disabled]="!charterForm.dirty || charterForm.invalid"></lfx-button>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
@@ -3,10 +3,14 @@
 
 <div data-testid="committee-charter-edit-dialog">
   <label for="committee-charter-url" class="text-gray-950 block text-sm font-medium mb-2">Charter URL</label>
+  <!-- [id] (bound), not a static id=: a static attribute on a custom element lands on both the
+       <lfx-input-text> host and (via its id input()) the native <input> it renders -- two elements
+       sharing one id, with label[for] resolving to the first (the non-labelable host) in document
+       order. Binding it keeps the id off the host entirely. -->
   <lfx-input-text
     [form]="charterForm"
     control="url"
-    id="committee-charter-url"
+    [id]="'committee-charter-url'"
     type="url"
     placeholder="https://example.org/charter.pdf"
     styleClass="!w-full"

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
@@ -16,7 +16,7 @@
     styleClass="!w-full"
     dataTest="committee-view-charter-input"></lfx-input-text>
   @if (charterForm.get('url')?.invalid && charterForm.get('url')?.dirty) {
-    <p class="text-xs text-red-600 mt-1" data-testid="committee-charter-url-error">
+    <p role="alert" class="text-xs text-red-600 mt-1" data-testid="committee-charter-url-error">
       @if (charterForm.get('url')?.errors?.['maxCodePoints']) {
         URL is too long (max 2,048 characters).
       } @else {

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
@@ -2,18 +2,32 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div data-testid="committee-charter-edit-dialog">
+  <label for="committee-charter-url" class="text-gray-950 block text-sm font-medium mb-2">Charter URL</label>
   <lfx-input-text
     [form]="charterForm"
     control="url"
+    id="committee-charter-url"
     type="url"
     placeholder="https://example.org/charter.pdf"
     styleClass="!w-full"
     dataTest="committee-view-charter-input"></lfx-input-text>
   @if (charterForm.get('url')?.invalid && charterForm.get('url')?.dirty) {
-    <p class="text-xs text-red-600 mt-1" data-testid="committee-charter-url-error">Enter a valid http(s) URL, or leave blank to remove the charter.</p>
+    <p class="text-xs text-red-600 mt-1" data-testid="committee-charter-url-error">
+      @if (charterForm.get('url')?.errors?.['maxlength']) {
+        URL is too long (max 2,048 characters).
+      } @else {
+        Enter a valid http(s) URL, or leave blank to remove the charter.
+      }
+    </p>
   }
   <div class="flex justify-end gap-2 mt-4">
-    <lfx-button label="Cancel" severity="secondary" [outlined]="true" size="small" (onClick)="cancel()"></lfx-button>
-    <lfx-button label="Save" severity="info" size="small" (onClick)="save()" [disabled]="!charterForm.dirty || charterForm.invalid"></lfx-button>
+    <lfx-button label="Cancel" severity="secondary" [outlined]="true" size="small" (onClick)="cancel()" data-testid="charter-dialog-cancel"></lfx-button>
+    <lfx-button
+      label="Save"
+      severity="info"
+      size="small"
+      (onClick)="save()"
+      [disabled]="!charterForm.dirty || charterForm.invalid"
+      data-testid="charter-dialog-save"></lfx-button>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.html
@@ -17,7 +17,7 @@
     dataTest="committee-view-charter-input"></lfx-input-text>
   @if (charterForm.get('url')?.invalid && charterForm.get('url')?.dirty) {
     <p class="text-xs text-red-600 mt-1" data-testid="committee-charter-url-error">
-      @if (charterForm.get('url')?.errors?.['maxlength']) {
+      @if (charterForm.get('url')?.errors?.['maxCodePoints']) {
         URL is too long (max 2,048 characters).
       } @else {
         Enter a valid http(s) URL, or leave blank to remove the charter.

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.spec.ts
@@ -82,6 +82,17 @@ describe('CharterDialogComponent', () => {
     expect(saveButton().disabled).toBe(true);
   });
 
+  it('accepts a URL at the 2,048 code-point limit built from non-BMP characters (would fail Validators.maxLength, which counts UTF-16 units)', async () => {
+    create();
+    // Each 😀 is 1 Unicode code point but 2 UTF-16 code units. 2000 of them + the 20-char prefix
+    // is under 2,048 code points (what the backend's Goa MaxLength(2048) counts) but over 2,048
+    // UTF-16 units (what Validators.maxLength counts) -- exactly the case maxCodePointsValidator
+    // exists to get right.
+    await typeUrl('https://example.org/' + '😀'.repeat(2000));
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-charter-url-error"]')).toBeNull();
+    expect(saveButton().disabled).toBe(false);
+  });
+
   it('treats a blank value as valid regardless of the pattern (the removal signal)', async () => {
     create('https://example.org/charter.pdf');
     await typeUrl('');

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.spec.ts
@@ -53,7 +53,12 @@ describe('CharterDialogComponent', () => {
   it('associates the visible label with the input by id, for accessible-name discovery', () => {
     create();
     const label: HTMLLabelElement = fixture.nativeElement.querySelector('label');
-    expect(label.getAttribute('for')).toBe(urlInput().id);
+    const id = urlInput().id;
+    expect(label.getAttribute('for')).toBe(id);
+    // A static `id=` on `lfx-input-text` lands on both the host and the native input it renders,
+    // so `label[for]` would resolve to the non-labelable host in a real browser -- guard against
+    // that regression by asserting the id is unique in the rendered DOM.
+    expect(fixture.nativeElement.querySelectorAll(`#${id}`).length).toBe(1);
   });
 
   it('accepts a contract-valid bare-host URL with no dot (matches the backend pattern, unlike the general website field)', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.spec.ts
@@ -1,0 +1,100 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CharterDialogComponent } from './charter-dialog.component';
+
+/**
+ * Covers the URL validator mirroring the backend's charterURLPattern/MaxLength(2048) exactly
+ * (PR #2218 review fix): a bare-host URL with no dot is contract-valid, whitespace and
+ * over-length values are not — plus the never-set no-op guard living in committee-view is
+ * exercised separately, this file only covers what the dialog itself validates.
+ */
+describe('CharterDialogComponent', () => {
+  let fixture: ComponentFixture<CharterDialogComponent>;
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+
+  function urlInput(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('[data-test="committee-view-charter-input"]');
+  }
+
+  function saveButton(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('[data-testid="charter-dialog-save"] button');
+  }
+
+  function cancelButton(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('[data-testid="charter-dialog-cancel"] button');
+  }
+
+  async function typeUrl(value: string): Promise<void> {
+    const input = urlInput();
+    input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function create(url = ''): void {
+    dialogRef = { close: vi.fn() };
+    TestBed.configureTestingModule({
+      imports: [CharterDialogComponent],
+      providers: [
+        { provide: DynamicDialogRef, useValue: dialogRef },
+        { provide: DynamicDialogConfig, useValue: { data: { url } } },
+      ],
+    });
+    fixture = TestBed.createComponent(CharterDialogComponent);
+    fixture.detectChanges();
+  }
+
+  it('associates the visible label with the input by id, for accessible-name discovery', () => {
+    create();
+    const label: HTMLLabelElement = fixture.nativeElement.querySelector('label');
+    expect(label.getAttribute('for')).toBe(urlInput().id);
+  });
+
+  it('accepts a contract-valid bare-host URL with no dot (matches the backend pattern, unlike the general website field)', async () => {
+    create();
+    await typeUrl('http://committee/charter');
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-charter-url-error"]')).toBeNull();
+    expect(saveButton().disabled).toBe(false);
+  });
+
+  it('rejects a URL containing whitespace', async () => {
+    create();
+    await typeUrl('http://exa mple.com/charter');
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-charter-url-error"]')?.textContent).toContain('Enter a valid http(s) URL');
+    expect(saveButton().disabled).toBe(true);
+  });
+
+  it('rejects a URL over the 2,048-character upstream limit, with a length-specific message', async () => {
+    create();
+    await typeUrl('https://example.org/' + 'a'.repeat(2048));
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-charter-url-error"]')?.textContent).toContain('too long');
+    expect(saveButton().disabled).toBe(true);
+  });
+
+  it('treats a blank value as valid regardless of the pattern (the removal signal)', async () => {
+    create('https://example.org/charter.pdf');
+    await typeUrl('');
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-charter-url-error"]')).toBeNull();
+    expect(saveButton().disabled).toBe(false);
+  });
+
+  it('Save closes with the typed URL', async () => {
+    create();
+    await typeUrl('https://example.org/charter.pdf');
+    saveButton().click();
+    expect(dialogRef.close).toHaveBeenCalledWith('https://example.org/charter.pdf');
+  });
+
+  it('Cancel closes without a value', () => {
+    create();
+    cancelButton().click();
+    expect(dialogRef.close).toHaveBeenCalledTimes(1);
+    expect(dialogRef.close.mock.calls[0]).toHaveLength(0);
+  });
+});

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
@@ -5,6 +5,7 @@ import { Component, inject } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+import { CHARTER_URL_MAX_LENGTH, CHARTER_URL_PATTERN } from '@lfx-one/shared/constants';
 import { CharterDialogData } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -20,14 +21,12 @@ export class CharterDialogComponent {
 
   public readonly url = this.config.data.url;
 
-  // Mirrors the backend's charterURLPattern/MaxLength(2048) exactly (cmd/committee-api/design/type.go
-  // in lfx-v2-committee-service) so a client-valid value is guaranteed API-valid -- no bare-host
-  // rejection (`http://committee/charter` is contract-valid, unlike the general `website` field's
-  // pattern) and no whitespace/length values that would pass here but fail upstream. Validators.pattern
-  // treats an empty value as valid regardless of the pattern, so clearing the field (the
-  // charter-removal signal) is never blocked by this validator.
+  // CHARTER_URL_PATTERN/CHARTER_URL_MAX_LENGTH mirror the backend's contract exactly, so a
+  // client-valid value is guaranteed API-valid. Validators.pattern treats an empty value as valid
+  // regardless of the pattern, so clearing the field (the charter-removal signal) is never blocked
+  // by this validator.
   public charterForm = new FormGroup({
-    url: new FormControl(this.url, [Validators.pattern(/^https?:\/\/[^\s/$.?#][^\s]*$/), Validators.maxLength(2048)]),
+    url: new FormControl(this.url, [Validators.pattern(CHARTER_URL_PATTERN), Validators.maxLength(CHARTER_URL_MAX_LENGTH)]),
   });
 
   public cancel(): void {

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
@@ -7,6 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { CHARTER_URL_MAX_LENGTH, CHARTER_URL_PATTERN } from '@lfx-one/shared/constants';
 import { CharterDialogData } from '@lfx-one/shared/interfaces';
+import { maxCodePointsValidator } from '@lfx-one/shared/validators';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 @Component({
@@ -24,9 +25,12 @@ export class CharterDialogComponent {
   // CHARTER_URL_PATTERN/CHARTER_URL_MAX_LENGTH mirror the backend's contract exactly, so a
   // client-valid value is guaranteed API-valid. Validators.pattern treats an empty value as valid
   // regardless of the pattern, so clearing the field (the charter-removal signal) is never blocked
-  // by this validator.
+  // by this validator. The length bound uses maxCodePointsValidator, not Validators.maxLength: the
+  // backend's Goa MaxLength(2048) counts Unicode code points (utf8.RuneCountInString), not the
+  // UTF-16 code units Validators.maxLength counts, so a non-BMP-heavy URL could be upstream-valid
+  // yet wrongly rejected here.
   public charterForm = new FormGroup({
-    url: new FormControl(this.url, [Validators.pattern(CHARTER_URL_PATTERN), Validators.maxLength(CHARTER_URL_MAX_LENGTH)]),
+    url: new FormControl(this.url, [Validators.pattern(CHARTER_URL_PATTERN), maxCodePointsValidator(CHARTER_URL_MAX_LENGTH)]),
   });
 
   public cancel(): void {

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { CharterDialogData } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+@Component({
+  selector: 'lfx-charter-dialog',
+  standalone: true,
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent],
+  templateUrl: './charter-dialog.component.html',
+})
+export class CharterDialogComponent {
+  private readonly config = inject(DynamicDialogConfig<CharterDialogData>);
+  private readonly ref = inject(DynamicDialogRef);
+
+  public readonly url = this.config.data.url;
+
+  // Same http(s) pattern used for the committee `website` field (committee-manage.component.ts)
+  // -- Validators.pattern treats an empty value as valid regardless of the pattern, so clearing
+  // the field (the charter-removal signal) is never blocked by this validator.
+  public charterForm = new FormGroup({
+    url: new FormControl(this.url, [Validators.pattern(/^https?:\/\/.+\..+/)]),
+  });
+
+  public cancel(): void {
+    this.ref.close();
+  }
+
+  public save(): void {
+    if (this.charterForm.invalid) {
+      return;
+    }
+    const newUrl = this.charterForm.get('url')?.value || '';
+    this.ref.close(newUrl);
+  }
+}

--- a/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/charter-dialog/charter-dialog.component.ts
@@ -20,11 +20,14 @@ export class CharterDialogComponent {
 
   public readonly url = this.config.data.url;
 
-  // Same http(s) pattern used for the committee `website` field (committee-manage.component.ts)
-  // -- Validators.pattern treats an empty value as valid regardless of the pattern, so clearing
-  // the field (the charter-removal signal) is never blocked by this validator.
+  // Mirrors the backend's charterURLPattern/MaxLength(2048) exactly (cmd/committee-api/design/type.go
+  // in lfx-v2-committee-service) so a client-valid value is guaranteed API-valid -- no bare-host
+  // rejection (`http://committee/charter` is contract-valid, unlike the general `website` field's
+  // pattern) and no whitespace/length values that would pass here but fail upstream. Validators.pattern
+  // treats an empty value as valid regardless of the pattern, so clearing the field (the
+  // charter-removal signal) is never blocked by this validator.
   public charterForm = new FormGroup({
-    url: new FormControl(this.url, [Validators.pattern(/^https?:\/\/.+\..+/)]),
+    url: new FormControl(this.url, [Validators.pattern(/^https?:\/\/[^\s/$.?#][^\s]*$/), Validators.maxLength(2048)]),
   });
 
   public cancel(): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -218,11 +218,10 @@
               data-testid="committee-about-charter-link">
               {{ committee().charter!.url }}
             </a>
-            @if (committee().charter?.updated_by; as updatedBy) {
-              <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
-                >Last updated by {{ updatedBy.name || updatedBy.username || 'someone' }} on {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
-              >
-            }
+            <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
+              >Last updated by {{ committee().charter?.updated_by?.name || committee().charter?.updated_by?.username || 'someone' }} on
+              {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
+            >
           </div>
         } @else if (committee().charter; as charter) {
           <span

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -220,8 +220,7 @@
             </a>
             @if (committee().charter?.updated_by; as updatedBy) {
               <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
-                >Last updated by {{ updatedBy.name || updatedBy.username }} on
-                {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
+                >Last updated by {{ updatedBy.name || updatedBy.username }} on {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
               >
             }
           </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -220,7 +220,7 @@
             </a>
             @if (committee().charter?.updated_by; as updatedBy) {
               <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
-                >Last updated by {{ updatedBy.name || updatedBy.username }} on {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
+                >Last updated by {{ updatedBy.name || updatedBy.username || 'someone' }} on {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
               >
             }
           </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -203,6 +203,56 @@
     </div>
   </lfx-card>
 
+  <!-- Charter -->
+  <lfx-card data-testid="committee-about-charter-card">
+    <div class="flex flex-col gap-2">
+      <h3 class="text-sm font-semibold text-gray-900">Charter</h3>
+      <div class="flex items-start gap-2">
+        @if (committee().charter?.url) {
+          <div class="flex-1 flex flex-col gap-1 min-w-0">
+            <a
+              [href]="committee().charter!.url"
+              target="_blank"
+              rel="noopener"
+              class="text-sm text-blue-600 hover:text-blue-800 break-all"
+              data-testid="committee-about-charter-link">
+              {{ committee().charter!.url }}
+            </a>
+            @if (committee().charter?.updated_by; as updatedBy) {
+              <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
+                >Last updated by {{ updatedBy.name || updatedBy.username }}</span
+              >
+            }
+          </div>
+        } @else if (committee().charter; as charter) {
+          <span
+            class="text-gray-400 text-sm italic flex-1 underline decoration-dotted"
+            [pTooltip]="
+              'Removed by ' + (charter.updated_by?.name || charter.updated_by?.username || 'someone') + ' on ' + (charter.updated_at | date: 'MMM d, y')
+            "
+            tooltipPosition="top"
+            data-testid="committee-about-charter-empty"
+            >No charter yet</span
+          >
+        } @else {
+          <span class="text-gray-400 text-sm italic flex-1" data-testid="committee-about-charter-empty">No charter yet</span>
+        }
+        @if (canEdit()) {
+          <lfx-button
+            icon="fa-light fa-pen-to-square"
+            [text]="true"
+            [rounded]="true"
+            size="small"
+            severity="secondary"
+            [ariaLabel]="committee().charter?.url ? 'Edit charter' : 'Add charter'"
+            [tooltip]="committee().charter?.url ? 'Edit charter' : 'Add charter'"
+            (onClick)="editCharterRequested.emit()"
+            data-testid="committee-about-edit-charter-btn"></lfx-button>
+        }
+      </div>
+    </div>
+  </lfx-card>
+
   <!-- Visitor Join CTA. data-testid sits directly on the component host (no wrapper div) — the
        host still exists in the DOM even when GroupJoinCtaComponent renders neither of its own
        branches (e.g. an application-mode visitor), but a toBeVisible() check on it correctly fails

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -220,7 +220,8 @@
             </a>
             @if (committee().charter?.updated_by; as updatedBy) {
               <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
-                >Last updated by {{ updatedBy.name || updatedBy.username }}</span
+                >Last updated by {{ updatedBy.name || updatedBy.username }} on
+                {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
               >
             }
           </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -208,37 +208,35 @@
     <div class="flex flex-col gap-2">
       <h3 class="text-sm font-semibold text-gray-900">Charter</h3>
       <div class="flex items-start gap-2">
-        @if (committee().charter?.url) {
-          <div class="flex-1 flex flex-col gap-1 min-w-0">
-            <a
-              [href]="committee().charter!.url"
-              target="_blank"
-              rel="noopener"
-              class="text-sm text-blue-600 hover:text-blue-800 break-all"
-              data-testid="committee-about-charter-link">
-              {{ committee().charter!.url }}
-            </a>
-            <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
-              >Last updated by {{ committee().charter?.updated_by?.name || committee().charter?.updated_by?.username || 'someone' }} on
-              {{ committee().charter!.updated_at | date: 'MMM d, y' }}</span
+        @if (committee().charter; as charter) {
+          @if (charter.url) {
+            <div class="flex-1 flex flex-col gap-1 min-w-0">
+              <a
+                [href]="charter.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm text-blue-600 hover:text-blue-800 break-all"
+                data-testid="committee-about-charter-link">
+                {{ charter.url }}
+              </a>
+              <span class="text-xs text-gray-400" data-testid="committee-about-charter-updated-by"
+                >Last updated by {{ charter.updated_by?.name || charter.updated_by?.username || 'someone' }} on
+                {{ charter.updated_at | date: 'MMM d, y' }}</span
+              >
+            </div>
+          } @else {
+            <span
+              class="text-gray-400 text-sm italic flex-1 underline decoration-dotted"
+              [pTooltip]="charterRemovedLabel()"
+              tooltipPosition="top"
+              tooltipEvent="both"
+              tabindex="0"
+              role="note"
+              [attr.aria-label]="charterRemovedLabel()"
+              data-testid="committee-about-charter-empty"
+              >No charter yet</span
             >
-          </div>
-        } @else if (committee().charter; as charter) {
-          <span
-            class="text-gray-400 text-sm italic flex-1 underline decoration-dotted"
-            [pTooltip]="
-              'Removed by ' + (charter.updated_by?.name || charter.updated_by?.username || 'someone') + ' on ' + (charter.updated_at | date: 'MMM d, y')
-            "
-            tooltipPosition="top"
-            tooltipEvent="both"
-            tabindex="0"
-            role="note"
-            [attr.aria-label]="
-              'Removed by ' + (charter.updated_by?.name || charter.updated_by?.username || 'someone') + ' on ' + (charter.updated_at | date: 'MMM d, y')
-            "
-            data-testid="committee-about-charter-empty"
-            >No charter yet</span
-          >
+          }
         } @else {
           <span class="text-gray-400 text-sm italic flex-1" data-testid="committee-about-charter-empty">No charter yet</span>
         }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.html
@@ -231,6 +231,12 @@
               'Removed by ' + (charter.updated_by?.name || charter.updated_by?.username || 'someone') + ' on ' + (charter.updated_at | date: 'MMM d, y')
             "
             tooltipPosition="top"
+            tooltipEvent="both"
+            tabindex="0"
+            role="note"
+            [attr.aria-label]="
+              'Removed by ' + (charter.updated_by?.name || charter.updated_by?.username || 'someone') + ' on ' + (charter.updated_at | date: 'MMM d, y')
+            "
             data-testid="committee-about-charter-empty"
             >No charter yet</span
           >

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.spec.ts
@@ -63,7 +63,7 @@ describe('CommitteeAboutComponent charter card', () => {
           url: '',
           version: 2,
           updated_at: '2026-08-01T00:00:00Z',
-          updated_by: { username: 'alice', email: 'alice@example.org', name: 'Alice Example' },
+          updated_by: { username: 'alice', name: 'Alice Example' },
         },
       })
     );
@@ -85,7 +85,7 @@ describe('CommitteeAboutComponent charter card', () => {
           url: 'https://example.org/governance/charter.pdf',
           version: 1,
           updated_at: '2026-08-01T00:00:00Z',
-          updated_by: { username: 'alice', email: 'alice@example.org', name: 'Alice Example' },
+          updated_by: { username: 'alice', name: 'Alice Example' },
         },
       })
     );

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.spec.ts
@@ -1,0 +1,113 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Committee } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CommitteeAboutComponent } from './committee-about.component';
+
+/**
+ * Covers the three charter empty-value states on the About-tab Charter card, the one piece of
+ * genuinely new logic in an otherwise cloned card (LFXV2-2659): never set, set-then-removed
+ * (dotted-underline + tooltip), and set-with-link.
+ */
+function committee(overrides: Partial<Committee> = {}): Committee {
+  return {
+    uid: 'committee-1',
+    name: 'Test Committee',
+    category: 'governance',
+    enable_voting: false,
+    public: true,
+    sso_group_enabled: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    total_members: 3,
+    project_uid: 'project-1',
+    ...overrides,
+  };
+}
+
+describe('CommitteeAboutComponent charter card', () => {
+  let fixture: ComponentFixture<CommitteeAboutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [CommitteeAboutComponent] }).compileComponents();
+    fixture = TestBed.createComponent(CommitteeAboutComponent);
+  });
+
+  function emptyState(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="committee-about-charter-empty"]');
+  }
+
+  function link(): HTMLAnchorElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="committee-about-charter-link"]');
+  }
+
+  it('renders plain, undecorated "No charter yet" with no tooltip when charter was never set', async () => {
+    fixture.componentRef.setInput('committee', committee());
+    await fixture.whenStable();
+
+    const el = emptyState();
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toContain('No charter yet');
+    expect(el!.className).not.toContain('underline');
+    expect(link()).toBeNull();
+  });
+
+  it('renders dotted-underline "No charter yet" with a removal tooltip when the charter was set then removed', async () => {
+    fixture.componentRef.setInput(
+      'committee',
+      committee({
+        charter: {
+          url: '',
+          version: 2,
+          updated_at: '2026-08-01T00:00:00Z',
+          updated_by: { username: 'alice', email: 'alice@example.org', name: 'Alice Example' },
+        },
+      })
+    );
+    await fixture.whenStable();
+
+    const el = emptyState();
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toContain('No charter yet');
+    expect(el!.className).toContain('underline');
+    expect(el!.className).toContain('decoration-dotted');
+    expect(link()).toBeNull();
+  });
+
+  it('renders the charter as a link, with a "Last updated by" line, when set', async () => {
+    fixture.componentRef.setInput(
+      'committee',
+      committee({
+        charter: {
+          url: 'https://example.org/governance/charter.pdf',
+          version: 1,
+          updated_at: '2026-08-01T00:00:00Z',
+          updated_by: { username: 'alice', email: 'alice@example.org', name: 'Alice Example' },
+        },
+      })
+    );
+    await fixture.whenStable();
+
+    const el = link();
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('href')).toBe('https://example.org/governance/charter.pdf');
+    expect(el!.textContent).toContain('https://example.org/governance/charter.pdf');
+    expect(emptyState()).toBeNull();
+
+    const updatedBy = fixture.nativeElement.querySelector('[data-testid="committee-about-charter-updated-by"]');
+    expect(updatedBy).not.toBeNull();
+    expect(updatedBy!.textContent).toContain('Alice Example');
+  });
+
+  it('shows an "Add charter" edit button when editable and no charter exists', async () => {
+    fixture.componentRef.setInput('committee', committee());
+    fixture.componentRef.setInput('canEdit', true);
+    await fixture.whenStable();
+
+    const btn = fixture.nativeElement.querySelector('[data-testid="committee-about-edit-charter-btn"]');
+    expect(btn).not.toBeNull();
+  });
+});

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.spec.ts
@@ -102,6 +102,24 @@ describe('CommitteeAboutComponent charter card', () => {
     expect(updatedBy!.textContent).toContain('Alice Example');
   });
 
+  it('still shows the "Last updated by someone on <date>" line when the charter has no updated_by (upstream permits it to be absent)', async () => {
+    fixture.componentRef.setInput(
+      'committee',
+      committee({
+        charter: {
+          url: 'https://example.org/governance/charter.pdf',
+          version: 1,
+          updated_at: '2026-08-01T00:00:00Z',
+        },
+      })
+    );
+    await fixture.whenStable();
+
+    const updatedBy = fixture.nativeElement.querySelector('[data-testid="committee-about-charter-updated-by"]');
+    expect(updatedBy).not.toBeNull();
+    expect(updatedBy!.textContent).toContain('Last updated by someone');
+  });
+
   it('shows an "Add charter" edit button when editable and no charter exists', async () => {
     fixture.componentRef.setInput('committee', committee());
     fixture.componentRef.setInput('canEdit', true);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe, NgClass } from '@angular/common';
+import { DatePipe, formatDate, NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, input, output, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -81,6 +81,14 @@ export class CommitteeAboutComponent {
 
   // Complex computed
   public cadenceSummary: Signal<string> = computed(() => buildCommitteeCadenceSummary(this.upcomingMeetings()));
+  // Single source for the "Removed by … on …" charter attribution, shared by the tooltip and the
+  // aria-label so a future copy tweak can't desynchronize the sighted and screen-reader text.
+  public charterRemovedLabel: Signal<string> = computed(() => {
+    const charter = this.committee().charter;
+    const who = charter?.updated_by?.name || charter?.updated_by?.username || 'someone';
+    const when = charter?.updated_at ? formatDate(charter.updated_at, 'MMM d, y', 'en-US') : '';
+    return `Removed by ${who} on ${when}`;
+  });
 
   // Public methods
   public onSubscribe(): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-about/committee-about.component.ts
@@ -14,6 +14,7 @@ import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { DialogService } from 'primeng/dynamicdialog';
 import { PopoverModule } from 'primeng/popover';
 import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { CommitteeChannelsCardComponent } from '../committee-channels-card/committee-channels-card.component';
 import { GroupJoinCtaComponent } from '../group-join-cta/group-join-cta.component';
@@ -37,6 +38,7 @@ import { openIcalSubscribeDialog } from '../../utils/ical-subscribe.util';
     TagComponent,
     SkeletonModule,
     PopoverModule,
+    TooltipModule,
     NgClass,
     GroupJoinCtaComponent,
     CommitteeChannelsCardComponent,
@@ -72,6 +74,7 @@ export class CommitteeAboutComponent {
   // Outputs
   public readonly joinRequested = output<void>();
   public readonly editDescriptionRequested = output<void>();
+  public readonly editCharterRequested = output<void>();
   public readonly parentProjectNavigationRequested = output<void>();
   public readonly parentGroupNavigationRequested = output<void>();
   public readonly subGroupNavigationRequested = output<Committee>();

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -47,6 +47,16 @@ export const SLACK_INCOMING_WEBHOOK_URL_PATTERN = /^https:\/\/hooks\.slack\.com\
 export const CHAT_WEBHOOK_URL_MAX_LENGTH = 500;
 
 /**
+ * Mirrors upstream's `charterURLPattern` (lfx-v2-committee-service's `cmd/committee-api/design/type.go`)
+ * exactly, so a client-valid charter URL is guaranteed API-valid — no bare-host rejection
+ * (`http://committee/charter` is contract-valid, unlike the general `website` field's pattern).
+ */
+export const CHARTER_URL_PATTERN = /^https?:\/\/[^\s/$.?#][^\s]*$/;
+
+/** Mirrors upstream's charter `MaxLength(2048)` bound, checked alongside {@link CHARTER_URL_PATTERN}. */
+export const CHARTER_URL_MAX_LENGTH = 2048;
+
+/**
  * Configurable labels for committees displayed throughout the UI
  * @description This constant allows the user-facing labels to be changed (e.g., to "Group/Groups")
  * while keeping all code and file names as "committees"

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -477,6 +477,12 @@ export interface Committee {
   my_member_uid?: string;
   /** Source-labeled external entities linked to this committee (e.g. OCG groups/events). Linked activity metadata only — never overrides category, governance, or other LFX-owned attributes. */
   external_sources?: CommitteeExternalSource[];
+  /**
+   * Committee charter: a link to an externally hosted governance document. Present once a
+   * charter has ever been set for the committee, including after removal (see
+   * {@link CommitteeCharter.url}). Absent only when the committee has never had a charter set.
+   */
+  charter?: CommitteeCharter;
 }
 
 /** A single source-labeled external entity linked to a committee (e.g. an OCG group or event). */
@@ -489,6 +495,21 @@ export interface CommitteeExternalSource {
   external_category?: string;
   external_region?: string;
   external_event_category?: string;
+}
+
+/**
+ * Committee charter: a link to an externally hosted governance document (e.g. a PDF, or a
+ * `CHARTER.md` in a repo) — not a file upload into this system.
+ */
+export interface CommitteeCharter {
+  /** External URL to the charter document. Empty string once a previously-set charter has been removed — a deliberate "removed" signal, not an "unset" one. */
+  url: string;
+  /** Increments on every change (set, edit, or clear). Never resets, even across a clear — see {@link url}. */
+  version: number;
+  /** ISO date string of the last change (set, edit, or clear) */
+  updated_at: string;
+  /** User who made the last change */
+  updated_by?: CommitteeUser;
 }
 
 /**
@@ -624,6 +645,12 @@ export interface CommitteeUpdateData extends Partial<CommitteeCreateData> {
   writers?: CommitteeUser[];
   /** Update the list of users with review (audit) access */
   auditors?: CommitteeUser[];
+  /**
+   * Set or clear the committee charter. Write-only — the read shape is {@link CommitteeCharter}.
+   * `{ url: '' }` is a legal, meaningful payload (removes the charter), not an omit-this-field
+   * placeholder.
+   */
+  charter?: { url: string };
 }
 
 /**
@@ -1081,6 +1108,11 @@ export interface MailingListPickerDialogResult {
 export interface DescriptionDialogData {
   mode: 'view' | 'edit';
   description: string;
+}
+
+export interface CharterDialogData {
+  /** Current charter URL, or `''` if never set / previously removed. */
+  url: string;
 }
 
 export interface IcalSubscribeDialogData {

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -498,6 +498,18 @@ export interface CommitteeExternalSource {
 }
 
 /**
+ * User reference shown on publicly-visible committee fields, without contact details.
+ * Mirrors the upstream `public-audit-user` Goa type — unlike {@link CommitteeUser} (writers/
+ * auditors, authenticated-only), this shape can reach anonymous viewers of public committees, so
+ * it omits `email` and leaves every field optional.
+ */
+export interface PublicAuditUser {
+  name?: string;
+  username?: string;
+  avatar?: string;
+}
+
+/**
  * Committee charter: a link to an externally hosted governance document (e.g. a PDF, or a
  * `CHARTER.md` in a repo) — not a file upload into this system.
  */
@@ -509,7 +521,7 @@ export interface CommitteeCharter {
   /** ISO date string of the last change (set, edit, or clear) */
   updated_at: string;
   /** User who made the last change */
-  updated_by?: CommitteeUser;
+  updated_by?: PublicAuditUser;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a Charter card to the committee About tab: renders the charter URL as a link with a "Last updated by" line, distinguishes never-set from set-then-removed (dotted-underline text with a tooltip naming who removed it and when), and offers an edit affordance via a new minimal `CharterDialogComponent` (single URL field, reusing the same `website`-field URL pattern and empty-string-is-valid semantics as removal).
- Adds `charter?: CommitteeCharter` to the shared `Committee` interface and write-only `charter?: { url: string }` to `CommitteeUpdateData`.
- Confirmed the BFF (`committee.service.ts`'s `updateCommittee`) needs no changes — `charter` rides through the existing full-replace `...committeeData` spread untouched, and the backend's write-only payload type only ever reads `url`, silently ignoring any extra fields.

Linked ticket: [LFXV2-2659](https://linuxfoundation.atlassian.net/browse/LFXV2-2659)

**Depends on:** [linuxfoundation/lfx-v2-committee-service#203](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/203) — the backend PR that adds the `charter` field to the committee resource. This PR reads `committee.charter`, which doesn't exist until that one is merged and deployed; please don't merge/deploy this before that lands.

## Test plan

- [x] `yarn format:check` / `yarn lint:check` clean
- [x] `yarn test` — 96 files, 1924 tests passing, including a new spec covering the three charter card states (never set / set-then-removed / set) and edit-button visibility
- [x] `yarn build` clean

[LFXV2-2659]: https://linuxfoundation.atlassian.net/browse/LFXV2-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ