### PR TITLE
fix(meetings): broaden reconcile-attendance access beyond organizer

### DIFF
--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
@@ -287,66 +287,69 @@ describe.each([
     stubServiceCall: () => meetingSvc.deletePastMeetingParticipant.mockResolvedValue(undefined),
     serviceMock: () => meetingSvc.deletePastMeetingParticipant,
   },
-])('PastMeetingController.$name — shares the attendance-management authorization gate', ({ invoke, buildReq: buildParticipantReq, stubServiceCall, serviceMock }) => {
-  let controller: PastMeetingController;
+])(
+  'PastMeetingController.$name — shares the attendance-management authorization gate',
+  ({ invoke, buildReq: buildParticipantReq, stubServiceCall, serviceMock }) => {
+    let controller: PastMeetingController;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    validateUidParameterMock.mockReturnValue(true);
-    checkSingleAccessMock.mockResolvedValue(false);
-    getPersonasMock.mockResolvedValue({ isRootWriter: false, isLFStaff: false, personaProjects: {} });
-    controller = new PastMeetingController();
-    meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting({ project_uid: 'project-1' }));
-    stubServiceCall();
-  });
-
-  it('runs when the caller is the organizer', async () => {
-    addAccessToResourceMock.mockResolvedValue({ organizer: true });
-    const res = buildRes();
-    const next = vi.fn();
-
-    await invoke(controller, buildParticipantReq(true), res, next);
-
-    expect(serviceMock()).toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('runs when the caller is a writer on the meeting project', async () => {
-    addAccessToResourceMock.mockResolvedValue({ organizer: false });
-    checkSingleAccessMock.mockResolvedValue(true);
-    const res = buildRes();
-    const next = vi.fn();
-
-    await invoke(controller, buildParticipantReq(true), res, next);
-
-    expect(serviceMock()).toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('runs when the caller is an Executive Director of the meeting project', async () => {
-    addAccessToResourceMock.mockResolvedValue({ organizer: false });
-    getPersonasMock.mockResolvedValue({
-      isRootWriter: false,
-      isLFStaff: false,
-      personaProjects: { 'executive-director': [{ projectUid: 'project-1', projectSlug: 'proj-slug', projectName: 'Proj' }] },
+    beforeEach(() => {
+      vi.clearAllMocks();
+      validateUidParameterMock.mockReturnValue(true);
+      checkSingleAccessMock.mockResolvedValue(false);
+      getPersonasMock.mockResolvedValue({ isRootWriter: false, isLFStaff: false, personaProjects: {} });
+      controller = new PastMeetingController();
+      meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting({ project_uid: 'project-1' }));
+      stubServiceCall();
     });
-    const res = buildRes();
-    const next = vi.fn();
 
-    await invoke(controller, buildParticipantReq(true), res, next);
+    it('runs when the caller is the organizer', async () => {
+      addAccessToResourceMock.mockResolvedValue({ organizer: true });
+      const res = buildRes();
+      const next = vi.fn();
 
-    expect(serviceMock()).toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
-  });
+      await invoke(controller, buildParticipantReq(true), res, next);
 
-  it('rejects with 403 when the caller is not the organizer, not a project writer, and not a project ED', async () => {
-    addAccessToResourceMock.mockResolvedValue({ organizer: false });
-    const res = buildRes();
-    const next = vi.fn();
+      expect(serviceMock()).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
 
-    await invoke(controller, buildParticipantReq(true), res, next);
+    it('runs when the caller is a writer on the meeting project', async () => {
+      addAccessToResourceMock.mockResolvedValue({ organizer: false });
+      checkSingleAccessMock.mockResolvedValue(true);
+      const res = buildRes();
+      const next = vi.fn();
 
-    expect(serviceMock()).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
-  });
-});
+      await invoke(controller, buildParticipantReq(true), res, next);
+
+      expect(serviceMock()).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('runs when the caller is an Executive Director of the meeting project', async () => {
+      addAccessToResourceMock.mockResolvedValue({ organizer: false });
+      getPersonasMock.mockResolvedValue({
+        isRootWriter: false,
+        isLFStaff: false,
+        personaProjects: { 'executive-director': [{ projectUid: 'project-1', projectSlug: 'proj-slug', projectName: 'Proj' }] },
+      });
+      const res = buildRes();
+      const next = vi.fn();
+
+      await invoke(controller, buildParticipantReq(true), res, next);
+
+      expect(serviceMock()).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('rejects with 403 when the caller is not the organizer, not a project writer, and not a project ED', async () => {
+      addAccessToResourceMock.mockResolvedValue({ organizer: false });
+      const res = buildRes();
+      const next = vi.fn();
+
+      await invoke(controller, buildParticipantReq(true), res, next);
+
+      expect(serviceMock()).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    });
+  }
+);

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const PAST_MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { meetingSvc, reconciliationSvc, addAccessToResourceMock, validateUidParameterMock } = vi.hoisted(() => ({
+const { meetingSvc, reconciliationSvc, addAccessToResourceMock, checkSingleAccessMock, getPersonasMock, validateUidParameterMock } = vi.hoisted(() => ({
   meetingSvc: {
     getPastMeetingById: vi.fn(),
   },
@@ -14,6 +14,8 @@ const { meetingSvc, reconciliationSvc, addAccessToResourceMock, validateUidParam
     reconcilePastMeetingParticipants: vi.fn(),
   },
   addAccessToResourceMock: vi.fn(),
+  checkSingleAccessMock: vi.fn(),
+  getPersonasMock: vi.fn(),
   validateUidParameterMock: vi.fn(() => true),
 }));
 
@@ -47,8 +49,11 @@ vi.mock('../services/attendance-reconciliation.service', () => ({
 }));
 vi.mock('../services/access-check.service', () => ({
   AccessCheckService: vi.fn(function () {
-    return { addAccessToResource: addAccessToResourceMock };
+    return { addAccessToResource: addAccessToResourceMock, checkSingleAccess: checkSingleAccessMock };
   }),
+}));
+vi.mock('../utils/persona-helper', () => ({
+  personaDetectionService: { getPersonas: getPersonasMock },
 }));
 vi.mock('../services/logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -75,14 +80,17 @@ function buildPastMeeting(overrides: Record<string, unknown> = {}): any {
 }
 
 // Reconciliation matching logic itself is tested at its source (attendance-reconciliation.service.spec.ts)
-// per the three-file pattern. This spec covers only the controller's authorization gate: a non-organizer
-// must never reach the AI-backed reconciliation call (GH-1672 item 4 organizer-only trigger).
-describe('PastMeetingController.reconcilePastMeetingParticipants — organizer gate', () => {
+// per the three-file pattern. This spec covers only the controller's authorization gate: only the
+// organizer, a project writer, or a project ED may reach the AI-backed reconciliation call (GH-1672
+// follow-up broadened this from organizer-only).
+describe('PastMeetingController.reconcilePastMeetingParticipants — attendance-management authorization gate', () => {
   let controller: PastMeetingController;
 
   beforeEach(() => {
     vi.clearAllMocks();
     validateUidParameterMock.mockReturnValue(true);
+    checkSingleAccessMock.mockResolvedValue(false);
+    getPersonasMock.mockResolvedValue({ isRootWriter: false, isLFStaff: false, personaProjects: {} });
     controller = new PastMeetingController();
     meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting());
   });
@@ -135,5 +143,95 @@ describe('PastMeetingController.reconcilePastMeetingParticipants — organizer g
     expect(reconciliationSvc.reconcilePastMeetingParticipants).toHaveBeenCalledWith(expect.anything(), PAST_MEETING_UID, buildPastMeeting());
     expect(res.json).toHaveBeenCalledWith(result);
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it('runs reconciliation when the caller is not the organizer but is a writer on the meeting project', async () => {
+    const pastMeeting = buildPastMeeting({ project_uid: 'project-1' });
+    meetingSvc.getPastMeetingById.mockResolvedValue(pastMeeting);
+    addAccessToResourceMock.mockResolvedValue({ ...pastMeeting, organizer: false });
+    checkSingleAccessMock.mockResolvedValue(true);
+    const result = { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
+    reconciliationSvc.reconcilePastMeetingParticipants.mockResolvedValue(result);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(checkSingleAccessMock).toHaveBeenCalledWith(expect.anything(), { resource: 'project', id: 'project-1', access: 'writer' });
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(result);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('runs reconciliation when the caller is an Executive Director of the meeting project', async () => {
+    const pastMeeting = buildPastMeeting({ project_uid: 'project-1' });
+    meetingSvc.getPastMeetingById.mockResolvedValue(pastMeeting);
+    addAccessToResourceMock.mockResolvedValue({ ...pastMeeting, organizer: false });
+    checkSingleAccessMock.mockResolvedValue(false);
+    getPersonasMock.mockResolvedValue({
+      isRootWriter: false,
+      isLFStaff: false,
+      personaProjects: { 'executive-director': [{ projectUid: 'project-1', projectSlug: 'proj-slug', projectName: 'Proj' }] },
+    });
+    const result = { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
+    reconciliationSvc.reconcilePastMeetingParticipants.mockResolvedValue(result);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(result);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('runs reconciliation when the caller is root-writer/LF-staff, bypassing per-project ED scoping', async () => {
+    const pastMeeting = buildPastMeeting({ project_uid: 'project-1' });
+    meetingSvc.getPastMeetingById.mockResolvedValue(pastMeeting);
+    addAccessToResourceMock.mockResolvedValue({ ...pastMeeting, organizer: false });
+    checkSingleAccessMock.mockResolvedValue(false);
+    getPersonasMock.mockResolvedValue({ isRootWriter: true, isLFStaff: false, personaProjects: {} });
+    const result = { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0 };
+    reconciliationSvc.reconcilePastMeetingParticipants.mockResolvedValue(result);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(result);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 when the caller is not the organizer, not a project writer, and not a project ED', async () => {
+    const pastMeeting = buildPastMeeting({ project_uid: 'project-1' });
+    meetingSvc.getPastMeetingById.mockResolvedValue(pastMeeting);
+    addAccessToResourceMock.mockResolvedValue({ ...pastMeeting, organizer: false });
+    checkSingleAccessMock.mockResolvedValue(false);
+    getPersonasMock.mockResolvedValue({ isRootWriter: false, isLFStaff: false, personaProjects: {} });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 and fails closed when the ED persona check itself throws', async () => {
+    const pastMeeting = buildPastMeeting({ project_uid: 'project-1' });
+    meetingSvc.getPastMeetingById.mockResolvedValue(pastMeeting);
+    addAccessToResourceMock.mockResolvedValue({ ...pastMeeting, organizer: false });
+    checkSingleAccessMock.mockResolvedValue(false);
+    getPersonasMock.mockRejectedValue(new Error('persona service unavailable'));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.reconcilePastMeetingParticipants(buildReq(true), res, next);
+
+    expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.spec.ts
@@ -9,6 +9,9 @@ const PAST_MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 const { meetingSvc, reconciliationSvc, addAccessToResourceMock, checkSingleAccessMock, getPersonasMock, validateUidParameterMock } = vi.hoisted(() => ({
   meetingSvc: {
     getPastMeetingById: vi.fn(),
+    createPastMeetingParticipant: vi.fn(),
+    updatePastMeetingParticipant: vi.fn(),
+    deletePastMeetingParticipant: vi.fn(),
   },
   reconciliationSvc: {
     reconcilePastMeetingParticipants: vi.fn(),
@@ -233,5 +236,117 @@ describe('PastMeetingController.reconcilePastMeetingParticipants — attendance-
     expect(reconciliationSvc.reconcilePastMeetingParticipants).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
     expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+// The three participant-mutation endpoints share the same isPastMeetingOrganizer gate as
+// reconcile above. Run the same organizer/writer/ED/reject authorization matrix against each
+// so a future regression isolated to one handler doesn't go undetected.
+const PARTICIPANT_ID = 'attendee-1';
+
+describe.each([
+  {
+    name: 'createPastMeetingParticipant',
+    invoke: (controller: PastMeetingController, req: any, res: any, next: any) => controller.createPastMeetingParticipant(req, res, next),
+    buildReq: (authenticated: boolean) => ({
+      params: { uid: PAST_MEETING_UID },
+      body: { is_attended: true },
+      query: {},
+      path: '/test',
+      log: {},
+      oidc: { isAuthenticated: () => authenticated },
+    }),
+    stubServiceCall: () => meetingSvc.createPastMeetingParticipant.mockResolvedValue({ id: PARTICIPANT_ID }),
+    serviceMock: () => meetingSvc.createPastMeetingParticipant,
+  },
+  {
+    name: 'updatePastMeetingParticipant',
+    invoke: (controller: PastMeetingController, req: any, res: any, next: any) => controller.updatePastMeetingParticipant(req, res, next),
+    buildReq: (authenticated: boolean) => ({
+      params: { uid: PAST_MEETING_UID, participantId: PARTICIPANT_ID },
+      body: { is_attended: true },
+      query: {},
+      path: '/test',
+      log: {},
+      oidc: { isAuthenticated: () => authenticated },
+    }),
+    stubServiceCall: () => meetingSvc.updatePastMeetingParticipant.mockResolvedValue({ id: PARTICIPANT_ID }),
+    serviceMock: () => meetingSvc.updatePastMeetingParticipant,
+  },
+  {
+    name: 'deletePastMeetingParticipant',
+    invoke: (controller: PastMeetingController, req: any, res: any, next: any) => controller.deletePastMeetingParticipant(req, res, next),
+    buildReq: (authenticated: boolean) => ({
+      params: { uid: PAST_MEETING_UID, participantId: PARTICIPANT_ID },
+      body: {},
+      query: {},
+      path: '/test',
+      log: {},
+      oidc: { isAuthenticated: () => authenticated },
+    }),
+    stubServiceCall: () => meetingSvc.deletePastMeetingParticipant.mockResolvedValue(undefined),
+    serviceMock: () => meetingSvc.deletePastMeetingParticipant,
+  },
+])('PastMeetingController.$name — shares the attendance-management authorization gate', ({ invoke, buildReq: buildParticipantReq, stubServiceCall, serviceMock }) => {
+  let controller: PastMeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateUidParameterMock.mockReturnValue(true);
+    checkSingleAccessMock.mockResolvedValue(false);
+    getPersonasMock.mockResolvedValue({ isRootWriter: false, isLFStaff: false, personaProjects: {} });
+    controller = new PastMeetingController();
+    meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting({ project_uid: 'project-1' }));
+    stubServiceCall();
+  });
+
+  it('runs when the caller is the organizer', async () => {
+    addAccessToResourceMock.mockResolvedValue({ organizer: true });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await invoke(controller, buildParticipantReq(true), res, next);
+
+    expect(serviceMock()).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('runs when the caller is a writer on the meeting project', async () => {
+    addAccessToResourceMock.mockResolvedValue({ organizer: false });
+    checkSingleAccessMock.mockResolvedValue(true);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await invoke(controller, buildParticipantReq(true), res, next);
+
+    expect(serviceMock()).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('runs when the caller is an Executive Director of the meeting project', async () => {
+    addAccessToResourceMock.mockResolvedValue({ organizer: false });
+    getPersonasMock.mockResolvedValue({
+      isRootWriter: false,
+      isLFStaff: false,
+      personaProjects: { 'executive-director': [{ projectUid: 'project-1', projectSlug: 'proj-slug', projectName: 'Proj' }] },
+    });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await invoke(controller, buildParticipantReq(true), res, next);
+
+    expect(serviceMock()).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 403 when the caller is not the organizer, not a project writer, and not a project ED', async () => {
+    addAccessToResourceMock.mockResolvedValue({ organizer: false });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await invoke(controller, buildParticipantReq(true), res, next);
+
+    expect(serviceMock()).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
   });
 });

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -26,6 +26,7 @@ import { AccessCheckService } from '../services/access-check.service';
 import { AttendanceReconciliationService } from '../services/attendance-reconciliation.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
+import { personaDetectionService } from '../utils/persona-helper';
 
 /**
  * Controller for handling past meeting HTTP requests
@@ -175,8 +176,8 @@ export class PastMeetingController {
 
   /**
    * POST /past-meetings/:uid/participants
-   * Organizer-only, enforced both here and by lfx-v2-meeting-service on the ITX endpoint —
-   * belt-and-suspenders defense in depth, matching the reconcile endpoint's BFF-level check.
+   * Restricted to the meeting organizer, a writer on the meeting's project, or an Executive
+   * Director of that project (GH-1672 follow-up) — matches the reconcile endpoint's gate.
    */
   public async createPastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
@@ -209,7 +210,7 @@ export class PastMeetingController {
 
       if (!isOrganizer) {
         return next(
-          new AuthorizationError('Only the meeting organizer can manage past meeting participants', {
+          new AuthorizationError("You do not have permission to manage this meeting's participants", {
             operation: 'create_past_meeting_participant',
             service: 'past_meeting_controller',
           })
@@ -231,8 +232,8 @@ export class PastMeetingController {
 
   /**
    * PUT /past-meetings/:uid/participants/:participantId
-   * Organizer-only, enforced both here and by lfx-v2-meeting-service on the ITX endpoint —
-   * belt-and-suspenders defense in depth, matching the reconcile endpoint's BFF-level check.
+   * Restricted to the meeting organizer, a writer on the meeting's project, or an Executive
+   * Director of that project (GH-1672 follow-up) — matches the reconcile endpoint's gate.
    */
   public async updatePastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid, participantId } = req.params;
@@ -275,7 +276,7 @@ export class PastMeetingController {
 
       if (!isOrganizer) {
         return next(
-          new AuthorizationError('Only the meeting organizer can manage past meeting participants', {
+          new AuthorizationError("You do not have permission to manage this meeting's participants", {
             operation: 'update_past_meeting_participant',
             service: 'past_meeting_controller',
           })
@@ -297,8 +298,8 @@ export class PastMeetingController {
 
   /**
    * DELETE /past-meetings/:uid/participants/:participantId
-   * Organizer-only, enforced both here and by lfx-v2-meeting-service on the ITX endpoint —
-   * belt-and-suspenders defense in depth, matching the reconcile endpoint's BFF-level check.
+   * Restricted to the meeting organizer, a writer on the meeting's project, or an Executive
+   * Director of that project (GH-1672 follow-up) — matches the reconcile endpoint's gate.
    */
   public async deletePastMeetingParticipant(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid, participantId } = req.params;
@@ -331,7 +332,7 @@ export class PastMeetingController {
 
       if (!isOrganizer) {
         return next(
-          new AuthorizationError('Only the meeting organizer can manage past meeting participants', {
+          new AuthorizationError("You do not have permission to manage this meeting's participants", {
             operation: 'delete_past_meeting_participant',
             service: 'past_meeting_controller',
           })
@@ -379,7 +380,7 @@ export class PastMeetingController {
 
       if (!isOrganizer) {
         return next(
-          new AuthorizationError('Only the meeting organizer can trigger attendance reconciliation', {
+          new AuthorizationError('You do not have permission to trigger attendance reconciliation for this meeting', {
             operation: 'reconcile_past_meeting_participants',
             service: 'past_meeting_controller',
           })
@@ -1018,8 +1019,10 @@ export class PastMeetingController {
   }
 
   /**
-   * Resolves whether the requesting user is the organizer of a past meeting. Unauthenticated
-   * requests and access-check failures both default to false (fail closed).
+   * Resolves whether the requesting user may manage a past meeting's participants/attendance —
+   * the meeting organizer, a writer on the meeting's project, or an Executive Director of that
+   * project (GH-1672 follow-up: reconciliation is no longer organizer-only). Unauthenticated
+   * requests and access-check failures all default to false (fail closed).
    */
   private async isPastMeetingOrganizer(req: Request, pastMeeting: PastMeeting, uid: string): Promise<boolean> {
     if (!req.oidc?.isAuthenticated()) {
@@ -1027,14 +1030,36 @@ export class PastMeetingController {
     }
 
     try {
-      const meetingWithAccess = await this.accessCheckService.addAccessToResource(
-        req,
-        { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid },
-        'v1_past_meeting',
-        'organizer'
-      );
-      return meetingWithAccess.organizer ?? false;
+      const [isOrganizer, isProjectWriter, isProjectED] = await Promise.all([
+        this.accessCheckService
+          .addAccessToResource(req, { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid }, 'v1_past_meeting', 'organizer')
+          .then((meetingWithAccess) => meetingWithAccess.organizer ?? false),
+        pastMeeting.project_uid
+          ? this.accessCheckService.checkSingleAccess(req, { resource: 'project', id: pastMeeting.project_uid, access: 'writer' })
+          : Promise.resolve(false),
+        this.isProjectExecutiveDirector(req, pastMeeting.project_uid),
+      ]);
+
+      return isOrganizer || isProjectWriter || isProjectED;
     } catch {
+      return false;
+    }
+  }
+
+  /** Root-writer/LF-staff bypass matches `requireExecutiveDirector`'s scope rules. */
+  private async isProjectExecutiveDirector(req: Request, projectUid: string | undefined): Promise<boolean> {
+    if (!projectUid) {
+      return false;
+    }
+
+    try {
+      const result = await personaDetectionService.getPersonas(req, undefined, 'none');
+      if (result.isRootWriter || result.isLFStaff) {
+        return true;
+      }
+      return (result.personaProjects?.['executive-director'] ?? []).some((project) => project.projectUid === projectUid);
+    } catch (error) {
+      logger.warning(req, 'is_project_executive_director', 'ED check failed, assuming no access', { err: error, project_uid: projectUid });
       return false;
     }
   }

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -112,7 +112,7 @@ export class PastMeetingController {
       }
 
       const meeting = await this.meetingService.getPastMeetingById(req, uid);
-      meeting.organizer = await this.isPastMeetingOrganizer(req, meeting, uid);
+      meeting.organizer = await this.canManagePastMeetingParticipants(req, meeting, uid);
 
       const counts = await this.addParticipantsCount(req, uid);
       meeting.individual_registrants_count = counts.individual_registrants_count;
@@ -206,9 +206,9 @@ export class PastMeetingController {
       }
 
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
-      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+      const isAuthorized = await this.canManagePastMeetingParticipants(req, pastMeeting, uid);
 
-      if (!isOrganizer) {
+      if (!isAuthorized) {
         return next(
           new AuthorizationError("You do not have permission to manage this meeting's participants", {
             operation: 'create_past_meeting_participant',
@@ -272,9 +272,9 @@ export class PastMeetingController {
       }
 
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
-      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+      const isAuthorized = await this.canManagePastMeetingParticipants(req, pastMeeting, uid);
 
-      if (!isOrganizer) {
+      if (!isAuthorized) {
         return next(
           new AuthorizationError("You do not have permission to manage this meeting's participants", {
             operation: 'update_past_meeting_participant',
@@ -328,9 +328,9 @@ export class PastMeetingController {
       }
 
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
-      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+      const isAuthorized = await this.canManagePastMeetingParticipants(req, pastMeeting, uid);
 
-      if (!isOrganizer) {
+      if (!isAuthorized) {
         return next(
           new AuthorizationError("You do not have permission to manage this meeting's participants", {
             operation: 'delete_past_meeting_participant',
@@ -376,9 +376,9 @@ export class PastMeetingController {
       }
 
       const pastMeeting = await this.meetingService.getPastMeetingById(req, uid);
-      const isOrganizer = await this.isPastMeetingOrganizer(req, pastMeeting, uid);
+      const isAuthorized = await this.canManagePastMeetingParticipants(req, pastMeeting, uid);
 
-      if (!isOrganizer) {
+      if (!isAuthorized) {
         return next(
           new AuthorizationError('You do not have permission to trigger attendance reconciliation for this meeting', {
             operation: 'reconcile_past_meeting_participants',
@@ -1022,25 +1022,32 @@ export class PastMeetingController {
    * Resolves whether the requesting user may manage a past meeting's participants/attendance —
    * the meeting organizer, a writer on the meeting's project, or an Executive Director of that
    * project (GH-1672 follow-up: reconciliation is no longer organizer-only). Unauthenticated
-   * requests and access-check failures all default to false (fail closed).
+   * requests and access-check failures all default to false (fail closed). The organizer check
+   * runs first and short-circuits, since it covers the common self-service case without needing
+   * the project-level writer/ED lookups.
    */
-  private async isPastMeetingOrganizer(req: Request, pastMeeting: PastMeeting, uid: string): Promise<boolean> {
+  private async canManagePastMeetingParticipants(req: Request, pastMeeting: PastMeeting, uid: string): Promise<boolean> {
     if (!req.oidc?.isAuthenticated()) {
       return false;
     }
 
     try {
-      const [isOrganizer, isProjectWriter, isProjectED] = await Promise.all([
-        this.accessCheckService
-          .addAccessToResource(req, { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid }, 'v1_past_meeting', 'organizer')
-          .then((meetingWithAccess) => meetingWithAccess.organizer ?? false),
+      const isOrganizer = await this.accessCheckService
+        .addAccessToResource(req, { ...pastMeeting, id: pastMeeting.meeting_and_occurrence_id ?? uid }, 'v1_past_meeting', 'organizer')
+        .then((meetingWithAccess) => meetingWithAccess.organizer ?? false);
+
+      if (isOrganizer) {
+        return true;
+      }
+
+      const [isProjectWriter, isProjectED] = await Promise.all([
         pastMeeting.project_uid
           ? this.accessCheckService.checkSingleAccess(req, { resource: 'project', id: pastMeeting.project_uid, access: 'writer' })
           : Promise.resolve(false),
         this.isProjectExecutiveDirector(req, pastMeeting.project_uid),
       ]);
 
-      return isOrganizer || isProjectWriter || isProjectED;
+      return isProjectWriter || isProjectED;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary

- Loosens the authorization gate on past-meeting attendance management (create/update/delete participant, and reconcile) so it is no longer organizer-only.
- Access is now granted to: the meeting organizer, a writer on the meeting's project, or an Executive Director of the meeting's project.
- Renamed the internal check to `canManagePastMeetingParticipants` (was `isPastMeetingOrganizer`) to reflect the broadened scope, and short-circuits on the organizer check before running the project-writer/ED lookups so the common self-service path doesn't pay for three concurrent access checks.

Closes #2234

## Test plan

- [x] `yarn test:server src/server/controllers/past-meeting.controller.spec.ts` — 21/21 passing, including new coverage for organizer / project-writer / project-ED / none-of-the-above across all four gated endpoints
- [x] `yarn build`