### PR TITLE
fix(newsletters): correct stale project context on deep links (#1570)

### DIFF
--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -24,6 +24,10 @@
  *   - The same for a context-less survey EDIT link (`/project/surveys/:uid/edit`, GH-1569):
  *     context syncs from the loaded survey (enriched payload or uid fallback), and writerGuard
  *     authorizes against the survey's own project via its entity probe.
+ *   - A newsletter EDIT link whose `:projectUid` route param disagrees with the cookie-restored
+ *     context (GH-1570): newsletterAccessGuard authorizes against the route's project (resolving
+ *     the param's uid — including at the lens mount, where the param lives on the child
+ *     snapshot), and the manage page reconciles context from the route param.
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -50,6 +54,7 @@ const MOCK_MEETING_UID = 'm0000000-0000-0000-0000-00000000d001';
 const MOCK_VOTE_UID = 'v0000000-0000-0000-0000-00000000d001';
 const MOCK_MAILING_LIST_UID = 'l1000000-0000-0000-0000-00000000d001';
 const MOCK_SURVEY_UID = 's0000000-0000-0000-0000-00000000d001';
+const MOCK_NEWSLETTER_UID = 'n0000000-0000-0000-0000-00000000d001';
 
 function buildProjectStub(uid: string, slug: string, name: string) {
   return {
@@ -422,6 +427,40 @@ async function stubSurveyEditDetail(page: Page, survey: ReturnType<typeof buildS
 // Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
 // storageState, broken Auth0 login helper) still fail loudly when creds ARE configured.
 const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+/**
+ * Newsletter draft payload for the edit page. The route itself carries the owning
+ * project (`:projectUid`), so unlike the meeting/vote/list stubs there is no enriched
+ * vs unenriched variant — context reconciliation resolves the project by the route uid.
+ */
+function buildNewsletterStub() {
+  return {
+    id: MOCK_NEWSLETTER_UID,
+    project_uid: MOCK_FOUNDATION_UID,
+    subject: 'Test Foundation Monthly',
+    body_html: '<p>Newsletter stub for project-context deep-link specs</p>',
+    committee_uids: [],
+    status: 'draft',
+    version: 1,
+    scheduled_at: null,
+    created_at: '2025-01-15T00:00:00Z',
+    updated_at: '2025-06-01T00:00:00Z',
+  };
+}
+
+async function stubNewsletterEditDetail(page: Page, newsletter: ReturnType<typeof buildNewsletterStub>): Promise<void> {
+  // Catch-all registered FIRST (Playwright matches in reverse registration order) so
+  // incidental list calls under the project don't escape to the real BFF. `*` doesn't
+  // cross `/`, so the detail route needs its own exact pattern.
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+  });
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/${MOCK_NEWSLETTER_UID}`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(newsletter) });
+  });
+}
 
 function skipWhenAuthMissing(): void {
   if (!AUTH_CREDS_PRESENT) {
@@ -1069,5 +1108,100 @@ test.describe('Survey edit deep-link resolves the survey’s project context (GH
 
     await page.waitForTimeout(500);
     expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+});
+
+test.describe('Newsletter edit deep-link resolves the route’s project context (GH-1570)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mirror the issue: the user was last working in an unrelated PROJECT (cookie-restored),
+    // then opens an edit link whose :projectUid belongs to Test Foundation.
+    await setPersonaAndLensCookies(page, ['executive-director'], 'project');
+    await setProjectCookie(page, OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project');
+    await stubPersona(page, ['executive-director']);
+    await stubProjectApi(page);
+    await stubCommittees(page, buildCommittees());
+    await stubLensItems(page);
+    await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project')),
+      })
+    );
+    // The guard and the page reconciliation both resolve the route's :projectUid — the uid form
+    // needs its own stub (stubProjectApi keys on slugs). Funded + Membership + Series LLC
+    // satisfies computeIsFoundation, so the reconciled context lands in the foundation slot.
+    await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...buildProjectStub(MOCK_FOUNDATION_UID, MOCK_FOUNDATION_SLUG, 'Test Foundation'),
+          funding: 'Funded',
+          funding_model: ['Membership'],
+          legal_entity_type: 'Series LLC',
+        }),
+      })
+    );
+  });
+
+  test('edit link with a stale cookie context switches to the route’s project', async ({ page }) => {
+    await stubNewsletterEditDetail(page, buildNewsletterStub());
+
+    // The flat URL also exercises the lensRedirectGuard prefix redirect (project lens active):
+    // the rest of the path — including the route's :projectUid — must survive it.
+    await gotoSpa(page, `/newsletters/${MOCK_FOUNDATION_UID}/${MOCK_NEWSLETTER_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page).toHaveURL(new RegExp(`/project/newsletters/${MOCK_FOUNDATION_UID}/${MOCK_NEWSLETTER_UID}/edit`), {
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+    await expect(page.getByTestId('newsletter-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // The page reconciles context from the route's :projectUid (Test Foundation), replacing the
+    // cookie-restored Other Project — the selector and sidebar links follow the correction. The
+    // active lens stays 'project' (only routeLensKind re-points), so the project-lens item is
+    // the one carrying the corrected slug.
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('sidebar-project-newsletters')).toHaveAttribute('href', /[?&]project=test-foundation/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // The context correction must NOT inject ?project= into the entity URL (syncUrl guard) —
+    // give any NavigationEnd-driven backfill a tick to (not) fire before asserting absence.
+    await page.waitForTimeout(500);
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+
+  test('newsletterAccessGuard authorizes the edit page against the route’s :projectUid, not the stale context', async ({ page }) => {
+    // Non-ED persona: no synchronous fast path — the guard must resolve the route's :projectUid
+    // (also at the /project/newsletters mount, where the param sits on the child snapshot). The
+    // stale cookie context (Other Project) is intentionally NOT writable: if the guard authorized
+    // against it (the pre-fix behavior), the page would redirect to /project/overview.
+    await setPersonaAndLensCookies(page, ['maintainer'], 'project');
+    await stubPersona(page, ['maintainer']);
+    await page.route(`**/api/projects/${OTHER_PROJECT_SLUG}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...buildProjectStub(OTHER_PROJECT_UID, OTHER_PROJECT_SLUG, 'Other Project'), writer: false }),
+      })
+    );
+    await stubNewsletterEditDetail(page, buildNewsletterStub());
+
+    await gotoSpa(page, `/project/newsletters/${MOCK_FOUNDATION_UID}/${MOCK_NEWSLETTER_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('newsletter-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Still on the edit page (no access-denied redirect), and the context follows the route's project.
+    expect(page.url()).toContain(`/project/newsletters/${MOCK_FOUNDATION_UID}/${MOCK_NEWSLETTER_UID}/edit`);
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
   });
 });

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -27,7 +27,9 @@
  *   - A newsletter EDIT link whose `:projectUid` route param disagrees with the cookie-restored
  *     context (GH-1570): newsletterAccessGuard authorizes against the route's project (resolving
  *     the param's uid — including at the lens mount, where the param lives on the child
- *     snapshot), and the manage page reconciles context from the route param.
+ *     snapshot), and the manage page reconciles context from the route param. The same
+ *     stale-context case runs against the ANALYTICS link (`:projectUid/:id/analytics`), whose
+ *     component reconciles from its own route-param signal.
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -460,6 +462,40 @@ async function stubNewsletterEditDetail(page: Page, newsletter: ReturnType<typeo
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(newsletter) });
   });
+}
+
+/**
+ * Analytics payload for the analytics page (GH-1570). Minimal roll-up: no daily buckets and
+ * no click data, so every chart/click section renders its absent state and the test asserts
+ * only the header + context reconciliation. Like the edit route, the analytics URL carries
+ * the owning project (`:projectUid`), so reconciliation resolves by the route uid.
+ */
+function buildNewsletterAnalyticsStub() {
+  return {
+    newsletter_id: MOCK_NEWSLETTER_UID,
+    subject: 'Test Foundation Monthly',
+    status: 'sent',
+    sent_at: '2025-06-01T00:00:00Z',
+    total_recipients: 10,
+    delivered: 10,
+    failed: 0,
+    total_opens: 0,
+    unique_opens: 0,
+    open_rate: 0,
+    daily_opens: [],
+  };
+}
+
+async function stubNewsletterAnalytics(page: Page, analytics: ReturnType<typeof buildNewsletterAnalyticsStub>): Promise<void> {
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/${MOCK_NEWSLETTER_UID}/analytics`, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(analytics) });
+  });
+  // The recipient-engagement child fetches eagerly; 403 is its documented render-nothing
+  // path (endpoint is PII-gated behind the `auditor` relation), keeping the page chrome-only.
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_UID}/newsletters/${MOCK_NEWSLETTER_UID}/analytics/recipients*`, (route) =>
+    route.fulfill({ status: 403, contentType: 'application/json', body: JSON.stringify({ message: 'auditor relation required' }) })
+  );
 }
 
 function skipWhenAuthMissing(): void {
@@ -1172,6 +1208,31 @@ test.describe('Newsletter edit deep-link resolves the route’s project context 
 
     // The context correction must NOT inject ?project= into the entity URL (syncUrl guard) —
     // give any NavigationEnd-driven backfill a tick to (not) fire before asserting absence.
+    await page.waitForTimeout(500);
+    expect(new URL(page.url()).searchParams.has('project')).toBe(false);
+  });
+
+  test('analytics link with a stale cookie context switches to the route’s project', async ({ page }) => {
+    // The analytics component has its own projectUid signal and constructor path — a regression
+    // dropping its reconcileRouteProjectContext call passes the edit-route cases above, so the
+    // analytics deep-link needs its own coverage (PR #2224 review).
+    await stubNewsletterAnalytics(page, buildNewsletterAnalyticsStub());
+
+    await gotoSpa(page, `/project/newsletters/${MOCK_FOUNDATION_UID}/${MOCK_NEWSLETTER_UID}/analytics`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+    await expect(page.getByTestId('newsletter-analytics-subject')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Same reconciliation as the edit page: context follows the route's :projectUid (Test
+    // Foundation), replacing the cookie-restored Other Project.
+    await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('sidebar-project-newsletters')).toHaveAttribute('href', /[?&]project=test-foundation/, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+
     await page.waitForTimeout(500);
     expect(new URL(page.url()).searchParams.has('project')).toBe(false);
   });

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
@@ -4,20 +4,24 @@
 import { DatePipe, isPlatformBrowser } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TableComponent } from '@components/table/table.component';
 import { lfxColors, NEWSLETTER_TOP_LINKS_LIMIT } from '@lfx-one/shared/constants';
-import { NewsletterAnalytics, NewsletterChartData, NewsletterLinkRow } from '@lfx-one/shared/interfaces';
-import { normalizeToUrl } from '@lfx-one/shared/utils';
+import { NewsletterAnalytics, NewsletterChartData, NewsletterLinkRow, ProjectContext } from '@lfx-one/shared/interfaces';
+import { computeIsFoundation, normalizeToUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, finalize, of, switchMap, take } from 'rxjs';
+import { catchError, filter, finalize, of, switchMap, take } from 'rxjs';
+
+import { applyEntityProjectContext } from '@shared/utils/entity-project-context.util';
 
 import { NewsletterFailedRecipientsDrawerComponent } from '../components/newsletter-failed-recipients-drawer/newsletter-failed-recipients-drawer.component';
 import { NewsletterRecipientEngagementComponent } from '../components/newsletter-recipient-engagement/newsletter-recipient-engagement.component';
@@ -43,6 +47,8 @@ export class NewsletterAnalyticsComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly newsletterService = inject(NewsletterService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly projectService = inject(ProjectService);
   private readonly messageService = inject(MessageService);
   private readonly platformId = inject(PLATFORM_ID);
 
@@ -55,6 +61,13 @@ export class NewsletterAnalyticsComponent {
   // Route params, retained for the recipient engagement child component's inputs.
   protected readonly projectUid = signal<string>('');
   protected readonly newsletterId = signal<string>('');
+  // Route uid that disagrees with the active context (null when they match).
+  // Drives initRouteContextReconciliation.
+  private readonly unreconciledRouteProjectUid: Signal<string | null> = computed(() => {
+    const routeUid = this.projectUid();
+    if (!routeUid || routeUid === this.projectContextService.activeContextUid()) return null;
+    return routeUid;
+  });
 
   // === Computed (complex bodies extracted to private init* methods) ===
   protected readonly openRatePercent: Signal<number | null> = this.initOpenRatePercent();
@@ -131,6 +144,8 @@ export class NewsletterAnalyticsComponent {
       .subscribe((data) => {
         this.analytics.set(data);
       });
+
+    this.initRouteContextReconciliation();
   }
 
   // `['..']` on a 2-segment route resolves to `/<id>` — anchor to route.parent + explicit 'list' child.
@@ -259,6 +274,41 @@ export class NewsletterAnalyticsComponent {
         href: normalizeToUrl(link.url),
       }));
     });
