### PR TITLE
fix(guards): report feature-flag readiness timeouts to rum

### DIFF
--- a/apps/lfx-one/src/app/shared/guards/akrites-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/akrites-enabled.guard.ts
@@ -3,10 +3,8 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { CanMatchFn, Router } from '@angular/router';
 import { AKRITES_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
@@ -24,14 +22,9 @@ export const akritesEnabledGuard: CanMatchFn = async () => {
   const router = inject(Router);
 
   if (!featureFlagService.providerReady()) {
-    const ready = await firstValueFrom(
-      toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      )
-    );
-    // Provider never became ready (no client id / LD unreachable) → fail closed.
+    const ready = await featureFlagService.waitForReady({ guard: 'akritesEnabledGuard', flag: AKRITES_ENABLED_FLAG });
+    // Provider never became ready (no client id / LD unreachable) → fail closed. waitForReady()
+    // reports the timeout to RUM.
     if (!ready) {
       return router.parseUrl('/');
     }

--- a/apps/lfx-one/src/app/shared/guards/campaign-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/campaign-access.guard.ts
@@ -3,10 +3,9 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { MARKETING_OPS_FGA_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, map, of, switchMap, timeout } from 'rxjs';
+import { from, map, of, switchMap } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 import { PersonaService } from '../services/persona.service';
@@ -76,11 +75,7 @@ export const campaignAccessGuard: CanActivateFn = (route: ActivatedRouteSnapshot
 
   const providerReady$ = featureFlagService.providerReady()
     ? of(true)
-    : toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      );
+    : from(featureFlagService.waitForReady({ guard: 'campaignAccessGuard', flag: MARKETING_OPS_FGA_ENABLED_FLAG }));
 
   return providerReady$.pipe(
     switchMap((ready) => {

--- a/apps/lfx-one/src/app/shared/guards/marketing-impact-access.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/marketing-impact-access.guard.ts
@@ -3,10 +3,9 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { MARKETING_OPS_FGA_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, map, Observable, of, switchMap, timeout } from 'rxjs';
+import { from, map, Observable, of, switchMap } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 import { PersonaService } from '../services/persona.service';
@@ -84,11 +83,7 @@ export const marketingImpactAccessGuard: CanActivateFn = (route: ActivatedRouteS
 
   const providerReady$: Observable<boolean> = featureFlagService.providerReady()
     ? of(true)
-    : toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      );
+    : from(featureFlagService.waitForReady({ guard: 'marketingImpactAccessGuard', flag: MARKETING_OPS_FGA_ENABLED_FLAG }));
 
   return providerReady$.pipe(
     map((ready) => ready && featureFlagService.getBooleanFlag(MARKETING_OPS_FGA_ENABLED_FLAG, false)()),

--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.spec.ts
@@ -13,6 +13,7 @@ describe('mktgOsAgentsEnabledGuard', () => {
   let getFlagOverride: ReturnType<typeof vi.fn>;
   let providerReady: ReturnType<typeof signal<boolean>>;
   let getBooleanFlag: ReturnType<typeof vi.fn>;
+  let waitForReady: ReturnType<typeof vi.fn>;
   let getCurrentNavigation: ReturnType<typeof vi.fn>;
   let router: {
     url: string;
@@ -41,6 +42,16 @@ describe('mktgOsAgentsEnabledGuard', () => {
     getFlagOverride = vi.fn().mockReturnValue(undefined);
     providerReady = signal(true);
     getBooleanFlag = vi.fn().mockReturnValue(signal(false));
+    waitForReady = vi.fn().mockImplementation(
+      (_context: unknown, timeoutMs = 5000) =>
+        new Promise((resolve) => {
+          if (providerReady()) {
+            resolve(true);
+            return;
+          }
+          setTimeout(() => resolve(false), timeoutMs);
+        })
+    );
     getCurrentNavigation = vi.fn().mockReturnValue(null);
 
     router = {
@@ -54,7 +65,7 @@ describe('mktgOsAgentsEnabledGuard', () => {
       providers: [
         {
           provide: FeatureFlagService,
-          useValue: { getFlagOverride, providerReady: providerReady.asReadonly(), getBooleanFlag },
+          useValue: { getFlagOverride, providerReady: providerReady.asReadonly(), getBooleanFlag, waitForReady },
         },
         { provide: Router, useValue: router },
         { provide: PLATFORM_ID, useValue: 'browser' },

--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
@@ -3,10 +3,8 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { CanMatchFn, Route, Router, UrlTree } from '@angular/router';
 import { MKTG_OS_AGENTS_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
@@ -54,16 +52,10 @@ export const mktgOsAgentsEnabledGuard: CanMatchFn = async (route) => {
   }
 
   if (!featureFlagService.providerReady()) {
-    const ready = await firstValueFrom(
-      toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      )
-    );
+    const ready = await featureFlagService.waitForReady({ guard: 'mktgOsAgentsEnabledGuard', flag: MKTG_OS_AGENTS_ENABLED_FLAG });
     // Provider never became ready in time (LD slow / unreachable) → fail CLOSED. This is a
     // dark launch, so failing open would show the marketplace to anyone whenever LaunchDarkly
-    // is slow.
+    // is slow. waitForReady() reports the timeout to RUM.
     if (!ready) {
       return deniedOverview(router, route);
     }

--- a/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
@@ -3,10 +3,8 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { CanMatchFn, Router } from '@angular/router';
 import { MY_CLAS_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
@@ -30,18 +28,12 @@ export const myClasEnabledGuard: CanMatchFn = async () => {
   const router = inject(Router);
 
   if (!featureFlagService.providerReady()) {
-    const ready = await firstValueFrom(
-      toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      )
-    );
+    const ready = await featureFlagService.waitForReady({ guard: 'myClasEnabledGuard', flag: MY_CLAS_ENABLED_FLAG });
     // Provider never became ready in time (LD slow / unreachable) → fail open so users
     // aren't silently redirected away from a route the flag is enabled for in production.
-    // Log so the team can monitor frequency and detect drift if the flag scope ever narrows.
+    // waitForReady() reports the timeout to RUM so the team can monitor frequency and detect
+    // drift if the flag scope ever narrows.
     if (!ready) {
-      console.warn('myClasEnabledGuard: LD provider not ready after 5 s — failing open');
       return true;
     }
   }

--- a/apps/lfx-one/src/app/shared/guards/org-lens-cla-m3-enabled.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-cla-m3-enabled.guard.spec.ts
@@ -13,6 +13,7 @@ describe('orgLensClaM3EnabledGuard', () => {
   let getFlagOverride: ReturnType<typeof vi.fn>;
   let providerReady: ReturnType<typeof signal<boolean>>;
   let getBooleanFlag: ReturnType<typeof vi.fn>;
+  let waitForReady: ReturnType<typeof vi.fn>;
   let router: {
     parseUrl: ReturnType<typeof vi.fn>;
   };
@@ -26,6 +27,16 @@ describe('orgLensClaM3EnabledGuard', () => {
     getFlagOverride = vi.fn().mockReturnValue(undefined);
     providerReady = signal(true);
     getBooleanFlag = vi.fn().mockReturnValue(signal(false));
+    waitForReady = vi.fn().mockImplementation(
+      (_context: unknown, timeoutMs = 5000) =>
+        new Promise((resolve) => {
+          if (providerReady()) {
+            resolve(true);
+            return;
+          }
+          setTimeout(() => resolve(false), timeoutMs);
+        })
+    );
 
     router = {
       parseUrl: vi.fn().mockImplementation((url: string) => ({ redirected: url })),
@@ -35,7 +46,7 @@ describe('orgLensClaM3EnabledGuard', () => {
       providers: [
         {
           provide: FeatureFlagService,
-          useValue: { getFlagOverride, providerReady: providerReady.asReadonly(), getBooleanFlag },
+          useValue: { getFlagOverride, providerReady: providerReady.asReadonly(), getBooleanFlag, waitForReady },
         },
         { provide: Router, useValue: router },
         { provide: PLATFORM_ID, useValue: 'browser' },

--- a/apps/lfx-one/src/app/shared/guards/org-lens-cla-m3-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-cla-m3-enabled.guard.ts
@@ -3,10 +3,8 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { CanMatchFn, Router } from '@angular/router';
 import { ORG_LENS_CLA_M3_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
@@ -30,18 +28,13 @@ export const orgLensClaM3EnabledGuard: CanMatchFn = async () => {
   }
 
   if (!featureFlagService.providerReady()) {
-    const ready = await firstValueFrom(
-      toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      )
-    );
+    const ready = await featureFlagService.waitForReady({ guard: 'orgLensClaM3EnabledGuard', flag: ORG_LENS_CLA_M3_ENABLED_FLAG });
     // Provider never became ready in time (LD slow / unreachable) → fail CLOSED, deliberately
     // unlike `myClasEnabledGuard`, which fails open. That guard's flag is enabled for all
     // production users, so allowing the route grants access they already have; this one is a dark
     // launch, so the same behaviour would show an unfinished page to any Org Lens viewer whenever
-    // LaunchDarkly is slow — turning an outage into a release.
+    // LaunchDarkly is slow — turning an outage into a release. waitForReady() reports the timeout
+    // to RUM.
     if (!ready) {
       return router.parseUrl('/org/overview');
     }

--- a/apps/lfx-one/src/app/shared/guards/org-lens-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-enabled.guard.ts
@@ -3,10 +3,8 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { CanMatchFn, Router } from '@angular/router';
 import { ORG_LENS_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
@@ -24,14 +22,9 @@ export const orgLensEnabledGuard: CanMatchFn = async () => {
   const router = inject(Router);
 
   if (!featureFlagService.providerReady()) {
-    const ready = await firstValueFrom(
-      toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      )
-    );
-    // Provider never became ready (no client id / LD unreachable) → fail closed.
+    const ready = await featureFlagService.waitForReady({ guard: 'orgLensEnabledGuard', flag: ORG_LENS_ENABLED_FLAG });
+    // Provider never became ready (no client id / LD unreachable) → fail closed. waitForReady()
+    // reports the timeout to RUM.
     if (!ready) {
       return router.parseUrl('/');
     }

--- a/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
@@ -3,10 +3,8 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { inject, PLATFORM_ID } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { CanMatchFn, Router } from '@angular/router';
 import { ORG_LENS_ROI_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
@@ -30,18 +28,13 @@ export const orgLensRoiEnabledGuard: CanMatchFn = async () => {
   }
 
   if (!featureFlagService.providerReady()) {
-    const ready = await firstValueFrom(
-      toObservable(featureFlagService.providerReady).pipe(
-        filter((isReady): isReady is true => isReady === true),
-        timeout(5000),
-        catchError(() => of(false))
-      )
-    );
+    const ready = await featureFlagService.waitForReady({ guard: 'orgLensRoiEnabledGuard', flag: ORG_LENS_ROI_ENABLED_FLAG });
     // Provider never became ready in time (LD slow / unreachable) → fail CLOSED, deliberately
     // unlike `myClasEnabledGuard`, which fails open. That guard's flag is enabled for all
     // production users, so allowing the route grants access they already have; this one is a dark
     // launch, so the same behaviour would show an unfinished page to any Org Lens viewer whenever
-    // LaunchDarkly is slow — turning an outage into a release.
+    // LaunchDarkly is slow — turning an outage into a release. waitForReady() reports the timeout
+    // to RUM.
     //
     // Revisit at GA: once the flag is on for everyone, failing open becomes the better trade and
     // this should match its sibling.

--- a/apps/lfx-one/src/app/shared/providers/feature-flag.provider.ts
+++ b/apps/lfx-one/src/app/shared/providers/feature-flag.provider.ts
@@ -7,6 +7,7 @@ import { LaunchDarklyClientProvider } from '@openfeature/launchdarkly-client-pro
 import { OpenFeature } from '@openfeature/web-sdk';
 import { basicLogger } from 'launchdarkly-js-client-sdk';
 
+import { DataDogRumService } from '../services/datadog-rum.service';
 import { getRuntimeConfig } from './runtime-config.provider';
 
 /**
@@ -19,6 +20,9 @@ async function initializeOpenFeature(): Promise<void> {
     return;
   }
 
+  // Injected before the first `await` — inject() needs the active injection context, which this
+  // app-initializer callback only holds synchronously.
+  const dataDogRumService = inject(DataDogRumService);
   const transferState = inject(TransferState);
   const runtimeConfig = getRuntimeConfig(transferState);
   const clientId = runtimeConfig.launchDarklyClientId;
@@ -39,7 +43,10 @@ async function initializeOpenFeature(): Promise<void> {
     await OpenFeature.setProviderAndWait(provider);
   } catch (error) {
     console.error('Failed to initialize OpenFeature with LaunchDarkly:', error);
-    // App continues without feature flags
+    // App continues without feature flags — but the provider never reaches READY, so every
+    // flag-gated guard will independently wait out its own timeout later (GH-1351). Report here
+    // too so the bootstrap failure itself is visible, not just each guard's downstream timeout.
+    dataDogRumService.addError(error instanceof Error ? error : new Error(String(error)), { source: 'initializeOpenFeature' });
   }
 }
 

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.spec.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DataDogRumService } from './datadog-rum.service';
+import { FeatureFlagService } from './feature-flag.service';
+
+/**
+ * Covers waitForReady() — the shared wait every flag-gated CanMatch guard uses to survive a
+ * provider that's still initializing. Must be called synchronously from an injection context
+ * (see the method's JSDoc), so each test runs it via TestBed.runInInjectionContext().
+ */
+describe('FeatureFlagService', () => {
+  let service: FeatureFlagService;
+  let addError: ReturnType<typeof vi.fn>;
+
+  const context = { guard: 'testGuard', flag: 'test-flag' };
+
+  beforeEach(() => {
+    addError = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: DataDogRumService, useValue: { addError } }],
+    });
+
+    service = TestBed.inject(FeatureFlagService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves true immediately without reporting when the provider is already ready', async () => {
+    (service as unknown as { isProviderReady: { set: (value: boolean) => void } }).isProviderReady.set(true);
+
+    const result = await TestBed.runInInjectionContext(() => service.waitForReady(context, 5000));
+
+    expect(result).toBe(true);
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('resolves true if the provider becomes ready before the timeout, without reporting', async () => {
+    vi.useFakeTimers();
+    const isProviderReady = (service as unknown as { isProviderReady: { set: (value: boolean) => void } }).isProviderReady;
+
+    const pending = TestBed.runInInjectionContext(() => service.waitForReady(context, 5000));
+    isProviderReady.set(true);
+    TestBed.tick();
+    const result = await pending;
+
+    expect(result).toBe(true);
+    expect(addError).not.toHaveBeenCalled();
+  });
+
+  it('resolves false and reports to RUM exactly once when the provider never becomes ready before the timeout', async () => {
+    vi.useFakeTimers();
+
+    const pending = TestBed.runInInjectionContext(() => service.waitForReady(context, 5000));
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await pending;
+
+    expect(result).toBe(false);
+    expect(addError).toHaveBeenCalledTimes(1);
+    expect(addError).toHaveBeenCalledWith(expect.any(Error), context);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.spec.ts
@@ -8,9 +8,11 @@ import { DataDogRumService } from './datadog-rum.service';
 import { FeatureFlagService } from './feature-flag.service';
 
 /**
- * Covers waitForReady() — the shared wait every flag-gated CanMatch guard uses to survive a
- * provider that's still initializing. Must be called synchronously from an injection context
- * (see the method's JSDoc), so each test runs it via TestBed.runInInjectionContext().
+ * Covers waitForReady() — the shared wait every flag-gated guard uses to survive a provider
+ * that's still initializing, including both `CanMatch` guards (e.g. `mktgOsAgentsEnabledGuard`)
+ * and the two `CanActivateFn` guards (`campaignAccessGuard`, `marketingImpactAccessGuard`).
+ * `providerReady$` is built once as a service field at construction time, so `waitForReady()`
+ * itself has no injection-context requirement and can be awaited from any async context.
  */
 describe('FeatureFlagService', () => {
   let service: FeatureFlagService;
@@ -35,7 +37,7 @@ describe('FeatureFlagService', () => {
   it('resolves true immediately without reporting when the provider is already ready', async () => {
     (service as unknown as { isProviderReady: { set: (value: boolean) => void } }).isProviderReady.set(true);
 
-    const result = await TestBed.runInInjectionContext(() => service.waitForReady(context, 5000));
+    const result = await service.waitForReady(context, 5000);
 
     expect(result).toBe(true);
     expect(addError).not.toHaveBeenCalled();
@@ -45,7 +47,7 @@ describe('FeatureFlagService', () => {
     vi.useFakeTimers();
     const isProviderReady = (service as unknown as { isProviderReady: { set: (value: boolean) => void } }).isProviderReady;
 
-    const pending = TestBed.runInInjectionContext(() => service.waitForReady(context, 5000));
+    const pending = service.waitForReady(context, 5000);
     isProviderReady.set(true);
     TestBed.tick();
     const result = await pending;
@@ -57,7 +59,7 @@ describe('FeatureFlagService', () => {
   it('resolves false and reports to RUM exactly once when the provider never becomes ready before the timeout', async () => {
     vi.useFakeTimers();
 
-    const pending = TestBed.runInInjectionContext(() => service.waitForReady(context, 5000));
+    const pending = service.waitForReady(context, 5000);
     await vi.advanceTimersByTimeAsync(5000);
     const result = await pending;
 

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
@@ -1,10 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { computed, Injectable, Signal, signal } from '@angular/core';
+import { computed, inject, Injectable, Signal, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { environment } from '@environments/environment';
 import { FEATURE_FLAG_OVERRIDE_STORAGE_KEY, User } from '@lfx-one/shared';
 import { Client, EvaluationContext, JsonValue, OpenFeature, ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
+import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
+
+import { DataDogRumService } from './datadog-rum.service';
 
 /**
  * A locally-forced value for one flag, or `undefined` when none is set.
@@ -37,6 +41,8 @@ function readFlagOverride(key: string): boolean | undefined {
   providedIn: 'root',
 })
 export class FeatureFlagService {
+  private readonly dataDogRumService = inject(DataDogRumService);
+
   private client: Client | null = null;
   private readonly isInitialized = signal<boolean>(false);
   private readonly isProviderReady = signal<boolean>(false);
@@ -84,6 +90,36 @@ export class FeatureFlagService {
       console.error('Failed to initialize feature flag service:', error);
       this.isInitialized.set(false);
     }
+  }
+
+  /**
+   * Wait for the provider to reach READY, up to `timeoutMs`.
+   *
+   * Every flag-gated `CanMatch` guard needs this exact wait — the provider can still be
+   * initializing (or stuck, if LaunchDarkly was slow/unreachable during app bootstrap) when a
+   * user navigates. Centralized here so the timeout's fail path is instrumented exactly once,
+   * rather than duplicated per guard — a guard that resolves this way is otherwise a silent
+   * redirect with no way to tell it happened after the fact (see GH-1351); LD's own logger is
+   * disabled in production and a `console.*` call isn't forwarded to RUM.
+   */
+  public async waitForReady(context: { guard: string; flag: string }, timeoutMs = 5000): Promise<boolean> {
+    if (this.isProviderReady()) {
+      return true;
+    }
+
+    const ready = await firstValueFrom(
+      toObservable(this.isProviderReady).pipe(
+        filter((isReady): isReady is true => isReady === true),
+        timeout(timeoutMs),
+        catchError(() => of(false))
+      )
+    );
+
+    if (!ready) {
+      this.dataDogRumService.addError(new Error('Feature flag provider not ready before guard timeout'), context);
+    }
+
+    return ready;
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
@@ -49,6 +49,13 @@ export class FeatureFlagService {
   private readonly isProviderReady = signal<boolean>(false);
   private readonly context = signal<EvaluationContext | null>(null);
 
+  /**
+   * Built once as a field (not per-call) so `waitForReady()` can be awaited from anywhere —
+   * `toObservable()` only needs the injection context at construction time, and a service field
+   * initializer already runs inside one.
+   */
+  private readonly providerReady$ = toObservable(this.isProviderReady);
+
   // Public readonly signals
   public readonly initialized = this.isInitialized.asReadonly();
 
@@ -96,18 +103,18 @@ export class FeatureFlagService {
   /**
    * Wait for the provider to reach READY, up to `timeoutMs`.
    *
-   * Every flag-gated `CanMatch` guard needs this exact wait — the provider can still be
-   * initializing (or stuck, if LaunchDarkly was slow/unreachable during app bootstrap) when a
-   * user navigates. Centralized here so the timeout's fail path is instrumented exactly once,
-   * rather than duplicated per guard — a guard that resolves this way is otherwise a silent
-   * redirect with no way to tell it happened after the fact (see GH-1351); LD's own logger is
-   * disabled in production and a `console.*` call isn't forwarded to RUM.
+   * Every flag-gated route guard needs this exact wait — the provider can still be initializing
+   * (or stuck, if LaunchDarkly was slow/unreachable during app bootstrap) when a user navigates.
+   * Centralized here so the timeout's fail path is instrumented exactly once, rather than
+   * duplicated per guard — a guard that resolves this way is otherwise a silent redirect with no
+   * way to tell it happened after the fact (see GH-1351); LD's own logger is disabled in
+   * production and a `console.*` call isn't forwarded to RUM.
    *
-   * **Must be called synchronously from an active injection context** (e.g. directly inside a
-   * `CanMatchFn`, before any `await`). It internally builds an observable via `toObservable()`,
-   * which calls `inject()` — that only works while the injection context from the guard's own
-   * invocation is still open. Awaiting anything in the caller first closes that context and this
-   * call throws.
+   * Safe to call from any async context — `providerReady$` is built once as a field, so this no
+   * longer needs the injection context that building it per-call would have required.
+   *
+   * Reports once per call, not deduped across calls — intentional: per-navigation frequency is
+   * the signal (a sustained outage should show as sustained RUM volume, not a single flat line).
    */
   public async waitForReady(context: FeatureFlagGuardContext, timeoutMs = 5000): Promise<boolean> {
     if (this.isProviderReady()) {
@@ -115,7 +122,7 @@ export class FeatureFlagService {
     }
 
     const ready = await firstValueFrom(
-      toObservable(this.isProviderReady).pipe(
+      this.providerReady$.pipe(
         filter((isReady): isReady is true => isReady === true),
         timeout(timeoutMs),
         catchError(() => of(false))

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
@@ -5,6 +5,7 @@ import { computed, inject, Injectable, Signal, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { environment } from '@environments/environment';
 import { FEATURE_FLAG_OVERRIDE_STORAGE_KEY, User } from '@lfx-one/shared';
+import { FeatureFlagGuardContext } from '@lfx-one/shared/interfaces';
 import { Client, EvaluationContext, JsonValue, OpenFeature, ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
 import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
@@ -101,8 +102,14 @@ export class FeatureFlagService {
    * rather than duplicated per guard — a guard that resolves this way is otherwise a silent
    * redirect with no way to tell it happened after the fact (see GH-1351); LD's own logger is
    * disabled in production and a `console.*` call isn't forwarded to RUM.
+   *
+   * **Must be called synchronously from an active injection context** (e.g. directly inside a
+   * `CanMatchFn`, before any `await`). It internally builds an observable via `toObservable()`,
+   * which calls `inject()` — that only works while the injection context from the guard's own
+   * invocation is still open. Awaiting anything in the caller first closes that context and this
+   * call throws.
    */
-  public async waitForReady(context: { guard: string; flag: string }, timeoutMs = 5000): Promise<boolean> {
+  public async waitForReady(context: FeatureFlagGuardContext, timeoutMs = 5000): Promise<boolean> {
     if (this.isProviderReady()) {
       return true;
     }

--- a/docs/architecture/frontend/feature-flags.md
+++ b/docs/architecture/frontend/feature-flags.md
@@ -184,15 +184,24 @@ export class FeatureFlagService {
   }
 
   /**
+   * Built once as a field (not per-call) so `waitForReady()` can be awaited from anywhere —
+   * `toObservable()` only needs the injection context at construction time, and a service field
+   * initializer already runs inside one.
+   */
+  private readonly providerReady$ = toObservable(this.isProviderReady);
+
+  /**
    * Wait for the provider to reach READY, up to `timeoutMs` (default 5000). Every flag-gated
-   * `CanMatch` guard uses this so the provider being slow to initialize (or stuck, if
-   * LaunchDarkly was unreachable during bootstrap) doesn't produce a silent, unexplained redirect
-   * when a user navigates — the timeout path is reported to Datadog RUM exactly once here rather
-   * than duplicated per guard (see GH-1351).
+   * route guard uses this so the provider being slow to initialize (or stuck, if LaunchDarkly
+   * was unreachable during bootstrap) doesn't produce a silent, unexplained redirect when a user
+   * navigates — the timeout path is reported to Datadog RUM exactly once here rather than
+   * duplicated per guard (see GH-1351).
    *
-   * Must be called synchronously from an active injection context (e.g. directly inside a
-   * `CanMatchFn`, before any `await`) — it builds an observable via `toObservable()`, which needs
-   * the caller's own still-open injection context.
+   * Safe to call from any async context — `providerReady$` is built once as a field, so this no
+   * longer needs the injection context that building it per-call would have required.
+   *
+   * Reports once per call, not deduped across calls — intentional: per-navigation frequency is
+   * the signal (a sustained outage should show as sustained RUM volume, not a single flat line).
    */
   public async waitForReady(context: FeatureFlagGuardContext, timeoutMs = 5000): Promise<boolean> {
     if (this.isProviderReady()) {
@@ -200,7 +209,7 @@ export class FeatureFlagService {
     }
 
     const ready = await firstValueFrom(
-      toObservable(this.isProviderReady).pipe(
+      this.providerReady$.pipe(
         filter((isReady): isReady is true => isReady === true),
         timeout(timeoutMs),
         catchError(() => of(false))
@@ -223,7 +232,7 @@ export class FeatureFlagService {
 - **Public Readonly Signals**: Exposed signals use `asReadonly()` to prevent external mutation
 - **Lazy Initialization**: Service doesn't initialize in constructor; waits for explicit `initialize()` call
 - **Idempotent**: Multiple `initialize()` calls are safe (checks `isInitialized()` first)
-- **Instrumented readiness wait**: `waitForReady()` centralizes the guard-facing timeout so every flag-gated route reports the same way to RUM on failure, instead of each guard duplicating its own wait/timeout/log logic
+- **Instrumented readiness wait**: `waitForReady()` centralizes the guard-facing timeout so every flag-gated route — both `CanMatch` guards and the two `CanActivateFn` guards (`campaignAccessGuard`, `marketingImpactAccessGuard`) — reports the same way to RUM on failure, instead of each guard duplicating its own wait/timeout/log logic
 
 ### Provider Setup
 

--- a/docs/architecture/frontend/feature-flags.md
+++ b/docs/architecture/frontend/feature-flags.md
@@ -133,18 +133,24 @@ The `FeatureFlagService` is located at `src/app/shared/services/feature-flag.ser
   providedIn: 'root',
 })
 export class FeatureFlagService {
+  private readonly dataDogRumService = inject(DataDogRumService);
+
   private client: Client | null = null;
   private readonly isInitialized = signal<boolean>(false);
+  private readonly isProviderReady = signal<boolean>(false);
   private readonly context = signal<EvaluationContext | null>(null);
 
   // Public readonly signals
   public readonly initialized = this.isInitialized.asReadonly();
 
+  /** True once the OpenFeature provider reaches READY (real flag values streamed); distinct from `initialized` (user context applied). */
+  public readonly providerReady = this.isProviderReady.asReadonly();
+
   /**
    * Initialize OpenFeature client with user context
    * Call this method from app.component when user is authenticated
    */
-  public async initialize(user: any): Promise<void> {
+  public async initialize(user: User): Promise<void> {
     if (this.isInitialized()) {
       return;
     }
@@ -162,11 +168,50 @@ export class FeatureFlagService {
       this.context.set(userContext);
       this.isInitialized.set(true);
 
+      // Register handlers BEFORE seeding from the current status so a READY transition that
+      // lands in the gap can't be missed — the Ready handler covers the slower streaming case,
+      // and the status seed below covers the already-READY case (the app initializer awaits
+      // setProviderAndWait before bootstrap).
       this.setupEventHandlers();
+
+      if (this.client.providerStatus === ProviderStatus.READY) {
+        this.isProviderReady.set(true);
+      }
     } catch (error) {
       console.error('Failed to initialize feature flag service:', error);
       this.isInitialized.set(false);
     }
+  }
+
+  /**
+   * Wait for the provider to reach READY, up to `timeoutMs` (default 5000). Every flag-gated
+   * `CanMatch` guard uses this so the provider being slow to initialize (or stuck, if
+   * LaunchDarkly was unreachable during bootstrap) doesn't produce a silent, unexplained redirect
+   * when a user navigates — the timeout path is reported to Datadog RUM exactly once here rather
+   * than duplicated per guard (see GH-1351).
+   *
+   * Must be called synchronously from an active injection context (e.g. directly inside a
+   * `CanMatchFn`, before any `await`) — it builds an observable via `toObservable()`, which needs
+   * the caller's own still-open injection context.
+   */
+  public async waitForReady(context: FeatureFlagGuardContext, timeoutMs = 5000): Promise<boolean> {
+    if (this.isProviderReady()) {
+      return true;
+    }
+
+    const ready = await firstValueFrom(
+      toObservable(this.isProviderReady).pipe(
+        filter((isReady): isReady is true => isReady === true),
+        timeout(timeoutMs),
+        catchError(() => of(false))
+      )
+    );
+
+    if (!ready) {
+      this.dataDogRumService.addError(new Error('Feature flag provider not ready before guard timeout'), context);
+    }
+
+    return ready;
   }
 }
 ```
@@ -174,10 +219,11 @@ export class FeatureFlagService {
 **Key Design Decisions:**
 
 - **Singleton Service**: `providedIn: 'root'` ensures single instance across application
-- **Private State**: `client`, `isInitialized`, and `context` are private for encapsulation
+- **Private State**: `client`, `isInitialized`, `isProviderReady`, and `context` are private for encapsulation
 - **Public Readonly Signals**: Exposed signals use `asReadonly()` to prevent external mutation
 - **Lazy Initialization**: Service doesn't initialize in constructor; waits for explicit `initialize()` call
 - **Idempotent**: Multiple `initialize()` calls are safe (checks `isInitialized()` first)
+- **Instrumented readiness wait**: `waitForReady()` centralizes the guard-facing timeout so every flag-gated route reports the same way to RUM on failure, instead of each guard duplicating its own wait/timeout/log logic
 
 ### Provider Setup
 
@@ -228,6 +274,7 @@ import { LaunchDarklyClientProvider } from '@openfeature/launchdarkly-client-pro
 import { OpenFeature } from '@openfeature/web-sdk';
 import { basicLogger } from 'launchdarkly-js-client-sdk';
 
+import { DataDogRumService } from '../services/datadog-rum.service';
 import { getRuntimeConfig } from './runtime-config.provider';
 
 async function initializeOpenFeature(): Promise<void> {
@@ -236,6 +283,9 @@ async function initializeOpenFeature(): Promise<void> {
     return;
   }
 
+  // Injected before the first `await` — inject() needs the active injection context, which this
+  // app-initializer callback only holds synchronously.
+  const dataDogRumService = inject(DataDogRumService);
   const transferState = inject(TransferState);
   const runtimeConfig = getRuntimeConfig(transferState);
   const clientId = runtimeConfig.launchDarklyClientId;
@@ -256,7 +306,10 @@ async function initializeOpenFeature(): Promise<void> {
     await OpenFeature.setProviderAndWait(provider);
   } catch (error) {
     console.error('Failed to initialize OpenFeature with LaunchDarkly:', error);
-    // App continues without feature flags
+    // App continues without feature flags — but the provider never reaches READY, so every
+    // flag-gated guard will independently wait out its own timeout later (GH-1351). Report here
+    // too so the bootstrap failure itself is visible, not just each guard's downstream timeout.
+    dataDogRumService.addError(error instanceof Error ? error : new Error(String(error)), { source: 'initializeOpenFeature' });
   }
 }
 
@@ -1114,13 +1167,14 @@ logger: basicLogger({ level: 'none' });
 
 **Error Types:**
 
-| Severity | Message                                     | When                          |
-| -------- | ------------------------------------------- | ----------------------------- |
-| WARN     | "LaunchDarkly client ID not configured"     | Missing environment variable  |
-| ERROR    | "Failed to initialize OpenFeature"          | Provider initialization fails |
-| ERROR    | "Failed to initialize feature flag service" | User context setup fails      |
-| ERROR    | "Error evaluating [type] flag '[key]'"      | Individual flag error         |
-| ERROR    | "Feature flag provider error"               | Provider runtime error        |
+| Severity    | Message                                                | When                                                                                                                                                                                                              |
+| ----------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| WARN        | "LaunchDarkly client ID not configured"                | Missing environment variable                                                                                                                                                                                      |
+| ERROR + RUM | "Failed to initialize OpenFeature with LaunchDarkly"   | Provider initialization fails — also reported via `dataDogRumService.addError()` with `{ source: 'initializeOpenFeature' }`, so the bootstrap failure itself is visible, not just each guard's downstream timeout |
+| ERROR       | "Failed to initialize feature flag service"            | User context setup fails                                                                                                                                                                                          |
+| ERROR       | "Error evaluating [type] flag '[key]'"                 | Individual flag error                                                                                                                                                                                             |
+| ERROR       | "Feature flag provider error"                          | Provider runtime error                                                                                                                                                                                            |
+| RUM only    | "Feature flag provider not ready before guard timeout" | `waitForReady()` times out before the provider reaches READY (GH-1351) — reported via `dataDogRumService.addError()` with `{ guard, flag }` context, not logged to console                                        |
 
 ## 🎨 Real-World Examples
 

--- a/packages/shared/src/interfaces/feature-flag.interface.ts
+++ b/packages/shared/src/interfaces/feature-flag.interface.ts
@@ -1,0 +1,8 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Identifies the guard and flag waiting on provider readiness, for the RUM error reported on timeout. */
+export interface FeatureFlagGuardContext extends Record<string, unknown> {
+  guard: string;
+  flag: string;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -339,3 +339,6 @@ export * from './user-preference.interface';
 
 // Individual Dashboard → LFX migration banner (LFXV2-3336)
 export * from './id-migration.interface';
+
+// Feature flag guard readiness context (GH-1351)
+export * from './feature-flag.interface';


### PR DESCRIPTION
## Summary

Fixes silent and user-visible redirects from the "My CLA" tab (and other flag-gated routes) that occur when the OpenFeature/LaunchDarkly provider is slow or fails to reach `READY` before a `CanMatch` guard runs. Previously these redirects had no observability — they looked like random, unreproducible navigation bugs.

- Adds `FeatureFlagService.waitForReady()` — a shared, centralized wait (default 5s timeout) that every flag-gated `CanMatch` guard now uses instead of duplicating its own wait/timeout logic. On timeout, it reports to Datadog RUM exactly once via `addError()`, with `{ guard, flag }` context, so a timeout-driven redirect is now traceable after the fact instead of silent.
- Each of the 6 flag-gated guards (`akrites-enabled`, `mktg-os-agents-enabled`, `my-clas-enabled`, `org-lens-cla-m3-enabled`, `org-lens-enabled`, `org-lens-roi-enabled`) now calls `waitForReady()` on the browser side when the provider isn't ready yet. Each guard keeps its own deliberate fail-open vs. fail-closed behavior on timeout (documented inline per guard) — this PR does not change any guard's pass/fail decision, only adds instrumentation around the existing wait.
- `feature-flag.provider.ts`'s `initializeOpenFeature()` app-initializer now also reports to RUM (`source: 'initializeOpenFeature'`) when the LaunchDarkly provider itself fails to initialize — this is a separate, earlier failure mode than a guard-level timeout, so both are now independently visible in RUM.
- New shared interface `FeatureFlagGuardContext` in `@lfx-one/shared/interfaces` for the RUM context shape.
- Updated `docs/architecture/frontend/feature-flags.md` to document the new `waitForReady()` pattern and error/RUM reporting table.

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn lint` clean (no new warnings)
- [x] Unit tests: 21/21 passing across `feature-flag.service.spec.ts`, `mktg-os-agents-enabled.guard.spec.ts`, `org-lens-cla-m3-enabled.guard.spec.ts`
- [x] `/lfx-self-serve-pr-readiness` — READY
- [x] `/preflight` — Phase 1 clean, Phase 2 REVIEW READY (1 discussion item, addressed above)

Refs linuxfoundation/lfx-self-serve#1351