### PR TITLE
feat(org-lens): render the organization's CLA Groups from the CLA service

### DIFF
--- a/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
@@ -1,0 +1,135 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared setup for the Org Lens EasyCLA specs (GH-1978).
+ *
+ * The gate spec, the content spec and the structural spec all need the same thing before they can
+ * assert anything: an authenticated app with an organization selected and the M3 flag pinned. Only
+ * the CLA list response differs between them, so that is the parameter and the rest is fixed here.
+ */
+
+import { ACCOUNT_COOKIE_KEY } from '@lfx-one/shared/constants/accounts.constants';
+import { ORG_LENS_CLA_M3_ENABLED_FLAG } from '@lfx-one/shared/constants/feature-flags.constants';
+import type { OrgClaGroup, OrgClaGroupList } from '@lfx-one/shared/interfaces';
+import { expect, Locator, Page, test } from '@playwright/test';
+
+import { stubFeatureFlags } from './org-roi.helper';
+
+export const EASYCLA_URL = '/org/easycla';
+export const PAGE_LOAD_TIMEOUT = 30_000;
+
+export const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+export const MOCK_ACCOUNT_NAME = 'Acme Motors';
+export const MOCK_ACCOUNT_SLUG = 'acme-motors';
+
+/** The route the page reads its list from — the one thing each spec stubs differently. */
+export const CLA_GROUPS_ROUTE = '**/api/orgs/*/lens/cla-groups';
+
+export function fulfillJson(page: Page, glob: string, body: unknown): Promise<void> {
+  return page.route(glob, (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) }));
+}
+
+/**
+ * A CLA Group row. Cases override only the field they are about, so a case that fails names the
+ * field it was testing rather than a fixture detail it never mentioned.
+ */
+export function claGroup(overrides: Partial<OrgClaGroup> = {}): OrgClaGroup {
+  return {
+    id: 'signature-uuid-1',
+    claGroupId: 'cla-group-uuid-1',
+    claGroupName: 'Nimbus Foundation CLA',
+    foundationName: 'Nimbus Foundation',
+    projects: [{ projectSfid: 'a09410000182dD3AAI', projectName: 'Cascade' }],
+    status: 'signed',
+    signedOn: '2024-03-11T09:20:00Z',
+    needsClaManager: false,
+    claManagersCount: 2,
+    approvalCriteriaCount: 4,
+    ...overrides,
+  };
+}
+
+/** Wraps rows in the list envelope the page's endpoint returns. */
+export function claGroupList(claGroups: OrgClaGroup[]): OrgClaGroupList {
+  return { orgUid: MOCK_ACCOUNT_ID, claGroups };
+}
+
+/**
+ * Enough org context for an account to be selected. Without it the lens has no organization, the
+ * sidebar never builds its org section, and a spec would assert against a page still waiting.
+ */
+export async function stubAccountContext(page: Page): Promise<void> {
+  await fulfillJson(page, '**/api/user/personas*', {
+    personas: ['contributor'],
+    personaProjects: {},
+    projects: [],
+    organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: '', uid: MOCK_ACCOUNT_ID }],
+    isRootWriter: false,
+  });
+
+  await fulfillJson(page, '**/api/analytics/org-lens-account-context*', [
+    { accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: 'Gold' },
+  ]);
+
+  await fulfillJson(page, '**/api/orgs/me/role-grants', {
+    writers: [MOCK_ACCOUNT_ID],
+    auditors: [],
+    cascadingWriters: [],
+    cascadingAuditors: [],
+    username: 'e2e-org-easycla',
+    loaded_at: new Date().toISOString(),
+  });
+
+  await fulfillJson(page, '**/api/nav/org-items*', {
+    items: [{ uid: MOCK_ACCOUNT_ID, accountId: MOCK_ACCOUNT_ID, name: MOCK_ACCOUNT_NAME, logoUrl: null, primaryDomain: 'acme-motors.example', isMember: true }],
+    next_page_token: null,
+    upstream_failed: false,
+    total: 1,
+  });
+
+  await page.context().addCookies([{ name: ACCOUNT_COOKIE_KEY, value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }), domain: 'localhost', path: '/' }]);
+}
+
+/**
+ * Land on `/org/easycla` with the M3 flag on and the CLA list stubbed by the caller.
+ *
+ * The visit to `/` first, then a reload, is the sequence the other Org Lens specs use to get an
+ * authenticated app running before the guarded URL is requested.
+ */
+export async function gotoEasyclaList(page: Page, stubList: (page: Page) => Promise<void>): Promise<void> {
+  await stubFeatureFlags(page, { [ORG_LENS_CLA_M3_ENABLED_FLAG]: true });
+  await stubAccountContext(page);
+  await stubList(page);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await page.goto(EASYCLA_URL, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+
+  // A redirect away from the whole lens means `org-lens-enabled` is off for this user, which is a
+  // missing prerequisite rather than a failure of anything these specs are about.
+  if (!page.url().includes('/org/')) {
+    test.skip(true, 'org-lens-enabled appears off — /org/easycla redirected out of the lens');
+  }
+}
+
+/**
+ * The search box.
+ *
+ * `lfx-input-text` emits its hook as `data-test`, not the `data-testid` Playwright resolves by
+ * default, so this one control is addressed by attribute while everything else on the page uses
+ * `getByTestId`.
+ */
+export function searchInput(page: Page): Locator {
+  return page.locator('[data-test="org-easycla-search"]');
+}
+
+/** Skips when the shared Playwright credentials are absent, as every authenticated spec does. */
+export function skipWithoutCredentials(): void {
+  if (!process.env.TEST_USERNAME || !process.env.TEST_PASSWORD) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}

--- a/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
@@ -39,6 +39,9 @@ export function claGroup(overrides: Partial<OrgClaGroup> = {}): OrgClaGroup {
     id: 'signature-uuid-1',
     claGroupId: 'cla-group-uuid-1',
     claGroupName: 'Nimbus Foundation CLA',
+    // Present on every fixture row so the signing-entity subline renders: the server sends it only
+    // when it differs from the organization's own name, which is what makes the subline meaningful.
+    signingEntityName: 'Acme Motors GmbH',
     foundationName: 'Nimbus Foundation',
     projects: [{ projectSfid: 'a09410000182dD3AAI', projectName: 'Cascade' }],
     status: 'signed',

--- a/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
@@ -10,7 +10,7 @@
  */
 
 import { ACCOUNT_COOKIE_KEY } from '@lfx-one/shared/constants/accounts.constants';
-import { ORG_LENS_CLA_M3_ENABLED_FLAG } from '@lfx-one/shared/constants/feature-flags.constants';
+import { ORG_LENS_CLA_M3_ENABLED_FLAG, ORG_LENS_ENABLED_FLAG } from '@lfx-one/shared/constants/feature-flags.constants';
 import type { OrgClaGroup, OrgClaGroupList } from '@lfx-one/shared/interfaces';
 import { expect, Locator, Page, test } from '@playwright/test';
 
@@ -101,7 +101,10 @@ export async function stubAccountContext(page: Page): Promise<void> {
  * authenticated app running before the guarded URL is requested.
  */
 export async function gotoEasyclaList(page: Page, stubList: (page: Page) => Promise<void>): Promise<void> {
-  await stubFeatureFlags(page, { [ORG_LENS_CLA_M3_ENABLED_FLAG]: true });
+  // Both flags, not just this feature's. `/org/*` sits behind the parent lens flag as well, so
+  // pinning only the child leaves these tests at the mercy of a remote flag: wherever it is off
+  // they skip rather than fail, and a suite that skips reports the same green as one that ran.
+  await stubFeatureFlags(page, { [ORG_LENS_ENABLED_FLAG]: true, [ORG_LENS_CLA_M3_ENABLED_FLAG]: true });
   await stubAccountContext(page);
   await stubList(page);
 

--- a/apps/lfx-one/e2e/org-easycla-flag-gate.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-flag-gate.spec.ts
@@ -20,67 +20,22 @@
  * route that was never guarded.
  */
 
-import { ACCOUNT_COOKIE_KEY } from '@lfx-one/shared/constants/accounts.constants';
 import { ORG_LENS_CLA_M3_ENABLED_FLAG } from '@lfx-one/shared/constants/feature-flags.constants';
 import { expect, Locator, Page, test } from '@playwright/test';
 
+import {
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  EASYCLA_URL,
+  fulfillJson,
+  MOCK_ACCOUNT_NAME,
+  PAGE_LOAD_TIMEOUT,
+  stubAccountContext,
+} from './helpers/org-easycla.helper';
 import { stubFeatureFlags } from './helpers/org-roi.helper';
-
-const EASYCLA_URL = '/org/easycla';
-const PAGE_LOAD_TIMEOUT = 30_000;
-
-const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
-const MOCK_ACCOUNT_NAME = 'Acme Motors';
-const MOCK_ACCOUNT_SLUG = 'acme-motors';
 
 function sidebarLink(page: Page, name: string): Locator {
   return page.getByTestId('sidebar').getByRole('link', { name, exact: true });
-}
-
-function fulfillJson(page: Page, glob: string, body: unknown): Promise<void> {
-  return page.route(glob, (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) }));
-}
-
-/**
- * Enough org context for an account to be selected. Without it the lens has no organization, the
- * sidebar never builds its org section, and both cases would assert against a page still waiting.
- */
-async function stubAccountContext(page: Page): Promise<void> {
-  await fulfillJson(page, '**/api/user/personas*', {
-    personas: ['contributor'],
-    personaProjects: {},
-    projects: [],
-    organizations: [{ accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: '', uid: MOCK_ACCOUNT_ID }],
-    isRootWriter: false,
-  });
-
-  await fulfillJson(page, '**/api/analytics/org-lens-account-context*', [
-    { accountId: MOCK_ACCOUNT_ID, accountName: MOCK_ACCOUNT_NAME, accountSlug: MOCK_ACCOUNT_SLUG, membershipTier: 'Gold' },
-  ]);
-
-  await fulfillJson(page, '**/api/orgs/me/role-grants', {
-    writers: [MOCK_ACCOUNT_ID],
-    auditors: [],
-    cascadingWriters: [],
-    cascadingAuditors: [],
-    username: 'e2e-org-easycla',
-    loaded_at: new Date().toISOString(),
-  });
-
-  await fulfillJson(page, '**/api/nav/org-items*', {
-    items: [{ uid: MOCK_ACCOUNT_ID, accountId: MOCK_ACCOUNT_ID, name: MOCK_ACCOUNT_NAME, logoUrl: null, primaryDomain: 'acme-motors.example', isMember: true }],
-    next_page_token: null,
-    upstream_failed: false,
-    total: 1,
-  });
-
-  await page.context().addCookies([{ name: ACCOUNT_COOKIE_KEY, value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }), domain: 'localhost', path: '/' }]);
-
-  // The page fetches its CLA list once an org is selected (GH-1978). Stubbed empty so the flag-on
-  // case still lands on the "signed nothing" state — unstubbed, the request would fail against the
-  // dev backend and the page would render its load-failure state instead, failing this spec for a
-  // reason that has nothing to do with the gate it exists to pin.
-  await fulfillJson(page, '**/api/orgs/*/lens/cla-groups', { orgUid: MOCK_ACCOUNT_ID, claGroups: [] });
 }
 
 /**
@@ -93,6 +48,12 @@ async function stubAccountContext(page: Page): Promise<void> {
 async function deepLinkToEasycla(page: Page, flagEnabled: boolean): Promise<void> {
   await stubFeatureFlags(page, { [ORG_LENS_CLA_M3_ENABLED_FLAG]: flagEnabled });
   await stubAccountContext(page);
+
+  // The page fetches its CLA list once an org is selected (GH-1978). Stubbed empty so the flag-on
+  // case still lands on the "signed nothing" state — unstubbed, the request would fail against the
+  // dev backend and the page would render its load-failure state instead, failing this spec for a
+  // reason that has nothing to do with the gate it exists to pin.
+  await fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList([]));
 
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await expect(page).not.toHaveURL(/auth0\.com/);

--- a/apps/lfx-one/e2e/org-easycla-flag-gate.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-flag-gate.spec.ts
@@ -75,6 +75,12 @@ async function stubAccountContext(page: Page): Promise<void> {
   });
 
   await page.context().addCookies([{ name: ACCOUNT_COOKIE_KEY, value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }), domain: 'localhost', path: '/' }]);
+
+  // The page fetches its CLA list once an org is selected (GH-1978). Stubbed empty so the flag-on
+  // case still lands on the "signed nothing" state — unstubbed, the request would fail against the
+  // dev backend and the page would render its load-failure state instead, failing this spec for a
+  // reason that has nothing to do with the gate it exists to pin.
+  await fulfillJson(page, '**/api/orgs/*/lens/cla-groups', { orgUid: MOCK_ACCOUNT_ID, claGroups: [] });
 }
 
 /**

--- a/apps/lfx-one/e2e/org-easycla-list-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list-robust.spec.ts
@@ -1,0 +1,112 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Lens EasyCLA list — structural E2E (GH-1978).
+ *
+ * The structural half of the repository's dual E2E architecture; `org-easycla-list.spec.ts` is the
+ * content half. This one asserts the `data-testid` contract and the component nesting rather than
+ * the copy, so the pair fails independently: reworded labels break only the content spec, and a
+ * card rebuilt behind the same testids leaves this one green.
+ *
+ * The states are mutually exclusive by construction — one list either has rows, or has none, or
+ * failed to load — so each is pinned together with the absence of the other two. A regression that
+ * renders two of them at once is otherwise invisible to a spec that only asserts presence.
+ *
+ * Prerequisites: as `org-easycla-list.spec.ts`.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+import {
+  claGroup,
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  fulfillJson,
+  gotoEasyclaList,
+  PAGE_LOAD_TIMEOUT,
+  skipWithoutCredentials,
+} from './helpers/org-easycla.helper';
+
+const CARD_FIELDS = [
+  'org-easycla-card-title',
+  'org-easycla-card-status',
+  'org-easycla-card-approval-count',
+  'org-easycla-card-approval-label',
+  'org-easycla-card-manager-count',
+];
+
+function stubRows(count: number) {
+  const rows = Array.from({ length: count }, (_, i) => claGroup({ id: `sig-${i + 1}`, claGroupName: `CLA Group ${i + 1}` }));
+  return (page: Page) => fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList(rows));
+}
+
+test.describe('Org Lens EasyCLA list — structure', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test.beforeEach(() => skipWithoutCredentials());
+
+  test('nests the page, header, toolbar and grid as the shell expects', async ({ page }) => {
+    await gotoEasyclaList(page, stubRows(3));
+
+    const pageRoot = page.getByTestId('org-easycla-page');
+    await expect(pageRoot).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    for (const testid of ['org-easycla-header', 'org-easycla-toolbar', 'org-easycla-grid']) {
+      await expect(pageRoot.getByTestId(testid)).toHaveCount(1);
+    }
+
+    await expect(pageRoot.getByTestId('org-easycla-header').getByTestId('org-easycla-title')).toHaveCount(1);
+    await expect(pageRoot.getByTestId('org-easycla-toolbar').locator('[data-test="org-easycla-search"]')).toHaveCount(1);
+    await expect(pageRoot.getByTestId('org-easycla-grid').getByTestId('org-easycla-card')).toHaveCount(3);
+  });
+
+  test('gives every card the full field contract', async ({ page }) => {
+    await gotoEasyclaList(page, stubRows(3));
+
+    const cards = page.getByTestId('org-easycla-card');
+    await expect(cards).toHaveCount(3, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Per card rather than per page: a page-level count of 3 titles is also satisfied by one card
+    // holding three and two holding none.
+    for (let i = 0; i < 3; i++) {
+      for (const field of CARD_FIELDS) {
+        await expect(cards.nth(i).getByTestId(field)).toHaveCount(1);
+      }
+    }
+  });
+
+  test('renders the pager only alongside a grid it can page', async ({ page }) => {
+    await gotoEasyclaList(page, stubRows(9));
+
+    await expect(page.getByTestId('org-easycla-grid')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    const pager = page.getByTestId('org-easycla-pager');
+    await expect(pager).toHaveCount(1);
+    await expect(pager.getByTestId('org-easycla-prev-page')).toHaveCount(1);
+    await expect(pager.getByTestId('org-easycla-next-page')).toHaveCount(1);
+    await expect(pager.getByTestId('org-easycla-page-label')).toHaveCount(1);
+  });
+
+  test('shows the empty state alone, with no grid and no error beside it', async ({ page }) => {
+    await gotoEasyclaList(page, stubRows(0));
+
+    await expect(page.getByTestId('org-easycla-empty-state')).toHaveCount(1, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-grid')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-pager')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-error-state')).toHaveCount(0);
+  });
+
+  test('shows the error state alone, with no grid and no empty state beside it', async ({ page }) => {
+    await gotoEasyclaList(page, (p) =>
+      p.route(CLA_GROUPS_ROUTE, (route) =>
+        route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ code: 'UPSTREAM_ERROR', message: 'upstream unavailable' }) })
+      )
+    );
+
+    await expect(page.getByTestId('org-easycla-error-state')).toHaveCount(1, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-grid')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-empty-state')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-easycla-list-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list-robust.spec.ts
@@ -66,6 +66,19 @@ test.describe('Org Lens EasyCLA list — structure', () => {
     await expect(pageRoot.getByTestId('org-easycla-grid').getByTestId('org-easycla-card')).toHaveCount(3);
   });
 
+  // A label element is not an accessible name until it resolves to the control. `getByLabel`
+  // performs the same association a screen reader does, so it fails where a `for` attribute points
+  // at a wrapper rather than the input inside it — which is invisible to any assertion that only
+  // checks the label's presence.
+  test('gives the search box an accessible name that resolves to the input itself', async ({ page }) => {
+    await gotoEasyclaList(page, stubRows(3));
+    await expect(page.getByTestId('org-easycla-grid')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    const labelled = page.getByLabel('Search CLAs');
+    await expect(labelled).toHaveCount(1);
+    await expect(labelled).toHaveJSProperty('tagName', 'INPUT');
+  });
+
   test('gives every card the full field contract', async ({ page }) => {
     await gotoEasyclaList(page, stubRows(3));
 

--- a/apps/lfx-one/e2e/org-easycla-list-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list-robust.spec.ts
@@ -52,7 +52,12 @@ test.describe('Org Lens EasyCLA list — structure', () => {
     const pageRoot = page.getByTestId('org-easycla-page');
     await expect(pageRoot).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
-    for (const testid of ['org-easycla-header', 'org-easycla-toolbar', 'org-easycla-grid']) {
+    // Anchor on the grid before asserting the rest of the nesting. The page shell renders before
+    // the list resolves, so an unanchored count runs against a page that is still loading and
+    // fails on timing rather than on structure.
+    await expect(pageRoot.getByTestId('org-easycla-grid')).toHaveCount(1, { timeout: PAGE_LOAD_TIMEOUT });
+
+    for (const testid of ['org-easycla-header', 'org-easycla-toolbar']) {
       await expect(pageRoot.getByTestId(testid)).toHaveCount(1);
     }
 
@@ -82,7 +87,7 @@ test.describe('Org Lens EasyCLA list — structure', () => {
     await expect(page.getByTestId('org-easycla-grid')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     const pager = page.getByTestId('org-easycla-pager');
-    await expect(pager).toHaveCount(1);
+    await expect(pager).toHaveCount(1, { timeout: PAGE_LOAD_TIMEOUT });
     await expect(pager.getByTestId('org-easycla-prev-page')).toHaveCount(1);
     await expect(pager.getByTestId('org-easycla-next-page')).toHaveCount(1);
     await expect(pager.getByTestId('org-easycla-page-label')).toHaveCount(1);

--- a/apps/lfx-one/e2e/org-easycla-list.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list.spec.ts
@@ -1,0 +1,171 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Lens EasyCLA list — content E2E (GH-1978).
+ *
+ * The content half of the repository's dual E2E architecture; `org-easycla-list-robust.spec.ts` is
+ * the structural half. This one drives the page the way a CLA manager does — read the cards, search
+ * for an agreement, page through the rest — and asserts on the words they end up looking at.
+ *
+ * The unit tests cover the same behaviours in jsdom, where the list is handed to the component
+ * directly. What they cannot cover is the path from an HTTP response to rendered text: the client
+ * service, the signal wiring, and the template all sit between the two and none of them are
+ * exercised by a component test that skips the request.
+ *
+ * Two of the cases below are about statements the page must not make. A failed request rendering as
+ * "no CLAs" and an unsigned agreement rendering as "Signed" are both false claims about an
+ * organization's legal position, and both are a one-line change away at all times.
+ *
+ * Prerequisites:
+ * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD
+ * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+import {
+  claGroup,
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  fulfillJson,
+  gotoEasyclaList,
+  MOCK_ACCOUNT_NAME,
+  PAGE_LOAD_TIMEOUT,
+  searchInput,
+  skipWithoutCredentials,
+} from './helpers/org-easycla.helper';
+
+/** Nine rows: one more than the page size, so the pager has something to page. */
+function nineClaGroups() {
+  return [
+    claGroup({ id: 'sig-1', claGroupName: 'Nimbus Foundation CLA', claManagersCount: 2, approvalCriteriaCount: 4 }),
+    claGroup({ id: 'sig-2', claGroupName: 'Cascade Project CLA', claManagersCount: 1, approvalCriteriaCount: 1 }),
+    claGroup({ id: 'sig-3', claGroupName: 'Driftwood CLA', needsClaManager: true, claManagersCount: 0 }),
+    claGroup({ id: 'sig-4', claGroupName: 'Meridian CLA', status: 'sanctioned' }),
+    claGroup({ id: 'sig-5', claGroupName: 'Lumen CLA', status: 'not-started' }),
+    claGroup({ id: 'sig-6', claGroupName: 'Harbor CLA', approvalCriteriaCount: undefined }),
+    claGroup({ id: 'sig-7', claGroupName: 'Quarry CLA' }),
+    claGroup({ id: 'sig-8', claGroupName: 'Ridgeway CLA' }),
+    claGroup({ id: 'sig-9', claGroupName: 'Solstice CLA' }),
+  ];
+}
+
+function stubList(rows: ReturnType<typeof nineClaGroups>) {
+  return (page: Page) => fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList(rows));
+}
+
+test.describe('Org Lens EasyCLA list — content', () => {
+  // The left-nav sidebar is `hidden lg:flex`, so a mobile project would fail visibility checks that
+  // have nothing to do with the list.
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test.beforeEach(() => skipWithoutCredentials());
+
+  test('renders a card per agreement, titled for the organization', async ({ page }) => {
+    await gotoEasyclaList(page, stubList(nineClaGroups()));
+
+    await expect(page.getByTestId('org-easycla-title')).toContainText(MOCK_ACCOUNT_NAME, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Eight of nine: the ninth is on page two, which is what the paging case below is about.
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(8);
+    await expect(page.getByTestId('org-easycla-card-title').first()).toHaveText('Nimbus Foundation CLA');
+  });
+
+  test('states each agreement\u2019s status in the words the design uses', async ({ page }) => {
+    await gotoEasyclaList(page, stubList(nineClaGroups()));
+
+    const card = (name: string) => page.getByTestId('org-easycla-card').filter({ hasText: name });
+
+    await expect(card('Nimbus Foundation CLA').getByTestId('org-easycla-card-status')).toHaveText('Signed', { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(card('Meridian CLA').getByTestId('org-easycla-card-status')).toHaveText('Sanctioned');
+
+    // The one that matters most: an unsigned agreement described as signed is a false statement
+    // about what this organization has agreed to.
+    await expect(card('Lumen CLA').getByTestId('org-easycla-card-status')).toHaveText('Not started');
+    await expect(card('Lumen CLA').getByTestId('org-easycla-card-status')).not.toHaveText('Signed');
+  });
+
+  test('reports counts, agreeing in number, and marks an unavailable count as unavailable', async ({ page }) => {
+    await gotoEasyclaList(page, stubList(nineClaGroups()));
+
+    const card = (name: string) => page.getByTestId('org-easycla-card').filter({ hasText: name });
+
+    await expect(card('Cascade Project CLA').getByTestId('org-easycla-card-approval-count')).toHaveText('1', { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(card('Cascade Project CLA').getByTestId('org-easycla-card-approval-label')).toHaveText('approval entry');
+    await expect(card('Cascade Project CLA').getByTestId('org-easycla-card-manager-count')).toHaveText('1');
+
+    await expect(card('Nimbus Foundation CLA').getByTestId('org-easycla-card-approval-label')).toHaveText('approval entries');
+
+    // A deployment that predates the producer's count field shows a dash, not a zero: "no rules"
+    // and "we could not read the rules" are different claims.
+    await expect(card('Harbor CLA').getByTestId('org-easycla-card-approval-count')).toHaveText('—');
+
+    await expect(card('Driftwood CLA').getByTestId('org-easycla-card-needs-manager')).toBeVisible();
+  });
+
+  test('narrows the list to a searched agreement, and says so when nothing matches', async ({ page }) => {
+    await gotoEasyclaList(page, stubList(nineClaGroups()));
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(8, { timeout: PAGE_LOAD_TIMEOUT });
+
+    await searchInput(page).fill('Driftwood');
+
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(1);
+    await expect(page.getByTestId('org-easycla-card-title')).toHaveText('Driftwood CLA');
+
+    await searchInput(page).fill('nothing matches this');
+
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-no-matches-state')).toBeVisible();
+
+    // Clearing restores the full list rather than leaving the page on its no-matches state.
+    await searchInput(page).fill('');
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(8);
+  });
+
+  test('pages through the agreements that do not fit on the first page', async ({ page }) => {
+    await gotoEasyclaList(page, stubList(nineClaGroups()));
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(8, { timeout: PAGE_LOAD_TIMEOUT });
+
+    await expect(page.getByTestId('org-easycla-pager')).toBeVisible();
+    await expect(page.getByTestId('org-easycla-card-title').filter({ hasText: 'Solstice CLA' })).toHaveCount(0);
+
+    await page.getByTestId('org-easycla-next-page').click();
+
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(1);
+    await expect(page.getByTestId('org-easycla-card-title')).toHaveText('Solstice CLA');
+
+    await page.getByTestId('org-easycla-prev-page').click();
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(8);
+  });
+
+  test('hides the pager when every agreement fits on one page', async ({ page }) => {
+    await gotoEasyclaList(page, stubList([claGroup({ id: 'sig-1', claGroupName: 'Nimbus Foundation CLA' })]));
+
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(1, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-pager')).toHaveCount(0);
+  });
+
+  test('says the organization has signed nothing only when that is what upstream said', async ({ page }) => {
+    await gotoEasyclaList(page, stubList([]));
+
+    await expect(page.getByTestId('org-easycla-empty-state')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-error-state')).toHaveCount(0);
+  });
+
+  // The counterpart to the case above, and the reason both exist. Upstream answers an organization
+  // it has never heard of with the same empty list it gives one that has signed nothing, so a
+  // failure quietly rendered as "no CLAs" would be indistinguishable from the truth.
+  test('shows a load failure as a failure, never as an organization with no CLAs', async ({ page }) => {
+    await gotoEasyclaList(page, (p) =>
+      p.route(CLA_GROUPS_ROUTE, (route) =>
+        route.fulfill({ status: 502, contentType: 'application/json', body: JSON.stringify({ code: 'UPSTREAM_ERROR', message: 'upstream unavailable' }) })
+      )
+    );
+
+    await expect(page.getByTestId('org-easycla-error-state')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-empty-state')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-easycla-list.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list.spec.ts
@@ -134,12 +134,12 @@ test.describe('Org Lens EasyCLA list — content', () => {
     await gotoEasyclaList(page, stubList(nineClaGroups()));
     await expect(page.getByTestId('org-easycla-card')).toHaveCount(8, { timeout: PAGE_LOAD_TIMEOUT });
 
-    await expect(page.getByTestId('org-easycla-pager')).toBeVisible();
+    await expect(page.getByTestId('org-easycla-pager')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
     await expect(page.getByTestId('org-easycla-card-title').filter({ hasText: 'Solstice CLA' })).toHaveCount(0);
 
     await page.getByTestId('org-easycla-next-page').click();
 
-    await expect(page.getByTestId('org-easycla-card')).toHaveCount(1);
+    await expect(page.getByTestId('org-easycla-card')).toHaveCount(1, { timeout: PAGE_LOAD_TIMEOUT });
     await expect(page.getByTestId('org-easycla-card-title')).toHaveText('Solstice CLA');
 
     await page.getByTestId('org-easycla-prev-page').click();

--- a/apps/lfx-one/e2e/org-easycla-list.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list.spec.ts
@@ -85,6 +85,12 @@ test.describe('Org Lens EasyCLA list — content', () => {
     // about what this organization has agreed to.
     await expect(card('Lumen CLA').getByTestId('org-easycla-card-status')).toHaveText('Not started');
     await expect(card('Lumen CLA').getByTestId('org-easycla-card-status')).not.toHaveText('Signed');
+
+    // And the whole card must agree with its own pill: the signing-entity subline is a second
+    // claim about the same agreement, so an unsigned card must not carry "Signed by" beneath a
+    // pill that reads "Not started".
+    await expect(card('Lumen CLA')).not.toContainText('Signed by');
+    await expect(card('Nimbus Foundation CLA').getByTestId('org-easycla-card-signing-entity')).toContainText('Signed by');
   });
 
   test('reports counts, agreeing in number, and marks an unavailable count as unavailable', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
@@ -3,7 +3,10 @@
 
 <article class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-easycla-card">
   <header class="flex flex-col gap-0.5">
-    <h3 class="font-medium text-base text-gray-900" data-testid="org-easycla-card-title">{{ claGroup().claGroupName }}</h3>
+    <!-- Level 2, not 3: the page's only other heading is its `h1`, and the `h2` beside it belongs to
+         the no-access state, which never renders alongside this grid. An `h3` here would leave a
+         screen reader stepping h1 → h3 with nothing at level 2 to explain the jump. -->
+    <h2 class="font-medium text-base text-gray-900" data-testid="org-easycla-card-title">{{ claGroup().claGroupName }}</h2>
     <!-- Only when the signing entity differs from the organization — the server suppresses it
          otherwise, so this never repeats the page title. It is what distinguishes two cards that
          share a CLA Group name because the organization signed under several entities. -->

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
@@ -1,0 +1,46 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<article class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-easycla-card">
+  <header class="flex flex-col gap-0.5">
+    <h3 class="font-medium text-base text-gray-900" data-testid="org-easycla-card-title">{{ claGroup().claGroupName }}</h3>
+    <!-- Only when the signing entity differs from the organization — the server suppresses it
+         otherwise, so this never repeats the page title. It is what distinguishes two cards that
+         share a CLA Group name because the organization signed under several entities. -->
+    @if (claGroup().signingEntityName; as signingEntityName) {
+      <p class="text-xs text-gray-500" data-testid="org-easycla-card-signing-entity">Signed by {{ signingEntityName }}</p>
+    }
+  </header>
+
+  <div class="flex flex-wrap items-center gap-2">
+    <!-- Static by design: the coverage dialog ships with the agreement detail view. -->
+    @for (chip of coverageChips(); track chip) {
+      <span class="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs text-gray-700" data-testid="org-easycla-card-coverage">{{ chip }}</span>
+    }
+
+    <lfx-tag [value]="status().label" [severity]="status().severity" data-testid="org-easycla-card-status" />
+
+    @if (claGroup().needsClaManager) {
+      <!-- Not in the approved design's card, which carries no unmanaged-group indicator at all.
+           Added because an unmanaged CLA Group silently blocks every contributor approval under it
+           and nothing else on this page would reveal it. -->
+      <lfx-tag
+        value="Needs a CLA Manager"
+        severity="warn"
+        icon="fa-light fa-triangle-exclamation"
+        tooltip="No one can approve contributors for this CLA Group until a CLA Manager is added."
+        data-testid="org-easycla-card-needs-manager" />
+    }
+  </div>
+
+  <dl class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-600">
+    <div class="flex items-baseline gap-1.5">
+      <dt class="order-2">approval entries</dt>
+      <dd class="order-1 font-semibold text-gray-900" data-testid="org-easycla-card-approval-count">{{ approvalCriteriaValue() }}</dd>
+    </div>
+    <div class="flex items-baseline gap-1.5">
+      <dt class="order-2">{{ managersLabel() }}</dt>
+      <dd class="order-1 font-semibold text-gray-900" data-testid="org-easycla-card-manager-count">{{ claGroup().claManagersCount }}</dd>
+    </div>
+  </dl>
+</article>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
@@ -35,7 +35,7 @@
 
   <dl class="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-600">
     <div class="flex items-baseline gap-1.5">
-      <dt class="order-2">approval entries</dt>
+      <dt class="order-2" data-testid="org-easycla-card-approval-label">{{ approvalCriteriaLabel() }}</dt>
       <dd class="order-1 font-semibold text-gray-900" data-testid="org-easycla-card-approval-count">{{ approvalCriteriaValue() }}</dd>
     </div>
     <div class="flex items-baseline gap-1.5">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.html
@@ -7,8 +7,8 @@
     <!-- Only when the signing entity differs from the organization — the server suppresses it
          otherwise, so this never repeats the page title. It is what distinguishes two cards that
          share a CLA Group name because the organization signed under several entities. -->
-    @if (claGroup().signingEntityName; as signingEntityName) {
-      <p class="text-xs text-gray-500" data-testid="org-easycla-card-signing-entity">Signed by {{ signingEntityName }}</p>
+    @if (claGroup().signingEntityName) {
+      <p class="text-xs text-gray-500" data-testid="org-easycla-card-signing-entity">{{ signingEntityLabel() }}</p>
     }
   </header>
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
@@ -53,6 +53,14 @@ describe('OrgEasyclaCardComponent', () => {
       expect(textOf(fixture, 'org-easycla-card-title')).toBe('Nimbus Foundation CLA');
     });
 
+    // The page it sits on has one `h1` and nothing else at level 2 while the grid is rendered, so
+    // an `h3` here would make a screen reader step h1 → h3 past a level that names nothing.
+    it('titles the card at the level below the page heading', async () => {
+      const fixture = await render(claGroup());
+
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-card-title"]')?.tagName).toBe('H2');
+    });
+
     it('shows the signing entity when the server sent one', async () => {
       const fixture = await render(claGroup({ signingEntityName: 'Vertex Robotics GmbH', status: 'signed' }));
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
@@ -1,0 +1,190 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
+import { describe, expect, it } from 'vitest';
+
+import { OrgEasyclaCardComponent } from './org-easycla-card.component';
+
+describe('OrgEasyclaCardComponent', () => {
+  function claGroup(overrides: Partial<OrgClaGroup> = {}): OrgClaGroup {
+    return {
+      id: 'signature-uuid-1',
+      claGroupName: 'Nimbus Foundation CLA',
+      claGroupId: 'cla-group-uuid-1',
+      foundationName: 'Nimbus Foundation',
+      projects: [{ projectName: 'Cascade' }, { projectName: 'Driftwood' }],
+      status: 'signed',
+      needsClaManager: false,
+      claManagersCount: 2,
+      ...overrides,
+    };
+  }
+
+  async function render(group: OrgClaGroup): Promise<ComponentFixture<OrgEasyclaCardComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaCardComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaCardComponent);
+    fixture.componentRef.setInput('claGroup', group);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function textOf(fixture: ComponentFixture<OrgEasyclaCardComponent>, id: string): string | undefined {
+    return fixture.nativeElement.querySelector(`[data-testid="${id}"]`)?.textContent?.trim();
+  }
+
+  function allText(fixture: ComponentFixture<OrgEasyclaCardComponent>, id: string): string[] {
+    return Array.from(fixture.nativeElement.querySelectorAll(`[data-testid="${id}"]`)).map((el) => (el as HTMLElement).textContent?.trim() ?? '');
+  }
+
+  describe('identity', () => {
+    it('names the CLA Group', async () => {
+      const fixture = await render(claGroup());
+
+      expect(textOf(fixture, 'org-easycla-card-title')).toBe('Nimbus Foundation CLA');
+    });
+
+    it('shows the signing entity when the server sent one', async () => {
+      const fixture = await render(claGroup({ signingEntityName: 'Vertex Robotics GmbH' }));
+
+      expect(textOf(fixture, 'org-easycla-card-signing-entity')).toContain('Vertex Robotics GmbH');
+    });
+
+    // The server suppresses it when it matches the organization's own name, which is the common
+    // case — repeating the page title under every heading is noise.
+    it('shows no signing-entity subline when the server omitted it', async () => {
+      const fixture = await render(claGroup({ signingEntityName: undefined }));
+
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-card-signing-entity"]')).toBeNull();
+    });
+  });
+
+  describe('coverage', () => {
+    it('names the project directly when the CLA Group covers exactly one', async () => {
+      const fixture = await render(claGroup({ projects: [{ projectName: 'Cascade' }] }));
+
+      expect(allText(fixture, 'org-easycla-card-coverage')).toEqual(['Cascade']);
+    });
+
+    it('names the foundation and counts the projects when it covers several', async () => {
+      const fixture = await render(claGroup());
+
+      expect(allText(fixture, 'org-easycla-card-coverage')).toEqual(['Nimbus Foundation', 'Covers 2 projects']);
+    });
+
+    it('falls back to the count alone when the foundation is unknown', async () => {
+      const fixture = await render(claGroup({ foundationName: undefined }));
+
+      expect(allText(fixture, 'org-easycla-card-coverage')).toEqual(['Covers 2 projects']);
+    });
+
+    it('renders no coverage element when nothing is covered', async () => {
+      const fixture = await render(claGroup({ projects: [] }));
+
+      expect(allText(fixture, 'org-easycla-card-coverage')).toEqual([]);
+    });
+
+    // The coverage dialog ships with the agreement detail view; until then a chip that looks
+    // actionable and does nothing reads as a defect.
+    it('renders coverage as static text, not as a link or a button', async () => {
+      const fixture = await render(claGroup());
+      const chips = fixture.nativeElement.querySelectorAll('[data-testid="org-easycla-card-coverage"]');
+
+      for (const chip of chips) {
+        expect((chip as HTMLElement).tagName).toBe('SPAN');
+        expect((chip as HTMLElement).querySelector('a, button')).toBeNull();
+      }
+    });
+  });
+
+  describe('status', () => {
+    it('reads as signed for an ordinary agreement', async () => {
+      const fixture = await render(claGroup({ status: 'signed' }));
+
+      expect(textOf(fixture, 'org-easycla-card-status')).toContain('Signed');
+    });
+
+    it('reads as sanctioned when the signing entity is flagged', async () => {
+      const fixture = await render(claGroup({ status: 'sanctioned' }));
+
+      expect(textOf(fixture, 'org-easycla-card-status')).toContain('Sanctioned');
+      expect(textOf(fixture, 'org-easycla-card-status')).not.toContain('Signed');
+    });
+  });
+
+  describe('needs a CLA manager', () => {
+    it('flags an agreement with no CLA manager', async () => {
+      const fixture = await render(claGroup({ needsClaManager: true, claManagersCount: 0 }));
+
+      expect(textOf(fixture, 'org-easycla-card-needs-manager')).toContain('Needs a CLA Manager');
+    });
+
+    it('does not flag a managed agreement', async () => {
+      const fixture = await render(claGroup({ needsClaManager: false }));
+
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-card-needs-manager"]')).toBeNull();
+    });
+
+    // Rendered from the flag alone. Re-deriving it from the count here would be a second
+    // definition of the same condition, free to drift from the producer's.
+    it('follows the flag rather than the manager count', async () => {
+      const fixture = await render(claGroup({ needsClaManager: false, claManagersCount: 0 }));
+
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-card-needs-manager"]')).toBeNull();
+    });
+  });
+
+  describe('statistics', () => {
+    it('shows the manager count', async () => {
+      const fixture = await render(claGroup({ claManagersCount: 3 }));
+
+      expect(textOf(fixture, 'org-easycla-card-manager-count')).toBe('3');
+    });
+
+    it('agrees in number with a single manager', async () => {
+      const fixture = await render(claGroup({ claManagersCount: 1 }));
+
+      expect(fixture.nativeElement.textContent).toContain('CLA Manager');
+      expect(fixture.nativeElement.textContent).not.toContain('CLA Managers');
+    });
+
+    it('agrees in number with no managers', async () => {
+      const fixture = await render(claGroup({ claManagersCount: 0 }));
+
+      expect(fixture.nativeElement.textContent).toContain('CLA Managers');
+    });
+
+    // The CLA service supplies no approval-criteria count. A zero here would assert the agreement
+    // approves nobody — a claim about a company's legal configuration this data cannot support.
+    it('shows the approval-entries stat as unavailable rather than as zero', async () => {
+      const fixture = await render(claGroup());
+
+      expect(textOf(fixture, 'org-easycla-card-approval-count')).toBe('—');
+      expect(textOf(fixture, 'org-easycla-card-approval-count')).not.toBe('0');
+      expect(fixture.nativeElement.textContent).toContain('approval entries');
+    });
+
+    // Pins the swap the placeholder exists to make cheap: when the producer adds the count, the
+    // mapper populates it and nothing in this template moves.
+    it('renders a real approval-criteria count once one is supplied', async () => {
+      const fixture = await render(claGroup({ approvalCriteriaCount: 7 }));
+
+      expect(textOf(fixture, 'org-easycla-card-approval-count')).toBe('7');
+    });
+
+    it('renders a supplied count of zero as zero, not as unavailable', async () => {
+      const fixture = await render(claGroup({ approvalCriteriaCount: 0 }));
+
+      expect(textOf(fixture, 'org-easycla-card-approval-count')).toBe('0');
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
@@ -163,8 +163,9 @@ describe('OrgEasyclaCardComponent', () => {
       expect(fixture.nativeElement.textContent).toContain('CLA Managers');
     });
 
-    // The CLA service supplies no approval-criteria count. A zero here would assert the agreement
-    // approves nobody — a claim about a company's legal configuration this data cannot support.
+    // A CLA service deployment predating the count sends nothing. A zero here would assert the
+    // agreement approves nobody — a claim about a company's legal configuration that an absent
+    // field cannot support.
     it('shows the approval-entries stat as unavailable rather than as zero', async () => {
       const fixture = await render(claGroup());
 
@@ -173,9 +174,7 @@ describe('OrgEasyclaCardComponent', () => {
       expect(fixture.nativeElement.textContent).toContain('approval entries');
     });
 
-    // Pins the swap the placeholder exists to make cheap: when the producer adds the count, the
-    // mapper populates it and nothing in this template moves.
-    it('renders a real approval-criteria count once one is supplied', async () => {
+    it('renders a real approval-criteria count when one is supplied', async () => {
       const fixture = await render(claGroup({ approvalCriteriaCount: 7 }));
 
       expect(textOf(fixture, 'org-easycla-card-approval-count')).toBe('7');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
@@ -54,9 +54,26 @@ describe('OrgEasyclaCardComponent', () => {
     });
 
     it('shows the signing entity when the server sent one', async () => {
-      const fixture = await render(claGroup({ signingEntityName: 'Vertex Robotics GmbH' }));
+      const fixture = await render(claGroup({ signingEntityName: 'Vertex Robotics GmbH', status: 'signed' }));
 
-      expect(textOf(fixture, 'org-easycla-card-signing-entity')).toContain('Vertex Robotics GmbH');
+      expect(textOf(fixture, 'org-easycla-card-signing-entity')).toBe('Signed by Vertex Robotics GmbH');
+    });
+
+    // The subline is a claim of its own, sitting under the status pill. Saying "Signed by" beneath
+    // a pill reading "Not started" makes the card deny and affirm the same agreement at once.
+    it('does not say the entity signed when the agreement is not signed', async () => {
+      const fixture = await render(claGroup({ signingEntityName: 'Vertex Robotics GmbH', status: 'not-started' }));
+
+      expect(textOf(fixture, 'org-easycla-card-signing-entity')).toBe('Signing entity: Vertex Robotics GmbH');
+      expect(textOf(fixture, 'org-easycla-card-signing-entity')).not.toContain('Signed by');
+    });
+
+    // Sanctioned is what the status collapses to when an agreement is both signed and sanctioned,
+    // so it carries no signedness of its own and the subline must not supply one.
+    it('stays non-committal about signing on a sanctioned agreement', async () => {
+      const fixture = await render(claGroup({ signingEntityName: 'Vertex Robotics GmbH', status: 'sanctioned' }));
+
+      expect(textOf(fixture, 'org-easycla-card-signing-entity')).not.toContain('Signed by');
     });
 
     // The server suppresses it when it matches the organization's own name, which is the common

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
@@ -119,6 +119,15 @@ describe('OrgEasyclaCardComponent', () => {
       expect(textOf(fixture, 'org-easycla-card-status')).toContain('Sanctioned');
       expect(textOf(fixture, 'org-easycla-card-status')).not.toContain('Signed');
     });
+
+    // The word matters more than the styling here: an unsigned agreement described as signed
+    // is a false statement about the organization's legal position.
+    it('reads as not started for an unsigned agreement, never as signed', async () => {
+      const fixture = await render(claGroup({ status: 'not-started' }));
+
+      expect(textOf(fixture, 'org-easycla-card-status')).toContain('Not started');
+      expect(textOf(fixture, 'org-easycla-card-status')).not.toContain('Signed');
+    });
   });
 
   describe('needs a CLA manager', () => {
@@ -184,6 +193,26 @@ describe('OrgEasyclaCardComponent', () => {
       const fixture = await render(claGroup({ approvalCriteriaCount: 0 }));
 
       expect(textOf(fixture, 'org-easycla-card-approval-count')).toBe('0');
+    });
+
+    // Agreement in number, as the manager label beside it already does. Invisible while every
+    // value was a placeholder; a populated count of one exposed it.
+    it('says "approval entry" for exactly one', async () => {
+      const fixture = await render(claGroup({ approvalCriteriaCount: 1 }));
+
+      expect(textOf(fixture, 'org-easycla-card-approval-label')).toBe('approval entry');
+    });
+
+    it('says "approval entries" for a count that is not one', async () => {
+      const fixture = await render(claGroup({ approvalCriteriaCount: 4 }));
+
+      expect(textOf(fixture, 'org-easycla-card-approval-label')).toBe('approval entries');
+    });
+
+    it('keeps the plural when no count is available, since none has been stated', async () => {
+      const fixture = await render(claGroup());
+
+      expect(textOf(fixture, 'org-easycla-card-approval-label')).toBe('approval entries');
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.spec.ts
@@ -104,8 +104,17 @@ describe('OrgEasyclaCardComponent', () => {
       expect(allText(fixture, 'org-easycla-card-coverage')).toEqual(['Covers 2 projects']);
     });
 
-    it('renders no coverage element when nothing is covered', async () => {
-      const fixture = await render(claGroup({ projects: [] }));
+    // The foundation-wide case. The source omits the entry whose project is the foundation itself,
+    // so an agreement covering a whole foundation arrives with no projects at all — showing nothing
+    // would hide the only coverage it has, on the card whose search can match that very name.
+    it('names the foundation when the agreement covers it and carries no projects', async () => {
+      const fixture = await render(claGroup({ projects: [], foundationName: 'Nimbus Foundation' }));
+
+      expect(allText(fixture, 'org-easycla-card-coverage')).toEqual(['Nimbus Foundation']);
+    });
+
+    it('renders no coverage element when neither a project nor a foundation is known', async () => {
+      const fixture = await render(claGroup({ projects: [], foundationName: undefined }));
 
       expect(allText(fixture, 'org-easycla-card-coverage')).toEqual([]);
     });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
@@ -42,7 +42,11 @@ export class OrgEasyclaCardComponent {
   protected readonly coverageChips = computed<string[]>(() => {
     const { projects, foundationName } = this.claGroup();
 
-    if (projects.length === 0) return [];
+    // An empty project list is the foundation-wide case, not an absence of coverage. The source
+    // omits the entry whose project is the foundation itself, so an agreement covering a whole
+    // foundation arrives with no projects and only its foundation name — and naming nothing would
+    // leave a card that search can match on that name while never showing it.
+    if (projects.length === 0) return foundationName ? [foundationName] : [];
     if (projects.length === 1) return [projects[0].projectName];
 
     const projectsChip = `Covers ${projects.length} projects`;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
@@ -56,11 +56,14 @@ export class OrgEasyclaCardComponent {
   /**
    * The approval-criteria count — how many rules decide who may be covered.
    *
-   * The CLA service returns no such count, so this is always absent and the card shows an em dash
-   * under the label rather than a number. It is deliberately not filled from the employee
-   * acknowledgement count, which counts the people covered rather than the rules covering them;
-   * a real number under a label naming a different quantity is worse than a visible gap. A zero
-   * would be worse still — it would assert the agreement approves nobody.
+   * Absent when the CLA service deployment does not return the count, in which case the card
+   * shows an em dash rather than a number — true, where a 0 would assert the agreement approves
+   * nobody. A real 0 from a deployment that does return it renders as 0, which is the honest
+   * answer for an agreement with no rules yet.
+   *
+   * Never filled from the employee acknowledgement count, which counts the people covered
+   * rather than the rules covering them: a real number under a label naming a different
+   * quantity is worse than a visible gap.
    */
   protected readonly approvalCriteriaValue = computed(() => {
     const count = this.claGroup().approvalCriteriaCount;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
@@ -1,0 +1,69 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
+import type { TagSeverity } from '@lfx-one/shared/interfaces';
+
+import { TagComponent } from '@components/tag/tag.component';
+
+/** Status label and severity, keyed by the server-derived status. */
+const STATUS_DISPLAY: Record<OrgClaGroup['status'], { label: string; severity: TagSeverity }> = {
+  signed: { label: 'Signed', severity: 'success' },
+  sanctioned: { label: 'Sanctioned', severity: 'danger' },
+};
+
+/**
+ * One corporate CLA on the Organization Lens EasyCLA list (#1978).
+ *
+ * Presentational only — it takes a row and renders it, injecting no service and holding no state,
+ * so the page's retrieval and paging logic and this card's display rules are testable apart.
+ */
+@Component({
+  selector: 'lfx-org-easycla-card',
+  imports: [TagComponent],
+  templateUrl: './org-easycla-card.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaCardComponent {
+  public readonly claGroup = input.required<OrgClaGroup>();
+
+  protected readonly status = computed(() => STATUS_DISPLAY[this.claGroup().status]);
+
+  /**
+   * Coverage as the approved design frames it: name the project when there is exactly one,
+   * otherwise name the foundation and say how many projects are covered.
+   *
+   * Static text, not a link. The design's chip opens a coverage dialog that ships with the
+   * agreement detail view; a chip styled as actionable that does nothing reads as a bug, so it
+   * stays plain until there is somewhere for it to go.
+   */
+  protected readonly coverageChips = computed<string[]>(() => {
+    const { projects, foundationName } = this.claGroup();
+
+    if (projects.length === 0) return [];
+    if (projects.length === 1) return [projects[0].projectName];
+
+    const projectsChip = `Covers ${projects.length} projects`;
+    return foundationName ? [foundationName, projectsChip] : [projectsChip];
+  });
+
+  protected readonly managersLabel = computed(() => {
+    const count = this.claGroup().claManagersCount;
+    return `CLA Manager${count === 1 ? '' : 's'}`;
+  });
+
+  /**
+   * The approval-criteria count — how many rules decide who may be covered.
+   *
+   * The CLA service returns no such count, so this is always absent and the card shows an em dash
+   * under the label rather than a number. It is deliberately not filled from the employee
+   * acknowledgement count, which counts the people covered rather than the rules covering them;
+   * a real number under a label naming a different quantity is worse than a visible gap. A zero
+   * would be worse still — it would assert the agreement approves nobody.
+   */
+  protected readonly approvalCriteriaValue = computed(() => {
+    const count = this.claGroup().approvalCriteriaCount;
+    return count === undefined ? '—' : String(count);
+  });
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
@@ -10,6 +10,7 @@ import { TagComponent } from '@components/tag/tag.component';
 /** Status label and severity, keyed by the server-derived status. */
 const STATUS_DISPLAY: Record<OrgClaGroup['status'], { label: string; severity: TagSeverity }> = {
   signed: { label: 'Signed', severity: 'success' },
+  'not-started': { label: 'Not started', severity: 'secondary' },
   sanctioned: { label: 'Sanctioned', severity: 'danger' },
 };
 
@@ -68,5 +69,17 @@ export class OrgEasyclaCardComponent {
   protected readonly approvalCriteriaValue = computed(() => {
     const count = this.claGroup().approvalCriteriaCount;
     return count === undefined ? '—' : String(count);
+  });
+
+  /**
+   * Agrees in number with the value beside it, as the manager label does.
+   *
+   * The unavailable case takes the plural, because no count has been stated for it to agree
+   * with — "— approval entry" would read as a singular claim about an agreement whose count
+   * is precisely what is unknown.
+   */
+  protected readonly approvalCriteriaLabel = computed(() => {
+    const count = this.claGroup().approvalCriteriaCount;
+    return `approval entr${count === 1 ? 'y' : 'ies'}`;
   });
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
@@ -7,13 +7,6 @@ import type { TagSeverity } from '@lfx-one/shared/interfaces';
 
 import { TagComponent } from '@components/tag/tag.component';
 
-/** Status label and severity, keyed by the server-derived status. */
-const STATUS_DISPLAY: Record<OrgClaGroup['status'], { label: string; severity: TagSeverity }> = {
-  signed: { label: 'Signed', severity: 'success' },
-  'not-started': { label: 'Not started', severity: 'secondary' },
-  sanctioned: { label: 'Sanctioned', severity: 'danger' },
-};
-
 /**
  * One corporate CLA on the Organization Lens EasyCLA list (#1978).
  *
@@ -27,9 +20,16 @@ const STATUS_DISPLAY: Record<OrgClaGroup['status'], { label: string; severity: T
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OrgEasyclaCardComponent {
+  /** Status label and severity, keyed by the server-derived status. */
+  private static readonly statusDisplay: Record<OrgClaGroup['status'], { label: string; severity: TagSeverity }> = {
+    signed: { label: 'Signed', severity: 'success' },
+    'not-started': { label: 'Not started', severity: 'secondary' },
+    sanctioned: { label: 'Sanctioned', severity: 'danger' },
+  };
+
   public readonly claGroup = input.required<OrgClaGroup>();
 
-  protected readonly status = computed(() => STATUS_DISPLAY[this.claGroup().status]);
+  protected readonly status = computed(() => OrgEasyclaCardComponent.statusDisplay[this.claGroup().status]);
 
   /**
    * Coverage as the approved design frames it: name the project when there is exactly one,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-card/org-easycla-card.component.ts
@@ -49,6 +49,19 @@ export class OrgEasyclaCardComponent {
     return foundationName ? [foundationName, projectsChip] : [projectsChip];
   });
 
+  /**
+   * Names the signing entity, and says it signed only where the status says so.
+   *
+   * "Signed by" is an assertion in its own right, sitting under a pill that may read "Not
+   * started" — the card would then both deny and affirm the same agreement. Only `signed`
+   * licenses the word: `not-started` has not been signed, and `sanctioned` deliberately says
+   * nothing about signedness, since it is what the status collapses toward when both are true.
+   */
+  protected readonly signingEntityLabel = computed(() => {
+    const { signingEntityName, status } = this.claGroup();
+    return status === 'signed' ? `Signed by ${signingEntityName}` : `Signing entity: ${signingEntityName}`;
+  });
+
   protected readonly managersLabel = computed(() => {
     const count = this.claGroup().claManagersCount;
     return `CLA Manager${count === 1 ? '' : 's'}`;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -62,12 +62,18 @@
            copy points at. Only the grid and the pager collapse. -->
       <div class="flex" data-testid="org-easycla-toolbar">
         <!-- The placeholder is not a label: it disappears as soon as anything is typed, leaving a
-             screen reader with an unnamed field. Same pattern as the groups list's search. -->
+             screen reader with an unnamed field.
+
+             `[id]` is bound, not written as a plain attribute. A static `id` would set the wrapper
+             component's input *and* stay on its host element, so two elements would carry the id
+             and `for` would resolve to the wrapper — which labels nothing. The binding reaches only
+             the native input. `org-easycla-list-robust.spec.ts` asserts the association resolves,
+             because a label that names nothing looks identical in the markup to one that works. -->
         <label for="org-easycla-search-input" class="sr-only">Search CLAs</label>
         <lfx-input-text
           [form]="filterForm"
           control="search"
-          id="org-easycla-search-input"
+          [id]="'org-easycla-search-input'"
           placeholder="Search CLAs…"
           icon="fa-light fa-magnifying-glass"
           class="w-full sm:max-w-xs"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -58,8 +58,8 @@
   } @else {
     @if (showToolbar()) {
       <!-- Survives both empty states on purpose: a viewer whose search matched nothing needs the
-           box to revise it, and a viewer with no CLAs needs the Sign CLA button the empty-state
-           copy points at. Only the grid and the pager collapse. -->
+           box to revise it. Only the grid and the pager collapse. The Sign CLA button the no-CLAs
+           copy points at is in the header above, outside this block, so it is unaffected. -->
       <div class="flex" data-testid="org-easycla-toolbar">
         <!-- The placeholder is not a label: it disappears as soon as anything is typed, leaving a
              screen reader with an unnamed field.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -2,15 +2,29 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <main class="container mx-auto flex flex-col gap-6 px-4 sm:px-6 lg:px-8" data-testid="org-easycla-page">
-  <header class="flex flex-col gap-2" data-testid="org-easycla-header">
-    <h1 class="font-display font-light text-2xl" data-testid="org-easycla-title">
-      @if (companyName()) {
-        EasyCLA &mdash; {{ companyName() }}
-      } @else {
-        EasyCLA
-      }
-    </h1>
-    <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization has signed across Linux Foundation projects.</p>
+  <header class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between" data-testid="org-easycla-header">
+    <div class="flex flex-col gap-2">
+      <h1 class="font-display font-light text-2xl" data-testid="org-easycla-title">
+        @if (companyName()) {
+          EasyCLA &mdash; {{ companyName() }}
+        } @else {
+          EasyCLA
+        }
+      </h1>
+      <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization has signed across Linux Foundation projects.</p>
+    </div>
+
+    <!-- Rendered but not yet operable: the signing hand-off ships separately. It is here now
+         because the no-CLAs empty state tells the viewer to use it, and disabled reads as
+         "not yet available" where an enabled control wired to nothing reads as broken. There is
+         deliberately no click handler to leave behind — enabling it is the signing feature's job. -->
+    <lfx-button
+      label="Sign CLA"
+      icon="fa-light fa-file-signature"
+      [disabled]="true"
+      tooltip="Signing a new CLA from the Organization Lens is coming soon."
+      styleClass="shrink-0"
+      data-testid="org-easycla-sign-cla" />
   </header>
 
   @if (hasNoOrgAccess()) {
@@ -42,10 +56,77 @@
       title="No org selected"
       subtitle="Select an organization to view its CLAs." />
   } @else {
-    <lfx-empty-state
-      data-testid="org-easycla-empty-state"
-      icon="fa-light fa-file-signature"
-      title="No CLAs signed yet"
-      subtitle="Corporate CLAs your organization signs will appear here." />
+    @if (showToolbar()) {
+      <!-- Survives both empty states on purpose: a viewer whose search matched nothing needs the
+           box to revise it, and a viewer with no CLAs needs the Sign CLA button the empty-state
+           copy points at. Only the grid and the pager collapse. -->
+      <div class="flex" data-testid="org-easycla-toolbar">
+        <lfx-input-text
+          [form]="filterForm"
+          control="search"
+          placeholder="Search signed CLAs…"
+          icon="fa-light fa-magnifying-glass"
+          class="w-full sm:max-w-xs"
+          dataTest="org-easycla-search" />
+      </div>
+    }
+
+    @if (claLoading()) {
+      <section class="flex flex-col gap-3" data-testid="org-easycla-list-loading">
+        <p-skeleton width="100%" height="6rem" />
+        <p-skeleton width="100%" height="6rem" />
+      </section>
+    } @else if (fetchError()) {
+      <!-- Never the "signed nothing" copy: a failed load and an empty list are different facts,
+           and only one of them is a statement about the organization's legal position. -->
+      <lfx-empty-state
+        data-testid="org-easycla-error-state"
+        icon="fa-light fa-triangle-exclamation"
+        title="We couldn't load your CLAs"
+        subtitle="Something went wrong fetching this organization's corporate CLAs. Refresh the page to try again." />
+    } @else if (showNoClasEmptyState()) {
+      <lfx-empty-state
+        data-testid="org-easycla-empty-state"
+        icon="fa-light fa-file-signature"
+        [title]="noClasTitle()"
+        subtitle='Use "Sign CLA" above to find a CLA and get started.' />
+    } @else if (showNoMatchesEmptyState()) {
+      <lfx-empty-state
+        data-testid="org-easycla-no-matches-state"
+        icon="fa-light fa-magnifying-glass"
+        title="No CLAs match your search"
+        subtitle="Try a different project, foundation, or CLA name." />
+    } @else {
+      <section class="grid grid-cols-1 gap-4 md:grid-cols-2" data-testid="org-easycla-grid">
+        @for (claGroup of pagedClaGroups(); track claGroup.id) {
+          <lfx-org-easycla-card [claGroup]="claGroup" />
+        }
+      </section>
+
+      @if (showPager()) {
+        <div class="flex items-center justify-between gap-4" data-testid="org-easycla-pager">
+          <span class="text-sm text-gray-600" data-testid="org-easycla-page-label">{{ pageLabel() }}</span>
+          <div class="flex gap-2">
+            <lfx-button
+              label="Previous"
+              icon="fa-light fa-arrow-left"
+              [outlined]="true"
+              size="small"
+              [disabled]="onFirstPage()"
+              (onClick)="changePage(-1)"
+              data-testid="org-easycla-prev-page" />
+            <lfx-button
+              label="Next"
+              icon="fa-light fa-arrow-right"
+              iconPos="right"
+              [outlined]="true"
+              size="small"
+              [disabled]="onLastPage()"
+              (onClick)="changePage(1)"
+              data-testid="org-easycla-next-page" />
+          </div>
+        </div>
+      }
+    }
   }
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -18,10 +18,16 @@
          because the no-CLAs empty state tells the viewer to use it, and disabled reads as
          "not yet available" where an enabled control wired to nothing reads as broken. There is
          deliberately no click handler to leave behind — enabling it is the signing feature's job. -->
+    <!-- The reason is in the accessible name as well as the tooltip, because the tooltip alone
+         cannot reach everyone it needs to: the directive sits on the non-focusable `<p-button>`
+         host while the button inside it is disabled, so it opens on hover and never on focus.
+         Without this, assistive technology announces only "Sign CLA, disabled" and the viewer is
+         left to guess whether the control is unavailable to them or unavailable to everyone. -->
     <lfx-button
       label="Sign CLA"
       icon="fa-light fa-file-signature"
       [disabled]="true"
+      ariaLabel="Sign CLA — signing a new CLA from the Organization Lens is coming soon."
       tooltip="Signing a new CLA from the Organization Lens is coming soon."
       styleClass="shrink-0"
       data-testid="org-easycla-sign-cla" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -11,7 +11,7 @@
           EasyCLA
         }
       </h1>
-      <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization has signed across Linux Foundation projects.</p>
+      <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization holds across Linux Foundation projects.</p>
     </div>
 
     <!-- Rendered but not yet operable: the signing hand-off ships separately. It is here now
@@ -64,7 +64,7 @@
         <lfx-input-text
           [form]="filterForm"
           control="search"
-          placeholder="Search signed CLAs…"
+          placeholder="Search CLAs…"
           icon="fa-light fa-magnifying-glass"
           class="w-full sm:max-w-xs"
           dataTest="org-easycla-search" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -61,9 +61,13 @@
            box to revise it, and a viewer with no CLAs needs the Sign CLA button the empty-state
            copy points at. Only the grid and the pager collapse. -->
       <div class="flex" data-testid="org-easycla-toolbar">
+        <!-- The placeholder is not a label: it disappears as soon as anything is typed, leaving a
+             screen reader with an unnamed field. Same pattern as the groups list's search. -->
+        <label for="org-easycla-search-input" class="sr-only">Search CLAs</label>
         <lfx-input-text
           [form]="filterForm"
           control="search"
+          id="org-easycla-search-input"
           placeholder="Search CLAs…"
           icon="fa-light fa-magnifying-glass"
           class="w-full sm:max-w-xs"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -437,6 +437,21 @@ describe('OrgEasyclaComponent', () => {
       expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(3);
     });
 
+    // `companyName()` reacts to the account signal in the same pass, while the response in hand is
+    // still the previous organization's, so timing alone does not hold the invariant. Rows are
+    // gated on the orgUid the server echoed matching the organization the header names — and the
+    // gate holds the loading state rather than emptying the list, because an empty list on a
+    // settled page is not neutral, it is the "hasn't signed any CLAs yet" claim.
+    it("withholds a response carrying another organization's uid", async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: OTHER_ACCOUNT.uid, claGroups: manyClaGroups(3) }));
+
+      const fixture = await render();
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(0);
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+      expect(byTestId(fixture, 'org-easycla-list-loading')).toBeTruthy();
+    });
+
     it("opens the new organization's list at the first page", async () => {
       getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(11) }));
       const fixture = await render();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -125,6 +125,16 @@ describe('OrgEasyclaComponent', () => {
       expect(signCla).toBeTruthy();
       expect(signCla?.querySelector('button')?.disabled).toBe(true);
     });
+
+    // The tooltip carrying the reason opens on hover only: its directive is on the non-focusable
+    // host while the button inside is disabled. The accessible name is the path that reaches a
+    // screen reader, which would otherwise hear "Sign CLA, disabled" and no reason for it.
+    it('names the reason the Sign CLA control is disabled, not just that it is', async () => {
+      const fixture = await render();
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+
+      expect(button?.getAttribute('aria-label')).toContain('coming soon');
+    });
   });
 
   describe('access and org-selection states', () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -7,24 +7,50 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 // The no-access branch renders a `lfxOpenIntercom` support button, which injects MessageService.
 import { MessageService } from 'primeng/api';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OrgEasyclaComponent } from './org-easycla.component';
 
 describe('OrgEasyclaComponent', () => {
-  const SELECTED_ACCOUNT = { uid: 'org-acme', accountName: 'Acme Motors, Inc.' };
+  const SELECTED_ACCOUNT = { uid: '0014100000Te2ovAAB', accountName: 'Vertex Robotics' };
 
   const selectedAccount = signal<{ uid?: string; accountName: string } | null>(null);
   const hasOrgSelectorAccess = signal(true);
   const grantsLoaded = signal(true);
   const personaLoaded = signal(true);
   const navLoaded = signal(true);
+
+  const getClaGroups = vi.fn();
+
+  function claGroup(overrides: Partial<OrgClaGroup> = {}): OrgClaGroup {
+    return {
+      id: 'signature-uuid-1',
+      claGroupName: 'Nimbus Foundation CLA',
+      claGroupId: 'cla-group-uuid-1',
+      foundationName: 'Nimbus Foundation',
+      projects: [{ projectName: 'Cascade' }, { projectName: 'Driftwood' }],
+      status: 'signed',
+      needsClaManager: false,
+      claManagersCount: 2,
+      ...overrides,
+    };
+  }
+
+  /** Eight fills exactly one page; anything past that is on page two. */
+  function manyClaGroups(count: number): OrgClaGroup[] {
+    return Array.from({ length: count }, (_, index) =>
+      claGroup({ id: `signature-${index}`, claGroupName: `Foundation ${index} CLA`, projects: [{ projectName: `Project ${index}` }] })
+    );
+  }
 
   async function render(): Promise<ComponentFixture<OrgEasyclaComponent>> {
     TestBed.resetTestingModule();
@@ -37,13 +63,30 @@ describe('OrgEasyclaComponent', () => {
         { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
         { provide: PersonaService, useValue: { personaLoaded } },
         { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+        { provide: OrgLensClaService, useValue: { getClaGroups } },
         MessageService,
       ],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(OrgEasyclaComponent);
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
     return fixture;
+  }
+
+  function byTestId(fixture: ComponentFixture<OrgEasyclaComponent>, id: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+  }
+
+  function allByTestId(fixture: ComponentFixture<OrgEasyclaComponent>, id: string): HTMLElement[] {
+    return Array.from(fixture.nativeElement.querySelectorAll(`[data-testid="${id}"]`));
+  }
+
+  async function search(fixture: ComponentFixture<OrgEasyclaComponent>, term: string): Promise<void> {
+    fixture.componentInstance['filterForm'].controls.search.setValue(term);
+    await fixture.whenStable();
+    fixture.detectChanges();
   }
 
   beforeEach(() => {
@@ -52,81 +95,268 @@ describe('OrgEasyclaComponent', () => {
     grantsLoaded.set(true);
     personaLoaded.set(true);
     navLoaded.set(true);
+    getClaGroups.mockReset();
+    getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] }));
   });
 
-  it('renders the empty-state scaffold', async () => {
-    const fixture = await render();
-    const page = fixture.nativeElement.querySelector('[data-testid="org-easycla-page"]');
-    const empty = fixture.nativeElement.querySelector('[data-testid="org-easycla-empty-state"]');
+  describe('page chrome', () => {
+    // Matches the sibling org-lens pages (memberships, projects) and the approved M3 design,
+    // which titles the page "EasyCLA — {Company}".
+    it('titles the page with the selected company', async () => {
+      const fixture = await render();
 
-    expect(page).toBeTruthy();
-    expect(empty).toBeTruthy();
-    expect(empty.textContent).toContain('No CLAs signed yet');
+      expect(byTestId(fixture, 'org-easycla-title')?.textContent).toContain('EasyCLA');
+      expect(byTestId(fixture, 'org-easycla-title')?.textContent).toContain('Vertex Robotics');
+    });
+
+    it('falls back to the bare title before an account resolves', async () => {
+      selectedAccount.set(null);
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-title')?.textContent).toContain('EasyCLA');
+      expect(byTestId(fixture, 'org-easycla-title')?.textContent).not.toContain('—');
+    });
+
+    it('renders the Sign CLA control, disabled, so the empty-state copy points at something real', async () => {
+      const fixture = await render();
+      const signCla = byTestId(fixture, 'org-easycla-sign-cla');
+
+      expect(signCla).toBeTruthy();
+      expect(signCla?.querySelector('button')?.disabled).toBe(true);
+    });
   });
 
-  // Matches the sibling org-lens pages (memberships, projects) and the approved M3 design,
-  // which titles the page "EasyCLA — {Company}".
-  it('titles the page with the selected company', async () => {
-    const fixture = await render();
-    const title = fixture.nativeElement.querySelector('[data-testid="org-easycla-title"]');
+  describe('access and org-selection states', () => {
+    // The route guard only checks the dark-launch flag, so the component owns the access answer.
+    // Telling an unauthorized caller "No CLAs signed yet" would describe their CLAs rather than
+    // their access, and imply the org has none.
+    it('says the lens is unavailable, not that no CLAs exist, when the caller holds no org access', async () => {
+      hasOrgSelectorAccess.set(false);
 
-    expect(title.textContent).toContain('EasyCLA');
-    expect(title.textContent).toContain('Acme Motors, Inc.');
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-no-access-state')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    it('withholds both answers until the grant and persona fetches have returned', async () => {
+      hasOrgSelectorAccess.set(false);
+      grantsLoaded.set(false);
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-loading')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-no-access-state')).toBeNull();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    // Grants and personas can settle while the org list is still being fetched and default-selected,
+    // so an authorized user would otherwise be told they have no CLAs before a company existed.
+    it('keeps waiting while the org list is still resolving, even with grants and personas settled', async () => {
+      navLoaded.set(false);
+      selectedAccount.set(null);
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-loading')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    // LF staff satisfy hasOrgSelectorAccess with an empty account list, so "no CLAs signed yet" would
+    // be a claim about an organization they have not picked.
+    it('asks for an organization rather than reporting no CLAs when none is selected', async () => {
+      selectedAccount.set(null);
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-no-company-empty-state')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+      expect(getClaGroups).not.toHaveBeenCalled();
+    });
   });
 
-  it('falls back to the bare title before an account resolves', async () => {
-    selectedAccount.set(null);
+  describe('the list', () => {
+    it('renders one card per agreement', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ id: 'a' }), claGroup({ id: 'b' }), claGroup({ id: 'c' })] }));
 
-    const fixture = await render();
-    const title = fixture.nativeElement.querySelector('[data-testid="org-easycla-title"]');
+      const fixture = await render();
 
-    expect(title.textContent).toContain('EasyCLA');
-    expect(title.textContent).not.toContain('—');
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(3);
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    it('fetches once for the selected organization', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+
+      await render();
+
+      expect(getClaGroups).toHaveBeenCalledTimes(1);
+      expect(getClaGroups).toHaveBeenCalledWith(SELECTED_ACCOUNT.uid);
+    });
   });
 
-  // The route guard only checks the dark-launch flag, so the component owns the access answer.
-  // Telling an unauthorized caller "No CLAs signed yet" would describe their CLAs rather than
-  // their access, and imply the org has none.
-  it('says the lens is unavailable, not that no CLAs exist, when the caller holds no org access', async () => {
-    hasOrgSelectorAccess.set(false);
+  describe('empty states', () => {
+    it('names the organization when it has signed nothing', async () => {
+      const fixture = await render();
+      const empty = byTestId(fixture, 'org-easycla-empty-state');
 
-    const fixture = await render();
+      expect(empty).toBeTruthy();
+      expect(empty?.textContent).toContain("Vertex Robotics hasn't signed any CLAs yet");
+      expect(empty?.textContent).toContain('Sign CLA');
+    });
 
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-no-access-state"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-empty-state"]')).toBeNull();
+    it('says no matches — not "signed nothing" — when a search excludes everything', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+
+      const fixture = await render();
+      await search(fixture, 'zzzzz');
+
+      expect(byTestId(fixture, 'org-easycla-no-matches-state')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    it('never shows both empty states at once', async () => {
+      const fixture = await render();
+      await search(fixture, 'zzzzz');
+
+      // Nothing signed AND a search that matches nothing: only the "signed nothing" answer is true.
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-no-matches-state')).toBeNull();
+    });
+
+    // The toolbar not collapsing with the list is what lets a viewer revise a failed search or
+    // start a first agreement without reloading the page.
+    it('keeps the search box and Sign CLA control visible in both empty states', async () => {
+      const noneSigned = await render();
+
+      expect(byTestId(noneSigned, 'org-easycla-toolbar')).toBeTruthy();
+      expect(byTestId(noneSigned, 'org-easycla-sign-cla')).toBeTruthy();
+
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+      const noMatches = await render();
+      await search(noMatches, 'zzzzz');
+
+      expect(byTestId(noMatches, 'org-easycla-no-matches-state')).toBeTruthy();
+      expect(byTestId(noMatches, 'org-easycla-toolbar')).toBeTruthy();
+      expect(byTestId(noMatches, 'org-easycla-sign-cla')).toBeTruthy();
+    });
+
+    // Upstream returns an empty list both for an org with no agreements and for one it has no
+    // record of, so a failure degraded to an empty list would be indistinguishable from "you have
+    // signed nothing" — a false statement about the company's legal position.
+    it('reports a failed load as a failure, not as an empty list', async () => {
+      getClaGroups.mockReturnValue(throwError(() => new Error('upstream exploded')));
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-error-state')).toBeTruthy();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+      consoleError.mockRestore();
+    });
   });
 
-  it('withholds both answers until the grant and persona fetches have returned', async () => {
-    hasOrgSelectorAccess.set(false);
-    grantsLoaded.set(false);
+  describe('search', () => {
+    beforeEach(() => {
+      getClaGroups.mockReturnValue(
+        of({
+          orgUid: SELECTED_ACCOUNT.uid,
+          claGroups: [
+            claGroup({ id: 'a', claGroupName: 'Nimbus Foundation CLA', foundationName: 'Nimbus Foundation', projects: [{ projectName: 'Cascade' }] }),
+            claGroup({ id: 'b', claGroupName: 'Alder Project CLA', foundationName: 'Alder Foundation', projects: [{ projectName: 'Driftwood' }] }),
+          ],
+        })
+      );
+    });
 
-    const fixture = await render();
+    it('matches on the CLA Group name', async () => {
+      const fixture = await render();
+      await search(fixture, 'nimbus foundation cla');
 
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-loading"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-no-access-state"]')).toBeNull();
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-empty-state"]')).toBeNull();
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(1);
+    });
+
+    it('matches on the foundation name', async () => {
+      const fixture = await render();
+      await search(fixture, 'Alder Foundation');
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(1);
+    });
+
+    it('matches on a covered project name', async () => {
+      const fixture = await render();
+      await search(fixture, 'driftwood');
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(1);
+    });
+
+    it('ignores case and surrounding whitespace', async () => {
+      const fixture = await render();
+      await search(fixture, '   CASCADE   ');
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(1);
+    });
+
+    it('restores every card when the query is cleared', async () => {
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      await search(fixture, '');
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(2);
+    });
+
+    it('does not re-fetch while searching', async () => {
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      await search(fixture, 'driftwood');
+
+      expect(getClaGroups).toHaveBeenCalledTimes(1);
+    });
   });
 
-  // Grants and personas can settle while the org list is still being fetched and default-selected,
-  // so an authorized user would otherwise be told they have no CLAs before a company existed.
-  it('keeps waiting while the org list is still resolving, even with grants and personas settled', async () => {
-    navLoaded.set(false);
-    selectedAccount.set(null);
+  describe('paging', () => {
+    it('hides the pager when everything fits on one page', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(8) }));
 
-    const fixture = await render();
+      const fixture = await render();
 
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-loading"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-empty-state"]')).toBeNull();
-  });
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(8);
+      expect(byTestId(fixture, 'org-easycla-pager')).toBeNull();
+    });
 
-  // LF staff satisfy hasOrgSelectorAccess with an empty account list, so "no CLAs signed yet" would
-  // be a claim about an organization they have not picked.
-  it('asks for an organization rather than reporting no CLAs when none is selected', async () => {
-    selectedAccount.set(null);
+    it('pages at eight and reports the range of the total', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(11) }));
 
-    const fixture = await render();
+      const fixture = await render();
 
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-no-company-empty-state"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-empty-state"]')).toBeNull();
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(8);
+      expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 1–8 of 11');
+    });
+
+    it('moves to the next page without re-fetching', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(11) }));
+
+      const fixture = await render();
+      fixture.componentInstance['changePage'](1);
+      fixture.detectChanges();
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(3);
+      expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 9–11 of 11');
+      expect(getClaGroups).toHaveBeenCalledTimes(1);
+    });
+
+    // Without this a viewer who narrows while on page two lands on an empty page of a non-empty
+    // result set, which reads as "no matches" while matches exist.
+    it('returns to the first page when the query changes', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(11) }));
+
+      const fixture = await render();
+      fixture.componentInstance['changePage'](1);
+      fixture.detectChanges();
+      await search(fixture, 'Project');
+
+      expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 1–8 of 11');
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -15,7 +15,7 @@ import { PersonaService } from '@services/persona.service';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 // The no-access branch renders a `lfxOpenIntercom` support button, which injects MessageService.
 import { MessageService } from 'primeng/api';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OrgEasyclaComponent } from './org-easycla.component';
@@ -355,6 +355,81 @@ describe('OrgEasyclaComponent', () => {
       fixture.componentInstance['changePage'](1);
       fixture.detectChanges();
       await search(fixture, 'Project');
+
+      expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 1–8 of 11');
+    });
+  });
+
+  // The component survives an org switch, so every piece of state keyed to the previous company
+  // has to be dropped by hand. What makes this more than a tidiness concern is the subject matter:
+  // one company's agreements shown under another company's name is a false claim about who has
+  // signed what.
+  describe('switching organizations', () => {
+    const OTHER_ACCOUNT = { uid: '0014100000Zq8xbAAB', accountName: 'Halcyon Systems' };
+
+    async function switchOrg(fixture: ComponentFixture<OrgEasyclaComponent>): Promise<void> {
+      selectedAccount.set(OTHER_ACCOUNT);
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+
+    it("drops the previous organization's cards while the new request is in flight", async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(3) }));
+      const fixture = await render();
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(3);
+
+      getClaGroups.mockReturnValue(new Subject());
+      await switchOrg(fixture);
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(0);
+      expect(byTestId(fixture, 'org-easycla-list-loading')).not.toBeNull();
+    });
+
+    it('does not claim the new organization has signed nothing before its response lands', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] }));
+      const fixture = await render();
+      expect(byTestId(fixture, 'org-easycla-empty-state')).not.toBeNull();
+
+      getClaGroups.mockReturnValue(new Subject());
+      await switchOrg(fixture);
+
+      expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    it("shows the new organization's agreements once they arrive", async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(3) }));
+      const fixture = await render();
+
+      getClaGroups.mockReturnValue(of({ orgUid: OTHER_ACCOUNT.uid, claGroups: manyClaGroups(5) }));
+      await switchOrg(fixture);
+
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(5);
+      expect(getClaGroups).toHaveBeenLastCalledWith(OTHER_ACCOUNT.uid);
+    });
+
+    // A query aimed at the previous company would otherwise hide the new company's agreements
+    // behind the no-matches state, which reads as "this company has none".
+    it('clears a search carried over from the previous organization', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(3) }));
+      const fixture = await render();
+      await search(fixture, 'Foundation 0');
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(1);
+
+      getClaGroups.mockReturnValue(of({ orgUid: OTHER_ACCOUNT.uid, claGroups: manyClaGroups(3) }));
+      await switchOrg(fixture);
+
+      expect(fixture.componentInstance['filterForm'].controls.search.value).toBe('');
+      expect(allByTestId(fixture, 'org-easycla-card')).toHaveLength(3);
+    });
+
+    it("opens the new organization's list at the first page", async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: manyClaGroups(11) }));
+      const fixture = await render();
+      fixture.componentInstance['changePage'](1);
+      fixture.detectChanges();
+
+      getClaGroups.mockReturnValue(of({ orgUid: OTHER_ACCOUNT.uid, claGroups: manyClaGroups(11) }));
+      await switchOrg(fixture);
 
       expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 1–8 of 11');
     });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -255,6 +255,21 @@ describe('OrgEasyclaComponent', () => {
       expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
       consoleError.mockRestore();
     });
+
+    // On the failure state there is nothing loaded to filter, and the no-matches state cannot fire,
+    // so the box would accept input and change nothing — a second, unexplained fault on a page that
+    // has already told the viewer what went wrong.
+    it('withholds the search box on the failure state, where it could filter nothing', async () => {
+      getClaGroups.mockReturnValue(throwError(() => new Error('upstream exploded')));
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-toolbar')).toBeNull();
+      // Sign CLA is in the header rather than the toolbar, so the failure state does not take it.
+      expect(byTestId(fixture, 'org-easycla-sign-cla')).toBeTruthy();
+      consoleError.mockRestore();
+    });
   });
 
   describe('search', () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -1,19 +1,32 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, Signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup } from '@angular/forms';
+import type { OrgClaGroup, OrgClaGroupList } from '@lfx-one/shared/interfaces';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, distinctUntilChanged, filter, of, switchMap, tap } from 'rxjs';
 
+import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 import { AccountContextService } from '@services/account-context.service';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
-import { SkeletonModule } from 'primeng/skeleton';
+
+import { OrgEasyclaCardComponent } from './org-easycla-card/org-easycla-card.component';
+
+/** Matches the approved design's page size. */
+const PAGE_SIZE = 8;
 
 @Component({
   selector: 'lfx-org-easycla',
-  imports: [EmptyStateComponent, OpenIntercomDirective, SkeletonModule],
+  imports: [ButtonComponent, EmptyStateComponent, InputTextComponent, OpenIntercomDirective, OrgEasyclaCardComponent, SkeletonModule],
   templateUrl: './org-easycla.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -22,15 +35,25 @@ export class OrgEasyclaComponent {
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
   private readonly orgNavigation = inject(OrgNavigationService);
+  private readonly claService = inject(OrgLensClaService);
+  private readonly platformId = inject(PLATFORM_ID);
 
+  // ── Search (client-side; the upstream list takes no search parameter) ──────
+  protected readonly filterForm = new FormGroup({
+    search: new FormControl<string>('', { nonNullable: true }),
+  });
+
+  protected readonly fetchError = signal(false);
+  private readonly page = signal(0);
+
+  // ── Org context ───────────────────────────────────────────────────────────
   protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
-
   protected readonly hasCompany = computed(() => !!this.accountContext.selectedAccount()?.uid);
 
   /**
    * True once both grant fetches have returned and the caller holds no org access. The route guard
    * only checks the dark-launch flag, so without this an unauthorized deep link would be told
-   * "No CLAs signed yet" — a statement about their CLAs rather than about their access.
+   * "hasn't signed any CLAs yet" — a statement about their CLAs rather than about their access.
    *
    * Shares `hasOrgSelectorAccess` with the sidebar org-selector so the two cannot drift, and waits
    * on `personaLoaded()` as well: for users whose orgs arrive only via the async personas response,
@@ -53,4 +76,133 @@ export class OrgEasyclaComponent {
   protected readonly orgContextLoaded: Signal<boolean> = computed(
     () => this.hasNoOrgAccess() || (this.orgNavigation.loaded() && this.orgRoleGrantsService.loaded() && this.personaService.personaLoaded())
   );
+
+  // ── Data ──────────────────────────────────────────────────────────────────
+  private readonly searchTerm: Signal<string> = this.initSearchTerm();
+  private readonly claData: Signal<OrgClaGroupList | null | undefined> = this.initClaData();
+
+  /** Undefined until the first response lands; `null` after a failure, which is a different state. */
+  protected readonly claLoading = computed(() => this.hasCompany() && this.claData() === undefined && !this.fetchError());
+
+  protected readonly claGroups: Signal<OrgClaGroup[]> = computed(() => this.claData()?.claGroups ?? []);
+  protected readonly filteredClaGroups: Signal<OrgClaGroup[]> = this.initFilteredClaGroups();
+
+  // ── Paging (client-side; the upstream list is unpaged) ────────────────────
+  protected readonly pageCount = computed(() => Math.max(1, Math.ceil(this.filteredClaGroups().length / PAGE_SIZE)));
+
+  /**
+   * Clamped rather than read raw, so a narrowing that shrinks the result set below the current
+   * page cannot strand the viewer on a page that no longer exists. The reset in the constructor
+   * handles the common case; this covers the rest without a second writer.
+   */
+  protected readonly currentPage = computed(() => Math.min(this.page(), this.pageCount() - 1));
+  protected readonly pagedClaGroups: Signal<OrgClaGroup[]> = this.initPagedClaGroups();
+  protected readonly showPager = computed(() => this.filteredClaGroups().length > PAGE_SIZE);
+  protected readonly pageLabel: Signal<string> = this.initPageLabel();
+  protected readonly onFirstPage = computed(() => this.currentPage() === 0);
+  protected readonly onLastPage = computed(() => this.currentPage() >= this.pageCount() - 1);
+
+  // ── Empty states (mutually exclusive) ─────────────────────────────────────
+  private readonly settled = computed(() => this.hasCompany() && !this.claLoading() && !this.fetchError());
+
+  /** The organization has signed nothing at all. */
+  protected readonly showNoClasEmptyState = computed(() => this.settled() && this.claGroups().length === 0);
+
+  /** The organization has CLAs but the search matched none. Never shown alongside the above. */
+  protected readonly showNoMatchesEmptyState = computed(() => this.settled() && this.claGroups().length > 0 && this.filteredClaGroups().length === 0);
+
+  protected readonly noClasTitle = computed(() => `${this.companyName()} hasn't signed any CLAs yet`);
+
+  /**
+   * The toolbar does not collapse with the list: both empty states keep the search box and the
+   * Sign CLA button visible, so a viewer can revise a search or start an agreement without
+   * reloading. Only the card grid and the pager hide.
+   */
+  protected readonly showToolbar = computed(() => this.settled() || this.fetchError());
+
+  public constructor() {
+    // A narrowed set has its own first page; keeping the old index would show the viewer an empty
+    // page of a non-empty result. Driven off the raw control value rather than the trimmed term so
+    // clearing a query down to trailing whitespace also returns to the top.
+    this.filterForm.controls.search.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => this.page.set(0));
+  }
+
+  protected changePage(delta: number): void {
+    this.page.set(Math.min(Math.max(this.currentPage() + delta, 0), this.pageCount() - 1));
+  }
+
+  private initSearchTerm(): Signal<string> {
+    const value = toSignal(this.filterForm.controls.search.valueChanges, { initialValue: '' });
+    return computed(() => value().trim().toLowerCase());
+  }
+
+  private initClaData(): Signal<OrgClaGroupList | null | undefined> {
+    if (!isPlatformBrowser(this.platformId)) {
+      return signal<OrgClaGroupList | null | undefined>(undefined);
+    }
+
+    const orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(
+      filter((uid): uid is string => !!uid),
+      distinctUntilChanged()
+    );
+
+    return toSignal(
+      orgUid$.pipe(
+        tap(() => this.fetchError.set(false)),
+        switchMap((uid) =>
+          this.claService.getClaGroups(uid).pipe(
+            catchError((error: unknown) => {
+              // A failure must never become an empty list here. Upstream returns an empty list both
+              // for an organization with no agreements and for one it has no record of, so there is
+              // no signal left to distinguish "could not load" from "has signed nothing" — and only
+              // one of those is a claim about the company's legal position.
+              console.error('Failed to load organization CLA groups:', error);
+              this.fetchError.set(true);
+              return of(null);
+            })
+          )
+        ),
+        takeUntilDestroyed()
+      )
+    );
+  }
+
+  /**
+   * Matches the approved design's predicate: CLA Group name, foundation name, or any covered
+   * project name.
+   *
+   * Signing entity is deliberately not matched. It is not in the design's predicate, and in the
+   * common case where it equals the organization's own name, searching that name would match
+   * every row and narrow nothing.
+   */
+  private initFilteredClaGroups(): Signal<OrgClaGroup[]> {
+    return computed(() => {
+      const term = this.searchTerm();
+      if (!term) return this.claGroups();
+
+      return this.claGroups().filter(
+        (group) =>
+          group.claGroupName.toLowerCase().includes(term) ||
+          (group.foundationName?.toLowerCase().includes(term) ?? false) ||
+          group.projects.some((project) => project.projectName.toLowerCase().includes(term))
+      );
+    });
+  }
+
+  private initPagedClaGroups(): Signal<OrgClaGroup[]> {
+    return computed(() => {
+      const start = this.currentPage() * PAGE_SIZE;
+      return this.filteredClaGroups().slice(start, start + PAGE_SIZE);
+    });
+  }
+
+  private initPageLabel(): Signal<string> {
+    return computed(() => {
+      const total = this.filteredClaGroups().length;
+      if (total === 0) return '';
+
+      const start = this.currentPage() * PAGE_SIZE;
+      return `Showing ${start + 1}–${Math.min(start + PAGE_SIZE, total)} of ${total}`;
+    });
+  }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -90,12 +90,32 @@ export class OrgEasyclaComponent {
   private readonly claData: Signal<OrgClaGroupList | null | undefined> = this.initClaData();
 
   /**
+   * True while the response in hand does not belong to the organization named in the header.
+   *
+   * The server echoes the `orgUid` it served precisely so the client can key on it. Timing alone
+   * does not hold the invariant: `companyName()` reacts to `selectedAccount` immediately, while
+   * `orgUid$` re-emits only when `toObservable`'s effect flushes — after the template pass — so
+   * `claLoadingState` is still false for one cycle after a switch. Comparing identity closes that
+   * window regardless of when the flush lands.
+   */
+  private readonly claDataIsForSelectedOrg = computed(() => {
+    const data = this.claData();
+    return !data || data.orgUid === this.accountContext.selectedAccount()?.uid;
+  });
+
+  /**
    * Undefined until the first response lands; `null` after a failure, which is a different state.
    * The explicit flag covers the switch: `toSignal` holds the previous organization's response
    * until the new one arrives, so `=== undefined` alone would let that organization's cards — or
    * its "signed nothing" empty state — render under the newly selected company's name.
+   *
+   * The mismatch is folded in here rather than emptying `claGroups()`, because an empty list on a
+   * settled page is not a neutral value — it is the "hasn't signed any CLAs yet" claim. Holding the
+   * loading state instead shows a skeleton, which asserts nothing.
    */
-  protected readonly claLoading = computed(() => this.hasCompany() && (this.claData() === undefined || this.claLoadingState()) && !this.fetchError());
+  protected readonly claLoading = computed(
+    () => this.hasCompany() && (this.claData() === undefined || this.claLoadingState() || !this.claDataIsForSelectedOrg()) && !this.fetchError()
+  );
 
   protected readonly claGroups: Signal<OrgClaGroup[]> = computed(() => this.claData()?.claGroups ?? []);
   protected readonly filteredClaGroups: Signal<OrgClaGroup[]> = this.initFilteredClaGroups();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { FormControl, FormGroup } from '@angular/forms';
 import type { OrgClaGroup, OrgClaGroupList } from '@lfx-one/shared/interfaces';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, filter, of, switchMap, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, of, skip, switchMap, tap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -44,6 +44,7 @@ export class OrgEasyclaComponent {
   });
 
   protected readonly fetchError = signal(false);
+  private readonly claLoadingState = signal(false);
   private readonly page = signal(0);
 
   // ── Org context ───────────────────────────────────────────────────────────
@@ -79,10 +80,22 @@ export class OrgEasyclaComponent {
 
   // ── Data ──────────────────────────────────────────────────────────────────
   private readonly searchTerm: Signal<string> = this.initSearchTerm();
+
+  // Shared with the constructor's org-switch reset below — mirrors org-groups' orgUid$.
+  private readonly orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(
+    filter((uid): uid is string => !!uid),
+    distinctUntilChanged()
+  );
+
   private readonly claData: Signal<OrgClaGroupList | null | undefined> = this.initClaData();
 
-  /** Undefined until the first response lands; `null` after a failure, which is a different state. */
-  protected readonly claLoading = computed(() => this.hasCompany() && this.claData() === undefined && !this.fetchError());
+  /**
+   * Undefined until the first response lands; `null` after a failure, which is a different state.
+   * The explicit flag covers the switch: `toSignal` holds the previous organization's response
+   * until the new one arrives, so `=== undefined` alone would let that organization's cards — or
+   * its "signed nothing" empty state — render under the newly selected company's name.
+   */
+  protected readonly claLoading = computed(() => this.hasCompany() && (this.claData() === undefined || this.claLoadingState()) && !this.fetchError());
 
   protected readonly claGroups: Signal<OrgClaGroup[]> = computed(() => this.claData()?.claGroups ?? []);
   protected readonly filteredClaGroups: Signal<OrgClaGroup[]> = this.initFilteredClaGroups();
@@ -125,6 +138,14 @@ export class OrgEasyclaComponent {
     // page of a non-empty result. Driven off the raw control value rather than the trimmed term so
     // clearing a query down to trailing whitespace also returns to the top.
     this.filterForm.controls.search.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => this.page.set(0));
+
+    // A query typed against the previous organization would carry over and hide the new one's
+    // agreements behind the no-matches empty state, and a leftover index would open its list
+    // part-way through. `skip(1)` leaves the first load alone; only an actual switch resets.
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
+      this.filterForm.reset({ search: '' });
+      this.page.set(0);
+    });
   }
 
   protected changePage(delta: number): void {
@@ -141,16 +162,15 @@ export class OrgEasyclaComponent {
       return signal<OrgClaGroupList | null | undefined>(undefined);
     }
 
-    const orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(
-      filter((uid): uid is string => !!uid),
-      distinctUntilChanged()
-    );
-
     return toSignal(
-      orgUid$.pipe(
-        tap(() => this.fetchError.set(false)),
+      this.orgUid$.pipe(
+        tap(() => {
+          this.claLoadingState.set(true);
+          this.fetchError.set(false);
+        }),
         switchMap((uid) =>
           this.claService.getClaGroups(uid).pipe(
+            tap(() => this.claLoadingState.set(false)),
             catchError((error: unknown) => {
               // A failure must never become an empty list here. Upstream returns an empty list both
               // for an organization with no agreements and for one it has no record of, so there is
@@ -158,6 +178,7 @@ export class OrgEasyclaComponent {
               // one of those is a claim about the company's legal position.
               console.error('Failed to load organization CLA groups:', error);
               this.fetchError.set(true);
+              this.claLoadingState.set(false);
               return of(null);
             })
           )

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -21,9 +21,6 @@ import { OrgNavigationService } from '@shared/services/org-navigation.service';
 
 import { OrgEasyclaCardComponent } from './org-easycla-card/org-easycla-card.component';
 
-/** Matches the approved design's page size. */
-const PAGE_SIZE = 8;
-
 @Component({
   selector: 'lfx-org-easycla',
   imports: [ButtonComponent, EmptyStateComponent, InputTextComponent, OpenIntercomDirective, OrgEasyclaCardComponent, SkeletonModule],
@@ -31,6 +28,9 @@ const PAGE_SIZE = 8;
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OrgEasyclaComponent {
+  /** Matches the approved design's page size. */
+  private static readonly pageSize = 8;
+
   private readonly accountContext = inject(AccountContextService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
@@ -101,7 +101,7 @@ export class OrgEasyclaComponent {
   protected readonly filteredClaGroups: Signal<OrgClaGroup[]> = this.initFilteredClaGroups();
 
   // ── Paging (client-side; the upstream list is unpaged) ────────────────────
-  protected readonly pageCount = computed(() => Math.max(1, Math.ceil(this.filteredClaGroups().length / PAGE_SIZE)));
+  protected readonly pageCount = computed(() => Math.max(1, Math.ceil(this.filteredClaGroups().length / OrgEasyclaComponent.pageSize)));
 
   /**
    * Clamped rather than read raw, so a narrowing that shrinks the result set below the current
@@ -110,7 +110,7 @@ export class OrgEasyclaComponent {
    */
   protected readonly currentPage = computed(() => Math.min(this.page(), this.pageCount() - 1));
   protected readonly pagedClaGroups: Signal<OrgClaGroup[]> = this.initPagedClaGroups();
-  protected readonly showPager = computed(() => this.filteredClaGroups().length > PAGE_SIZE);
+  protected readonly showPager = computed(() => this.filteredClaGroups().length > OrgEasyclaComponent.pageSize);
   protected readonly pageLabel: Signal<string> = this.initPageLabel();
   protected readonly onFirstPage = computed(() => this.currentPage() === 0);
   protected readonly onLastPage = computed(() => this.currentPage() >= this.pageCount() - 1);
@@ -212,8 +212,8 @@ export class OrgEasyclaComponent {
 
   private initPagedClaGroups(): Signal<OrgClaGroup[]> {
     return computed(() => {
-      const start = this.currentPage() * PAGE_SIZE;
-      return this.filteredClaGroups().slice(start, start + PAGE_SIZE);
+      const start = this.currentPage() * OrgEasyclaComponent.pageSize;
+      return this.filteredClaGroups().slice(start, start + OrgEasyclaComponent.pageSize);
     });
   }
 
@@ -222,8 +222,8 @@ export class OrgEasyclaComponent {
       const total = this.filteredClaGroups().length;
       if (total === 0) return '';
 
-      const start = this.currentPage() * PAGE_SIZE;
-      return `Showing ${start + 1}–${Math.min(start + PAGE_SIZE, total)} of ${total}`;
+      const start = this.currentPage() * OrgEasyclaComponent.pageSize;
+      return `Showing ${start + 1}–${Math.min(start + OrgEasyclaComponent.pageSize, total)} of ${total}`;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -127,11 +127,15 @@ export class OrgEasyclaComponent {
   protected readonly noClasTitle = computed(() => `${this.companyName()} hasn't signed any CLAs yet`);
 
   /**
-   * The toolbar does not collapse with the list: both empty states keep the search box and the
-   * Sign CLA button visible, so a viewer can revise a search or start an agreement without
-   * reloading. Only the card grid and the pager hide.
+   * The toolbar holds the search box and nothing else — the Sign CLA button lives in the header and
+   * renders unconditionally, so it is not what keeps this visible.
+   *
+   * It does not collapse with the list: a viewer whose search matched nothing needs the box to
+   * revise it. It is withheld on the failure state, where `claGroups()` is empty and
+   * `showNoMatchesEmptyState` cannot fire, so typing would filter nothing and change nothing — a
+   * field that looks interactive and is inert reads as a second, unexplained fault.
    */
-  protected readonly showToolbar = computed(() => this.settled() || this.fetchError());
+  protected readonly showToolbar = computed(() => this.settled());
 
   public constructor() {
     // A narrowed set has its own first page; keeping the old index would show the viewer an empty

--- a/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
@@ -11,7 +11,8 @@ import { Observable } from 'rxjs';
  *
  * No transformation here: the server already shapes the row, including the status the card
  * renders. Searching and paging are done in the page component over the fetched set, so this
- * is called once per page load and never again.
+ * is called once per selected organization — on load, and again whenever the selection
+ * changes — and never for a search term or a page turn.
  */
 @Injectable({
   providedIn: 'root',

--- a/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import type { OrgClaGroupList } from '@lfx-one/shared/interfaces';
+import { Observable } from 'rxjs';
+
+/**
+ * Client for the Org Lens EasyCLA list (#1978).
+ *
+ * No transformation here: the server already shapes the row, including the status the card
+ * renders. Searching and paging are done in the page component over the fetched set, so this
+ * is called once per page load and never again.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgLensClaService {
+  private readonly http = inject(HttpClient);
+
+  public getClaGroups(orgUid: string): Observable<OrgClaGroupList> {
+    return this.http.get<OrgClaGroupList>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups`);
+  }
+}

--- a/apps/lfx-one/src/server/helpers/cla-service-url.helper.ts
+++ b/apps/lfx-one/src/server/helpers/cla-service-url.helper.ts
@@ -13,8 +13,12 @@ import { MicroserviceError } from '../errors';
 /**
  * Derived from API_GW_AUDIENCE, which is already required to mint the gateway token —
  * mirroring user.service.ts.
+ *
+ * `service` names the caller, not the upstream: the misconfiguration this can throw on belongs to
+ * whichever service failed to reach EasyCLA, and that is what a log reader needs to see. Defaulted
+ * to the Me-lens service so the original caller keeps its existing metadata unchanged.
  */
-export function claServiceBaseUrl(): string {
+export function claServiceBaseUrl(service = 'cla_service'): string {
   // Local-only override so a laptop BFF can talk to a standalone cla-backend-go
   // (see CLA_SERVICE_URL in apps/lfx-one/.env). Do not commit a non-empty value.
   const override = process.env['CLA_SERVICE_URL'];
@@ -23,9 +27,7 @@ export function claServiceBaseUrl(): string {
   }
   const audience = process.env['API_GW_AUDIENCE'];
   if (!audience) {
-    throw new MicroserviceError('API_GW_AUDIENCE environment variable is not configured', 503, 'API_GATEWAY_MISCONFIGURED', {
-      service: 'cla_service',
-    });
+    throw new MicroserviceError('API_GW_AUDIENCE environment variable is not configured', 503, 'API_GATEWAY_MISCONFIGURED', { service });
   }
   return `${audience.replace(/\/+$/, '')}/cla-service`;
 }

--- a/apps/lfx-one/src/server/helpers/cla-service-url.helper.ts
+++ b/apps/lfx-one/src/server/helpers/cla-service-url.helper.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Base URL for the EasyCLA service behind the API gateway.
+//
+// Lives in its own helper rather than in cla.service.ts because two unrelated services now
+// need it — the Me-lens CLA service and the Org Lens EasyCLA service (#1978) — and importing
+// the whole Me-lens service to reach one pure string function would give the Org Lens module
+// a dependency on Auth0 and email-verification wiring it does not use.
+
+import { MicroserviceError } from '../errors';
+
+/**
+ * Derived from API_GW_AUDIENCE, which is already required to mint the gateway token —
+ * mirroring user.service.ts.
+ */
+export function claServiceBaseUrl(): string {
+  // Local-only override so a laptop BFF can talk to a standalone cla-backend-go
+  // (see CLA_SERVICE_URL in apps/lfx-one/.env). Do not commit a non-empty value.
+  const override = process.env['CLA_SERVICE_URL'];
+  if (override) {
+    return override.replace(/\/+$/, '');
+  }
+  const audience = process.env['API_GW_AUDIENCE'];
+  if (!audience) {
+    throw new MicroserviceError('API_GW_AUDIENCE environment variable is not configured', 503, 'API_GATEWAY_MISCONFIGURED', {
+      service: 'cla_service',
+    });
+  }
+  return `${audience.replace(/\/+$/, '')}/cla-service`;
+}

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -47,6 +47,7 @@ import {
   ResolvedClaIdentity,
 } from '../types/cla.types';
 import { MicroserviceError } from '../errors';
+import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
 import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername, isImpersonating } from '../utils/auth-helper';
 import { Auth0Service } from './auth0.service';
@@ -65,23 +66,9 @@ const MAX_CLA_EMAILS = 100;
 // Pure helpers (unit-tested in isolation). No I/O.
 // ---------------------------------------------------------------------------
 
-/**
- * Base URL for the CLA service behind the API gateway. Derived from API_GW_AUDIENCE
- * (already required to mint the gateway token), mirroring user.service.ts.
- */
-export function claServiceBaseUrl(): string {
-  // Local-only override so a laptop BFF can talk to a standalone cla-backend-go
-  // (see CLA_SERVICE_URL in apps/lfx-one/.env). Do not commit a non-empty value.
-  const override = process.env['CLA_SERVICE_URL'];
-  if (override) {
-    return override.replace(/\/+$/, '');
-  }
-  const audience = process.env['API_GW_AUDIENCE'];
-  if (!audience) {
-    throw new MicroserviceError('API_GW_AUDIENCE environment variable is not configured', 503, 'API_GATEWAY_MISCONFIGURED', { service: SERVICE });
-  }
-  return `${audience.replace(/\/+$/, '')}/cla-service`;
-}
+// Moved to helpers/cla-service-url.helper.ts once the Org Lens EasyCLA service (#1978) needed
+// it too. Re-exported here so existing importers of this module keep working.
+export { claServiceBaseUrl };
 
 // Values the producer's `matchTypes` and `organizations[].source` enums may take. Anything else
 // is out of contract and is dropped rather than forwarded: the picker renders each of these with

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -164,6 +164,15 @@ describe('OrgClaService.listClaGroups — empty versus failed', () => {
     await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).rejects.toMatchObject({ code: 'UPSTREAM_INVALID_RESPONSE' });
   });
 
+  // The signature id is the row's identity and the list is keyed on it. Defaulting it to an empty
+  // string would give every such row the same key, letting the view reuse one agreement's rendered
+  // card for another — worse than declining to render the list at all.
+  it('rejects a row that arrives without its signature id', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signatureID: undefined })));
+
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).rejects.toMatchObject({ code: 'UPSTREAM_INVALID_RESPONSE' });
+  });
+
   it('lets an upstream failure propagate rather than degrading it to an empty list', async () => {
     // The distinction matters more here than on most endpoints: upstream returns the same
     // empty list for an unknown organization as for one that has signed nothing, so if a

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -286,6 +286,27 @@ describe('OrgClaService.listClaGroups — status', () => {
     expect(row.status).toBe('not-started');
   });
 
+  // Upstream backfills its date field with the signature's creation time when there is no signing
+  // timestamp, so an unsigned row arrives carrying a real date that is not a signing date. Passing
+  // it on would give the detail view something to present as a signature date for an agreement
+  // that has none — the status fix above, undone one field over.
+  it('withholds the signed date on an unsigned agreement', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: false, signedOn: '2024-03-11T09:20:00Z' })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.signedOn).toBeUndefined();
+    expect(row.status).toBe('not-started');
+  });
+
+  it('carries the signed date on a signed agreement', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: true, signedOn: '2024-03-11T09:20:00Z' })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.signedOn).toBe('2024-03-11T09:20:00Z');
+  });
+
   it('lets sanctioned win over an unsigned agreement too', async () => {
     gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: false, sanctioned: true })));
 

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -5,28 +5,353 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Request } from 'express';
 
+import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
+
 const { gatewayFetch } = vi.hoisted(() => ({ gatewayFetch: vi.fn() }));
 
 vi.mock('../helpers/gateway-fetch.helper', () => ({ gatewayFetch }));
+vi.mock('../helpers/cla-service-url.helper', () => ({ claServiceBaseUrl: () => 'https://gw.example.org/cla-service' }));
 
 const { OrgClaService } = await import('./org-cla.service');
+
+const ORG_UID = '0014100000Te2ovAAB';
+
+/** A complete upstream entry. Individual cases override only what they are about. */
+function upstreamEntry(overrides: Partial<EasyClaCompanyClaGroup> = {}): EasyClaCompanyClaGroup {
+  return {
+    companyID: 'company-uuid-1',
+    companySFID: ORG_UID,
+    companyName: 'Vertex Robotics',
+    signingEntityName: 'Vertex Robotics',
+    claGroupID: 'cla-group-uuid-1',
+    claGroupName: 'Nimbus Foundation CLA',
+    foundationSFID: 'a09410000182dD2AAI',
+    foundationName: 'Nimbus Foundation',
+    projects: [
+      { projectSFID: 'a09410000182dD3AAI', projectName: 'Cascade' },
+      { projectSFID: 'a09410000182dD4AAI', projectName: 'Driftwood' },
+    ],
+    signed: true,
+    signedOn: '2024-03-11T09:20:00Z',
+    signatureID: 'signature-uuid-1',
+    sanctioned: false,
+    approvedContributorsCount: 412,
+    claManagersCount: 2,
+    claManagers: [
+      { userID: 'user-uuid-1', lfUsername: 'aporter' },
+      { userID: 'user-uuid-2', lfUsername: 'kmensah' },
+    ],
+    needsClaManager: false,
+    autoCreateECLA: true,
+    ...overrides,
+  };
+}
+
+function upstreamList(...entries: EasyClaCompanyClaGroup[]): EasyClaCompanyClaGroupList {
+  return { companySFID: ORG_UID, resultCount: entries.length, list: entries };
+}
+
+function req(overrides: Partial<Request> = {}): Request {
+  return overrides as unknown as Request;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('OrgClaService.listClaGroups', () => {
-  it('returns an empty list for the grant-checked org and does not read a client-passed user id', async () => {
-    const req = { query: { userId: 'someone-else' }, body: { userID: 'someone-else' } } as unknown as Request;
+describe('OrgClaService.listClaGroups — the upstream call', () => {
+  it('calls the organization CLA list with the grant-checked orgUid, unchanged', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList());
 
-    const result = await new OrgClaService().listClaGroups(req, '0014100000Te2ovAAB');
+    await new OrgClaService().listClaGroups(req(), ORG_UID);
 
-    expect(result).toEqual({ orgUid: '0014100000Te2ovAAB', claGroups: [] });
+    expect(gatewayFetch).toHaveBeenCalledTimes(1);
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      `https://gw.example.org/cla-service/v4/company/external/${ORG_UID}/cla-groups`,
+      expect.objectContaining({ operation: 'org_cla_list_cla_groups', service: 'org_cla_service' })
+    );
   });
 
-  it('does not call EasyCLA v4', async () => {
-    await new OrgClaService().listClaGroups({} as Request, '0014100000Te2ovAAB');
+  it('ignores a company id the caller tried to supply in the query or body', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList());
 
-    expect(gatewayFetch).not.toHaveBeenCalled();
+    const result = await new OrgClaService().listClaGroups(
+      req({ query: { companySFID: 'someone-elses-org' }, body: { orgUid: 'someone-elses-org' } } as Partial<Request>),
+      ORG_UID
+    );
+
+    expect(gatewayFetch).toHaveBeenCalledWith(expect.anything(), expect.stringContaining(ORG_UID), expect.anything());
+    expect(gatewayFetch).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('someone-elses-org'), expect.anything());
+    expect(result.orgUid).toBe(ORG_UID);
+  });
+
+  it('issues exactly one upstream request however many agreements come back', async () => {
+    gatewayFetch.mockResolvedValue(
+      upstreamList(
+        upstreamEntry({ signatureID: 's1' }),
+        upstreamEntry({ signatureID: 's2' }),
+        upstreamEntry({ signatureID: 's3' }),
+        upstreamEntry({ signatureID: 's4' })
+      )
+    );
+
+    const result = await new OrgClaService().listClaGroups(req(), ORG_UID);
+
+    expect(result.claGroups).toHaveLength(4);
+    expect(gatewayFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OrgClaService.listClaGroups — empty versus failed', () => {
+  it('treats an empty upstream list as "signed nothing", not an error', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList());
+
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).resolves.toEqual({ orgUid: ORG_UID, claGroups: [] });
+  });
+
+  it('treats a null upstream body as an empty list', async () => {
+    gatewayFetch.mockResolvedValue(null);
+
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).resolves.toEqual({ orgUid: ORG_UID, claGroups: [] });
+  });
+
+  it('lets an upstream failure propagate rather than degrading it to an empty list', async () => {
+    // The distinction matters more here than on most endpoints: upstream returns the same
+    // empty list for an unknown organization as for one that has signed nothing, so if a
+    // failure also became an empty list there would be no signal left to tell a broken page
+    // from a company that has signed no CLAs.
+    gatewayFetch.mockRejectedValue(new Error('upstream exploded'));
+
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).rejects.toThrow('upstream exploded');
+  });
+});
+
+describe('OrgClaService.listClaGroups — what must not cross to the client', () => {
+  it('carries no CLA manager identity or username anywhere in the response', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry()));
+
+    const result = await new OrgClaService().listClaGroups(req(), ORG_UID);
+
+    // Asserted over the whole serialized response rather than against named fields: a future
+    // field carrying the same identities under another name would slip past a field-specific
+    // check, and this is the one guarantee the feature cannot afford to lose quietly.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('aporter');
+    expect(serialized).not.toContain('kmensah');
+    expect(serialized).not.toContain('user-uuid-1');
+    expect(serialized).not.toContain('user-uuid-2');
+    expect(serialized).not.toContain('claManagers"');
+  });
+
+  it('keeps the manager count while dropping the managers', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ claManagersCount: 2 })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.claManagersCount).toBe(2);
+    expect(row).not.toHaveProperty('claManagers');
+  });
+
+  it('does not carry the auto-ECLA flag, which belongs to a later surface', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ autoCreateECLA: true })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row).not.toHaveProperty('autoCreateECLA');
+  });
+});
+
+describe('OrgClaService.listClaGroups — the approval-criteria count', () => {
+  it('leaves the approval-criteria count absent rather than defaulting it to zero', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry()));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.approvalCriteriaCount).toBeUndefined();
+    expect(row.approvalCriteriaCount).not.toBe(0);
+  });
+
+  it('does not fill the approval-criteria count from the employee-acknowledgement count', async () => {
+    // These are different quantities: approval criteria are the rules deciding who may be
+    // covered, acknowledgements are the people covered. Asserting "not zero" alone would
+    // still pass if the acknowledgement count were substituted here, which is the specific
+    // mistake worth pinning.
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ approvedContributorsCount: 412 })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.approvalCriteriaCount).not.toBe(412);
+    expect(JSON.stringify(row)).not.toContain('412');
+  });
+});
+
+describe('OrgClaService.listClaGroups — status', () => {
+  it('maps a signed, unsanctioned agreement to signed', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: true, sanctioned: false })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('signed');
+  });
+
+  it('maps a sanctioned signing entity to sanctioned', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ sanctioned: true })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('sanctioned');
+  });
+
+  it('lets sanctioned win when the agreement is both signed and sanctioned', async () => {
+    // The case the two independent upstream booleans make reachable and the single status
+    // slot cannot represent. Showing this as an ordinary signed agreement is the damaging
+    // direction, so the collapse goes the other way.
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: true, sanctioned: true })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('sanctioned');
+  });
+
+  it('treats a missing sanctions flag as unsanctioned', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ sanctioned: undefined })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('signed');
+  });
+});
+
+describe('OrgClaService.listClaGroups — needs a CLA manager', () => {
+  it('takes the upstream flag verbatim', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ needsClaManager: true, claManagersCount: 0 })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.needsClaManager).toBe(true);
+  });
+
+  it('does not re-derive the flag from the manager count when upstream disagrees', async () => {
+    // Zero managers with the flag unset should surface as upstream reported it. Recomputing
+    // it here would create a second definition of the same condition, which is exactly how
+    // the two drift apart later.
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ needsClaManager: false, claManagersCount: 0 })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.needsClaManager).toBe(false);
+    expect(row.claManagersCount).toBe(0);
+  });
+
+  it('treats a missing flag as not needing a manager', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ needsClaManager: undefined })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.needsClaManager).toBe(false);
+  });
+});
+
+describe('OrgClaService.listClaGroups — identity and naming', () => {
+  it('keys the row on the signature, so two signing entities on one CLA group stay distinct', async () => {
+    gatewayFetch.mockResolvedValue(
+      upstreamList(
+        upstreamEntry({ signatureID: 'signature-a', signingEntityName: 'Vertex Robotics GmbH' }),
+        upstreamEntry({ signatureID: 'signature-b', signingEntityName: 'Vertex Robotics KK' })
+      )
+    );
+
+    const { claGroups } = await new OrgClaService().listClaGroups(req(), ORG_UID);
+
+    expect(claGroups.map((row) => row.id)).toEqual(['signature-a', 'signature-b']);
+    expect(claGroups[0].claGroupId).toBe(claGroups[1].claGroupId);
+  });
+
+  it('falls back to the CLA group id when the name is missing, so the card is still identifiable', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ claGroupName: undefined, claGroupID: 'cla-group-uuid-9' })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.claGroupName).toBe('cla-group-uuid-9');
+  });
+
+  it('omits the signing entity when it matches the organization name', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ companyName: 'Vertex Robotics', signingEntityName: 'Vertex Robotics' })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.signingEntityName).toBeUndefined();
+  });
+
+  it('keeps the signing entity when it differs from the organization name', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ companyName: 'Vertex Robotics', signingEntityName: 'Vertex Robotics GmbH' })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.signingEntityName).toBe('Vertex Robotics GmbH');
+  });
+
+  it('compares the signing entity after trimming, so stray whitespace does not produce a subline', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ companyName: 'Vertex Robotics', signingEntityName: '  Vertex Robotics  ' })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.signingEntityName).toBeUndefined();
+  });
+});
+
+describe('OrgClaService.listClaGroups — coverage', () => {
+  it('carries covered projects in the upstream order', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry()));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.projects.map((project) => project.projectName)).toEqual(['Cascade', 'Driftwood']);
+    expect(row.projects[0].projectSfid).toBe('a09410000182dD3AAI');
+  });
+
+  it('drops a project with no name rather than counting it', async () => {
+    // An unnamed project cannot be rendered or searched, and counting it would overstate the
+    // "Covers N projects" line against what the card actually shows.
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ projects: [{ projectSFID: 'a1', projectName: 'Cascade' }, { projectSFID: 'a2' }] })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.projects).toHaveLength(1);
+    expect(row.projects[0].projectName).toBe('Cascade');
+  });
+
+  it('yields an empty coverage list when upstream sends none', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ projects: undefined })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.projects).toEqual([]);
+  });
+});
+
+describe('OrgClaService.listClaGroups — order and detail hand-off', () => {
+  it('preserves the upstream order rather than re-sorting', async () => {
+    gatewayFetch.mockResolvedValue(
+      upstreamList(
+        upstreamEntry({ signatureID: 's1', claGroupName: 'Zephyr Foundation CLA' }),
+        upstreamEntry({ signatureID: 's2', claGroupName: 'Alder Foundation CLA' })
+      )
+    );
+
+    const { claGroups } = await new OrgClaService().listClaGroups(req(), ORG_UID);
+
+    expect(claGroups.map((row) => row.claGroupName)).toEqual(['Zephyr Foundation CLA', 'Alder Foundation CLA']);
+  });
+
+  it('carries the signed date and foundation ids the agreement detail view reads off the row', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry()));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.signedOn).toBe('2024-03-11T09:20:00Z');
+    expect(row.foundationSfid).toBe('a09410000182dD2AAI');
+    expect(row.foundationName).toBe('Nimbus Foundation');
   });
 });

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -7,10 +7,11 @@ import type { Request } from 'express';
 
 import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
 