+  }
+
+  /**
+   * Same route-carried-project reconciliation as the manage component (GH-1570):
+   * the URL's `:projectUid` is authoritative for the fetch below, but page chrome
+   * (name/logo, sidebar) follows `activeContext()`, which a stale cookie-restored
+   * context can leave pointing at a different project. When the two disagree,
+   * resolve the route project by uid and re-point the context via
+   * applyEntityProjectContext; the write quiets the trigger, and a route-lens
+   * re-assert flips the mismatch back on so the correction self-heals. A failed
+   * uid lookup leaves the existing context untouched. See
+   * NewsletterManageComponent.initRouteContextReconciliation for the full rationale.
+   */
+  private initRouteContextReconciliation(): void {
+    toObservable(this.unreconciledRouteProjectUid)
+      .pipe(
+        filter((uid): uid is string => uid !== null),
+        switchMap((uid) => this.projectService.getProject(uid, false)),
+        takeUntilDestroyed()
+      )
+      .subscribe((project) => {
+        // null = deleted/unknown project (or no viewer relation) — keep the
+        // existing context rather than erroring the page.
+        if (!project) return;
+        const context: ProjectContext = {
+          uid: project.uid,
+          name: project.name,
+          slug: project.slug,
+          parent_uid: project.parent_uid,
+          logoUrl: project.logo_url,
+        };
+        // Mirror the entity-context utils: only write ?project= to the URL when already present.
+        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
+        applyEntityProjectContext(this.projectContextService, context, computeIsFoundation(project), syncUrl);
+      });
   }
 
   // Chart.js expects an rgba string for area fills; lfxColors entries are #RRGGBB.

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
@@ -3,25 +3,24 @@
 
 import { DatePipe, isPlatformBrowser } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TableComponent } from '@components/table/table.component';
 import { lfxColors, NEWSLETTER_TOP_LINKS_LIMIT } from '@lfx-one/shared/constants';
-import { NewsletterAnalytics, NewsletterChartData, NewsletterLinkRow, ProjectContext } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation, normalizeToUrl } from '@lfx-one/shared/utils';
+import { NewsletterAnalytics, NewsletterChartData, NewsletterLinkRow } from '@lfx-one/shared/interfaces';
+import { normalizeToUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
+import { reconcileRouteProjectContext } from '@shared/utils/entity-project-context.util';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, filter, finalize, of, switchMap, take } from 'rxjs';
-
-import { applyEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { catchError, finalize, of, switchMap, take } from 'rxjs';
 
 import { NewsletterFailedRecipientsDrawerComponent } from '../components/newsletter-failed-recipients-drawer/newsletter-failed-recipients-drawer.component';
 import { NewsletterRecipientEngagementComponent } from '../components/newsletter-recipient-engagement/newsletter-recipient-engagement.component';
@@ -51,6 +50,7 @@ export class NewsletterAnalyticsComponent {
   private readonly projectService = inject(ProjectService);
   private readonly messageService = inject(MessageService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly destroyRef = inject(DestroyRef);
 
   // === Signals ===
   protected readonly analytics = signal<NewsletterAnalytics | null>(null);
@@ -61,13 +61,6 @@ export class NewsletterAnalyticsComponent {
   // Route params, retained for the recipient engagement child component's inputs.
   protected readonly projectUid = signal<string>('');
   protected readonly newsletterId = signal<string>('');
-  // Route uid that disagrees with the active context (null when they match).
-  // Drives initRouteContextReconciliation.
-  private readonly unreconciledRouteProjectUid: Signal<string | null> = computed(() => {
-    const routeUid = this.projectUid();
-    if (!routeUid || routeUid === this.projectContextService.activeContextUid()) return null;
-    return routeUid;
-  });
 
   // === Computed (complex bodies extracted to private init* methods) ===
   protected readonly openRatePercent: Signal<number | null> = this.initOpenRatePercent();
@@ -145,7 +138,11 @@ export class NewsletterAnalyticsComponent {
         this.analytics.set(data);
       });
 
-    this.initRouteContextReconciliation();
+    // Same route-carried-project reconciliation as the manage component (GH-1570): the URL's
+    // `:projectUid` is authoritative for the fetch above, but page chrome (name/logo, sidebar)
+    // follows `activeContext()`, which a stale cookie-restored context can leave pointing at a
+    // different project.
+    reconcileRouteProjectContext(this.projectUid, this.projectService, this.projectContextService, this.router, this.destroyRef);
   }
 
   // `['..']` on a 2-segment route resolves to `/<id>` — anchor to route.parent + explicit 'list' child.
@@ -274,41 +271,6 @@ export class NewsletterAnalyticsComponent {
         href: normalizeToUrl(link.url),
       }));
     });
