### PR TITLE
fix(dashboards): stop falling back to legacy v1 health score

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.spec.ts
@@ -5,7 +5,7 @@ import { signal, type WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, type ParamMap, Router, UrlTree } from '@angular/router';
-import { Account, BoardDisplayRow } from '@lfx-one/shared/interfaces';
+import { Account, BoardDisplayRow, OrgLensProjectHero } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { OrgLensProjectDetailService } from '@services/org-lens-project-detail.service';
@@ -144,5 +144,94 @@ describe('OrgProjectDetailComponent — leaderboard detail drawer opening', () =
     await fixture.whenStable();
 
     expect(component['leaderboardDetailOpen']()).toBe(false);
+  });
+});
+
+/**
+ * LFXV2-3379: when the warehouse has no v2 health category, the hero's `health` is `null`. The
+ * badge must render an "Unavailable" tag matching the Org Lens projects table's equivalent state,
+ * not omit the "Health score" section entirely (the pre-fix behavior — `healthMeta()` returned
+ * `null` and the template's `@if (healthMeta(); as hm)` has no `@else`).
+ */
+describe('OrgProjectDetailComponent — healthMeta', () => {
+  const HERO: OrgLensProjectHero = {
+    projectName: 'Test Project',
+    description: '',
+    logoUrl: '',
+    lfxInsightsUrl: null,
+    firstCommit: null,
+    softwareValueUsd: null,
+    health: null,
+    healthMaxScore: null,
+    healthCoveredCategoryCount: null,
+    foundationLabel: '',
+  };
+
+  async function createComponent(hero: OrgLensProjectHero): Promise<OrgProjectDetailComponent> {
+    await TestBed.configureTestingModule({
+      imports: [OrgProjectDetailComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: AccountContextService, useValue: { selectedAccount: signal({ accountId: 'acc-1', accountName: 'Test Org', uid: 'acc-1' } as Account) } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        {
+          provide: OrgLensProjectDetailService,
+          useValue: {
+            getHero: vi.fn(() => of({ hero, isNonLfProject: false })),
+            getInfluenceBlock: vi.fn(() => of(null)),
+            getTrendBlock: vi.fn(() => of(null)),
+            getTechnicalBoard: vi.fn(() => of({ rows: [], total: 0 })),
+            getEcosystemBoard: vi.fn(() => of({ rows: [], total: 0 })),
+            getLeaderboardBreakdown: vi.fn(() => of(null)),
+          },
+        },
+        {
+          provide: PersonDetailDrawerService,
+          useValue: {
+            open: vi.fn(),
+            close: vi.fn(),
+            isOpen: signal(false),
+            activeContext: signal(null),
+            activeTab: signal('events'),
+            loading: signal(false),
+            error: signal(null),
+            emailError: signal(false),
+            companyEmails: signal([]),
+          },
+        },
+        { provide: Router, useValue: { navigate: vi.fn(), events: EMPTY, createUrlTree: vi.fn(() => ({}) as UrlTree), serializeUrl: vi.fn(() => '') } },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ projectSlug: 'k8s' })),
+            queryParamMap: of(convertToParamMap({})),
+            snapshot: { queryParamMap: convertToParamMap({}) },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgProjectDetailComponent);
+    await fixture.whenStable();
+    return fixture.componentInstance;
+  }
+
+  it('renders the "Unavailable" tag when the warehouse has no v2 health category', async () => {
+    const component = await createComponent({ ...HERO, health: null });
+
+    expect(component['healthMeta']()).toEqual(expect.objectContaining({ label: 'Unavailable' }));
+  });
+
+  it('renders the plain band label for a full, non-null health score', async () => {
+    const component = await createComponent({ ...HERO, health: 'fair', healthMaxScore: 100, healthCoveredCategoryCount: 3 });
+
+    expect(component['healthMeta']()).toEqual(expect.objectContaining({ label: 'Fair' }));
+  });
+
+  it('still appends the partial suffix when exactly 2 of 3 categories are covered (LFXV2-1262)', async () => {
+    const component = await createComponent({ ...HERO, health: 'fair', healthMaxScore: 65, healthCoveredCategoryCount: 2 });
+
+    expect(component['healthMeta']()).toEqual(expect.objectContaining({ label: expect.stringContaining('Fair') }));
+    expect(component['healthMeta']()?.label).toContain('Partial');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -29,6 +29,8 @@ import {
   PD_VALID_TABS,
   PD_DEFAULT_TIME_RANGE,
   PD_DRAWER_QUERY_PARAM,
+  HEALTH_SCORE_BADGE,
+  HEALTH_SCORE_LABELS,
   HEALTH_SCORE_PARTIAL_SUFFIX,
   PD_HEALTH_TAG,
   PD_NON_LF_MARKER,
@@ -213,8 +215,10 @@ export class OrgProjectDetailComponent {
   protected readonly healthMeta = computed(() => {
     const hero = this.hero();
     const health = hero?.health;
+    // Null health (no v2 category, LFXV2-3379) renders the same "Unavailable" tag the Org Lens
+    // projects table shows for the identical condition, rather than omitting the badge entirely.
     if (!health) {
-      return null;
+      return { label: HEALTH_SCORE_LABELS.unavailable, ...HEALTH_SCORE_BADGE.unavailable };
     }
     const tag = PD_HEALTH_TAG[health];
     // Bare-band bg/text stay unsuffixed for color lookup; only the rendered label gets " - Partial",

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -239,12 +239,20 @@ describe('OrgLensProjectDetailService.getHeroBlock health mapping', () => {
     });
   }
 
-  it('falls back to the raw v2 score when the v2 category is unrecognized', async () => {
+  it('returns null health when the v2 category is unrecognized, never falling back to the raw v2 score (LFXV2-3379)', async () => {
     mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' });
 
     const block = await service.getHeroBlock(ORG, SLUG);
 
-    expect(block?.hero.health).toBe('fair');
+    expect(block?.hero.health).toBeNull();
+  });
+
+  it('returns null health when a raw v2 score is present but the v2 category is not (LFXV2-3379)', async () => {
+    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 90, HEALTH_SCORE_CATEGORY_V2: null });
+
+    const block = await service.getHeroBlock(ORG, SLUG);
+
+    expect(block?.hero.health).toBeNull();
   });
 
   it('returns null health when no v2 score or category is present', async () => {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -239,24 +239,16 @@ describe('OrgLensProjectDetailService.getHeroBlock health mapping', () => {
     });
   }
 
-  it('returns null health when the v2 category is unrecognized, never falling back to the raw v2 score (LFXV2-3379)', async () => {
-    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' });
+  it('returns null health when the v2 category is unrecognized (LFXV2-3379)', async () => {
+    mockHeroRow({ HEALTH_SCORE_CATEGORY_V2: 'Typo' });
 
     const block = await service.getHeroBlock(ORG, SLUG);
 
     expect(block?.hero.health).toBeNull();
   });
 
-  it('returns null health when a raw v2 score is present but the v2 category is not (LFXV2-3379)', async () => {
-    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 90, HEALTH_SCORE_CATEGORY_V2: null });
-
-    const block = await service.getHeroBlock(ORG, SLUG);
-
-    expect(block?.hero.health).toBeNull();
-  });
-
-  it('returns null health when no v2 score or category is present', async () => {
-    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: null, HEALTH_SCORE_CATEGORY_V2: null });
+  it('returns null health when the v2 category is null (LFXV2-3379)', async () => {
+    mockHeroRow({ HEALTH_SCORE_CATEGORY_V2: null });
 
     const block = await service.getHeroBlock(ORG, SLUG);
 

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -30,7 +30,7 @@ import type {
   OrgLensProjectTrendSeries,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl, classifyHealthScore, normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { escapeSqlLikePattern } from '../helpers/validation.helper';
@@ -1892,12 +1892,10 @@ export class OrgLensProjectDetailService {
     };
   }
 
-  private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
-    const v2 = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
-    if (v2) return v2;
-    const score = row.HEALTH_OVERALL_SCORE_V2;
-    if (score === null || score === undefined) return null;
-    return classifyHealthScore(score);
+  private mapHealth(row: Pick<HeroRow, 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
+    // The warehouse v2 category is the sole source of truth for the health label — never fall back to
+    // classifying the legacy v1 score when the v2 category is null (LFXV2-3379).
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
   }
 
   private buildTechnicalCards(cards: CardsRow | null, index: SparklineIndex, axis: string[]): OrgLensProjectInfluenceCard[] {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1887,7 +1887,7 @@ export class OrgLensProjectDetailService {
       firstCommit: toIsoDate(row.FIRST_COMMIT_TS),
       softwareValueUsd: row.SOFTWARE_VALUE ?? null,
       health: this.mapHealth(row),
-      // Sourced straight from the warehouse — never recomputed, per health.mapHealth's v2-category/score precedence.
+      // Sourced straight from the warehouse — never recomputed, independent of mapHealth's category normalization.
       healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
       healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
       foundationLabel,
@@ -1898,7 +1898,7 @@ export class OrgLensProjectDetailService {
     // The warehouse v2 category is the sole source of truth for the health label — never fall back to
     // classifying the legacy v1 score when the v2 category is null (LFXV2-3379).
     const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
-    if (row.HEALTH_SCORE_CATEGORY_V2 && !category) {
+    if (row.HEALTH_SCORE_CATEGORY_V2 != null && !category) {
       logger.warning(undefined, 'map_org_project_health', 'Unrecognized warehouse health_score_category_v2; treating as unavailable', {
         slug: row.PROJECT_SLUG,
         category: row.HEALTH_SCORE_CATEGORY_V2,

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -34,6 +34,7 @@ import { buildInsightsUrl, normalizeHealthScoreCategoryV2 } from '@lfx-one/share
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { escapeSqlLikePattern } from '../helpers/validation.helper';
+import { logger } from './logger.service';
 import { buildOrgCacheKey, valkeyService } from './valkey.service';
 import { SnowflakeService } from './snowflake.service';
 
@@ -1893,10 +1894,17 @@ export class OrgLensProjectDetailService {
     };
   }
 
-  private mapHealth(row: Pick<HeroRow, 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
+  private mapHealth(row: Pick<HeroRow, 'HEALTH_SCORE_CATEGORY_V2' | 'PROJECT_SLUG'>): OrgLensProjectHealth | null {
     // The warehouse v2 category is the sole source of truth for the health label — never fall back to
     // classifying the legacy v1 score when the v2 category is null (LFXV2-3379).
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
+    const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
+    if (row.HEALTH_SCORE_CATEGORY_V2 && !category) {
+      logger.warning(undefined, 'map_org_project_health', 'Unrecognized warehouse health_score_category_v2; treating as unavailable', {
+        slug: row.PROJECT_SLUG,
+        category: row.HEALTH_SCORE_CATEGORY_V2,
+      });
+    }
+    return category;
   }
 
   private buildTechnicalCards(cards: CardsRow | null, index: SparklineIndex, axis: string[]): OrgLensProjectInfluenceCard[] {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -44,7 +44,6 @@ interface HeroRow {
   FOUNDATION_NAME: string | null;
   IS_LF_PROJECT: boolean | null;
   DESCRIPTION: string | null;
-  HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
   COVERED_CATEGORY_COUNT_V2: number | null;
   HEALTH_MAX_SCORE_V2: number | null;
@@ -552,7 +551,9 @@ export class OrgLensProjectDetailService {
 
   public async getHeroBlock(orgUid: string, projectSlug: string): Promise<OrgLensHeroBlock | null> {
     const slug = projectSlug.trim().toLowerCase();
-    const key = buildOrgCacheKey(orgUid, `project-detail-hero:${this.paramSignature([slug])}`);
+    // `v2` bump: mapHealth no longer falls back to the legacy v1 score when the v2 category is null
+    // (LFXV2-3379) — bumping drops cached hero blocks computed under the old fallback logic (e.g. "Fair").
+    const key = buildOrgCacheKey(orgUid, `project-detail-hero:v2:${this.paramSignature([slug])}`);
     if (key !== null) {
       const cached = await valkeyService.getJson<OrgLensHeroBlock>(key, OrgLensProjectDetailService.isHeroBlock);
       if (cached !== null) return cached;
@@ -1100,7 +1101,7 @@ export class OrgLensProjectDetailService {
     const result = await this.snowflakeService.execute<HeroRow>(
       `
         SELECT PROJECT_NAME, PROJECT_SLUG, PROJECT_LOGO_URL, FOUNDATION_NAME, IS_LF_PROJECT,
-               DESCRIPTION, HEALTH_OVERALL_SCORE_V2, HEALTH_SCORE_CATEGORY_V2,
+               DESCRIPTION, HEALTH_SCORE_CATEGORY_V2,
                COVERED_CATEGORY_COUNT_V2, HEALTH_MAX_SCORE_V2,
                SOFTWARE_VALUE, FIRST_COMMIT_TS
         FROM ${this.projectsTable()}

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -83,15 +83,15 @@ describe('OrgLensProjectsService health score mapping', () => {
     execute.mockReset();
   });
 
-  it('classifies via the raw v2 score when no v2 category is present', async () => {
+  it('marks health unavailable when a raw v2 score is present but the v2 category is not (LFXV2-3379)', async () => {
     mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 90 }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
-    expect(response.projects[0]?.health).toBe('excellent');
+    expect(response.projects[0]?.health).toBe('unavailable');
   });
 
-  it('prefers the warehouse v2 category over the raw v2 score when both are present', async () => {
+  it('uses the warehouse v2 category when present', async () => {
     mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 10, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
@@ -99,12 +99,12 @@ describe('OrgLensProjectsService health score mapping', () => {
     expect(response.projects[0]?.health).toBe('fair');
   });
 
-  it('falls back to the raw v2 score when the v2 category is unrecognized', async () => {
+  it('marks health unavailable when the v2 category is unrecognized, never falling back to the raw v2 score (LFXV2-3379)', async () => {
     mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
-    expect(response.projects[0]?.health).toBe('fair');
+    expect(response.projects[0]?.health).toBe('unavailable');
   });
 
   it('marks health unavailable when no v2 score is present', async () => {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -170,4 +170,19 @@ describe('OrgLensProjectsService health score mapping', () => {
 
     expect(response.projects[0]?.healthMetrics).toEqual([]);
   });
+
+  it('omits health metrics when only some warehouse percentage columns are present, never fabricating 0% for the rest (LFXV2-3379)', async () => {
+    mockProjectsRow(
+      projectsRow({
+        HEALTH_CONTRIBUTOR_PERCENTAGE: 42,
+        HEALTH_POPULARITY_PERCENTAGE: null,
+        HEALTH_DEVELOPMENT_PERCENTAGE: 75,
+        HEALTH_SECURITY_PERCENTAGE: null,
+      })
+    );
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.healthMetrics).toEqual([]);
+  });
 });

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -54,7 +54,6 @@ function projectsRow(overrides: Record<string, unknown> = {}) {
     TREND_DIRECTION: null,
     COMBINED_SCORE_SERIES: null,
     DBT_RUN_AT: null,
-    HEALTH_OVERALL_SCORE_V2: null,
     HEALTH_SCORE_CATEGORY_V2: null,
     COVERED_CATEGORY_COUNT_V2: null,
     HEALTH_MAX_SCORE_V2: null,
@@ -83,31 +82,23 @@ describe('OrgLensProjectsService health score mapping', () => {
     execute.mockReset();
   });
 
-  it('marks health unavailable when a raw v2 score is present but the v2 category is not (LFXV2-3379)', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 90 }));
-
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
-
-    expect(response.projects[0]?.health).toBe('unavailable');
-  });
-
   it('uses the warehouse v2 category when present', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 10, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
+    mockProjectsRow(projectsRow({ HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('fair');
   });
 
-  it('marks health unavailable when the v2 category is unrecognized, never falling back to the raw v2 score (LFXV2-3379)', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
+  it('marks health unavailable when the v2 category is unrecognized (LFXV2-3379)', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('unavailable');
   });
 
-  it('marks health unavailable when no v2 score is present', async () => {
+  it('marks health unavailable when no v2 category is present', async () => {
     mockProjectsRow(projectsRow());
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
@@ -116,7 +107,7 @@ describe('OrgLensProjectsService health score mapping', () => {
   });
 
   it('passes healthMaxScore and healthCoveredCategoryCount straight through from the warehouse', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 70, HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 }));
+    mockProjectsRow(projectsRow({ HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
@@ -125,20 +116,12 @@ describe('OrgLensProjectsService health score mapping', () => {
   });
 
   it('passes through a full (3-category) score unchanged, not marked partial', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 90, COVERED_CATEGORY_COUNT_V2: 3, HEALTH_MAX_SCORE_V2: 100 }));
+    mockProjectsRow(projectsRow({ COVERED_CATEGORY_COUNT_V2: 3, HEALTH_MAX_SCORE_V2: 100 }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.healthCoveredCategoryCount).toBe(3);
     expect(response.projects[0]?.healthMaxScore).toBe(100);
-  });
-
-  it('uses the warehouse v2 category even when the raw v2 score is null (LFXV2-3379)', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: null, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
-
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
-
-    expect(response.projects[0]?.health).toBe('fair');
   });
 
   it('renders health metrics from the warehouse percentage columns even when the v2 category is null (LFXV2-3379)', async () => {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -132,4 +132,42 @@ describe('OrgLensProjectsService health score mapping', () => {
     expect(response.projects[0]?.healthCoveredCategoryCount).toBe(3);
     expect(response.projects[0]?.healthMaxScore).toBe(100);
   });
+
+  it('uses the warehouse v2 category even when the raw v2 score is null (LFXV2-3379)', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: null, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('fair');
+  });
+
+  it('renders health metrics from the warehouse percentage columns even when the v2 category is null (LFXV2-3379)', async () => {
+    mockProjectsRow(
+      projectsRow({
+        HEALTH_SCORE_CATEGORY_V2: null,
+        HEALTH_CONTRIBUTOR_PERCENTAGE: 42,
+        HEALTH_POPULARITY_PERCENTAGE: 10,
+        HEALTH_DEVELOPMENT_PERCENTAGE: 75,
+        HEALTH_SECURITY_PERCENTAGE: 30,
+      })
+    );
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('unavailable');
+    expect(response.projects[0]?.healthMetrics).toEqual([
+      { label: 'Contributors', value: 42 },
+      { label: 'Popularity', value: 10 },
+      { label: 'Development', value: 75 },
+      { label: 'Security', value: 30 },
+    ]);
+  });
+
+  it('omits health metrics when no warehouse percentage columns are present', async () => {
+    mockProjectsRow(projectsRow());
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.healthMetrics).toEqual([]);
+  });
 });

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -496,7 +496,7 @@ export class OrgLensProjectsService {
   private mapProject(row: OrgLensProjectRow, peopleRows: OrgLensProjectPersonRow[]): OrgLensProject {
     const people = peopleRows.filter((person) => person.PROJECT_SLUG === row.PROJECT_SLUG);
     const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
-    if (row.HEALTH_SCORE_CATEGORY_V2 && !category) {
+    if (row.HEALTH_SCORE_CATEGORY_V2 != null && !category) {
       logger.warning(undefined, 'map_org_project_health', 'Unrecognized warehouse health_score_category_v2; treating as unavailable', {
         slug: row.PROJECT_SLUG,
         category: row.HEALTH_SCORE_CATEGORY_V2,
@@ -533,7 +533,7 @@ export class OrgLensProjectsService {
       commits1y: 0,
       changeDriver: { label: 'Not calculated yet', direction: 'flat' },
       description: row.DESCRIPTION ?? `${row.PROJECT_NAME} is an open source project in the ${this.mapFoundation(row).name} ecosystem.`,
-      healthMetrics: this.hasHealthMetrics(row) ? this.mapHealthMetrics(row) : [],
+      healthMetrics: category && this.hasHealthMetrics(row) ? this.mapHealthMetrics(row) : [],
       // Real org-scoped row (org-dashboard parity): every metric is genuine, including participating
       // projects with activity_count = 0. fetchNoActivityProjects overrides this for its fallback rows.
       metricsState: 'full',

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -49,9 +49,10 @@ export class OrgLensProjectsService {
   private readonly microserviceProxy = new MicroserviceProxyService();
 
   public async getProjects(accountId: string, orgName: string, slugs: string[] | null): Promise<OrgLensProjectsResponse> {
-    // `v4` bump: hasHealthScore/mapHealthScore no longer fall back to the legacy v1 score when the v2 category
-    // is null (LFXV2-3379) — bumping drops cache entries computed under the old fallback logic (e.g. "Fair").
-    const cacheKey = `projects:v4:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
+    // `v5` bump: hasHealthMetrics now requires all four warehouse percentage columns to be present, instead of
+    // fabricating 0% for a column that's actually unmeasured (LFXV2-3379) — bump drops cache entries computed
+    // under the old fallback/partial-metrics logic.
+    const cacheKey = `projects:v5:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
     const key = buildOrgCacheKey(accountId, cacheKey);
     if (key !== null) {
       const cached = await valkeyService.getJson<OrgLensProjectsResponse>(key, OrgLensProjectsService.isProjectsResponse);
@@ -404,7 +405,6 @@ export class OrgLensProjectsService {
         FOUNDATION_SLUG,
         FOUNDATION_NAME,
         FOUNDATION_LOGO_URL,
-        HEALTH_OVERALL_SCORE_V2,
         HEALTH_SCORE_CATEGORY_V2,
         COVERED_CATEGORY_COUNT_V2,
         HEALTH_MAX_SCORE_V2,
@@ -416,8 +416,10 @@ export class OrgLensProjectsService {
       WHERE LOWER(PROJECT_SLUG) IN (${missing.map(() => '?').join(', ')})
     `;
     const result = await this.snowflakeService.execute<OrgLensProjectRow>(sql, missing);
-    // mapProject fills unselected org-relative metrics with placeholders and maps health from the columns above.
-    // Split on computed health: present → 'health-only' (Health renders); NULL → 'unavailable' (all-Unavailable row).
+    // mapProject fills unselected org-relative metrics with placeholders and maps health/healthMetrics from the
+    // columns above. metricsState here reflects only the health label (category present → 'health-only'; null →
+    // 'unavailable') — healthMetrics is gated independently inside mapProject and may still be populated on an
+    // 'unavailable' row if the warehouse percentage columns are present without a category.
     return result.rows.map((row) => {
       const hasHealthScore = this.hasHealthScore(row);
       // Emit both discriminators: metricsState for the new frontend, noActivityYet so a still-running pre-close-out
@@ -454,7 +456,6 @@ export class OrgLensProjectsService {
         TREND_DIRECTION,
         COMBINED_SCORE_SERIES,
         DBT_RUN_AT,
-        HEALTH_OVERALL_SCORE_V2,
         HEALTH_SCORE_CATEGORY_V2,
         COVERED_CATEGORY_COUNT_V2,
         HEALTH_MAX_SCORE_V2,
@@ -582,10 +583,13 @@ export class OrgLensProjectsService {
       'HEALTH_CONTRIBUTOR_PERCENTAGE' | 'HEALTH_POPULARITY_PERCENTAGE' | 'HEALTH_DEVELOPMENT_PERCENTAGE' | 'HEALTH_SECURITY_PERCENTAGE'
     >
   ): boolean {
+    // All four required (not "any"): mapHealthMetrics emits all four dimensions unconditionally and
+    // roundMetric() defaults a missing value to 0 — an OR gate would render an unmeasured dimension as a
+    // fabricated 0% for a row where only some of the four columns are populated (LFXV2-3379).
     return (
-      row.HEALTH_CONTRIBUTOR_PERCENTAGE != null ||
-      row.HEALTH_POPULARITY_PERCENTAGE != null ||
-      row.HEALTH_DEVELOPMENT_PERCENTAGE != null ||
+      row.HEALTH_CONTRIBUTOR_PERCENTAGE != null &&
+      row.HEALTH_POPULARITY_PERCENTAGE != null &&
+      row.HEALTH_DEVELOPMENT_PERCENTAGE != null &&
       row.HEALTH_SECURITY_PERCENTAGE != null
     );
   }

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -15,7 +15,7 @@ import {
   ORG_PROJECTS_SEARCH_PRELOAD_LIMIT,
   VALKEY_CACHE,
 } from '@lfx-one/shared/constants';
-import { classifyHealthScore, normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
+import { normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
 import type {
   HealthScore,
   InfluenceBand,
@@ -50,10 +50,9 @@ export class OrgLensProjectsService {
   private readonly microserviceProxy = new MicroserviceProxyService();
 
   public async getProjects(accountId: string, orgName: string, slugs: string[] | null): Promise<OrgLensProjectsResponse> {
-    // `v3` bump: pre-close-out entries lack the `metricsState` discriminator. The frontend now treats a missing
-    // field as full (rolling-deploy safe), but versioning still drops stale cache entries; the validator below
-    // also rejects any entry missing metricsState so we don't keep serving mixed-shape payloads.
-    const cacheKey = `projects:v3:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
+    // `v4` bump: hasHealthScore/mapHealthScore no longer fall back to the legacy v1 score when the v2 category
+    // is null (LFXV2-3379) — bumping drops cache entries computed under the old fallback logic (e.g. "Fair").
+    const cacheKey = `projects:v4:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
     const key = buildOrgCacheKey(accountId, cacheKey);
     if (key !== null) {
       const cached = await valkeyService.getJson<OrgLensProjectsResponse>(key, OrgLensProjectsService.isProjectsResponse);
@@ -573,14 +572,13 @@ export class OrgLensProjectsService {
     return value === 'up' || value === 'down' || value === 'flat' ? value : 'flat';
   }
 
-  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE_V2'>): boolean {
-    return row.HEALTH_OVERALL_SCORE_V2 != null;
+  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): boolean {
+    return row.HEALTH_OVERALL_SCORE_V2 != null && normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) != null;
   }
 
-  private mapHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): Exclude<HealthScore, 'unavailable'> {
-    // The trailing `?? 0` is an unreachable safety net since callers only invoke this when hasHealthScore()
-    // has confirmed HEALTH_OVERALL_SCORE_V2 is present.
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE_V2 ?? 0);
+  private mapHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_SCORE_CATEGORY_V2'>): Exclude<HealthScore, 'unavailable'> {
+    // Callers only invoke this when hasHealthScore() has confirmed the v2 category resolves to a known value.
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2)!;
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -496,6 +496,12 @@ export class OrgLensProjectsService {
   private mapProject(row: OrgLensProjectRow, peopleRows: OrgLensProjectPersonRow[]): OrgLensProject {
     const people = peopleRows.filter((person) => person.PROJECT_SLUG === row.PROJECT_SLUG);
     const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
+    if (row.HEALTH_SCORE_CATEGORY_V2 && !category) {
+      logger.warning(undefined, 'map_org_project_health', 'Unrecognized warehouse health_score_category_v2; treating as unavailable', {
+        slug: row.PROJECT_SLUG,
+        category: row.HEALTH_SCORE_CATEGORY_V2,
+      });
+    }
     return {
       slug: row.PROJECT_SLUG,
       name: row.PROJECT_NAME,

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -533,7 +533,11 @@ export class OrgLensProjectsService {
       commits1y: 0,
       changeDriver: { label: 'Not calculated yet', direction: 'flat' },
       description: row.DESCRIPTION ?? `${row.PROJECT_NAME} is an open source project in the ${this.mapFoundation(row).name} ecosystem.`,
-      healthMetrics: category && this.hasHealthMetrics(row) ? this.mapHealthMetrics(row) : [],
+      // Independent of `category`/`health`: the warehouse can populate these percentage columns without a
+      // resolvable category, and per-metric "Unavailable" (see hasHealthMetrics) is the correct render for
+      // that case, not suppressing metrics that genuinely have data — same pattern as insights' health
+      // breakdown, where each sub-score renders off its own null-ness, not off the top-level label.
+      healthMetrics: this.hasHealthMetrics(row) ? this.mapHealthMetrics(row) : [],
       // Real org-scoped row (org-dashboard parity): every metric is genuine, including participating
       // projects with activity_count = 0. fetchNoActivityProjects overrides this for its fallback rows.
       metricsState: 'full',

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -17,7 +17,6 @@ import {
 } from '@lfx-one/shared/constants';
 import { normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
 import type {
-  HealthScore,
   InfluenceBand,
   InfluenceTrendDirection,
   OrgLensProject,
@@ -495,14 +494,15 @@ export class OrgLensProjectsService {
 
   private mapProject(row: OrgLensProjectRow, peopleRows: OrgLensProjectPersonRow[]): OrgLensProject {
     const people = peopleRows.filter((person) => person.PROJECT_SLUG === row.PROJECT_SLUG);
-    const hasHealthScore = this.hasHealthScore(row);
+    const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
     return {
       slug: row.PROJECT_SLUG,
       name: row.PROJECT_NAME,
       logoUrl: row.PROJECT_LOGO_URL ?? '',
       foundation: this.mapFoundation(row),
-      health: hasHealthScore ? this.mapHealthScore(row) : 'unavailable',
-      // Sourced straight from the warehouse — never recomputed, per mapHealthScore's v2-category/score precedence.
+      health: category ?? 'unavailable',
+      // Sourced straight from the warehouse — never recomputed; independent of the category fallback removed
+      // by LFXV2-3379.
       healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
       healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
       // These 'silent'/'non-lf' fallbacks are only user-visible for real (activity) rows. For no-activity rows the
@@ -526,7 +526,7 @@ export class OrgLensProjectsService {
       commits1y: 0,
       changeDriver: { label: 'Not calculated yet', direction: 'flat' },
       description: row.DESCRIPTION ?? `${row.PROJECT_NAME} is an open source project in the ${this.mapFoundation(row).name} ecosystem.`,
-      healthMetrics: hasHealthScore ? this.mapHealthMetrics(row) : [],
+      healthMetrics: this.hasHealthMetrics(row) ? this.mapHealthMetrics(row) : [],
       // Real org-scoped row (org-dashboard parity): every metric is genuine, including participating
       // projects with activity_count = 0. fetchNoActivityProjects overrides this for its fallback rows.
       metricsState: 'full',
@@ -572,13 +572,22 @@ export class OrgLensProjectsService {
     return value === 'up' || value === 'down' || value === 'flat' ? value : 'flat';
   }
 
-  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): boolean {
-    return row.HEALTH_OVERALL_SCORE_V2 != null && normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) != null;
+  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_SCORE_CATEGORY_V2'>): boolean {
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) != null;
   }
 
-  private mapHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_SCORE_CATEGORY_V2'>): Exclude<HealthScore, 'unavailable'> {
-    // Callers only invoke this when hasHealthScore() has confirmed the v2 category resolves to a known value.
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2)!;
+  private hasHealthMetrics(
+    row: Pick<
+      OrgLensProjectRow,
+      'HEALTH_CONTRIBUTOR_PERCENTAGE' | 'HEALTH_POPULARITY_PERCENTAGE' | 'HEALTH_DEVELOPMENT_PERCENTAGE' | 'HEALTH_SECURITY_PERCENTAGE'
+    >
+  ): boolean {
+    return (
+      row.HEALTH_CONTRIBUTOR_PERCENTAGE != null ||
+      row.HEALTH_POPULARITY_PERCENTAGE != null ||
+      row.HEALTH_DEVELOPMENT_PERCENTAGE != null ||
+      row.HEALTH_SECURITY_PERCENTAGE != null
+    );
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -64,7 +64,7 @@ export interface OrgLensProjectHero {
   firstCommit: string | null;
   /** Project-level CHAOSS / Insights software-value estimate in USD (not the org's individual return). */
   softwareValueUsd: number | null;
-  /** Overall health tier; null when the warehouse has no health score for the project (hero hides the badge). */
+  /** Overall health tier; null when the warehouse has no health score for the project (hero renders an "Unavailable" tag). */
   health: OrgLensProjectHealth | null;
   /**
    * Warehouse-computed max score for `health` (100 when all 3 CHAOSS categories are covered; 60/65/75 when

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -267,7 +267,6 @@ export interface OrgLensProjectRow {
   TREND_DIRECTION: string | null;
   COMBINED_SCORE_SERIES: unknown;
   DBT_RUN_AT: string | Date | null;
-  HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
   COVERED_CATEGORY_COUNT_V2: number | null;
   HEALTH_MAX_SCORE_V2: number | null;

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -59,8 +59,9 @@ export function buildLensAwareInsightsUrl(
  * `get_health_score_category_v2` macro and the Insights primary project Health Score component
  * (`health-score.vue`): `>= 85` Excellent, `>= 70` Healthy, `>= 50` Fair, `>= 30` Concerning, else
  * Critical. The `unavailable` state (no score) is handled by callers, so this returns only the five
- * scored bands and is the single source both the Org Lens Projects table and the project-detail hero
- * classify through (they must never disagree).
+ * scored bands. LFXV2-3379 removed the Org Lens Projects table's and project-detail hero's calls to
+ * this legacy v1 classifier in favor of the warehouse-computed `health_score_category_v2` (see
+ * `normalizeHealthScoreCategoryV2` below).
  */
 export function classifyHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
   if (score >= 85) {

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -93,8 +93,8 @@ const HEALTH_SCORE_CATEGORIES = new Set<Exclude<HealthScore, 'unavailable'>>(['e
 /**
  * Normalizes the warehouse-computed `health_score_category_v2` column (lf-dbt's `get_health_score_category_v2`
  * macro, e.g. "Excellent"/"Fair"/"Concerning") into the lowercase `HealthScore` band. Returns `null` for
- * unset/unrecognized values so callers can fall back to `classifyHealthScore` on the v1 score for projects
- * the warehouse hasn't backfilled with a v2 category yet.
+ * unset/unrecognized values — callers must treat that as "no score" (`unavailable`), never fall back to
+ * `classifyHealthScore` on the legacy v1 score; the warehouse is the sole source of truth for the label.
  */
 export function normalizeHealthScoreCategoryV2(category: string | null | undefined): Exclude<HealthScore, 'unavailable'> | null {
   if (!category) {


### PR DESCRIPTION
Issue: https://github.com/linuxfoundation/lfx-self-serve/issues/2229

Org Lens' projects table and project-detail hero fell back to the legacy v1 `classifyHealthScore()` bucketing whenever the warehouse's v2 `HEALTH_SCORE_CATEGORY_V2` was null, reintroducing on the Snowflake/BFF side the exact fallback anti-pattern already banned on the Tinybird side. korg (The Linux Kernel Organization) showed a stale "Fair" label instead of the correct no-score state, because its legacy `HEALTH_OVERALL_SCORE_V2` was still non-null even though the v2 category had gone null.

Both services now derive the health label from `normalizeHealthScoreCategoryV2(HEALTH_SCORE_CATEGORY_V2)` only, with no fallback to the v1 score. `healthMetrics`/`metricsState` are gated on the four warehouse percentage columns independently of the category, so they don't disappear just because the label happens to be null, and don't fabricate 0% for a dimension the warehouse hasn't measured. Response cache keys were bumped to drop rows computed under the old fallback logic.

**This branch also fixes a regression independently reintroduced by IN-1262** (merged to `main` as `fc7dc2544` while this ticket was in flight). That PR's `mapHealthScore()` fell back to `classifyHealthScore(row.HEALTH_OVERALL_SCORE_V2 ?? 0)` whenever the v2 category was null — the same anti-pattern this ticket removes. Rebasing onto the merged `main` surfaced the conflict and confirmed it; this branch's fix wins, and IN-1262's new `healthMaxScore`/`healthCoveredCategoryCount` fields (used for the partial-Health-Score UI treatment) are preserved unchanged.

## Commits

- `stop falling back to legacy v1 health score` — the projects-table fix
- `fix legacy v1 health fallback in detail hero too` — same fix in the sibling detail-hero service
- `stop fabricating health data on round-2 review findings` — AND-gate the four warehouse percentage columns instead of OR
- `drop dead HEALTH_OVERALL_SCORE_V2 field` — remove the now-unused column from the shared row interface
- `log unrecognized v2 health category` — WARN log when a non-null category fails to parse, so that case stays distinguishable from "not yet backfilled"

## Test plan

- `yarn workspace lfx-one-ui test:server` — 104 files / 2744 tests pass, including cases for: v2 category present, v2 category null, v2 category unrecognized (WARN logged), metrics present/partial/absent independent of the category.
- `yarn build` and `yarn lint:check` clean.
- No Tinybird or `insights` repo changes — Tinybird's health-label pipeline was already correct; this fix is isolated to lfx-self-serve's Snowflake/BFF mapping layer.

[LFXV2-3379]: https://linuxfoundation.atlassian.net/browse/LFXV2-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