-const { gatewayFetch } = vi.hoisted(() => ({ gatewayFetch: vi.fn() }));
+const { gatewayFetch, isImpersonating } = vi.hoisted(() => ({ gatewayFetch: vi.fn(), isImpersonating: vi.fn(() => false) }));
 
 vi.mock('../helpers/gateway-fetch.helper', () => ({ gatewayFetch }));
 vi.mock('../helpers/cla-service-url.helper', () => ({ claServiceBaseUrl: () => 'https://gw.example.org/cla-service' }));
+vi.mock('../utils/auth-helper', () => ({ isImpersonating }));
 
 const { OrgClaService } = await import('./org-cla.service');
 
@@ -57,6 +58,7 @@ function req(overrides: Partial<Request> = {}): Request {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  isImpersonating.mockReturnValue(false);
 });
 
 describe('OrgClaService.listClaGroups — the upstream call', () => {
@@ -71,6 +73,37 @@ describe('OrgClaService.listClaGroups — the upstream call', () => {
       `https://gw.example.org/cla-service/v4/company/external/${ORG_UID}/cla-groups`,
       expect.objectContaining({ operation: 'org_cla_list_cla_groups', service: 'org_cla_service' })
     );
+  });
+
+  // The mapper keeps manager identities off the wire to the browser, but the fetch helper logs
+  // raw payloads on a non-OK status or an unparseable body. Without redaction that second path
+  // puts the same identities in application logs, defeating the boundary from the other side.
+  it('redacts the response body so manager identities cannot reach the logs', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList());
+
+    await new OrgClaService().listClaGroups(req(), ORG_UID);
+
+    expect(gatewayFetch).toHaveBeenCalledWith(expect.anything(), expect.any(String), expect.objectContaining({ redactResponseBody: true }));
+  });
+
+  it('sends no explicit bearer token when nobody is being impersonated', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList());
+
+    await new OrgClaService().listClaGroups(req(), ORG_UID);
+
+    expect(gatewayFetch).toHaveBeenCalledWith(expect.anything(), expect.any(String), expect.objectContaining({ bearerToken: undefined }));
+  });
+
+  // The route authorizes the impersonated user, so the upstream call has to run as that user.
+  // Sending the impersonator's token audits the request as the wrong identity, and fails
+  // outright wherever only the target holds the organization scope.
+  it("sends the target user's token while impersonating", async () => {
+    isImpersonating.mockReturnValue(true);
+    gatewayFetch.mockResolvedValue(upstreamList());
+
+    await new OrgClaService().listClaGroups(req({ bearerToken: 'target-user-token' } as Partial<Request>), ORG_UID);
+
+    expect(gatewayFetch).toHaveBeenCalledWith(expect.anything(), expect.any(String), expect.objectContaining({ bearerToken: 'target-user-token' }));
   });
 
   it('ignores a company id the caller tried to supply in the query or body', async () => {
@@ -110,10 +143,25 @@ describe('OrgClaService.listClaGroups — empty versus failed', () => {
     await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).resolves.toEqual({ orgUid: ORG_UID, claGroups: [] });
   });
 
-  it('treats a null upstream body as an empty list', async () => {
+  // A body the contract does not allow is a failure, and must reach the client as one. Reading
+  // it as an empty list would state that the organization has signed nothing — the same false
+  // claim the rejected-request case below refuses to make, arrived at by a different route.
+  it('rejects a null upstream body rather than reading it as an empty list', async () => {
     gatewayFetch.mockResolvedValue(null);
 
-    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).resolves.toEqual({ orgUid: ORG_UID, claGroups: [] });
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).rejects.toMatchObject({ code: 'UPSTREAM_INVALID_RESPONSE' });
+  });
+
+  it('rejects a response whose list is missing', async () => {
+    gatewayFetch.mockResolvedValue({ companySFID: ORG_UID, resultCount: 0 });
+
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).rejects.toMatchObject({ code: 'UPSTREAM_INVALID_RESPONSE' });
+  });
+
+  it('rejects a response whose list is not an array', async () => {
+    gatewayFetch.mockResolvedValue({ companySFID: ORG_UID, list: 'not-a-list' });
+
+    await expect(new OrgClaService().listClaGroups(req(), ORG_UID)).rejects.toMatchObject({ code: 'UPSTREAM_INVALID_RESPONSE' });
   });
 
   it('lets an upstream failure propagate rather than degrading it to an empty list', async () => {
@@ -214,6 +262,36 @@ describe('OrgClaService.listClaGroups — status', () => {
     const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
 
     expect(row.status).toBe('signed');
+  });
+
+  // The producer passes the signature's own signed flag through and its tests pin a returned
+  // row whose flag is false, so this list is not exclusively signed agreements. Calling one
+  // signed would state that an organization has signed something it has not.
+  it('maps an unsigned agreement to not-started rather than to signed', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: false, sanctioned: false })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('not-started');
+  });
+
+  // Absence understates rather than overstates: upstream always sends the flag, so a missing
+  // one means a producer this consumer does not recognise, and claiming "signed" on its behalf
+  // is the direction that does harm.
+  it('treats a missing signed flag as not-started', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: undefined, sanctioned: false })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('not-started');
+  });
+
+  it('lets sanctioned win over an unsigned agreement too', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: false, sanctioned: true })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.status).toBe('sanctioned');
   });
 
   it('maps a sanctioned signing entity to sanctioned', async () => {

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -163,13 +163,34 @@ describe('OrgClaService.listClaGroups — what must not cross to the client', ()
 });
 
 describe('OrgClaService.listClaGroups — the approval-criteria count', () => {
-  it('leaves the approval-criteria count absent rather than defaulting it to zero', async () => {
-    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry()));
+  it('carries the count upstream supplies', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ approvalCriteriaCount: 7 })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.approvalCriteriaCount).toBe(7);
+  });
+
+  // Upstream declares the field `x-omitempty: false`, so a deployment carrying it sends 0 for an
+  // agreement with no rules. That is a real answer and has to survive the mapper.
+  it('carries a supplied zero rather than dropping it', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ approvalCriteriaCount: 0 })));
+
+    const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
+
+    expect(row.approvalCriteriaCount).toBe(0);
+  });
+
+  // The distinction the previous test protects only means something if the other side holds:
+  // a deployment predating the producer change sends nothing, and nothing must not become 0.
+  // One says "this agreement approves nobody"; the other says "this deployment cannot tell you".
+  it('leaves the count absent when upstream omits it, rather than defaulting to zero', async () => {
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ approvalCriteriaCount: undefined })));
 
     const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
 
     expect(row.approvalCriteriaCount).toBeUndefined();