-  }
-
-  /**
-   * Same route-carried-project reconciliation as the manage component (GH-1570):
-   * the URL's `:projectUid` is authoritative for the fetch below, but page chrome
-   * (name/logo, sidebar) follows `activeContext()`, which a stale cookie-restored
-   * context can leave pointing at a different project. When the two disagree,
-   * resolve the route project by uid and re-point the context via
-   * applyEntityProjectContext; the write quiets the trigger, and a route-lens
-   * re-assert flips the mismatch back on so the correction self-heals. A failed
-   * uid lookup leaves the existing context untouched. See
-   * NewsletterManageComponent.initRouteContextReconciliation for the full rationale.
-   */
-  private initRouteContextReconciliation(): void {
-    toObservable(this.unreconciledRouteProjectUid)
-      .pipe(
-        filter((uid): uid is string => uid !== null),
-        switchMap((uid) => this.projectService.getProject(uid, false)),
-        takeUntilDestroyed()
-      )
-      .subscribe((project) => {
-        // null = deleted/unknown project (or no viewer relation) — keep the
-        // existing context rather than erroring the page.
-        if (!project) return;
-        const context: ProjectContext = {
-          uid: project.uid,
-          name: project.name,
-          slug: project.slug,
-          parent_uid: project.parent_uid,
-          logoUrl: project.logo_url,
-        };
-        // Mirror the entity-context utils: only write ?project= to the URL when already present.
-        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
-        applyEntityProjectContext(this.projectContextService, context, computeIsFoundation(project), syncUrl);
-      });
   }
 
   // Chart.js expects an rgba string for area fills; lfxColors entries are #RRGGBB.

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -32,6 +32,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import {
   combineDateTime,
+  computeIsFoundation,
   formatFutureRelativeTime,
   formatRelativeTime,
   formatTo12HourInTimezone,
@@ -46,6 +47,7 @@ import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
+import { applyEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { isSchedulingDisabledReply } from '@shared/utils/upstream-error.utils';
 import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { toZonedTime } from 'date-fns-tz';
@@ -177,6 +179,13 @@ export class NewsletterManageComponent {
   // project context switch. Create mode has no projectUid segment, so we fall
   // back to the active context.
   private readonly routeProjectUid: Signal<string | null> = toSignal(this.route.paramMap.pipe(map((p) => p.get('projectUid'))), { initialValue: null });
+  // Route uid that disagrees with the active context (null when they match, or
+  // when the route carries no uid — create mode). Drives initRouteContextReconciliation.
+  private readonly unreconciledRouteProjectUid: Signal<string | null> = computed(() => {
+    const routeUid = this.routeProjectUid();
+    if (!routeUid || routeUid === this.projectContextService.activeContextUid()) return null;
+    return routeUid;
+  });
   public readonly projectUid: Signal<string> = computed(() => this.routeProjectUid() || this.projectContextService.activeContextUid());
   public readonly displayName: Signal<string> = computed(() => this.activeContext()?.name ?? '');
   private readonly fetchedLogoUrl = signal<string | undefined>(undefined);
@@ -391,6 +400,7 @@ export class NewsletterManageComponent {
   public constructor() {
     this.initScheduleTimezone();
     this.initContextLogo();
+    this.initRouteContextReconciliation();
     this.initFormMirrors();
     this.initLoadDraft();
     this.initSaveChannel();
@@ -1354,6 +1364,48 @@ export class NewsletterManageComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((url) => this.fetchedLogoUrl.set(url));
+  }
+
+  /**
+   * Reconciles the active context with the route's own `:projectUid` (edit mode).
+   * The URL carries the owning project, but `displayName`/`logoUrl` (and every
+   * other context-derived read) follow `activeContext()` — after a project switch
+   * or a shared/bookmarked link, the cookie-restored context can point at a
+   * different project, showing the wrong name/logo over the right project's data
+   * (GH-1570). When the two disagree, resolve the route project by uid and
+   * re-point the context via applyEntityProjectContext — the uid-only variant of
+   * gh-1432's fallback path, since there is no enriched entity payload here.
+   *
+   * The write makes route uid and context agree, which quiets the trigger; a
+   * later route-lens re-assert (e.g. MainLayout on `?step=N` navigations) flips
+   * the mismatch back on, so the correction self-heals without NavigationEnd
+   * wiring. The re-apply hits the shareReplay-cached getProject — the guard has
+   * already resolved the same uid on activation, so the happy path costs no
+   * extra request. A failed uid lookup leaves the existing context untouched
+   * (legacy behavior, same degradation philosophy as gh-1432's guard probe).
+   */
+  private initRouteContextReconciliation(): void {
+    toObservable(this.unreconciledRouteProjectUid)
+      .pipe(
+        filter((uid): uid is string => uid !== null),
+        switchMap((uid) => this.projectService.getProject(uid, false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((project) => {
+        // null = deleted/unknown project (or no viewer relation) — keep the
+        // existing context rather than erroring the page.
+        if (!project) return;
+        const context: ProjectContext = {
+          uid: project.uid,
+          name: project.name,
+          slug: project.slug,
+          parent_uid: project.parent_uid,
+          logoUrl: project.logo_url,
+        };
+        // Mirror the entity-context utils: only write ?project= to the URL when already present.
+        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
+        applyEntityProjectContext(this.projectContextService, context, computeIsFoundation(project), syncUrl);
+      });
   }
 
   private initLoadDraft(): void {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts
@@ -32,7 +32,6 @@ import {
 } from '@lfx-one/shared/interfaces';
 import {
   combineDateTime,
-  computeIsFoundation,
   formatFutureRelativeTime,
   formatRelativeTime,
   formatTo12HourInTimezone,
@@ -47,7 +46,7 @@ import { NewsletterService } from '@services/newsletter.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
-import { applyEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { reconcileRouteProjectContext } from '@shared/utils/entity-project-context.util';
 import { isSchedulingDisabledReply } from '@shared/utils/upstream-error.utils';
 import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { toZonedTime } from 'date-fns-tz';
@@ -179,13 +178,6 @@ export class NewsletterManageComponent {
   // project context switch. Create mode has no projectUid segment, so we fall
   // back to the active context.
   private readonly routeProjectUid: Signal<string | null> = toSignal(this.route.paramMap.pipe(map((p) => p.get('projectUid'))), { initialValue: null });
-  // Route uid that disagrees with the active context (null when they match, or
-  // when the route carries no uid — create mode). Drives initRouteContextReconciliation.
-  private readonly unreconciledRouteProjectUid: Signal<string | null> = computed(() => {
-    const routeUid = this.routeProjectUid();
-    if (!routeUid || routeUid === this.projectContextService.activeContextUid()) return null;
-    return routeUid;
-  });
   public readonly projectUid: Signal<string> = computed(() => this.routeProjectUid() || this.projectContextService.activeContextUid());
   public readonly displayName: Signal<string> = computed(() => this.activeContext()?.name ?? '');
   private readonly fetchedLogoUrl = signal<string | undefined>(undefined);
@@ -400,7 +392,10 @@ export class NewsletterManageComponent {
   public constructor() {
     this.initScheduleTimezone();
     this.initContextLogo();
-    this.initRouteContextReconciliation();
+    // Reconcile the active context with the route's own `:projectUid` (edit mode) — the URL
+    // carries the owning project, but `displayName`/`logoUrl` follow `activeContext()`, which a
+    // stale cookie-restored context can leave pointing at a different project (GH-1570).
+    reconcileRouteProjectContext(this.routeProjectUid, this.projectService, this.projectContextService, this.router, this.destroyRef);
     this.initFormMirrors();
     this.initLoadDraft();
     this.initSaveChannel();
@@ -1364,48 +1359,6 @@ export class NewsletterManageComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((url) => this.fetchedLogoUrl.set(url));
-  }
-
-  /**
-   * Reconciles the active context with the route's own `:projectUid` (edit mode).
-   * The URL carries the owning project, but `displayName`/`logoUrl` (and every
-   * other context-derived read) follow `activeContext()` — after a project switch
-   * or a shared/bookmarked link, the cookie-restored context can point at a
-   * different project, showing the wrong name/logo over the right project's data
-   * (GH-1570). When the two disagree, resolve the route project by uid and
-   * re-point the context via applyEntityProjectContext — the uid-only variant of
-   * gh-1432's fallback path, since there is no enriched entity payload here.
-   *
-   * The write makes route uid and context agree, which quiets the trigger; a
-   * later route-lens re-assert (e.g. MainLayout on `?step=N` navigations) flips
-   * the mismatch back on, so the correction self-heals without NavigationEnd
-   * wiring. The re-apply hits the shareReplay-cached getProject — the guard has
-   * already resolved the same uid on activation, so the happy path costs no
-   * extra request. A failed uid lookup leaves the existing context untouched
-   * (legacy behavior, same degradation philosophy as gh-1432's guard probe).
-   */
-  private initRouteContextReconciliation(): void {
-    toObservable(this.unreconciledRouteProjectUid)
-      .pipe(
-        filter((uid): uid is string => uid !== null),
-        switchMap((uid) => this.projectService.getProject(uid, false)),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe((project) => {
-        // null = deleted/unknown project (or no viewer relation) — keep the
-        // existing context rather than erroring the page.
-        if (!project) return;
-        const context: ProjectContext = {
-          uid: project.uid,
-          name: project.name,
-          slug: project.slug,
-          parent_uid: project.parent_uid,
-          logoUrl: project.logo_url,
-        };
-        // Mirror the entity-context utils: only write ?project= to the URL when already present.
-        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
-        applyEntityProjectContext(this.projectContextService, context, computeIsFoundation(project), syncUrl);
-      });
   }
 
   private initLoadDraft(): void {

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
@@ -39,8 +39,8 @@ describe('newsletterAccessGuard', () => {
 
   const runGuard = async (r: ActivatedRouteSnapshot): Promise<boolean | UrlTree> => {
     const result = TestBed.runInInjectionContext(() => newsletterAccessGuard(r, {} as RouterStateSnapshot));
-    // The ED fast path returns `true` synchronously and the no-context fallback a bare UrlTree;
-    // every other branch returns an Observable.
+    // The no-:projectUid ED fast path returns `true` synchronously and the no-context
+    // fallback a bare UrlTree; every other branch returns an Observable.
     if (result instanceof Observable) {
       return firstValueFrom(result as Observable<boolean | UrlTree>);
     }
@@ -68,13 +68,37 @@ describe('newsletterAccessGuard', () => {
     });
   });
 
-  it('allows the executive-director persona synchronously without resolving any project', async () => {
+  it('allows the executive-director persona synchronously on routes without a :projectUid', async () => {
     currentPersona.set('executive-director');
+
+    const result = await runGuard(route());
+
+    expect(result).toBe(true);
+    expect(getProject).not.toHaveBeenCalled();
+  });
+
+  it('awaits the route-project resolution for the executive-director persona on :projectUid routes', async () => {
+    // The page's reconcileRouteProjectContext reuses this shareReplay-cached lookup —
+    // resolving it in the guard keeps chrome from painting a stale cookie-restored
+    // context while the page's own fetch is in flight (GH-1570).
+    currentPersona.set('executive-director');
+    projectsByKey = { 'uid-a': { slug: 'route-project' } };
 
     const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' } }));
 
     expect(result).toBe(true);
-    expect(getProject).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledWith('uid-a', false);
+  });
+
+  it('does not deny the executive-director persona when the route-project resolution fails', async () => {
+    // Fail-open: 'uid-gone' is intentionally unseeded, so the lookup resolves null —
+    // a deleted/unknown project or fetch error must not deny the ED fast path.
+    currentPersona.set('executive-director');
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-gone', id: 'n1' } }));
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('uid-gone', false);
   });
 
   it('authorizes against the route :projectUid rather than a stale query param or cookie-restored context', async () => {

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
@@ -17,8 +17,9 @@ import { newsletterAccessGuard } from './newsletter-access.guard';
 // Covers the GH-1570 resolution order: the route's own `:projectUid` wins over a stale
 // `?project=` / cookie-restored context (including at the lens mount, where the param lives on
 // the child snapshot), a confirmed-missing uid lookup (400/404) degrades to the legacy slug
-// chain while a transient failure fails closed, and every denial carries `_notice: 'access'`
-// so AppComponent can toast it.
+// chain while a transient failure fails closed. Only route-project (`:projectUid`) denials
+// carry `_notice: 'access'` for AppComponent to toast; legacy-chain denials keep the plain
+// pre-GH-1570 redirect so list/create behave exactly as before.
 describe('newsletterAccessGuard', () => {
   let currentPersona: ReturnType<typeof signal<string>>;
   let activeContext: ReturnType<typeof signal<ProjectContext | null>>;
@@ -95,18 +96,18 @@ describe('newsletterAccessGuard', () => {
     const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' } }));
 
     expect(result).toBe(true);
-    expect(getProject).toHaveBeenCalledWith('uid-a', false);
+    expect(getProjectStrict).toHaveBeenCalledWith('uid-a');
   });
 
   it('does not deny the executive-director persona when the route-project resolution fails', async () => {
-    // Fail-open: 'uid-gone' is intentionally unseeded, so the lookup resolves null —
+    // Fail-open: 'uid-gone' is intentionally unseeded, so the strict lookup errors 404 —
     // a deleted/unknown project or fetch error must not deny the ED fast path.
     currentPersona.set('executive-director');
 
     const result = await runGuard(route({ params: { projectUid: 'uid-gone', id: 'n1' } }));
 
     expect(result).toBe(true);
-    expect(getProject).toHaveBeenCalledWith('uid-gone', false);
+    expect(getProjectStrict).toHaveBeenCalledWith('uid-gone');
   });
 
   it('authorizes against the route :projectUid rather than a stale query param or cookie-restored context', async () => {
@@ -212,7 +213,8 @@ describe('newsletterAccessGuard', () => {
 
     const result = await runGuard(route());
 
-    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'ctx-slug', _notice: 'access' } } });
+    // Legacy-chain denial keeps the pre-GH-1570 plain redirect — no `_notice` toast.
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'ctx-slug' } } });
   });
 
   it('redirects to the project overview when no project can be resolved at all', async () => {

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, convertToParamMap, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
@@ -8,22 +9,25 @@ import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { PersonaService } from '@shared/services/persona.service';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { ProjectService } from '@shared/services/project.service';
-import { firstValueFrom, Observable, of } from 'rxjs';
+import { firstValueFrom, Observable, of, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { newsletterAccessGuard } from './newsletter-access.guard';
 
 // Covers the GH-1570 resolution order: the route's own `:projectUid` wins over a stale
 // `?project=` / cookie-restored context (including at the lens mount, where the param lives on
-// the child snapshot), a failed uid lookup degrades to the legacy slug chain instead of
-// denying, and every denial carries `_notice: 'access'` so AppComponent can toast it.
+// the child snapshot), a confirmed-missing uid lookup (400/404) degrades to the legacy slug
+// chain while a transient failure fails closed, and every denial carries `_notice: 'access'`
+// so AppComponent can toast it.
 describe('newsletterAccessGuard', () => {
   let currentPersona: ReturnType<typeof signal<string>>;
   let activeContext: ReturnType<typeof signal<ProjectContext | null>>;
   let getProject: ReturnType<typeof vi.fn>;
+  let getProjectStrict: ReturnType<typeof vi.fn>;
   let router: { parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
-  // Per-test project registry keyed by the slugOrUid getProject is called with;
-  // a missing key resolves null (relation-gated / failed lookup).
+  // Per-test project registry keyed by the slugOrUid the service is called with:
+  // getProject resolves a missing key as null (relation-gated / failed lookup);
+  // getProjectStrict errors it as a 404 (confirmed missing).
   let projectsByKey: Record<string, Partial<Project> | null>;
 
   const route = (
@@ -52,6 +56,10 @@ describe('newsletterAccessGuard', () => {
     activeContext = signal<ProjectContext | null>(null);
     projectsByKey = {};
     getProject = vi.fn().mockImplementation((key: string) => of((projectsByKey[key] ?? null) as Project | null));
+    getProjectStrict = vi.fn().mockImplementation((key: string) => {
+      const project = projectsByKey[key];
+      return project ? of(project as Project) : throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' }));
+    });
 
     router = {
       parseUrl: vi.fn().mockImplementation((url: string) => ({ redirect: url }) as unknown as UrlTree),
@@ -62,7 +70,7 @@ describe('newsletterAccessGuard', () => {
       providers: [
         { provide: PersonaService, useValue: { currentPersona } },
         { provide: ProjectContextService, useValue: { activeContext } },
-        { provide: ProjectService, useValue: { getProject } },
+        { provide: ProjectService, useValue: { getProject, getProjectStrict } },
         { provide: Router, useValue: router },
       ],
     });
@@ -113,7 +121,7 @@ describe('newsletterAccessGuard', () => {
     const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' }, query: { project: 'stale-slug' } }));
 
     expect(result).toBe(true);
-    expect(getProject).toHaveBeenCalledWith('uid-a', false);
+    expect(getProjectStrict).toHaveBeenCalledWith('uid-a');
     expect(getProject).not.toHaveBeenCalledWith('stale-slug', false);
   });
 
@@ -123,20 +131,20 @@ describe('newsletterAccessGuard', () => {
     const result = await runGuard(route({ childParams: { projectUid: 'uid-a', id: 'n1' } }));
 
     expect(result).toBe(true);
-    expect(getProject).toHaveBeenCalledWith('uid-a', false);
+    expect(getProjectStrict).toHaveBeenCalledWith('uid-a');
   });
 
-  it('degrades to the legacy slug chain when the uid lookup resolves null', async () => {
+  it('degrades to the legacy slug chain when the uid lookup confirms the project missing', async () => {
     activeContext.set({ uid: 'uid-ctx', slug: 'ctx-slug', name: 'Context Project' });
     projectsByKey = {
-      'uid-gone': null, // deleted/unknown project
+      'uid-gone': null, // deleted/unknown project → getProjectStrict 404s
       'ctx-slug': { slug: 'ctx-slug', writer: true },
     };
 
     const result = await runGuard(route({ params: { projectUid: 'uid-gone', id: 'n1' } }));
 
     expect(result).toBe(true);
-    expect(getProject).toHaveBeenCalledWith('uid-gone', false);
+    expect(getProjectStrict).toHaveBeenCalledWith('uid-gone');
     expect(getProject).toHaveBeenCalledWith('ctx-slug', false);
   });
 
@@ -146,7 +154,23 @@ describe('newsletterAccessGuard', () => {
     const result = await runGuard(route({ params: { projectUid: 'uid-gone', id: 'n1' } }));
 
     expect(result).toEqual({ redirect: '/project/overview' });
-    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getProjectStrict).toHaveBeenCalledTimes(1);
+    expect(getProject).not.toHaveBeenCalled();
+  });
+
+  it('fails closed without consulting the stale context when the uid lookup errors transiently', async () => {
+    // The pre-review behavior rechecked the writer bit against the restored context on ANY
+    // failure — a transient 5xx could deny a legitimate route-project writer or authorize
+    // against an unrelated project (GH-1570). Only a confirmed 400/404 may degrade.
+    activeContext.set({ uid: 'uid-stale', slug: 'stale-slug', name: 'Stale Project' });
+    projectsByKey = { 'stale-slug': { slug: 'stale-slug', writer: true } };
+    getProjectStrict.mockReturnValueOnce(throwError(() => new HttpErrorResponse({ status: 500 })));
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' } }));
+
+    // Plain overview redirect — no `_notice: 'access'`, since a blip is not a denial.
+    expect(result).toEqual({ redirect: '/project/overview' });
+    expect(getProject).not.toHaveBeenCalled();
   });
 
   it('denies with the resolved slug and the access notice when the route project is not writable', async () => {
@@ -155,6 +179,7 @@ describe('newsletterAccessGuard', () => {
     const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' } }));
 
     expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'route-project', _notice: 'access' } } });
+    expect(getProjectStrict).toHaveBeenCalledWith('uid-a');
   });
 
   it('prefers the ?project= query param over the active context on routes without :projectUid', async () => {

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts
@@ -1,0 +1,183 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, convertToParamMap, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
+import { PersonaService } from '@shared/services/persona.service';
+import { ProjectContextService } from '@shared/services/project-context.service';
+import { ProjectService } from '@shared/services/project.service';
+import { firstValueFrom, Observable, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { newsletterAccessGuard } from './newsletter-access.guard';
+
+// Covers the GH-1570 resolution order: the route's own `:projectUid` wins over a stale
+// `?project=` / cookie-restored context (including at the lens mount, where the param lives on
+// the child snapshot), a failed uid lookup degrades to the legacy slug chain instead of
+// denying, and every denial carries `_notice: 'access'` so AppComponent can toast it.
+describe('newsletterAccessGuard', () => {
+  let currentPersona: ReturnType<typeof signal<string>>;
+  let activeContext: ReturnType<typeof signal<ProjectContext | null>>;
+  let getProject: ReturnType<typeof vi.fn>;
+  let router: { parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
+  // Per-test project registry keyed by the slugOrUid getProject is called with;
+  // a missing key resolves null (relation-gated / failed lookup).
+  let projectsByKey: Record<string, Partial<Project> | null>;
+
+  const route = (
+    options: { query?: Record<string, string>; params?: Record<string, string>; childParams?: Record<string, string>; lens?: 'foundation' | 'project' } = {}
+  ): ActivatedRouteSnapshot =>
+    ({
+      queryParamMap: convertToParamMap(options.query ?? {}),
+      paramMap: convertToParamMap(options.params ?? {}),
+      firstChild: options.childParams ? ({ paramMap: convertToParamMap(options.childParams) } as unknown as ActivatedRouteSnapshot) : null,
+      parent: options.lens ? ({ data: { lens: options.lens } } as unknown as ActivatedRouteSnapshot) : null,
+      data: {},
+    }) as unknown as ActivatedRouteSnapshot;
+
+  const runGuard = async (r: ActivatedRouteSnapshot): Promise<boolean | UrlTree> => {
+    const result = TestBed.runInInjectionContext(() => newsletterAccessGuard(r, {} as RouterStateSnapshot));
+    // The ED fast path returns `true` synchronously and the no-context fallback a bare UrlTree;
+    // every other branch returns an Observable.
+    if (result instanceof Observable) {
+      return firstValueFrom(result as Observable<boolean | UrlTree>);
+    }
+    return result as boolean | UrlTree;
+  };
+
+  beforeEach(() => {
+    currentPersona = signal('maintainer');
+    activeContext = signal<ProjectContext | null>(null);
+    projectsByKey = {};
+    getProject = vi.fn().mockImplementation((key: string) => of((projectsByKey[key] ?? null) as Project | null));
+
+    router = {
+      parseUrl: vi.fn().mockImplementation((url: string) => ({ redirect: url }) as unknown as UrlTree),
+      createUrlTree: vi.fn().mockImplementation((commands: string[], opts: unknown) => ({ denied: commands[0], opts }) as unknown as UrlTree),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PersonaService, useValue: { currentPersona } },
+        { provide: ProjectContextService, useValue: { activeContext } },
+        { provide: ProjectService, useValue: { getProject } },
+        { provide: Router, useValue: router },
+      ],
+    });
+  });
+
+  it('allows the executive-director persona synchronously without resolving any project', async () => {
+    currentPersona.set('executive-director');
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' } }));
+
+    expect(result).toBe(true);
+    expect(getProject).not.toHaveBeenCalled();
+  });
+
+  it('authorizes against the route :projectUid rather than a stale query param or cookie-restored context', async () => {
+    // The stale context is intentionally NOT writable: authorizing against it (the pre-fix
+    // behavior) would deny a legitimate manager of the route's project.
+    activeContext.set({ uid: 'uid-stale', slug: 'stale-slug', name: 'Stale Project' });
+    projectsByKey = {
+      'uid-a': { slug: 'route-project', writer: true },
+      'stale-slug': { slug: 'stale-slug', writer: false },
+    };
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' }, query: { project: 'stale-slug' } }));
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('uid-a', false);
+    expect(getProject).not.toHaveBeenCalledWith('stale-slug', false);
+  });
+
+  it('resolves :projectUid from the child snapshot when the guard runs at the lens mount', async () => {
+    projectsByKey = { 'uid-a': { slug: 'route-project', writer: true } };
+
+    const result = await runGuard(route({ childParams: { projectUid: 'uid-a', id: 'n1' } }));
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('uid-a', false);
+  });
+
+  it('degrades to the legacy slug chain when the uid lookup resolves null', async () => {
+    activeContext.set({ uid: 'uid-ctx', slug: 'ctx-slug', name: 'Context Project' });
+    projectsByKey = {
+      'uid-gone': null, // deleted/unknown project
+      'ctx-slug': { slug: 'ctx-slug', writer: true },
+    };
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-gone', id: 'n1' } }));
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('uid-gone', false);
+    expect(getProject).toHaveBeenCalledWith('ctx-slug', false);
+  });
+
+  it('redirects to the overview when the uid lookup fails and no slug context exists to fall back to', async () => {
+    projectsByKey = { 'uid-gone': null };
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-gone', id: 'n1' } }));
+
+    expect(result).toEqual({ redirect: '/project/overview' });
+    expect(getProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies with the resolved slug and the access notice when the route project is not writable', async () => {
+    projectsByKey = { 'uid-a': { slug: 'route-project', writer: false } };
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' } }));
+
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'route-project', _notice: 'access' } } });
+  });
+
+  it('prefers the ?project= query param over the active context on routes without :projectUid', async () => {
+    activeContext.set({ uid: 'uid-ctx', slug: 'ctx-slug', name: 'Context Project' });
+    projectsByKey = {
+      'query-slug': { slug: 'query-slug', writer: true },
+      'ctx-slug': { slug: 'ctx-slug', writer: false },
+    };
+
+    const result = await runGuard(route({ query: { project: 'query-slug' } }));
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('query-slug', false);
+    expect(getProject).not.toHaveBeenCalledWith('ctx-slug', false);
+  });
+
+  it('falls back to the active context slug when the URL carries no project hint', async () => {
+    activeContext.set({ uid: 'uid-ctx', slug: 'ctx-slug', name: 'Context Project' });
+    projectsByKey = { 'ctx-slug': { slug: 'ctx-slug', writer: true } };
+
+    const result = await runGuard(route());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('ctx-slug', false);
+  });
+
+  it('denies fail-closed when the legacy-chain project lookup fails', async () => {
+    activeContext.set({ uid: 'uid-ctx', slug: 'ctx-slug', name: 'Context Project' });
+    projectsByKey = {};
+
+    const result = await runGuard(route());
+
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'ctx-slug', _notice: 'access' } } });
+  });
+
+  it('redirects to the project overview when no project can be resolved at all', async () => {
+    const result = await runGuard(route());
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
+  });
+
+  it('redirects to the foundation overview on foundation-lens denials', async () => {
+    projectsByKey = { 'uid-a': { slug: 'route-project', writer: false } };
+
+    const result = await runGuard(route({ params: { projectUid: 'uid-a', id: 'n1' }, lens: 'foundation' }));
+
+    expect(result).toEqual({ denied: '/foundation/overview', opts: { queryParams: { project: 'route-project', _notice: 'access' } } });
+  });
+});

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -56,11 +56,16 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
   // route-project resolution because the page's reconcileRouteProjectContext
   // reuses this shareReplay-cached lookup — returning before it resolves would
   // let chrome paint the stale cookie-restored context for the request's
-  // duration (GH-1570). Fail-open: getProject maps errors to null, and the ED
+  // duration (GH-1570). Fail-open: lookup errors are swallowed to null and the ED
   // is never denied here.
   if (personaService.currentPersona() === 'executive-director') {
     if (projectUid) {
-      return projectService.getProject(projectUid, false).pipe(map(() => true));
+      // Same shareReplay-cached strict lookup as the writer path below, so the ED
+      // deep link also resolves the route project with the one shared request.
+      return projectService.getProjectStrict(projectUid).pipe(
+        catchError(() => of(null)),
+        map(() => true)
+      );
     }
     return true;
   }
@@ -72,10 +77,9 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
     projectService.getProject(slug, false).pipe(
       map((project) => {
         if (project?.writer !== true) {
-          // `_notice: 'access'` mirrors writerGuard's denial convention — AppComponent turns it
-          // into the generic "Access Denied" toast (survives the SSR redirect, unlike a
-          // guard-side MessageService.add, which has no DOM on the server).
-          return router.createUrlTree([overviewPath], { queryParams: { project: slug, _notice: 'access' } });
+          // Legacy list/create denial — plain redirect, no `_notice` toast: GH-1570 requires
+          // the no-`:projectUid` pages to behave exactly as before.
+          return router.createUrlTree([overviewPath], { queryParams: { project: slug } });
         }
         return true;
       })
@@ -91,14 +95,18 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
     // getProject would collapse every failure to null) so the legacy chain below runs
     // only for a CONFIRMED missing project — a transient 5xx must not silently
     // re-check the writer bit against the possibly-stale contextSlug, reintroducing
-    // the wrong-context authorization this guard removed (GH-1570). Uncached, so
-    // reconcileRouteProjectContext's cached getProject re-fetches on activation — one
-    // extra GET per deep link, the price of distinguishing statuses.
+    // the wrong-context authorization this guard removed (GH-1570). The lookup is
+    // shareReplay-cached, so this guard's mount- and child-route invocations and
+    // reconcileRouteProjectContext share the one request per deep link.
     return projectService.getProjectStrict(projectUid).pipe(
       map((resolved): boolean | UrlTree => {
         // The uid lookup already returned the project entity, so check writer
         // directly on it; the resolved slug is only needed for the denial redirect.
         if (resolved.writer !== true) {
+          // `_notice: 'access'` mirrors writerGuard's denial convention — AppComponent turns it
+          // into the generic "Access Denied" toast (survives the SSR redirect, unlike a
+          // guard-side MessageService.add, which has no DOM on the server). Only the
+          // route-project denial carries it; the legacy chain above stays notice-free.
           return router.createUrlTree([overviewPath], { queryParams: { project: resolved.slug, _notice: 'access' } });
         }
         return true;

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -63,7 +63,12 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
       // Same shareReplay-cached strict lookup as the writer path below, so the ED
       // deep link also resolves the route project with the one shared request.
       return projectService.getProjectStrict(projectUid).pipe(
-        catchError(() => of(null)),
+        catchError((error: unknown) => {
+          const status = error instanceof HttpErrorResponse ? error.status : 0;
+          // Bounded diagnostics (uid + status only) before the fail-open fallback — §14.6.
+          console.warn(`newsletterAccessGuard: ED route-project lookup failed for uid ${projectUid} (status ${status}) — failing open`);
+          return of(null);
+        }),
         map(() => true)
       );
     }
@@ -113,6 +118,8 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
       }),
       catchError((error: unknown) => {
         const status = error instanceof HttpErrorResponse ? error.status : 0;
+        // Bounded diagnostics (uid + status only) before the fallback — §14.6.
+        console.warn(`newsletterAccessGuard: route-project lookup failed for uid ${projectUid} (status ${status})`);
         if (status === 400 || status === 404) {
           // Confirmed deleted/unknown project — degrade to the legacy chain rather
           // than deny outright.

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
-import { map } from 'rxjs';
+import { ActivatedRouteSnapshot, CanActivateFn, Router, UrlTree } from '@angular/router';
+import { map, Observable, of, switchMap } from 'rxjs';
 
 import { PersonaService } from '../services/persona.service';
 import { ProjectContextService } from '../services/project-context.service';
@@ -14,15 +14,21 @@ import { ProjectService } from '../services/project.service';
  *
  * Grants access to:
  *   - Executive Director persona (fast path, synchronous), OR
- *   - Users with writer (or owner-equivalent) permission on the currently
- *     active foundation/project — `project.writer === true` set by the
- *     backend's FGA-driven role check.
+ *   - Users with writer (or owner-equivalent) permission on the route's
+ *     foundation/project — `project.writer === true` set by the backend's
+ *     FGA-driven role check.
  *
- * Slug resolution prefers the URL's `?project=<slug>` query param so deep
- * links and hard reloads work before the lens has finished syncing the
- * active context. Falls back to the active context's slug only when no
- * query param is present (e.g., the bare `/newsletters` lens-redirect
- * path). Redirects to the lens-appropriate overview on denial to preserve
+ * Project resolution order:
+ *   1. The route's own `:projectUid` param (edit/analytics routes) — the URL
+ *      carries the owning project, so a stale `?project=` or cookie-restored
+ *      context can't deny a legitimate manager (or authorize against the wrong
+ *      project) (GH-1570).
+ *   2. The URL's `?project=<slug>` query param, then the active context's
+ *      slug — the legacy chain, used by the list/create routes and as the
+ *      fallback when uid resolution fails (deleted/unknown project), so a
+ *      fetch error degrades to the old behavior instead of denying.
+ *
+ * Redirects to the lens-appropriate overview on denial to preserve
  * the active project context without triggering a lens switch.
  */
 export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
@@ -37,27 +43,52 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
     return true;
   }
 
-  // Prefer the URL's project query param: it's authoritative for the
-  // navigation target and doesn't depend on the lens having synced yet.
-  // Fall back to the active context for cases where the URL doesn't carry
-  // it (e.g., the `/newsletters` lens-redirect parent).
-  const slug = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
-
   const routeLens = route.parent?.data?.['lens'] ?? route.data?.['lens'];
   const overviewPath = routeLens === 'foundation' ? '/foundation/overview' : '/project/overview';
 
-  if (!slug) {
-    return router.parseUrl(overviewPath);
+  const checkWriterAccess = (slug: string): Observable<boolean | UrlTree> =>
+    projectService.getProject(slug, false).pipe(
+      map((project) => {
+        if (project?.writer !== true) {
+          return router.createUrlTree([overviewPath], { queryParams: { project: slug } });
+        }
+        return true;
+      })
+    );
+
+  // Legacy slug chain: prefer the URL's `?project=` query param (authoritative
+  // for deep links before the lens has synced), then the active context for
+  // routes that carry neither (e.g., the `/newsletters` lens-redirect parent).
+  const contextSlug = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
+
+  // Edit/analytics routes carry the owning project as `:projectUid` — it wins
+  // over the query param and the cookie-restored context, both of which can be
+  // stale when a link is shared or the user switched projects since it was cut.
+  // The /foundation|project/newsletters mounts run this guard at the parent too
+  // (the flat mount deliberately omits it), where the param lives on the child
+  // snapshot being activated — look one level down so the mount-level invocation
+  // authorizes against the same route project instead of the legacy chain.
+  const projectUid = route.paramMap.get('projectUid') ?? route.firstChild?.paramMap.get('projectUid') ?? null;
+  if (projectUid) {
+    return projectService.getProject(projectUid, false).pipe(
+      switchMap((resolved) => {
+        if (!resolved) {
+          // Deleted/unknown project — degrade to the legacy chain rather than
+          // deny on a fetch error.
+          return contextSlug ? checkWriterAccess(contextSlug) : of(router.parseUrl(overviewPath));
+        }
+        // The uid lookup already returned the project entity, so check writer
+        // directly on it; the resolved slug is only needed for the denial redirect.
+        if (resolved.writer !== true) {
+          return of(router.createUrlTree([overviewPath], { queryParams: { project: resolved.slug } }));
+        }
+        return of(true);
+      })
+    );
   }
 
-  const deniedUrl = router.createUrlTree([overviewPath], { queryParams: { project: slug } });
-
-  return projectService.getProject(slug, false).pipe(
-    map((project) => {
-      if (project?.writer !== true) {
-        return deniedUrl;
-      }
-      return true;
-    })
-  );
+  if (!contextSlug) {
+    return router.parseUrl(overviewPath);
+  }
+  return checkWriterAccess(contextSlug);
 };

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -1,9 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router, UrlTree } from '@angular/router';
-import { map, Observable, of, switchMap } from 'rxjs';
+import { catchError, map, Observable, of } from 'rxjs';
 
 import { PersonaService } from '../services/persona.service';
 import { ProjectContextService } from '../services/project-context.service';
@@ -27,8 +28,9 @@ import { ProjectService } from '../services/project.service';
  *      project) (GH-1570).
  *   2. The URL's `?project=<slug>` query param, then the active context's
  *      slug — the legacy chain, used by the list/create routes and as the
- *      fallback when uid resolution fails (deleted/unknown project), so a
- *      fetch error degrades to the old behavior instead of denying.
+ *      fallback only when the uid lookup confirms the project is gone
+ *      (400/404); a transient lookup failure fails closed instead of
+ *      re-checking the writer bit against a possibly-stale context.
  *
  * Redirects to the lens-appropriate overview on denial to preserve
  * the active project context without triggering a lens switch.
@@ -85,19 +87,33 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
   const contextSlug = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
 
   if (projectUid) {
-    return projectService.getProject(projectUid, false).pipe(
-      switchMap((resolved) => {
-        if (!resolved) {
-          // Deleted/unknown project — degrade to the legacy chain rather than
-          // deny on a fetch error.
-          return contextSlug ? checkWriterAccess(contextSlug) : of(router.parseUrl(overviewPath));
-        }
+    // Status-preserving lookup (getProjectStrict propagates HttpErrorResponse where
+    // getProject would collapse every failure to null) so the legacy chain below runs
+    // only for a CONFIRMED missing project — a transient 5xx must not silently
+    // re-check the writer bit against the possibly-stale contextSlug, reintroducing
+    // the wrong-context authorization this guard removed (GH-1570). Uncached, so
+    // reconcileRouteProjectContext's cached getProject re-fetches on activation — one
+    // extra GET per deep link, the price of distinguishing statuses.
+    return projectService.getProjectStrict(projectUid).pipe(
+      map((resolved): boolean | UrlTree => {
         // The uid lookup already returned the project entity, so check writer
         // directly on it; the resolved slug is only needed for the denial redirect.
         if (resolved.writer !== true) {
-          return of(router.createUrlTree([overviewPath], { queryParams: { project: resolved.slug, _notice: 'access' } }));
+          return router.createUrlTree([overviewPath], { queryParams: { project: resolved.slug, _notice: 'access' } });
         }
-        return of(true);
+        return true;
+      }),
+      catchError((error: unknown) => {
+        const status = error instanceof HttpErrorResponse ? error.status : 0;
+        if (status === 400 || status === 404) {
+          // Confirmed deleted/unknown project — degrade to the legacy chain rather
+          // than deny outright.
+          return contextSlug ? checkWriterAccess(contextSlug) : of(router.parseUrl(overviewPath));
+        }
+        // Transient/unknown failure — fail closed rather than authorize against a
+        // stale context. Plain overview redirect without `_notice: 'access'`: a blip
+        // is not a denial, and the user can retry the navigation.
+        return of(router.parseUrl(overviewPath));
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -13,7 +13,9 @@ import { ProjectService } from '../services/project.service';
  * Route guard for the newsletters feature.
  *
  * Grants access to:
- *   - Executive Director persona (fast path, synchronous), OR
+ *   - Executive Director persona (fast path — synchronous except on `:projectUid`
+ *     deep links, which await the route-project resolution so page chrome never
+ *     paints a stale cookie-restored context, GH-1570), OR
  *   - Users with writer (or owner-equivalent) permission on the route's
  *     foundation/project — `project.writer === true` set by the backend's
  *     FGA-driven role check.
@@ -37,9 +39,27 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
   const projectService = inject(ProjectService);
   const router = inject(Router);
 
-  // Fast path: ED persona. Synchronous (cookie-seeded) so SSR + first-paint
-  // navigations don't need to await an HTTP round-trip.
+  // Edit/analytics routes carry the owning project as `:projectUid` — for writer
+  // checks it wins over the query param and the cookie-restored context, both of
+  // which can be stale when a link is shared or the user switched projects since
+  // it was cut. The /foundation|project/newsletters mounts run this guard at the
+  // parent too (the flat mount deliberately omits it), where the param lives on
+  // the child snapshot being activated — look one level down so the mount-level
+  // invocation resolves the same route project.
+  const projectUid = route.paramMap.get('projectUid') ?? route.firstChild?.paramMap.get('projectUid') ?? null;
+
+  // Fast path: ED persona. Synchronous (cookie-seeded) on routes without a
+  // :projectUid, so SSR + first-paint navigations don't need to await an HTTP
+  // round-trip. Edit/analytics deep links are the exception: they await the
+  // route-project resolution because the page's reconcileRouteProjectContext
+  // reuses this shareReplay-cached lookup — returning before it resolves would
+  // let chrome paint the stale cookie-restored context for the request's
+  // duration (GH-1570). Fail-open: getProject maps errors to null, and the ED
+  // is never denied here.
   if (personaService.currentPersona() === 'executive-director') {
+    if (projectUid) {
+      return projectService.getProject(projectUid, false).pipe(map(() => true));
+    }
     return true;
   }
 
@@ -64,14 +84,6 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
   // routes that carry neither (e.g., the `/newsletters` lens-redirect parent).
   const contextSlug = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
 
-  // Edit/analytics routes carry the owning project as `:projectUid` — it wins
-  // over the query param and the cookie-restored context, both of which can be
-  // stale when a link is shared or the user switched projects since it was cut.
-  // The /foundation|project/newsletters mounts run this guard at the parent too
-  // (the flat mount deliberately omits it), where the param lives on the child
-  // snapshot being activated — look one level down so the mount-level invocation
-  // authorizes against the same route project instead of the legacy chain.
-  const projectUid = route.paramMap.get('projectUid') ?? route.firstChild?.paramMap.get('projectUid') ?? null;
   if (projectUid) {
     return projectService.getProject(projectUid, false).pipe(
       switchMap((resolved) => {

--- a/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts
@@ -50,7 +50,10 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
     projectService.getProject(slug, false).pipe(
       map((project) => {
         if (project?.writer !== true) {
-          return router.createUrlTree([overviewPath], { queryParams: { project: slug } });
+          // `_notice: 'access'` mirrors writerGuard's denial convention — AppComponent turns it
+          // into the generic "Access Denied" toast (survives the SSR redirect, unlike a
+          // guard-side MessageService.add, which has no DOM on the server).
+          return router.createUrlTree([overviewPath], { queryParams: { project: slug, _notice: 'access' } });
         }
         return true;
       })
@@ -80,7 +83,7 @@ export const newsletterAccessGuard: CanActivateFn = (route: ActivatedRouteSnapsh
         // The uid lookup already returned the project entity, so check writer
         // directly on it; the resolved slug is only needed for the denial redirect.
         if (resolved.writer !== true) {
-          return of(router.createUrlTree([overviewPath], { queryParams: { project: resolved.slug } }));
+          return of(router.createUrlTree([overviewPath], { queryParams: { project: resolved.slug, _notice: 'access' } }));
         }
         return of(true);
       })

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -140,3 +140,55 @@ describe('ProjectService.getProject', () => {
     expect(result).toEqual(projectA);
   });
 });
+
+describe('ProjectService.getProjectStrict', () => {
+  let service: ProjectService;
+  let httpGet: ReturnType<typeof vi.fn>;
+
+  const projectA = { uid: 'uid-a', slug: 'slug-a', name: 'Project A' } as Project;
+
+  beforeEach(() => {
+    httpGet = vi.fn().mockReturnValue(of(projectA));
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: HttpClient,
+          useValue: { get: httpGet, post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+        },
+      ],
+    });
+    service = TestBed.inject(ProjectService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('shares one request across the callers a deep link stacks up (mount guard, child guard, reconciliation)', () => {
+    const results: Project[] = [];
+    service.getProjectStrict('uid-a').subscribe((p) => results.push(p));
+    service.getProjectStrict('uid-a').subscribe((p) => results.push(p));
+    service.getProjectStrict('uid-a').subscribe((p) => results.push(p));
+
+    expect(httpGet).toHaveBeenCalledTimes(1);
+    expect(httpGet).toHaveBeenCalledWith('/api/projects/uid-a');
+    expect(results).toEqual([projectA, projectA, projectA]);
+  });
+
+  it('propagates HTTP errors instead of mapping them to null, so callers can distinguish 400/404 from 5xx', () => {
+    httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
+    let caught: unknown;
+    service.getProjectStrict('uid-a').subscribe({ error: (e) => (caught = e) });
+    expect(caught).toBeInstanceOf(Error);
+  });
+
+  it('evicts the cache entry on error so the next lookup retries instead of replaying the failure', () => {
+    httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
+    service.getProjectStrict('uid-a').subscribe({ error: () => undefined });
+
+    let second: Project | undefined;
+    service.getProjectStrict('uid-a').subscribe((p) => (second = p));
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(second).toEqual(projectA);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -3,7 +3,8 @@
 
 import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { Project } from '@lfx-one/shared/interfaces';
+import { of, Subject, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectService } from './project.service';
@@ -71,5 +72,71 @@ describe('ProjectService.getProjectSlugs', () => {
     let result: string[] | null = ['sentinel'];
     service.getProjectSlugs().subscribe((slugs) => (result = slugs));
     expect(result).toBeNull();
+  });
+});
+
+describe('ProjectService.getProject', () => {
+  let service: ProjectService;
+  let httpGet: ReturnType<typeof vi.fn>;
+
+  const projectA = { uid: 'uid-a', slug: 'slug-a', name: 'Project A' } as Project;
+
+  beforeEach(() => {
+    httpGet = vi.fn().mockReturnValue(of(projectA));
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: HttpClient,
+          useValue: { get: httpGet, post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+        },
+      ],
+    });
+    service = TestBed.inject(ProjectService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('caches a successful lookup so a second call for the same key shares one request', () => {
+    const results: (Project | null)[] = [];
+    service.getProject('slug-a', false).subscribe((p) => results.push(p));
+    service.getProject('slug-a', false).subscribe((p) => results.push(p));
+    expect(httpGet).toHaveBeenCalledTimes(1);
+    expect(httpGet).toHaveBeenCalledWith('/api/projects/slug-a', { params: undefined });
+    expect(results).toEqual([projectA, projectA]);
+  });
+
+  it('evicts the cache entry on error so the next getProject call re-fetches instead of replaying null', () => {
+    // Plain Error (not HttpErrorResponse) — the failure path under test is the same either way.
+    httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
+    let first: Project | null | undefined;
+    service.getProject('slug-a', false).subscribe((p) => (first = p));
+    expect(first).toBeNull();
+
+    // The errored entry must be gone: the next lookup issues a fresh HTTP request
+    // rather than replaying the cached null for the rest of the session.
+    let second: Project | null | undefined;
+    service.getProject('slug-a', false).subscribe((p) => (second = p));
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(second).toEqual(projectA);
+  });
+
+  it('evicts via the upstream error tap even when the error lands with zero downstream subscribers', () => {
+    const source = new Subject<Project>();
+    httpGet.mockReturnValueOnce(source.asObservable());
+
+    // Subscribe then unsubscribe before the error lands — a canceled navigation.
+    // shareReplay (refCount: false) keeps the source subscription alive, so the error
+    // arrives with no downstream subscriber to run the post-shareReplay eviction tap.
+    service.getProject('slug-a', false).subscribe().unsubscribe();
+    source.error(new Error('network-error'));
+
+    // Without the upstream tap({ error }) eviction, the poisoned entry would stay
+    // cached and replay null here instead of re-fetching.
+    let result: Project | null | undefined;
+    service.getProject('slug-a', false).subscribe((p) => (result = p));
+    expect(httpGet).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(projectA);
   });
 });

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -18,6 +18,7 @@ export class ProjectService {
 
   private readonly http = inject(HttpClient);
   private readonly projectCache = new Map<string, Observable<Project | null>>();
+  private readonly strictProjectCache = new Map<string, Observable<Project>>();
   private readonly projectsCache = new Map<string, Observable<Project[]>>();
   private slugsCache$: Observable<string[] | null> | null = null;
 
@@ -134,13 +135,29 @@ export class ProjectService {
   }
 
   /**
-   * Slug lookup that propagates HTTP failures instead of mapping them to null,
-   * for callers that must distinguish a missing project (400/404) from an
-   * upstream outage (5xx) — e.g. the newsletter reader's SSR 404 signaling.
-   * Uncached and side-effect free (does not touch the active-project state).
+   * Slug-or-uid lookup that propagates HTTP failures instead of mapping them to null,
+   * for callers that must distinguish a missing project (400/404) from an upstream
+   * outage (5xx) — e.g. the newsletter reader's SSR 404 signaling and the newsletter
+   * access guard's confirmed-missing degradation (GH-1570). shareReplay-cached like
+   * getProject so a deep link's stacked callers (the guard's mount- and child-route
+   * invocations, then route reconciliation) share one request per identifier; the
+   * entry evicts on error so a transient failure retries on the next lookup instead
+   * of replaying for the session. Cached separately from getProject's null-mapping
+   * entries and side-effect free (does not touch the active-project state). Note the
+   * slug and uid forms cache under separate keys for the same project.
    */
-  public getProjectStrict(slug: string): Observable<Project> {
-    return this.http.get<Project>(`/api/projects/${encodeURIComponent(slug)}`);
+  public getProjectStrict(slugOrUid: string): Observable<Project> {
+    if (!this.strictProjectCache.has(slugOrUid)) {
+      const project$ = this.http.get<Project>(`/api/projects/${encodeURIComponent(slugOrUid)}`).pipe(
+        // Evict on source error, before shareReplay pins it — shareReplay keeps its source
+        // subscription alive after downstream unsubscribes (refCount: false), so a canceled
+        // navigation could otherwise pin the error for the session (same race as getProject).
+        tap({ error: () => this.strictProjectCache.delete(slugOrUid) }),
+        shareReplay(1)
+      );
+      this.strictProjectCache.set(slugOrUid, project$);
+    }
+    return this.strictProjectCache.get(slugOrUid)!;
   }
 
   public getProjectSfid(uid: string): Observable<string | null> {

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -112,6 +112,14 @@ export class ProjectService {
             this.project$.next(project);
             this.project.set(project);
           }
+          // null only ever comes from the catchError above — evict failures so the next
+          // caller retries instead of replaying a transient error for the rest of the
+          // session (GH-1570: a poisoned entry would pin the newsletter guard and route
+          // reconciliation to a stale context). Concurrent subscribers still share this
+          // emission; only future lookups re-fetch.
+          if (!project) {
+            this.projectCache.delete(cacheKey);
+          }
         })
       );
       this.projectCache.set(cacheKey, project$);

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -102,6 +102,12 @@ export class ProjectService {
     if (!this.projectCache.has(cacheKey)) {
       const params = options?.meetingCoordinator ? new HttpParams().set('meeting_coordinator', 'true') : undefined;
       const project$ = this.http.get<Project>(`/api/projects/${slugOrUid}`, { params }).pipe(
+        // Evict on source error, before catchError/shareReplay: shareReplay keeps its source
+        // subscription alive after downstream unsubscribes (refCount: false), so a canceled
+        // navigation can let the request fail with zero subscribers — a downstream eviction
+        // tap would never run and the entry would replay the catchError'd null to the next
+        // lookup instead of retrying (matches the meeting and mailing-list detail caches).
+        tap({ error: () => this.projectCache.delete(cacheKey) }),
         catchError((error) => {
           console.error('Failed to fetch project:', error);
           return of(null);

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
@@ -1,0 +1,162 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ApplicationRef, computed, DestroyRef, inject, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { ProjectFunding, ProjectStage } from '@lfx-one/shared/enums';
+import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
+import { ProjectContextService } from '@shared/services/project-context.service';
+import { ProjectService } from '@shared/services/project.service';
+import { of, Subject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reconcileRouteProjectContext } from './entity-project-context.util';
+
+// Regression coverage for the GH-1570 route-param reconciliation's NavigationEnd re-apply
+// (PR #2224 review): a query-param-only navigation (?step=N on the newsletter edit stepper)
+// doesn't re-run guards, but MainLayoutComponent.syncLensFromRoute re-asserts the route's
+// DECLARED lens kind on every NavigationEnd — clobbering the correction for a foundation-owned
+// newsletter sitting under /project/newsletters/:projectUid/... The re-apply must restore the
+// resolved context synchronously from the per-uid cache (no second fetch) and stay a same-value
+// no-op once kind + full context already match (loop guard). Mirrors the fallback-path coverage
+// in vote-manage.component.spec.ts.
+describe('reconcileRouteProjectContext', () => {
+  const ROUTE_UID = 'foundation-uid-1';
+  const EDIT_URL = `/project/newsletters/${ROUTE_UID}/n-1/edit`;
+
+  // computeIsFoundation: Funded + Membership + Active, and not an Internal Allocation.
+  const foundationProject = {
+    uid: ROUTE_UID,
+    name: 'Test Foundation',
+    slug: 'test-foundation',
+    parent_uid: '',
+    logo_url: '',
+    stage: ProjectStage.Active,
+    funding: ProjectFunding.Funded,
+    funding_model: ['Membership'],
+    legal_entity_type: 'Series LLC',
+  } as Project;
+
+  // The context shape reconcileRouteProjectContext builds from the resolved project.
+  const resolvedContext: ProjectContext = {
+    uid: ROUTE_UID,
+    name: 'Test Foundation',
+    slug: 'test-foundation',
+    parent_uid: '',
+    logoUrl: '',
+  };
+
+  let routeProjectUid: ReturnType<typeof signal<string | null>>;
+  let routerEvents$: Subject<NavigationEnd>;
+  let getProject: ReturnType<typeof vi.fn>;
+  let setRouteLensKind: ReturnType<typeof vi.fn>;
+  let setFoundation: ReturnType<typeof vi.fn>;
+  let setProject: ReturnType<typeof vi.fn>;
+  let routeLensKind: ReturnType<typeof signal<'foundation' | 'project' | null>>;
+  let projectContextService: ProjectContextService;
+
+  const start = (): void => {
+    TestBed.runInInjectionContext(() =>
+      reconcileRouteProjectContext(routeProjectUid.asReadonly(), { getProject } as unknown as ProjectService, projectContextService, router, inject(DestroyRef))
+    );
+  };
+
+  const stable = (): Promise<void> => TestBed.inject(ApplicationRef).whenStable();
+
+  const emitStepNavigation = async (step: number): Promise<void> => {
+    routerEvents$.next(new NavigationEnd(1, `${EDIT_URL}?step=${step}`, `${EDIT_URL}?step=${step}`));
+    await stable();
+  };
+
+  let router: Router;
+
+  beforeEach(() => {
+    routeProjectUid = signal<string | null>(ROUTE_UID);
+    routerEvents$ = new Subject<NavigationEnd>();
+    getProject = vi.fn().mockReturnValue(of(foundationProject));
+
+    // Mini ProjectContextService: the two context slots + the route-kind override, composed the
+    // way the real service composes activeContext from them — so a MainLayout-style re-assert
+    // (routeLensKind back to the route's declared 'project') visibly flips activeContext back
+    // to the stale cookie-restored project, exactly what the re-apply must undo.
+    routeLensKind = signal<'foundation' | 'project' | null>('project');
+    const projectSlot = signal<ProjectContext | null>({ uid: 'other-uid', name: 'Other Project', slug: 'other-project' });
+    const foundationSlot = signal<ProjectContext | null>(null);
+    setRouteLensKind = vi.fn((kind: 'foundation' | 'project' | null) => routeLensKind.set(kind));
+    setFoundation = vi.fn((context: ProjectContext) => foundationSlot.set(context));
+    setProject = vi.fn((context: ProjectContext) => projectSlot.set(context));
+    projectContextService = {
+      activeRouteLensKind: computed(() => routeLensKind()),
+      activeContext: computed(() => (routeLensKind() === 'foundation' ? foundationSlot() : projectSlot())),
+      setRouteLensKind,
+      setFoundation,
+      setProject,
+    } as unknown as ProjectContextService;
+
+    // parseUrl returns no query params: the URL carries no ?project= to reseed (syncUrl=false).
+    router = {
+      events: routerEvents$.asObservable(),
+      url: EDIT_URL,
+      parseUrl: vi.fn().mockReturnValue({ queryParams: {} }),
+    } as unknown as Router;
+
+    TestBed.configureTestingModule({});
+  });
+
+  it('resolves the route project on activation and re-points the lens kind at its tier', async () => {
+    start();
+    await stable();
+
+    expect(getProject).toHaveBeenCalledWith(ROUTE_UID, false);
+    expect(setRouteLensKind).toHaveBeenCalledWith('foundation');
+    expect(setFoundation).toHaveBeenCalledWith(resolvedContext, false);
+    expect(setProject).not.toHaveBeenCalled();
+    expect(projectContextService.activeContext()).toEqual(resolvedContext);
+  });
+
+  it('re-applies the cached context on a later NavigationEnd after the route-lens re-assert clobbers it, without a second fetch', async () => {
+    start();
+    await stable();
+    expect(getProject).toHaveBeenCalledTimes(1);
+
+    // A ?step= navigation doesn't re-run guards, but MainLayout.syncLensFromRoute re-asserts the
+    // route's declared lens on the NavigationEnd — flipping the selector/sidebar back to the
+    // stale cookie project if the cached re-apply regresses.
+    routeLensKind.set('project');
+    await emitStepNavigation(1);
+
+    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(setFoundation).toHaveBeenCalledTimes(2);
+    expect(setRouteLensKind).toHaveBeenLastCalledWith('foundation');
+    expect(projectContextService.activeContext()).toEqual(resolvedContext);
+  });
+
+  it('suppresses the re-apply once kind and full context already match (loop guard)', async () => {
+    start();
+    await stable();
+
+    await emitStepNavigation(1);
+
+    // Kind and context already agree with the resolution — the NavigationEnd is a same-value
+    // no-op: no re-write and no second fetch.
+    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(setFoundation).toHaveBeenCalledTimes(1);
+    expect(setRouteLensKind).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the existing context untouched when the route project lookup resolves null', async () => {
+    getProject.mockReturnValue(of(null));
+
+    start();
+    await stable();
+
+    // Deleted/unknown project (or no viewer relation): fail-open, no writes — the stale context
+    // stays rather than erroring the page.
+    expect(getProject).toHaveBeenCalledWith(ROUTE_UID, false);
+    expect(setRouteLensKind).not.toHaveBeenCalled();
+    expect(setFoundation).not.toHaveBeenCalled();
+    expect(setProject).not.toHaveBeenCalled();
+    expect(projectContextService.activeContext()?.slug).toBe('other-project');
+  });
+});

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { ApplicationRef, computed, DestroyRef, inject, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { NavigationEnd, Router } from '@angular/router';
@@ -8,7 +9,7 @@ import { ProjectFunding, ProjectStage } from '@lfx-one/shared/enums';
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { ProjectService } from '@shared/services/project.service';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { reconcileRouteProjectContext } from './entity-project-context.util';
@@ -49,7 +50,7 @@ describe('reconcileRouteProjectContext', () => {
 
   let routeProjectUid: ReturnType<typeof signal<string | null>>;
   let routerEvents$: Subject<NavigationEnd>;
-  let getProject: ReturnType<typeof vi.fn>;
+  let getProjectStrict: ReturnType<typeof vi.fn>;
   let setRouteLensKind: ReturnType<typeof vi.fn>;
   let setFoundation: ReturnType<typeof vi.fn>;
   let setProject: ReturnType<typeof vi.fn>;
@@ -59,7 +60,13 @@ describe('reconcileRouteProjectContext', () => {
 
   const start = (): void => {
     TestBed.runInInjectionContext(() =>
-      reconcileRouteProjectContext(routeProjectUid.asReadonly(), { getProject } as unknown as ProjectService, projectContextService, router, inject(DestroyRef))
+      reconcileRouteProjectContext(
+        routeProjectUid.asReadonly(),
+        { getProjectStrict } as unknown as ProjectService,
+        projectContextService,
+        router,
+        inject(DestroyRef)
+      )
     );
   };
 
@@ -75,7 +82,7 @@ describe('reconcileRouteProjectContext', () => {
   beforeEach(() => {
     routeProjectUid = signal<string | null>(ROUTE_UID);
     routerEvents$ = new Subject<NavigationEnd>();
-    getProject = vi.fn().mockReturnValue(of(foundationProject));
+    getProjectStrict = vi.fn().mockReturnValue(of(foundationProject));
 
     // Mini ProjectContextService: the two context slots + the route-kind override, composed the
     // way the real service composes activeContext from them — so a MainLayout-style re-assert
@@ -109,7 +116,7 @@ describe('reconcileRouteProjectContext', () => {
     start();
     await stable();
 
-    expect(getProject).toHaveBeenCalledWith(ROUTE_UID, false);
+    expect(getProjectStrict).toHaveBeenCalledWith(ROUTE_UID);
     expect(setRouteLensKind).toHaveBeenCalledWith('foundation');
     expect(setFoundation).toHaveBeenCalledWith(resolvedContext, false);
     expect(setProject).not.toHaveBeenCalled();
@@ -126,7 +133,7 @@ describe('reconcileRouteProjectContext', () => {
     start();
     await stable();
 
-    expect(getProject).toHaveBeenCalledWith(ROUTE_UID, false);
+    expect(getProjectStrict).toHaveBeenCalledWith(ROUTE_UID);
     expect(setFoundation).toHaveBeenCalledWith(resolvedContext, false);
     expect(projectContextService.activeContext()).toEqual(resolvedContext);
   });
@@ -134,7 +141,7 @@ describe('reconcileRouteProjectContext', () => {
   it('re-applies the cached context on a later NavigationEnd after the route-lens re-assert clobbers it, without a second fetch', async () => {
     start();
     await stable();
-    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getProjectStrict).toHaveBeenCalledTimes(1);
 
     // A ?step= navigation doesn't re-run guards, but MainLayout.syncLensFromRoute re-asserts the
     // route's declared lens on the NavigationEnd — flipping the selector/sidebar back to the
@@ -142,7 +149,7 @@ describe('reconcileRouteProjectContext', () => {
     routeLensKind.set('project');
     await emitStepNavigation(1);
 
-    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getProjectStrict).toHaveBeenCalledTimes(1);
     expect(setFoundation).toHaveBeenCalledTimes(2);
     expect(setRouteLensKind).toHaveBeenLastCalledWith('foundation');
     expect(projectContextService.activeContext()).toEqual(resolvedContext);
@@ -156,7 +163,7 @@ describe('reconcileRouteProjectContext', () => {
 
     // Kind and context already agree with the resolution — the NavigationEnd is a same-value
     // no-op: no re-write and no second fetch.
-    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getProjectStrict).toHaveBeenCalledTimes(1);
     expect(setFoundation).toHaveBeenCalledTimes(1);
     expect(setRouteLensKind).toHaveBeenCalledTimes(1);
   });
@@ -184,15 +191,15 @@ describe('reconcileRouteProjectContext', () => {
     expect(setFoundation).toHaveBeenLastCalledWith(resolvedContext, true);
   });
 
-  it('leaves the existing context untouched when the route project lookup resolves null', async () => {
-    getProject.mockReturnValue(of(null));
+  it('leaves the existing context untouched when the route project lookup fails', async () => {
+    getProjectStrict.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
 
     start();
     await stable();
 
     // Deleted/unknown project (or no viewer relation): fail-open, no writes — the stale context
     // stays rather than erroring the page.
-    expect(getProject).toHaveBeenCalledWith(ROUTE_UID, false);
+    expect(getProjectStrict).toHaveBeenCalledWith(ROUTE_UID);
     expect(setRouteLensKind).not.toHaveBeenCalled();
     expect(setFoundation).not.toHaveBeenCalled();
     expect(setProject).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
@@ -161,6 +161,29 @@ describe('reconcileRouteProjectContext', () => {
     expect(setRouteLensKind).toHaveBeenCalledTimes(1);
   });
 
+  it('defers the stale ?project= repair past navigation finalization, then re-applies with the URL sync', async () => {
+    // A deep link carrying a stale slug from a prior selection: syncUrl=true (param present),
+    // urlAgrees=false (stale) — the activation apply corrects the context but syncProjectQueryParam
+    // no-ops while a navigation is in flight, and Angular only clears currentNavigation in the
+    // navigation stream's finalize (after NavigationEnd subscribers run), so the re-apply can't
+    // repair the URL synchronously either. The repair must re-fire from a microtask once the
+    // navigation has finalized (PR #2224 review: Cursor Bugbot + Copilot).
+    router.parseUrl = vi.fn().mockReturnValue({ queryParams: { project: 'stale-slug' } });
+    // Model Angular's finalize: the apply's check runs during the NavigationEnd dispatch
+    // (navigation still set — cleared only in the stream's finalize, after subscribers run);
+    // the deferred repair's check runs post-finalization (null).
+    let navChecks = 0;
+    router.getCurrentNavigation = vi.fn(() => (++navChecks === 1 ? ({ id: 1 } as unknown as ReturnType<Router['getCurrentNavigation']>) : null));
+
+    start();
+    await stable();
+
+    // Without the deferred repair the activation apply is the ONLY write (and its URL sync is
+    // suppressed); with it, a second same-value apply lands post-finalization with syncUrl=true.
+    expect(setFoundation).toHaveBeenCalledTimes(2);
+    expect(setFoundation).toHaveBeenLastCalledWith(resolvedContext, true);
+  });
+
   it('leaves the existing context untouched when the route project lookup resolves null', async () => {
     getProject.mockReturnValue(of(null));
 

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
@@ -54,6 +54,7 @@ describe('reconcileRouteProjectContext', () => {
   let setFoundation: ReturnType<typeof vi.fn>;
   let setProject: ReturnType<typeof vi.fn>;
   let routeLensKind: ReturnType<typeof signal<'foundation' | 'project' | null>>;
+  let foundationSlot: ReturnType<typeof signal<ProjectContext | null>>;
   let projectContextService: ProjectContextService;
 
   const start = (): void => {
@@ -82,7 +83,7 @@ describe('reconcileRouteProjectContext', () => {
     // to the stale cookie-restored project, exactly what the re-apply must undo.
     routeLensKind = signal<'foundation' | 'project' | null>('project');
     const projectSlot = signal<ProjectContext | null>({ uid: 'other-uid', name: 'Other Project', slug: 'other-project' });
-    const foundationSlot = signal<ProjectContext | null>(null);
+    foundationSlot = signal<ProjectContext | null>(null);
     setRouteLensKind = vi.fn((kind: 'foundation' | 'project' | null) => routeLensKind.set(kind));
     setFoundation = vi.fn((context: ProjectContext) => foundationSlot.set(context));
     setProject = vi.fn((context: ProjectContext) => projectSlot.set(context));
@@ -112,6 +113,21 @@ describe('reconcileRouteProjectContext', () => {
     expect(setRouteLensKind).toHaveBeenCalledWith('foundation');
     expect(setFoundation).toHaveBeenCalledWith(resolvedContext, false);
     expect(setProject).not.toHaveBeenCalled();
+    expect(projectContextService.activeContext()).toEqual(resolvedContext);
+  });
+
+  it('refreshes a matching-kind context carrying the route uid but stale name/slug/logo', async () => {
+    // Cookie-restored contexts can drift from the backend while keeping the right uid. The
+    // activation write only suppresses on a FULL context match (isSameProjectContext) — a
+    // uid-only regression would short-circuit here and leave the stale name/logo in the chrome.
+    routeLensKind.set('foundation');
+    foundationSlot.set({ uid: ROUTE_UID, name: 'Stale Foundation', slug: 'stale-foundation', logoUrl: 'https://stale.example/logo.png' });
+
+    start();
+    await stable();
+
+    expect(getProject).toHaveBeenCalledWith(ROUTE_UID, false);
+    expect(setFoundation).toHaveBeenCalledWith(resolvedContext, false);
     expect(projectContextService.activeContext()).toEqual(resolvedContext);
   });
 

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DestroyRef, Signal } from '@angular/core';
+import { computed, DestroyRef, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { EntityWithProject, ProjectContext } from '@lfx-one/shared/interfaces';
@@ -109,6 +109,61 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
       } else {
         projectContextService.setProject(context, syncUrl);
       }
+    });
+}
+
+/**
+ * Route-carried-project reconciliation for entity pages whose URL carries the owning project
+ * as a `:projectUid` route param (newsletter edit/analytics, GH-1570) rather than inside the
+ * entity payload. The URL is authoritative for the page's fetches, but page chrome (name/logo,
+ * sidebar) follows `activeContext()`, which a stale cookie-restored context can leave pointing
+ * at a different project. When the two disagree, resolve the route project by uid and re-point
+ * the context via applyEntityProjectContext — the uid-only variant of the entity-signal syncs
+ * above, for routes with no enriched entity payload.
+ *
+ * The mismatch is computed over BOTH the route uid and `activeContextUid()`: the context write
+ * makes them agree, which quiets the trigger, and a later route-lens re-assert (e.g. MainLayout
+ * on `?step=N` navigations) flips the mismatch back on, so the correction self-heals without
+ * NavigationEnd wiring. The re-apply hits the shareReplay-cached getProject — the route's guard
+ * has already resolved the same uid on activation, so the happy path costs no extra request.
+ *
+ * Call once from the component constructor (injection context is required for toObservable).
+ * A failed uid lookup resolves null (relation-gated `getProject(uid, false)`) and leaves the
+ * existing context untouched — legacy behavior, same degradation philosophy as the fallback sync.
+ */
+export function reconcileRouteProjectContext(
+  routeProjectUid: Signal<string | null>,
+  projectService: ProjectService,
+  projectContextService: ProjectContextService,
+  router: Router,
+  destroyRef: DestroyRef
+): void {
+  const unreconciledRouteProjectUid = computed(() => {
+    const uid = routeProjectUid();
+    if (!uid || uid === projectContextService.activeContextUid()) return null;
+    return uid;
+  });
+
+  toObservable(unreconciledRouteProjectUid)
+    .pipe(
+      filter((uid): uid is string => uid !== null),
+      switchMap((uid) => projectService.getProject(uid, false)),
+      takeUntilDestroyed(destroyRef)
+    )
+    .subscribe((project) => {
+      // null = deleted/unknown project (or no viewer relation) — keep the
+      // existing context rather than erroring the page.
+      if (!project) return;
+      const context: ProjectContext = {
+        uid: project.uid,
+        name: project.name,
+        slug: project.slug,
+        parent_uid: project.parent_uid,
+        logoUrl: project.logo_url,
+      };
+      // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
+      const syncUrl = 'project' in router.parseUrl(router.url).queryParams;
+      applyEntityProjectContext(projectContextService, context, computeIsFoundation(project), syncUrl);
     });
 }
 

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { DestroyRef, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
@@ -187,7 +188,12 @@ export function reconcileRouteProjectContext(
             resolvedCache.set(uid, resolved);
             return resolved;
           }),
-          catchError(() => of(null))
+          catchError((error: unknown) => {
+            const status = error instanceof HttpErrorResponse ? error.status : 0;
+            // Bounded diagnostics (uid + status only) before keeping the existing context — §14.6.
+            console.warn(`reconcileRouteProjectContext: route-project lookup failed for uid ${uid} (status ${status}) — keeping existing context`);
+            return of(null);
+          })
         );
       }),
       takeUntilDestroyed(destroyRef)

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -127,8 +127,8 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
  *    under the wrong context kind (a foundation-owned newsletter under /project/newsletters), so
  *    the write below only suppresses once the FULL context (isSameProjectContext), the
  *    computed kind, and the URL's ?project= all agree. The resolve hits the shareReplay-cached
- *    getProject — the route's
- *    guard already resolved the same uid on activation — so the happy path costs no request.
+ *    getProjectStrict — the route's newsletterAccessGuard already resolved the same uid on
+ *    activation — so the happy path costs no request.
  *  - NavigationEnd re-applies synchronously from the per-uid resolved cache: query-param-only
  *    navigations (?step=N) don't re-run guards, but MainLayout.syncLensFromRoute re-asserts the
  *    route's DECLARED lens kind on every navigation, clobbering this correction when the route
@@ -138,8 +138,9 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
  *    flash the wrong project for a frame per step change.
  *
  * Call once from the component constructor (injection context is required for toObservable).
- * A failed uid lookup resolves null (relation-gated `getProject(uid, false)`) and leaves the
- * existing context untouched — legacy behavior, same degradation philosophy as the fallback sync.
+ * A failed uid lookup (deleted/unknown project, no viewer relation, or transient error — the
+ * status-preserving `getProjectStrict` failure is caught to null here) leaves the existing
+ * context untouched — legacy behavior, same degradation philosophy as the fallback sync.
  */
 export function reconcileRouteProjectContext(
   routeProjectUid: Signal<string | null>,
@@ -166,11 +167,13 @@ export function reconcileRouteProjectContext(
         if (cached) {
           return of(cached);
         }
-        return projectService.getProject(uid, false).pipe(
+        // getProjectStrict (not getProject): it shares the guard's shareReplay-cached lookup —
+        // the route's newsletterAccessGuard resolved the same uid on activation — so the happy
+        // path costs no extra request. A failed lookup (deleted/unknown project, no viewer
+        // relation, transient error) catches to null: keep the existing context rather than
+        // erroring the page.
+        return projectService.getProjectStrict(uid).pipe(
           map((project) => {
-            // null = deleted/unknown project (or no viewer relation) — keep the
-            // existing context rather than erroring the page.
-            if (!project) return null;
             const resolved = {
               context: {
                 uid: project.uid,
@@ -183,7 +186,8 @@ export function reconcileRouteProjectContext(
             };
             resolvedCache.set(uid, resolved);
             return resolved;
-          })
+          }),
+          catchError(() => of(null))
         );
       }),
       takeUntilDestroyed(destroyRef)

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -1,11 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { computed, DestroyRef, Signal } from '@angular/core';
+import { DestroyRef, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { EntityWithProject, ProjectContext } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation } from '@lfx-one/shared/utils';
+import { computeIsFoundation, isSameProjectContext } from '@lfx-one/shared/utils';
 import { catchError, distinctUntilChanged, filter, map, merge, Observable, of, switchMap } from 'rxjs';
 
 import { ProjectContextService } from '../services/project-context.service';
@@ -117,15 +117,24 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
  * as a `:projectUid` route param (newsletter edit/analytics, GH-1570) rather than inside the
  * entity payload. The URL is authoritative for the page's fetches, but page chrome (name/logo,
  * sidebar) follows `activeContext()`, which a stale cookie-restored context can leave pointing
- * at a different project. When the two disagree, resolve the route project by uid and re-point
- * the context via applyEntityProjectContext — the uid-only variant of the entity-signal syncs
- * above, for routes with no enriched entity payload.
+ * at a different project. Resolve the route project by uid and re-point the context via
+ * applyEntityProjectContext — the uid-only variant of the entity-signal syncs above, for routes
+ * with no enriched entity payload.
  *
- * The mismatch is computed over BOTH the route uid and `activeContextUid()`: the context write
- * makes them agree, which quiets the trigger, and a later route-lens re-assert (e.g. MainLayout
- * on `?step=N` navigations) flips the mismatch back on, so the correction self-heals without
- * NavigationEnd wiring. The re-apply hits the shareReplay-cached getProject — the route's guard
- * has already resolved the same uid on activation, so the happy path costs no extra request.
+ * Two triggers:
+ *  - Route-uid changes resolve at least once per activation, even when the active context's uid
+ *    already matches: a uid-equal cookie context can still carry a stale name/logo/slug or sit
+ *    under the wrong context kind (a foundation-owned newsletter under /project/newsletters), so
+ *    the write below only suppresses once the FULL context (isSameProjectContext) and the
+ *    computed kind both match. The resolve hits the shareReplay-cached getProject — the route's
+ *    guard already resolved the same uid on activation — so the happy path costs no request.
+ *  - NavigationEnd re-applies synchronously from the per-uid resolved cache: query-param-only
+ *    navigations (?step=N) don't re-run guards, but MainLayout.syncLensFromRoute re-asserts the
+ *    route's DECLARED lens kind on every navigation, clobbering this correction when the route
+ *    project contradicts the URL lens. Ordering is safe (MainLayout subscribed at bootstrap, so
+ *    its re-assert runs first on the same NavigationEnd), and applying before change detection
+ *    runs means chrome never renders the stale context — a post-hoc signal self-heal would
+ *    flash the wrong project for a frame per step change.
  *
  * Call once from the component constructor (injection context is required for toObservable).
  * A failed uid lookup resolves null (relation-gated `getProject(uid, false)`) and leaves the
@@ -138,32 +147,60 @@ export function reconcileRouteProjectContext(
   router: Router,
   destroyRef: DestroyRef
 ): void {
-  const unreconciledRouteProjectUid = computed(() => {
-    const uid = routeProjectUid();
-    if (!uid || uid === projectContextService.activeContextUid()) return null;
-    return uid;
-  });
+  // Resolved route projects by uid: populated on first resolve, read by NavigationEnd re-applies
+  // so they run synchronously (pre-change-detection) instead of healing a frame late.
+  const resolvedCache = new Map<string, { context: ProjectContext; isFoundation: boolean }>();
 
-  toObservable(unreconciledRouteProjectUid)
+  const routeProjectChange$ = toObservable(routeProjectUid).pipe(distinctUntilChanged());
+  const navigationReapply$ = router.events.pipe(
+    filter((event) => event instanceof NavigationEnd),
+    map(() => routeProjectUid())
+  );
+
+  merge(routeProjectChange$, navigationReapply$)
     .pipe(
-      filter((uid): uid is string => uid !== null),
-      switchMap((uid) => projectService.getProject(uid, false)),
+      filter((uid): uid is string => !!uid),
+      switchMap((uid) => {
+        const cached = resolvedCache.get(uid);
+        if (cached) {
+          return of(cached);
+        }
+        return projectService.getProject(uid, false).pipe(
+          map((project) => {
+            // null = deleted/unknown project (or no viewer relation) — keep the
+            // existing context rather than erroring the page.
+            if (!project) return null;
+            const resolved = {
+              context: {
+                uid: project.uid,
+                name: project.name,
+                slug: project.slug,
+                parent_uid: project.parent_uid,
+                logoUrl: project.logo_url,
+              },
+              isFoundation: computeIsFoundation(project),
+            };
+            resolvedCache.set(uid, resolved);
+            return resolved;
+          })
+        );
+      }),
       takeUntilDestroyed(destroyRef)
     )
-    .subscribe((project) => {
-      // null = deleted/unknown project (or no viewer relation) — keep the
-      // existing context rather than erroring the page.
-      if (!project) return;
-      const context: ProjectContext = {
-        uid: project.uid,
-        name: project.name,
-        slug: project.slug,
-        parent_uid: project.parent_uid,
-        logoUrl: project.logo_url,
-      };
+    .subscribe((resolved) => {
+      if (!resolved) return;
+      // Suppress the repeat only once the FULL context (isSameProjectContext compares
+      // name/slug/logoUrl, not just uid) and the computed kind both match — a uid-equal cookie
+      // context can still carry stale chrome or sit under the wrong kind.
+      if (
+        projectContextService.activeRouteLensKind() === (resolved.isFoundation ? 'foundation' : 'project') &&
+        isSameProjectContext(projectContextService.activeContext(), resolved.context)
+      ) {
+        return;
+      }
       // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
       const syncUrl = 'project' in router.parseUrl(router.url).queryParams;
-      applyEntityProjectContext(projectContextService, context, computeIsFoundation(project), syncUrl);
+      applyEntityProjectContext(projectContextService, resolved.context, resolved.isFoundation, syncUrl);
     });
 }
 

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -193,11 +193,12 @@ export function reconcileRouteProjectContext(
       // Suppress the repeat only once the FULL context (isSameProjectContext compares
       // name/slug/logoUrl, not just uid), the computed kind, AND the URL all agree — a uid-equal
       // cookie context can still carry stale chrome or sit under the wrong kind, and a stale
-      // ?project= must still fall through so it gets repaired: syncProjectQueryParam skips while
-      // a navigation is in flight, so the activation-time apply can't fix the URL and this
-      // NavigationEnd re-apply is the first chance that can (setProject runs its URL sync outside
-      // the same-context early return). Suppressing on context alone would leave the old slug in
-      // the URL for the session.
+      // ?project= must still fall through so it gets repaired: suppressing on context alone
+      // would leave the old slug in the URL for the session. The repair can't land
+      // synchronously, though — syncProjectQueryParam skips while a navigation is in flight,
+      // and Angular only clears currentNavigation in the navigation stream's finalize, AFTER
+      // NavigationEnd subscribers run — so both the activation apply and this re-apply see the
+      // URL sync suppressed. The actual repair is deferred to a microtask below.
       const urlParams = router.parseUrl(router.url).queryParams;
       const urlAgrees = !('project' in urlParams) || urlParams['project'] === resolved.context.slug;
       if (
@@ -210,6 +211,20 @@ export function reconcileRouteProjectContext(
       // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
       const syncUrl = 'project' in urlParams;
       applyEntityProjectContext(projectContextService, resolved.context, resolved.isFoundation, syncUrl);
+      // The apply above corrects the context synchronously (pre-change-detection), but its URL
+      // sync is suppressed while a navigation is in flight — and this re-apply is itself still
+      // inside the navigation (currentNavigation clears in the stream's finalize, after
+      // NavigationEnd subscribers run). Defer the URL repair to a microtask: it runs after the
+      // finalizer, when getCurrentNavigation() is null and the re-invoked setter's URL sync can
+      // land (setProject/setFoundation run it outside the same-context early return, so the
+      // context re-writes are same-value no-ops and only the ?project= repair takes effect).
+      if (syncUrl && !urlAgrees && router.getCurrentNavigation()) {
+        queueMicrotask(() => {
+          // A newer navigation owns the URL now — skip; its own re-apply re-queues the repair.
+          if (router.getCurrentNavigation()) return;
+          applyEntityProjectContext(projectContextService, resolved.context, resolved.isFoundation, true);
+        });
+      }
     });
 }
 

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -125,8 +125,9 @@ export function syncEntityProjectContext<T extends EntityWithProject>(
  *  - Route-uid changes resolve at least once per activation, even when the active context's uid
  *    already matches: a uid-equal cookie context can still carry a stale name/logo/slug or sit
  *    under the wrong context kind (a foundation-owned newsletter under /project/newsletters), so
- *    the write below only suppresses once the FULL context (isSameProjectContext) and the
- *    computed kind both match. The resolve hits the shareReplay-cached getProject — the route's
+ *    the write below only suppresses once the FULL context (isSameProjectContext), the
+ *    computed kind, and the URL's ?project= all agree. The resolve hits the shareReplay-cached
+ *    getProject — the route's
  *    guard already resolved the same uid on activation — so the happy path costs no request.
  *  - NavigationEnd re-applies synchronously from the per-uid resolved cache: query-param-only
  *    navigations (?step=N) don't re-run guards, but MainLayout.syncLensFromRoute re-asserts the
@@ -190,16 +191,24 @@ export function reconcileRouteProjectContext(
     .subscribe((resolved) => {
       if (!resolved) return;
       // Suppress the repeat only once the FULL context (isSameProjectContext compares
-      // name/slug/logoUrl, not just uid) and the computed kind both match — a uid-equal cookie
-      // context can still carry stale chrome or sit under the wrong kind.
+      // name/slug/logoUrl, not just uid), the computed kind, AND the URL all agree — a uid-equal
+      // cookie context can still carry stale chrome or sit under the wrong kind, and a stale
+      // ?project= must still fall through so it gets repaired: syncProjectQueryParam skips while
+      // a navigation is in flight, so the activation-time apply can't fix the URL and this
+      // NavigationEnd re-apply is the first chance that can (setProject runs its URL sync outside
+      // the same-context early return). Suppressing on context alone would leave the old slug in
+      // the URL for the session.
+      const urlParams = router.parseUrl(router.url).queryParams;
+      const urlAgrees = !('project' in urlParams) || urlParams['project'] === resolved.context.slug;
       if (
         projectContextService.activeRouteLensKind() === (resolved.isFoundation ? 'foundation' : 'project') &&
-        isSameProjectContext(projectContextService.activeContext(), resolved.context)
+        isSameProjectContext(projectContextService.activeContext(), resolved.context) &&
+        urlAgrees
       ) {
         return;
       }
       // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
-      const syncUrl = 'project' in router.parseUrl(router.url).queryParams;
+      const syncUrl = 'project' in urlParams;
       applyEntityProjectContext(projectContextService, resolved.context, resolved.isFoundation, syncUrl);
     });
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Package-local test scope for `yarn workspace @lfx-one/shared test` (plain Node vitest).
+ * Required for correctness in the monorepo: when a package directory has no vitest config,
+ * vitest walks UP and adopts the nearest ancestor config — the repo-root vitest.config.ts
+ * guardrail — whose packages/** include doesn't resolve from this cwd, breaking the package's
+ * own `vitest run`. Owning the scope here keeps package runs self-contained regardless of
+ * ancestor configs.
+ */
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Guardrail for bare `vitest` invocations from the monorepo ROOT (editor/agent test runners,
+ * `npx vitest ...`): the hoisted root vitest binary's default globs otherwise collect specs it
+ * cannot run —
+ *
+ *   - apps/lfx-one/src/app/** specs need the Angular unit-test builder (`yarn ng test`, the
+ *     `test` target in apps/lfx-one/angular.json), which initializes the TestBed environment
+ *     and jsdom; under plain vitest they fail with "Need to call TestBed.initTestEnvironment()".
+ *   - apps/lfx-one/src/server/** specs need the `@lfx-one/shared` resolve aliases in
+ *     apps/lfx-one/vitest.config.ts (`yarn test:server` from apps/lfx-one).
+ *
+ * Scoping root-level vitest to packages/** (whose specs are plain Node and run anywhere) turns
+ * those misrouted runs into a correct "no test files found". Note vitest resolves config from
+ * the invocation cwd, walking UP to the nearest config when the cwd has none — so each package
+ * that runs plain vitest owns its scope: apps/lfx-one has its own vitest.config.ts, and
+ * packages/shared carries one for exactly this reason. `yarn test`, `yarn test:server`,
+ * `yarn ng test`, and `yarn workspace @lfx-one/shared test` are all unaffected by this file.
+ */
+export default defineConfig({
+  test: {
+    include: ['packages/**/*.spec.ts'],
+    exclude: ['**/node_modules/**', 'apps/**'],
+  },
+});


### PR DESCRIPTION
## Summary

Newsletter edit and analytics pages could show — and authorize against — the wrong project when opened from a deep link. The URL carries the owning project as `:projectUid`, but both the access guard and the page chrome (name, logo, sidebar) followed the `?project=` query param or a cookie-restored active context, which can be stale when a link is shared or the user switched projects since it was created. This PR makes the route's `:projectUid` authoritative for both authorization and page context, with the legacy slug chain kept as a fallback.

Resolves #1570

## Behavior changes

### Newsletter edit/analytics access check

| Before | After |
|---|---|
| Opening a newsletter edit or analytics link could wrongly deny access (or check permissions against a different project) if the saved context pointed at another project than the one in the link. | Access is checked against the project identified by the link itself, so a legitimate manager is never denied because of a stale saved context; the old behavior only applies when the link doesn't identify a project or it no longer exists. |

### Project shown on newsletter edit/analytics pages

| Before | After |
|---|---|
| The page header and sidebar could display a different project than the newsletter actually being viewed or edited, when the saved context was stale. | The displayed project automatically switches to the one the link belongs to, so the page chrome always matches the newsletter on screen. |

### Newsletter list/create access denial

| Before | After |
|---|---|
| A user denied on the newsletter list or create route landed silently back on the overview page. | The denial shows an "Access Denied" toast explaining why, matching the convention other guarded pages already use. |

## Technical changes

`apps/lfx-one/src/app/shared/guards/newsletter-access.guard.ts` — Newsletter access guard

- Resolution order is now: route `:projectUid` param first (own `paramMap`, then `firstChild` for the lens-mount invocation), then the legacy `?project=` → active-context slug chain.
- When `:projectUid` resolves, writer access is checked directly on the resolved project; denial redirects to the lens-appropriate overview with the resolved slug and the `_notice: 'access'` query param (mirroring `writerGuard`'s toast convention).
- A null uid lookup (deleted/unknown project) degrades to the legacy slug chain instead of denying on a fetch error. Legacy-chain denials (list/create routes) now also carry `_notice: 'access'`, surfacing the same "Access Denied" toast as `writerGuard` instead of redirecting silently.

`apps/lfx-one/src/app/shared/services/project.service.ts` — Project service

- `getProject` no longer caches the `null` produced by its error path: a failed lookup is evicted so the next caller retries instead of replaying a transient error for the rest of the session (review feedback — a poisoned entry could pin the guard and route reconciliation to a stale context).

`apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts` — Shared context reconciliation

- New `reconcileRouteProjectContext` helper: the uid-only variant of the existing entity-signal syncs, for routes whose URL carries the owning project as `:projectUid` but have no enriched entity payload.
- Computes a mismatch over both the route uid and `activeContextUid()` so the correction self-heals after later route-lens re-asserts, without `NavigationEnd` wiring; re-applies hit the `shareReplay`-cached `getProject` (the guard already resolved the same uid), so the happy path costs no extra request.
- A failed uid lookup resolves null and leaves the existing context untouched; `?project=` is only written to the URL when already present, mirroring `syncEntityProjectContext`.
- The repeat suppression now requires URL agreement too: a stale `?project=` falls through so the `NavigationEnd` re-apply repairs it once no navigation is in flight (review feedback — activation-time applies can't repair the URL, and suppressing on context alone left the old slug for the session).

`apps/lfx-one/src/app/modules/newsletters/newsletter-manage/newsletter-manage.component.ts, apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts` — Newsletter pages

- Both pages call `reconcileRouteProjectContext` once from the constructor so `displayName`/`logoUrl`/sidebar follow the route's project instead of a stale cookie-restored context.

`apps/lfx-one/src/app/shared/guards/newsletter-access.guard.spec.ts` — Guard unit tests

- New suite covering: ED fast path, `:projectUid` authorization over stale query param/context, child-snapshot resolution at the lens mount, null-lookup degradation to the legacy chain, denial with resolved slug + access notice, legacy-chain preference order, fail-closed lookup failure, and lens-appropriate overview redirects.

`apps/lfx-one/e2e/project-context-deep-link.spec.ts` — E2E tests

- New GH-1570 deep-link cases: edit link with a stale cookie context switches to the route's project, and the guard authorizes the edit page against the route's `:projectUid` rather than the stale context.