-    expect(row.approvalCriteriaCount).not.toBe(0);
+    expect('approvalCriteriaCount' in row).toBe(false);
   });
 
   it('does not fill the approval-criteria count from the employee-acknowledgement count', async () => {
@@ -177,11 +198,11 @@ describe('OrgClaService.listClaGroups — the approval-criteria count', () => {
     // covered, acknowledgements are the people covered. Asserting "not zero" alone would
     // still pass if the acknowledgement count were substituted here, which is the specific
     // mistake worth pinning.
-    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ approvedContributorsCount: 412 })));
+    gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ approvedContributorsCount: 412, approvalCriteriaCount: 3 })));
 
     const [row] = (await new OrgClaService().listClaGroups(req(), ORG_UID)).claGroups;
 
-    expect(row.approvalCriteriaCount).not.toBe(412);
+    expect(row.approvalCriteriaCount).toBe(3);
     expect(JSON.stringify(row)).not.toContain('412');
   });
 });

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -12,8 +12,10 @@ import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupProject, OrgClaGroupStatu
 import type { Request } from 'express';
 
 import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
+import { MicroserviceError } from '../errors';
 import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
+import { isImpersonating } from '../utils/auth-helper';
 
 const SERVICE = 'org_cla_service';
 
@@ -83,11 +85,19 @@ function toOrgClaGroup(entry: EasyClaCompanyClaGroup, companyName: string): OrgC
  * sanctioned entity's agreement as ordinarily signed is the more damaging of the two errors
  * available here.
  *
- * There is no unsigned case to handle. The upstream list is built from signed + approved
- * CCLA signatures, so an unsigned CLA Group never appears in it.
+ * An unsigned agreement is a real case, and it is read from the flag rather than assumed
+ * away. The producer sets each row's signed flag from the signature it was built from, and
+ * its own tests pin a returned row whose flag is false, so the list is not exclusively
+ * signed agreements. Defaulting to `signed` would state that an organization has signed
+ * something it has not — the same class of false claim the precedence above avoids, and the
+ * reason the flag is checked explicitly rather than treated as always true.
+ *
+ * Sanctions still win over an unsigned agreement, for the same reason they win over a signed
+ * one: the sanctions fact is the one a viewer must not miss.
  */
 function toStatus(entry: EasyClaCompanyClaGroup): OrgClaGroupStatus {
-  return entry.sanctioned === true ? 'sanctioned' : 'signed';
+  if (entry.sanctioned === true) return 'sanctioned';
+  return entry.signed === true ? 'signed' : 'not-started';
 }
 
 export class OrgClaService {
@@ -116,10 +126,30 @@ export class OrgClaService {
         service: SERVICE,
         errorMessage: 'Failed to fetch organization CLA groups',
         errorCode: 'UPSTREAM_ERROR',
+        // This response carries CLA managers by id and LF username. The mapper drops them, but
+        // that boundary only covers the browser: on a non-OK status or unparseable body the
+        // fetch helper logs the raw payload, which would put manager identities in application
+        // logs. Redaction closes the second path (same reason as rewards.service.ts).
+        redactResponseBody: true,
+        // The route authorizes the impersonated user, so the upstream call must run as that
+        // user too. Without this it runs as the impersonator, which is audited as the wrong
+        // identity and fails outright where only the target holds the organization scope.
+        bearerToken: isImpersonating(req) ? req.bearerToken : undefined,
       }
     );
 
-    const entries = upstream?.list ?? [];
+    // A malformed response is a failure, not an answer. `gatewayFetch` returns null on a 204,
+    // and a 200 can arrive without the list the contract guarantees; both would otherwise fall
+    // through to an empty list and be rendered as "this organization has signed nothing" —
+    // precisely the false claim the paragraph above refuses to make for a failed request.
+    if (!upstream || !Array.isArray(upstream.list)) {
+      throw new MicroserviceError('Failed to fetch organization CLA groups: malformed response from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
+        operation: 'org_cla_list_cla_groups',
+        service: SERVICE,
+      });
+    }
+
+    const entries = upstream.list;
     const companyName = entries.find((entry) => !!entry.companyName)?.companyName ?? '';
 
     return {

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -38,7 +38,14 @@ const SERVICE = 'org_cla_service';
  * feature, the second is folded into `status` so no consumer forms a second opinion about
  * what "signed" means for display.
  */
-function toOrgClaGroup(entry: EasyClaCompanyClaGroup, companyName: string): OrgClaGroup {
+/**
+ * Maps one upstream entry, once its signature id is known to be present.
+ *
+ * The id is required here rather than defaulted, so the check for it stays at the point where a
+ * malformed response can still be rejected as one. A default inside the mapper would silently
+ * produce a row that renders.
+ */
+function toOrgClaGroup(entry: EasyClaCompanyClaGroup & { signatureID: string }, companyName: string): OrgClaGroup {
   const projects: OrgClaGroupProject[] = (entry.projects ?? [])
     .map((project) => ({
       projectName: project.projectName?.trim() ?? '',
@@ -52,7 +59,7 @@ function toOrgClaGroup(entry: EasyClaCompanyClaGroup, companyName: string): OrgC
   const claGroupName = entry.claGroupName?.trim() ?? '';
 
   return {
-    id: entry.signatureID ?? '',
+    id: entry.signatureID,
     // Upstream declares claGroupName always present; the UUID fallback exists so a producer
     // that drops it yields an identifiable card rather than a blank heading.
     claGroupName: claGroupName || (entry.claGroupID ?? ''),
@@ -149,6 +156,17 @@ export class OrgClaService {
     // precisely the false claim the paragraph above refuses to make for a failed request.
     if (!upstream || !Array.isArray(upstream.list)) {
       throw new MicroserviceError('Failed to fetch organization CLA groups: malformed response from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
+        operation: 'org_cla_list_cla_groups',
+        service: SERVICE,
+      });
+    }
+
+    // A row without its signature id is malformed for the same reason the envelope above is: the
+    // id is the row's identity, and the list renders keyed on it. Substituting an empty string
+    // makes every such row share one key, which lets the view reuse one card's DOM for another
+    // agreement — a worse outcome than the load failure this raises instead.
+    if (!upstream.list.every((entry): entry is EasyClaCompanyClaGroup & { signatureID: string } => !!entry?.signatureID)) {
+      throw new MicroserviceError('Failed to fetch organization CLA groups: upstream row is missing its signature id', 502, 'UPSTREAM_INVALID_RESPONSE', {
         operation: 'org_cla_list_cla_groups',
         service: SERVICE,
       });

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -1,12 +1,129 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+// Organization Lens EasyCLA list (#1978). Reads the organization's corporate CLAs from
+// EasyCLA's organization CLA landing list (easycla#5188) and maps them onto the row the
+// Org Lens page renders.
+//
+// One upstream call per page load, whatever the number of agreements. Searching and paging
+// happen client-side over the fetched set, so nothing on this path fans out per row.
+
+import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupProject, OrgClaGroupStatus } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
-import type { OrgClaGroupList } from '@lfx-one/shared/interfaces';
+import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
+import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
+import { gatewayFetch } from '../helpers/gateway-fetch.helper';
+
+const SERVICE = 'org_cla_service';
+
+/**
+ * Maps one upstream entry onto the list row.
+ *
+ * Two upstream fields are dropped here rather than left unrendered, because a field the
+ * template ignores still reaches the browser inside the transferred state:
+ *
+ * - `claManagers` — the managers by id and LF username. This surface shows only how many
+ *   there are, so the identities have no reason to leave the server. Rendering them is a
+ *   separate feature and needs its own authorization argument.
+ * - `approvedContributorsCount` — a real number, but not the one the card's first stat
+ *   names. That slot is the approval *criteria* count (the rules deciding who may be
+ *   covered); this is the count of employee acknowledgements (the people covered). They are
+ *   easy to confuse because the console this replaces labels its rules section as though it
+ *   listed contributors. Mapping it here is how it ends up under the wrong label.
+ *
+ * `autoCreateECLA` and `signed` are likewise not carried: the first belongs to a later
+ * feature, the second is folded into `status` so no consumer forms a second opinion about
+ * what "signed" means for display.
+ */
+function toOrgClaGroup(entry: EasyClaCompanyClaGroup, companyName: string): OrgClaGroup {
+  const projects: OrgClaGroupProject[] = (entry.projects ?? [])
+    .map((project) => ({
+      projectName: project.projectName?.trim() ?? '',
+      ...(project.projectSFID ? { projectSfid: project.projectSFID } : {}),
+    }))
+    // A project that arrives without a name cannot be rendered as a chip or matched by
+    // search, and counting it would overstate coverage on the "Covers N projects" line.
+    .filter((project) => !!project.projectName);
+
+  const signingEntityName = entry.signingEntityName?.trim() ?? '';
+  const claGroupName = entry.claGroupName?.trim() ?? '';
+
+  return {
+    id: entry.signatureID ?? '',
+    // Upstream declares claGroupName always present; the UUID fallback exists so a producer
+    // that drops it yields an identifiable card rather than a blank heading.
+    claGroupName: claGroupName || (entry.claGroupID ?? ''),
+    ...(entry.claGroupID ? { claGroupId: entry.claGroupID } : {}),
+    // Suppressed when it matches the organization's own name, which is the common case:
+    // upstream falls back to the company name for a record with no signing entity of its
+    // own, and echoing the page title under every card's heading is noise. It earns its
+    // place only when it distinguishes two rows that share a CLA Group name.
+    ...(signingEntityName && signingEntityName !== companyName.trim() ? { signingEntityName } : {}),
+    ...(entry.foundationName ? { foundationName: entry.foundationName } : {}),
+    ...(entry.foundationSFID ? { foundationSfid: entry.foundationSFID } : {}),
+    projects,
+    ...(entry.signedOn ? { signedOn: entry.signedOn } : {}),
+    status: toStatus(entry),
+    needsClaManager: entry.needsClaManager === true,
+    claManagersCount: entry.claManagersCount ?? 0,
+    // approvalCriteriaCount is intentionally never set — see its doc on OrgClaGroup before
+    // adding it here. It is not approvedContributorsCount and it is not 0.
+  };
+}
+
+/**
+ * Sanctions win over signed-ness.
+ *
+ * Upstream carries the two as independent booleans and the card has one status slot, so the
+ * combination has to collapse somewhere. It collapses toward sanctioned: showing a
+ * sanctioned entity's agreement as ordinarily signed is the more damaging of the two errors
+ * available here.
+ *
+ * There is no unsigned case to handle. The upstream list is built from signed + approved
+ * CCLA signatures, so an unsigned CLA Group never appears in it.
+ */
+function toStatus(entry: EasyClaCompanyClaGroup): OrgClaGroupStatus {
+  return entry.sanctioned === true ? 'sanctioned' : 'signed';
+}
 
 export class OrgClaService {
-  public async listClaGroups(_req: Request, orgUid: string): Promise<OrgClaGroupList> {
-    return { orgUid, claGroups: [] };
+  /**
+   * Lists the organization's corporate CLAs.
+   *
+   * `orgUid` is the grant-checked path parameter, and it goes to the upstream unchanged:
+   * org-lens routes carry the 18-character Salesforce account id, which member-service made
+   * the canonical org uid, and that is the same value EasyCLA keys `companySFID` on. No
+   * resolution step sits between the two. The caller's own `orgUid` is the only source —
+   * nothing is read from the query string or the body.
+   *
+   * An empty list is a valid answer meaning the organization has signed nothing. Upstream
+   * returns the same for an organization it has no record of, and deliberately does not
+   * create one; there is no 404 on this path. An upstream failure therefore propagates
+   * rather than degrading to an empty list — with no 404 to distinguish them, "we could not
+   * load your CLAs" and "you have signed none" would otherwise be indistinguishable, and
+   * only one of them is a claim about a company's legal position.
+   */
+  public async listClaGroups(req: Request, orgUid: string): Promise<OrgClaGroupList> {
+    const upstream = await gatewayFetch<EasyClaCompanyClaGroupList>(
+      req,
+      `${claServiceBaseUrl()}/v4/company/external/${encodeURIComponent(orgUid)}/cla-groups`,
+      {
+        operation: 'org_cla_list_cla_groups',
+        service: SERVICE,
+        errorMessage: 'Failed to fetch organization CLA groups',
+        errorCode: 'UPSTREAM_ERROR',
+      }
+    );
+
+    const entries = upstream?.list ?? [];
+    const companyName = entries.find((entry) => !!entry.companyName)?.companyName ?? '';
+
+    return {
+      orgUid,
+      // Upstream order (signing entity, then CLA group name) is preserved, so what a support
+      // engineer sees probing the endpoint directly matches what the page shows.
+      claGroups: entries.map((entry) => toOrgClaGroup(entry, companyName)),
+    };
   }
 }

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -20,7 +20,11 @@ import { isImpersonating } from '../utils/auth-helper';
 const SERVICE = 'org_cla_service';
 
 /**
- * Maps one upstream entry onto the list row.
+ * Maps one upstream entry onto the list row, once its signature id is known to be present.
+ *
+ * The id is required here rather than defaulted, so the check for it stays at the point where a
+ * malformed response can still be rejected as one. A default inside the mapper would silently
+ * produce a row that renders.
  *
  * Two upstream fields are dropped here rather than left unrendered, because a field the
  * template ignores still reaches the browser inside the transferred state:
@@ -37,13 +41,6 @@ const SERVICE = 'org_cla_service';
  * `autoCreateECLA` and `signed` are likewise not carried: the first belongs to a later
  * feature, the second is folded into `status` so no consumer forms a second opinion about
  * what "signed" means for display.
- */
-/**
- * Maps one upstream entry, once its signature id is known to be present.
- *
- * The id is required here rather than defaulted, so the check for it stays at the point where a
- * malformed response can still be rejected as one. A default inside the mapper would silently
- * produce a row that renders.
  */
 function toOrgClaGroup(entry: EasyClaCompanyClaGroup & { signatureID: string }, companyName: string): OrgClaGroup {
   const projects: OrgClaGroupProject[] = (entry.projects ?? [])

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -129,7 +129,7 @@ export class OrgClaService {
   public async listClaGroups(req: Request, orgUid: string): Promise<OrgClaGroupList> {
     const upstream = await gatewayFetch<EasyClaCompanyClaGroupList>(
       req,
-      `${claServiceBaseUrl()}/v4/company/external/${encodeURIComponent(orgUid)}/cla-groups`,
+      `${claServiceBaseUrl(SERVICE)}/v4/company/external/${encodeURIComponent(orgUid)}/cla-groups`,
       {
         operation: 'org_cla_list_cla_groups',
         service: SERVICE,

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -27,10 +27,10 @@ const SERVICE = 'org_cla_service';
  *   there are, so the identities have no reason to leave the server. Rendering them is a
  *   separate feature and needs its own authorization argument.
  * - `approvedContributorsCount` — a real number, but not the one the card's first stat
- *   names. That slot is the approval *criteria* count (the rules deciding who may be
- *   covered); this is the count of employee acknowledgements (the people covered). They are
- *   easy to confuse because the console this replaces labels its rules section as though it
- *   listed contributors. Mapping it here is how it ends up under the wrong label.
+ *   names. That slot is `approvalCriteriaCount` (the rules deciding who may be covered);
+ *   this is the count of employee acknowledgements (the people covered). They are easy to
+ *   confuse because the console this replaces labels its rules section as though it listed
+ *   contributors. Mapping it here is how it ends up under the wrong label.
  *
  * `autoCreateECLA` and `signed` are likewise not carried: the first belongs to a later
  * feature, the second is folded into `status` so no consumer forms a second opinion about
@@ -67,8 +67,11 @@ function toOrgClaGroup(entry: EasyClaCompanyClaGroup, companyName: string): OrgC
     status: toStatus(entry),
     needsClaManager: entry.needsClaManager === true,
     claManagersCount: entry.claManagersCount ?? 0,
-    // approvalCriteriaCount is intentionally never set — see its doc on OrgClaGroup before
-    // adding it here. It is not approvedContributorsCount and it is not 0.
+    // Carried only when upstream actually sent a number, so an environment still running a
+    // producer without the field renders the stat as unavailable rather than asserting 0.
+    // `?? 0` here would turn "this deployment cannot tell you" into "this agreement approves
+    // nobody" — a legal claim, and a false one.
+    ...(typeof entry.approvalCriteriaCount === 'number' ? { approvalCriteriaCount: entry.approvalCriteriaCount } : {}),
   };
 }
 

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -65,7 +65,12 @@ function toOrgClaGroup(entry: EasyClaCompanyClaGroup, companyName: string): OrgC
     ...(entry.foundationName ? { foundationName: entry.foundationName } : {}),
     ...(entry.foundationSFID ? { foundationSfid: entry.foundationSFID } : {}),
     projects,
-    ...(entry.signedOn ? { signedOn: entry.signedOn } : {}),
+    // Only for an agreement that was actually signed. Upstream backfills this field with the
+    // signature's creation time when there is no signing timestamp, so on an unsigned row it
+    // holds when the signing was begun, not when it completed. Carrying it under a field the
+    // shared contract defines as the instant the CCLA was signed would hand the detail view a
+    // date to present as a signature date for an agreement that has none.
+    ...(entry.signed === true && entry.signedOn ? { signedOn: entry.signedOn } : {}),
     status: toStatus(entry),
     needsClaManager: entry.needsClaManager === true,
     claManagersCount: entry.claManagersCount ?? 0,

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -224,3 +224,96 @@ export interface RecordedGithubIdentity {
   githubId: string;
   githubUsername?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Organization Lens EasyCLA — `GET /v4/company/external/{companySFID}/cla-groups`
+// (easycla#5188). Server-only, like everything above: only the mapped
+// OrgClaGroup crosses into @lfx-one/shared. That boundary is not stylistic —
+// this payload carries the CCLA managers by name, and this surface renders only
+// how many there are. A type shared with the client is a type someone forwards.
+// ---------------------------------------------------------------------------
+
+/** One Salesforce project a CLA Group covers (`#/definitions/company-cla-group-project`). */
+export interface EasyClaCompanyClaGroupProject {
+  projectSFID?: string;
+  projectName?: string;
+}
+
+/**
+ * One CLA manager on the CCLA signature ACL (`#/definitions/company-cla-group-manager`).
+ *
+ * Typed so the count can be trusted against the array when they disagree — not so the
+ * entries can be forwarded. Nothing in this file's consumers may map one of these onto a
+ * shared interface; the managers surface is its own feature with its own authorization
+ * argument.
+ */
+export interface EasyClaCompanyClaGroupManager {
+  userID?: string;
+  lfUsername?: string;
+}
+
+/**
+ * One CCLA of one signing entity under one CLA group (`#/definitions/company-cla-group`).
+ *
+ * The grain is (signing entity x CLA group), not CLA group: one organization can hold
+ * agreements for the same group under several company records sharing its external SFID,
+ * so `claGroupID` alone does not identify an entry. `signatureID` does.
+ *
+ * Every field is optional here though upstream declares them present, because a producer
+ * that drops one should degrade a single card rather than fail the page.
+ */
+export interface EasyClaCompanyClaGroup {
+  companyID?: string;
+  companySFID?: string;
+  companyName?: string;
+  /** The signing entity's name; upstream falls back to the company name when it has none. */
+  signingEntityName?: string;
+  claGroupID?: string;
+  claGroupName?: string;
+  foundationSFID?: string;
+  foundationName?: string;
+  /** Sorted by `projectName` upstream. */
+  projects?: EasyClaCompanyClaGroupProject[];
+  /**
+   * Always true in practice: the list is derived from signed + approved CCLA signatures,
+   * so an unsigned group is not returned at all. Typed because the sanctions override
+   * reads better against an explicit flag than against its absence.
+   */
+  signed?: boolean;
+  signedOn?: string;
+  signatureID?: string;
+  /** Stored sanctions flag of the *signing entity*, not of the parent organization. */
+  sanctioned?: boolean;
+  /**
+   * Employee acknowledgements (ECLAs) under this CCLA — people covered.
+   *
+   * Deliberately not mapped onto the list row. This is not the count the CLA Group card
+   * previews: that slot is the approval *criteria* count, the rules that decide who may be
+   * covered, which this endpoint does not return in any form. The two are routinely
+   * confused because the surface being replaced labels its rules section as though it
+   * listed contributors. Substituting this here would put a real number under a label
+   * naming a different quantity.
+   */
+  approvedContributorsCount?: number;
+  claManagersCount?: number;
+  /** Sorted by `lfUsername` upstream. Counted, never forwarded. */
+  claManagers?: EasyClaCompanyClaGroupManager[];
+  /** Upstream-computed: signed with zero CLA managers. Taken as given, never re-derived. */
+  needsClaManager?: boolean;
+  autoCreateECLA?: boolean;
+}
+
+/**
+ * Response for `GET /v4/company/external/{companySFID}/cla-groups`
+ * (`#/definitions/company-cla-groups`).
+ *
+ * An unknown company and a company with no CCLAs both return 200 with an empty `list` —
+ * the endpoint never creates a company record as a side effect of being asked about one.
+ * There is no 404 on this path.
+ */
+export interface EasyClaCompanyClaGroupList {
+  companySFID?: string;
+  resultCount?: number;
+  /** Sorted by `signingEntityName` then `claGroupName` upstream. */
+  list?: EasyClaCompanyClaGroup[];
+}

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -284,6 +284,13 @@ export interface EasyClaCompanyClaGroup {
    * rather than overstates an organization's legal position.
    */
   signed?: boolean;
+  /**
+   * When the CCLA was signed — but only meaningful where `signed` is true.
+   *
+   * Upstream falls back to the signature's creation time when it holds no signing timestamp,
+   * so an unsigned row carries a real date that is not a signing date. Read it together with
+   * `signed`, never alone.
+   */
   signedOn?: string;
   signatureID?: string;
   /** Stored sanctions flag of the *signing entity*, not of the parent organization. */
@@ -293,10 +300,11 @@ export interface EasyClaCompanyClaGroup {
    *
    * Deliberately not mapped onto the list row. This is not the count the CLA Group card
    * previews: that slot is the approval *criteria* count, the rules that decide who may be
-   * covered, which this endpoint does not return in any form. The two are routinely
-   * confused because the surface being replaced labels its rules section as though it
-   * listed contributors. Substituting this here would put a real number under a label
-   * naming a different quantity.
+   * covered, which this endpoint returns separately as `approvalCriteriaCount`. The two are
+   * routinely confused because the surface being replaced labels its rules section as though
+   * it listed contributors. Substituting this here would put a real number under a label
+   * naming a different quantity — and now that the criteria count has its own field, doing so
+   * would also overwrite an accurate value with an unrelated one.
    */
   approvedContributorsCount?: number;
   /**

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -275,9 +275,13 @@ export interface EasyClaCompanyClaGroup {
   /** Sorted by `projectName` upstream. */
   projects?: EasyClaCompanyClaGroupProject[];
   /**
-   * Always true in practice: the list is derived from signed + approved CCLA signatures,
-   * so an unsigned group is not returned at all. Typed because the sanctions override
-   * reads better against an explicit flag than against its absence.
+   * Whether the CCLA is signed, taken from the signature the row was built from. It can be
+   * false: an unsigned record does reach this list, which the producer's own tests pin.
+   *
+   * Declared `x-omitempty: false` upstream, so a deployment always sends it and a `false`
+   * arrives explicitly rather than as an omission. Optional here only because the absence of
+   * a field is never assumed away — and absence is read as unsigned, which understates
+   * rather than overstates an organization's legal position.
    */
   signed?: boolean;
   signedOn?: string;

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -295,6 +295,18 @@ export interface EasyClaCompanyClaGroup {
    * naming a different quantity.
    */
   approvedContributorsCount?: number;
+  /**
+   * Approval criteria on the CCLA — rules granting coverage, summed across all six lists
+   * (email, email domain, GitHub username, GitHub org, GitLab username, GitLab group).
+   * This is the count the card previews, and it is unrelated to `approvedContributorsCount`
+   * above: one domain rule can cover a whole company.
+   *
+   * Optional because absence is meaningful. Upstream declares it `x-omitempty: false`, so a
+   * deployment carrying the field always sends it — including `0`. Absent therefore means the
+   * environment predates the producer change, which is a different fact from an agreement that
+   * approves nobody, and the two must not collapse.
+   */
+  approvalCriteriaCount?: number;
   claManagersCount?: number;
   /** Sorted by `lfUsername` upstream. Counted, never forwarded. */
   claManagers?: EasyClaCompanyClaGroupManager[];

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -568,13 +568,89 @@ export interface ClaRow {
 }
 
 /**
+ * Status of one organization CCLA, derived server-side (#1978).
+ *
+ * Upstream exposes signed-ness and the sanctions flag as two independent booleans; the card
+ * has one slot, and sanctions win — presenting a sanctioned entity's agreement as ordinarily
+ * signed is the more damaging of the two possible errors.
+ *
+ * The approved design's third value, "not started", is **not producible** here: the upstream
+ * list is derived from signed + approved CCLA signatures, so every row it returns is signed.
+ * An unsigned CLA Group is the Sign CLA flow's subject, not this list's. Recorded rather than
+ * omitted so its absence does not read as a defect to someone comparing against the design.
+ */
+export type OrgClaGroupStatus = 'signed' | 'sanctioned';
+
+/** One Salesforce project covered by an organization's CLA Group (#1978). */
+export interface OrgClaGroupProject {
+  projectSfid?: string;
+  projectName: string;
+}
+
+/**
+ * One corporate CLA the organization holds — one signing entity, one CLA Group (#1978).
+ *
+ * Every field here is organization-grain. The upstream payload carries the CCLA managers
+ * themselves; they are dropped at the mapper, so `claManagersCount` is all that survives.
+ * That drop is at the mapper and not at the template on purpose: a template that declines to
+ * render a field still ships it to the browser inside the transferred state.
+ */
+export interface OrgClaGroup {
+  /**
+   * The CCLA signature id. The row key.
+   *
+   * `claGroupId` is deliberately not the key: the upstream grain is (signing entity x CLA
+   * group), so one organization can hold two rows for the same CLA Group under different
+   * signing entities.
+   */
+  id: string;
+  /** CLA Group display name, falling back to its UUID so a nameless row still renders. */
+  claGroupName: string;
+  claGroupId?: string;
+  /**
+   * The signing entity that actually signed. Present only when it differs from the
+   * organization's own name — the common case would otherwise repeat the page title on
+   * every card.
+   */
+  signingEntityName?: string;
+  foundationName?: string;
+  foundationSfid?: string;
+  /** Covered projects, in the upstream's `projectName` order. May be empty. */
+  projects: OrgClaGroupProject[];
+  /** RFC3339 instant the CCLA was signed. Carried for the agreement detail view. */
+  signedOn?: string;
+  status: OrgClaGroupStatus;
+  /**
+   * Upstream's own `needsClaManager` — signed with zero CLA managers — taken verbatim.
+   *
+   * Not re-derived from `claManagersCount`, though the two agree today. Two definitions of
+   * one condition that agree now is precisely the arrangement that drifts later; the
+   * producer owns this one.
+   */
+  needsClaManager: boolean;
+  claManagersCount: number;
+  /**
+   * How many approval criteria (the rules deciding who may be covered) the agreement has.
+   *
+   * **Always absent.** The CLA service returns no such count, and the card's first stat is
+   * this one — not the employee-acknowledgement count, which is a different quantity with no
+   * slot on this page. The field exists so that when the producer adds the count, populating
+   * it is a one-line mapper change and no consumer moves.
+   *
+   * Do not populate this from `approvedContributorsCount`, do not default it to 0, and do not
+   * fetch it per row: an approval-list call per card is an N+1 on the landing page. Absent
+   * renders as unavailable, which is true; 0 would assert the agreement approves nobody.
+   */
+  approvalCriteriaCount?: number;
+}
+
+/**
  * Response of `GET /api/orgs/:orgUid/lens/cla-groups` — the Organization Lens EasyCLA list.
  *
  * `orgUid` echoes the grant-checked path parameter rather than anything the caller sent in a
  * body or query, so the client can key a cache on the org the server actually served.
- * `claGroups` is empty until the BE-1 wiring (#1978) lands.
  */
 export interface OrgClaGroupList {
   orgUid: string;
-  claGroups: [];
+  claGroups: OrgClaGroup[];
 }

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -579,7 +579,16 @@ export interface ClaRow {
  * An unsigned CLA Group is the Sign CLA flow's subject, not this list's. Recorded rather than
  * omitted so its absence does not read as a defect to someone comparing against the design.
  */
-export type OrgClaGroupStatus = 'signed' | 'sanctioned';
+/**
+ * The three statuses the approved design's status pill carries.
+ *
+ * `not-started` covers an agreement the CLA service reports as unsigned. The list is mostly
+ * signed agreements, but it is not exclusively so — the producer passes the signature's own
+ * signed flag through, and an unsigned record reaches the list. Rendering one as `signed`
+ * would be a false statement about the organization's legal position, which is the same
+ * failure the sanctions precedence and the empty-versus-failure split exist to prevent.
+ */
+export type OrgClaGroupStatus = 'signed' | 'not-started' | 'sanctioned';
 
 /** One Salesforce project covered by an organization's CLA Group (#1978). */
 export interface OrgClaGroupProject {

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -622,7 +622,14 @@ export interface OrgClaGroup {
   foundationSfid?: string;
   /** Covered projects, in the upstream's `projectName` order. May be empty. */
   projects: OrgClaGroupProject[];
-  /** RFC3339 instant the CCLA was signed. Carried for the agreement detail view. */
+  /**
+   * RFC3339 instant the CCLA was signed. Carried for the agreement detail view.
+   *
+   * Absent on an agreement that is not signed, and the absence is load-bearing: the source
+   * backfills its date field with the signature's creation time, so an unsigned agreement has
+   * a date that is not a signing date. The server withholds it rather than let a consumer
+   * present the moment signing began as the moment it completed.
+   */
   signedOn?: string;
   status: OrgClaGroupStatus;
   /**

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -570,23 +570,19 @@ export interface ClaRow {
 /**
  * Status of one organization CCLA, derived server-side (#1978).
  *
- * Upstream exposes signed-ness and the sanctions flag as two independent booleans; the card
- * has one slot, and sanctions win — presenting a sanctioned entity's agreement as ordinarily
- * signed is the more damaging of the two possible errors.
- *
- * The approved design's third value, "not started", is **not producible** here: the upstream
- * list is derived from signed + approved CCLA signatures, so every row it returns is signed.
- * An unsigned CLA Group is the Sign CLA flow's subject, not this list's. Recorded rather than
- * omitted so its absence does not read as a defect to someone comparing against the design.
- */
-/**
- * The three statuses the approved design's status pill carries.
+ * All three of the approved design's status values are reachable here. Upstream exposes
+ * signed-ness and the sanctions flag as two independent booleans; the card has one slot, and
+ * sanctions win — presenting a sanctioned entity's agreement as ordinarily signed is the more
+ * damaging of the two possible errors.
  *
  * `not-started` covers an agreement the CLA service reports as unsigned. The list is mostly
  * signed agreements, but it is not exclusively so — the producer passes the signature's own
  * signed flag through, and an unsigned record reaches the list. Rendering one as `signed`
  * would be a false statement about the organization's legal position, which is the same
  * failure the sanctions precedence and the empty-versus-failure split exist to prevent.
+ *
+ * Because signed-ness is folded in here rather than carried separately, copy elsewhere on the
+ * card must not assert signing on its own: only `signed` licenses the word.
  */
 export type OrgClaGroupStatus = 'signed' | 'not-started' | 'sanctioned';
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -630,16 +630,17 @@ export interface OrgClaGroup {
   needsClaManager: boolean;
   claManagersCount: number;
   /**
-   * How many approval criteria (the rules deciding who may be covered) the agreement has.
+   * How many approval criteria (the rules deciding who may be covered) the agreement has,
+   * summed across the six approval lists. This is the card's first stat.
    *
-   * **Always absent.** The CLA service returns no such count, and the card's first stat is
-   * this one — not the employee-acknowledgement count, which is a different quantity with no
-   * slot on this page. The field exists so that when the producer adds the count, populating
-   * it is a one-line mapper change and no consumer moves.
+   * Optional because absence carries meaning: it says the CLA service deployment did not
+   * return the count, which happens in any environment predating the producer change. That
+   * is not the same as an agreement with no rules, and the two must render differently —
+   * absent shows as unavailable, 0 shows as 0.
    *
-   * Do not populate this from `approvedContributorsCount`, do not default it to 0, and do not
-   * fetch it per row: an approval-list call per card is an N+1 on the landing page. Absent
-   * renders as unavailable, which is true; 0 would assert the agreement approves nobody.
+   * Do not populate this from `approvedContributorsCount`, which counts the people covered
+   * rather than the rules covering them; do not default it to 0; and do not fetch it per row,
+   * since an approval-list call per card is an N+1 on the landing page.
    */
   approvalCriteriaCount?: number;
 }


### PR DESCRIPTION
Fills the dark-launched Organization Lens EasyCLA page with the organization's
real corporate CLAs — one card per agreement showing its CLA Group, coverage,
status, CLA manager count and an unmanaged-group indicator, with client-side
search and paging, the two empty states, and a distinct load-failure state. The
route, the two-flag gate and the empty server module landed in #2209; this is
the data.

The card's approval-entries statistic is the approval-criteria count — the rules
deciding who may be covered — which linuxfoundation/easycla#5200 added to the
CLA service and this PR maps through. It is deliberately not filled from the
acknowledgement count the service also returns, since that counts the people
covered rather than the rules covering them. Absence and zero stay distinct: an
environment whose CLA service predates #5200 sends no count and the statistic
renders a dash, while a real zero renders as zero. Defaulting absence to zero
would turn "this deployment cannot tell you" into "this agreement approves
nobody".

Refs #1978 — Story A, the list half. The agreement detail shell is the other
half and ships separately, so this does not close the issue.

## External references

- Consumes the organization CLA landing list added in
  linuxfoundation/easycla#5188. **Deploy order:** that producer change must be
  live in the target environment before this page can return data.
- linuxfoundation/easycla#5200 adds the `approvalCriteriaCount` this statistic
  reads. It is merged and live in development; until it reaches a given
  environment the statistic renders a dash there by design, so this PR does not
  depend on the rollout.