### PR TITLE
feat(org-lens): hand off corporate CLA signing to EasyCLA

### DIFF
--- a/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
@@ -187,6 +187,15 @@ export const SIGN_ROUTE = '**/api/orgs/*/lens/cla-groups/sign';
  */
 export const STUB_SIGN_URL = 'https://signing.example.org/session/e2e-stub';
 
+/**
+ * The signature the stubbed hand-off says it opened.
+ *
+ * Deliberately the `id` of the default `claGroup()` row, because that is what makes the return
+ * landing observable: the page only navigates to an agreement it can see in the organization's own
+ * list, so a stub signature absent from the stubbed list would leave the signatory on it.
+ */
+export const STUB_SIGNATURE_ID = 'signature-uuid-1';
+
 /** A searchable CLA Group, corporate-signable unless a case says otherwise. */
 export function signOption(overrides: Record<string, unknown> = {}) {
   return {
@@ -221,7 +230,7 @@ export async function stubHandoff(page: Page, options: { search?: unknown; sign?
 
   await fulfillJson(page, SIGN_OPTIONS_ROUTE, options.search ?? signOptionsResponse([signOption()]));
 
-  const sign = options.sign ?? { status: 200, body: { signUrl } };
+  const sign = options.sign ?? { status: 200, body: { signUrl, signatureId: STUB_SIGNATURE_ID } };
   await page.route(SIGN_ROUTE, (route) => route.fulfill({ status: sign.status, contentType: 'application/json', body: JSON.stringify(sign.body) }));
 
   await page.route(`${signUrl}**`, (route) =>

--- a/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
@@ -168,6 +168,72 @@ export function searchInput(page: Page): Locator {
   return page.locator('[data-test="org-easycla-search"]');
 }
 
+// ---------------------------------------------------------------------------
+// The self-sign hand-off (GH-1983)
+// ---------------------------------------------------------------------------
+
+/** The CLA Group search behind the picker. */
+export const SIGN_OPTIONS_ROUTE = '**/api/orgs/*/lens/cla-groups/sign-options*';
+
+/** The write. Every spec below stubs it; none may ever let it reach a real CLA service. */
+export const SIGN_ROUTE = '**/api/orgs/*/lens/cla-groups/sign';
+
+/**
+ * Where the hand-off is told to send the signer.
+ *
+ * A synthetic address on a reserved domain, routed and fulfilled locally by `stubHandoff` so the
+ * browser never leaves the app under test. A real signing address here would create a real
+ * envelope against a real agreement on every run.
+ */
+export const STUB_SIGN_URL = 'https://signing.example.org/session/e2e-stub';
+
+/** A searchable CLA Group, corporate-signable unless a case says otherwise. */
+export function signOption(overrides: Record<string, unknown> = {}) {
+  return {
+    claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111',
+    claGroupName: 'Cascade CLA',
+    projectName: 'Cascade',
+    projectSfid: 'a09410000182dD2AAI',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+    ...overrides,
+  };
+}
+
+export function signOptionsResponse(results: ReturnType<typeof signOption>[], truncated = false) {
+  return { searchTerm: 'cascade', resultCount: results.length, truncated, results };
+}
+
+/**
+ * Stubs the whole hand-off chain: the picker's search, the signature request, and the signing
+ * address the request answers with.
+ *
+ * The last one is the important one and is not optional. The component assigns the returned
+ * address to `location.href`, so without a route intercepting it the browser navigates away to
+ * whatever the fixture said — and a fixture that ever named a real signing host would drive a
+ * real DocuSign session from CI. Fulfilling it locally keeps the assertion (did we navigate to
+ * exactly the address the server returned?) while the navigation lands on a blank local page.
+ */
+export async function stubHandoff(page: Page, options: { search?: unknown; sign?: { status: number; body: unknown }; signUrl?: string } = {}): Promise<void> {
+  const signUrl = options.signUrl ?? STUB_SIGN_URL;
+
+  await fulfillJson(page, SIGN_OPTIONS_ROUTE, options.search ?? signOptionsResponse([signOption()]));
+
+  const sign = options.sign ?? { status: 200, body: { signUrl } };
+  await page.route(SIGN_ROUTE, (route) => route.fulfill({ status: sign.status, contentType: 'application/json', body: JSON.stringify(sign.body) }));
+
+  await page.route(`${signUrl}**`, (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body data-testid="stub-signing-service">stub signing service</body></html>' })
+  );
+}
+
+/** The picker's search box. Same `data-test` quirk as the list's, for the same reason. */
+export function groupSearchInput(page: Page): Locator {
+  return page.locator('[data-test="org-easycla-group-select-search"]');
+}
+
 /** Skips when the shared Playwright credentials are absent, as every authenticated spec does. */
 export function skipWithoutCredentials(): void {
   if (!process.env.TEST_USERNAME || !process.env.TEST_PASSWORD) {

--- a/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
@@ -118,7 +118,9 @@ test.describe('Org Lens EasyCLA corporate self-sign — structure', () => {
 
     await onlyState(page, 'org-easycla-sign-ready');
     await expect(page.getByTestId('org-easycla-sign-review')).toBeVisible();
-    await expect(page.getByTestId('org-easycla-sign-cancel')).toBeVisible();
+    // No way out but forward: the agreement and its envelope exist by now, and the address behind
+    // this control is the only thing that reaches them.
+    await expect(page.getByTestId('org-easycla-sign-cancel')).toHaveCount(0);
   });
 
   test('settles on the failure state alone when the request is refused', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
@@ -38,10 +38,17 @@ import {
 
 const CASCADE = signOption();
 
+// The default budget is one authenticated boot; these cases are a boot plus a four-step chain. The
+// neighbouring Org Lens specs all raise it for the same reason, and the same figure.
+test.setTimeout(120_000);
+
 /** The dialogs, in the order the flow opens them. */
 const PICKER = 'org-easycla-group-select-dialog';
 const ATTESTATION = 'org-easycla-attestation-dialog';
 const HANDOFF = 'org-easycla-sign-handoff-dialog';
+
+/** Start, on the preview page the picker hands the choice to — the step between picker and dialogs. */
+const PREVIEW_START = 'org-easycla-detail-start-cla';
 
 const HANDOFF_STATES = ['org-easycla-sign-preparing', 'org-easycla-sign-ready', 'org-easycla-sign-failed'];
 
@@ -57,13 +64,28 @@ async function onlyState(page: Page, expected: string): Promise<void> {
   }
 }
 
-async function reachAttestation(page: Page): Promise<void> {
-  await page.getByTestId('org-easycla-sign-cla').click();
+/**
+ * Picks the CLA Group, which now lands on the preview page rather than opening the attestation.
+ *
+ * The inner `button`, not the `lfx-button` host the test id sits on. Sign CLA is disabled until the
+ * organization context settles, and Playwright's actionability check reads the element it is given
+ * — a custom element, which is never "disabled" — so a click on the host lands on a dead control
+ * instead of waiting for a live one.
+ */
+async function reachPreview(page: Page): Promise<void> {
+  await page.getByTestId('org-easycla-sign-cla').locator('button').click();
   await expect(page.getByTestId(PICKER)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
   await groupSearchInput(page).fill('cascade');
   await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
   await page.getByTestId('org-easycla-group-continue').locator('button').click();
+
+  await expect(page.getByTestId(PREVIEW_START)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+async function reachAttestation(page: Page): Promise<void> {
+  await reachPreview(page);
+  await page.getByTestId(PREVIEW_START).locator('button').click();
 }
 
 async function reachHandoff(page: Page): Promise<void> {
@@ -78,16 +100,19 @@ test.describe('Org Lens EasyCLA corporate self-sign — structure', () => {
 
   test.beforeEach(() => skipWithoutCredentials());
 
-  // One dialog at a time. The flow replaces each with the next rather than stacking them, so a
+  // One step at a time. The flow replaces each with the next rather than stacking them, so a
   // regression that leaves the picker mounted behind the attestation would let a signatory change
   // the CLA Group under a confirmation they have already given.
-  test('opens the three dialogs in sequence, one at a time', async ({ page }) => {
+  //
+  // The picker and the two dialogs are separated by a page: the choice is carried to the preview by
+  // a router navigation, and both dialogs are opened by that page rather than by the list.
+  test('opens the picker, the preview, then the two dialogs in sequence', async ({ page }) => {
     await gotoEasyclaList(page, async (p) => {
       await stubPage(p);
       await stubHandoff(p);
     });
 
-    await page.getByTestId('org-easycla-sign-cla').click();
+    await page.getByTestId('org-easycla-sign-cla').locator('button').click();
     await expect(page.getByTestId(PICKER)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
     await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
     await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
@@ -96,8 +121,17 @@ test.describe('Org Lens EasyCLA corporate self-sign — structure', () => {
     await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
     await page.getByTestId('org-easycla-group-continue').locator('button').click();
 
-    await expect(page.getByTestId(ATTESTATION)).toBeVisible();
+    await expect(page).toHaveURL(/\/org\/easycla\/new$/, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId(PREVIEW_START)).toBeVisible();
+    // The picker does not survive the navigation, and neither dialog opens before Start is pressed —
+    // so nothing is confirmed by arriving here.
     await expect(page.getByTestId(PICKER)).toHaveCount(0);
+    await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
+    await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
+
+    await page.getByTestId(PREVIEW_START).locator('button').click();
+
+    await expect(page.getByTestId(ATTESTATION)).toBeVisible();
     await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
 
     await page.locator('label[for="authorityAcked"]').click();
@@ -175,7 +209,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — structure', () => {
       await stubHandoff(p);
     });
 
-    await page.getByTestId('org-easycla-sign-cla').click();
+    await page.getByTestId('org-easycla-sign-cla').locator('button').click();
     const input = groupSearchInput(page);
 
     await expect(input).toHaveAttribute('role', 'combobox');

--- a/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
@@ -1,0 +1,212 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Lens EasyCLA corporate self-sign — structural E2E (GH-1983).
+ *
+ * The structural half of the repository's dual E2E architecture; `org-easycla-sign.spec.ts` is the
+ * content half. This one asserts the `data-testid` contract, the dialog sequence, and the request
+ * that goes on the wire — not the copy — so the pair fails independently: reworded legal text
+ * breaks only the content spec, and a dialog rebuilt behind the same testids leaves this one green.
+ *
+ * The hand-off's three states are mutually exclusive by construction, so each is pinned together
+ * with the absence of the others. A regression that renders "preparing" alongside "ready" is
+ * otherwise invisible to a spec that only asserts presence — and on this flow that pairing would
+ * show a signatory a spinner above a button that opens a legal agreement.
+ *
+ * Same standing constraint as the content spec: the signing request is stubbed and the address it
+ * returns is intercepted, so no run creates a real agreement or a real envelope.
+ *
+ * Prerequisites: as `org-easycla-sign.spec.ts`.
+ */
+
+import { expect, Page, Request, test } from '@playwright/test';
+
+import {
+  claGroup,
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  fulfillJson,
+  gotoEasyclaList,
+  groupSearchInput,
+  PAGE_LOAD_TIMEOUT,
+  signOption,
+  skipWithoutCredentials,
+  stubHandoff,
+  STUB_SIGN_URL,
+} from './helpers/org-easycla.helper';
+
+const CASCADE = signOption();
+
+/** The dialogs, in the order the flow opens them. */
+const PICKER = 'org-easycla-group-select-dialog';
+const ATTESTATION = 'org-easycla-attestation-dialog';
+const HANDOFF = 'org-easycla-sign-handoff-dialog';
+
+const HANDOFF_STATES = ['org-easycla-sign-preparing', 'org-easycla-sign-ready', 'org-easycla-sign-failed'];
+
+function stubPage(page: Page) {
+  return fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList([claGroup()]));
+}
+
+/** Asserts exactly one hand-off state is on screen. */
+async function onlyState(page: Page, expected: string): Promise<void> {
+  await expect(page.getByTestId(expected)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  for (const other of HANDOFF_STATES.filter((state) => state !== expected)) {
+    await expect(page.getByTestId(other)).toHaveCount(0);
+  }
+}
+
+async function reachAttestation(page: Page): Promise<void> {
+  await page.getByTestId('org-easycla-sign-cla').click();
+  await expect(page.getByTestId(PICKER)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  await groupSearchInput(page).fill('cascade');
+  await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
+  await page.getByTestId('org-easycla-group-continue').locator('button').click();
+}
+
+async function reachHandoff(page: Page): Promise<void> {
+  await reachAttestation(page);
+  await page.locator('label[for="authorityAcked"]').click();
+  await page.locator('label[for="embargoAcked"]').click();
+  await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+}
+
+test.describe('Org Lens EasyCLA corporate self-sign — structure', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test.beforeEach(() => skipWithoutCredentials());
+
+  // One dialog at a time. The flow replaces each with the next rather than stacking them, so a
+  // regression that leaves the picker mounted behind the attestation would let a signatory change
+  // the CLA Group under a confirmation they have already given.
+  test('opens the three dialogs in sequence, one at a time', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await page.getByTestId('org-easycla-sign-cla').click();
+    await expect(page.getByTestId(PICKER)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
+    await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
+
+    await groupSearchInput(page).fill('cascade');
+    await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
+    await page.getByTestId('org-easycla-group-continue').locator('button').click();
+
+    await expect(page.getByTestId(ATTESTATION)).toBeVisible();
+    await expect(page.getByTestId(PICKER)).toHaveCount(0);
+    await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
+
+    await page.locator('label[for="authorityAcked"]').click();
+    await page.locator('label[for="embargoAcked"]').click();
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId(HANDOFF)).toBeVisible();
+    await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
+  });
+
+  test('settles the hand-off on exactly one state', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await reachHandoff(page);
+
+    await onlyState(page, 'org-easycla-sign-ready');
+    await expect(page.getByTestId('org-easycla-sign-review')).toBeVisible();
+    await expect(page.getByTestId('org-easycla-sign-cancel')).toBeVisible();
+  });
+
+  test('settles on the failure state alone when the request is refused', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p, { sign: { status: 403, body: { error: 'Refused', code: 'FORBIDDEN' } } });
+    });
+
+    await reachHandoff(page);
+
+    await onlyState(page, 'org-easycla-sign-failed');
+    await expect(page.getByTestId('org-easycla-sign-failure-message')).toBeVisible();
+    await expect(page.getByTestId('org-easycla-sign-review')).toHaveCount(0);
+  });
+
+  /**
+   * What actually goes on the wire.
+   *
+   * Both confirmations must travel as the booleans the signatory gave, the organization must come
+   * from the path rather than the body, and no signing address may be composed by the client. A
+   * component test cannot see any of this: it asserts on the arguments handed to a stubbed
+   * service, one layer above the request that is the thing the CLA service reads.
+   */
+  test('sends both confirmations as booleans, keyed to the chosen CLA group', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    const signRequest = page.waitForRequest((request: Request) => request.url().includes('/lens/cla-groups/sign') && request.method() === 'POST');
+
+    await reachHandoff(page);
+
+    const body = (await (await signRequest).postDataJSON()) as Record<string, unknown>;
+
+    expect(body['authorityAcked']).toBe(true);
+    expect(body['embargoAcked']).toBe(true);
+    expect(body['claGroupId']).toBe(CASCADE.claGroupId);
+    expect(body['projectSfid']).toBe(CASCADE.projectSfid);
+    // The return address is the server's to derive: a client-supplied one turns the hand-off into
+    // an open redirect, since the CLA service stores it and redirects to it verbatim.
+    expect(body).not.toHaveProperty('claReturnUrl');
+    expect(body).not.toHaveProperty('returnUrl');
+  });
+
+  // The picker is a combobox and the focused element is the text box, so that is where the
+  // combobox state has to live. On the listbox — which nothing ever focuses — it is never
+  // announced, which looks identical on screen and is silent to a screen reader.
+  test('wires the combobox state onto the focused search input', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await page.getByTestId('org-easycla-sign-cla').click();
+    const input = groupSearchInput(page);
+
+    await expect(input).toHaveAttribute('role', 'combobox');
+    await expect(input).toHaveAttribute('aria-controls', 'org-easycla-group-select-results');
+
+    await input.fill('cascade');
+    await expect(page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await input.press('ArrowDown');
+    await expect(input).toHaveAttribute('aria-activedescendant', `org-easycla-group-option-${CASCADE.claGroupId}`);
+
+    // And the keyboard alone completes the choice, which is the reason the wiring exists.
+    await input.press('Enter');
+    await expect(page.getByTestId('org-easycla-group-continue').locator('button')).toBeEnabled();
+  });
+
+  // The hand-off is a full-page navigation in the same tab, not a popup and not an iframe: the
+  // signing service sets its own cookies and redirects back to the return address, neither of
+  // which survives being embedded.
+  test('leaves the app in the same tab, to the address the server returned', async ({ page, context }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await reachHandoff(page);
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    const pagesBefore = context.pages().length;
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+    expect(context.pages()).toHaveLength(pagesBefore);
+    await expect(page.locator('iframe')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-easycla-sign.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign.spec.ts
@@ -25,22 +25,31 @@
  * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
  */
 
+import { ORG_EASYCLA_RETURN_ORG_PARAM } from '@lfx-one/shared/constants';
 import { expect, Page, test } from '@playwright/test';
 
 import {
   claGroup,
   claGroupList,
   CLA_GROUPS_ROUTE,
+  EASYCLA_URL,
   fulfillJson,
   gotoEasyclaList,
   groupSearchInput,
+  MOCK_ACCOUNT_ID,
   PAGE_LOAD_TIMEOUT,
   signOption,
   signOptionsResponse,
   skipWithoutCredentials,
   stubHandoff,
+  STUB_SIGNATURE_ID,
   STUB_SIGN_URL,
 } from './helpers/org-easycla.helper';
+
+// The default budget is one authenticated boot; these cases are a boot plus a four-step chain, and
+// the return trip is a second boot on top of that. The neighbouring Org Lens specs all raise it for
+// the same reason, and the same figure.
+test.setTimeout(120_000);
 
 const CASCADE = signOption();
 
@@ -48,15 +57,35 @@ function stubList(page: Page) {
   return fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList([claGroup()]));
 }
 
-/** Opens the picker and chooses the one signable CLA Group, leaving the attestation dialog up. */
+/**
+ * Opens the picker and chooses the one signable CLA Group, landing on the preview page.
+ *
+ * The inner `button`, not the `lfx-button` host the test id sits on. Sign CLA is disabled until the
+ * organization context settles, and Playwright's actionability check reads the element it is given
+ * — a custom element, which is never "disabled" — so a click on the host lands on a dead control
+ * instead of waiting for a live one. The whole file's other controls are already reached this way.
+ */
 async function chooseClaGroup(page: Page): Promise<void> {
-  await page.getByTestId('org-easycla-sign-cla').click();
+  await page.getByTestId('org-easycla-sign-cla').locator('button').click();
   await expect(page.getByTestId('org-easycla-group-select-dialog')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
   await groupSearchInput(page).fill('cascade');
   await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
   await page.getByTestId('org-easycla-group-continue').locator('button').click();
 
+  await expect(page).toHaveURL(/\/org\/easycla\/new$/, { timeout: PAGE_LOAD_TIMEOUT });
+}
+
+/**
+ * Chooses the CLA Group and starts the process from the preview, leaving the attestation up.
+ *
+ * The preview between them is the part no unit test reaches: the choice crosses a router navigation
+ * as state, and the page it lands on has to read it back before Start can build a request from it.
+ */
+async function chooseThenStart(page: Page): Promise<void> {
+  await chooseClaGroup(page);
+
+  await page.getByTestId('org-easycla-detail-start-cla').locator('button').click();
   await expect(page.getByTestId('org-easycla-attestation-dialog')).toBeVisible();
 }
 
@@ -77,7 +106,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
       await stubHandoff(p);
     });
 
-    await chooseClaGroup(page);
+    await chooseThenStart(page);
     await confirmBoth(page);
     await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
 
@@ -87,6 +116,113 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
     // The whole point of the hand-off: the address is the server's, byte for byte, and the
     // navigation is a full-page one in the same tab rather than a popup or an embedded frame.
     await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  /**
+   * The preview page the picker now hands the choice to, and the reason it exists as a page rather
+   * than a fourth dialog: it names the agreement the two legally operative steps are about.
+   *
+   * Only reachable this way. There is no fetch-a-CLA-group-by-id endpoint, so the address carries
+   * nothing that could rebuild this page — which is also what the case below is about.
+   */
+  test('previews the chosen CLA Group before anything is confirmed', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseClaGroup(page);
+
+    await expect(page.getByTestId('org-easycla-detail-title')).toHaveText(CASCADE.claGroupName);
+    await expect(page.getByTestId('org-easycla-detail-not-started')).toBeVisible();
+    // The row-shaped states of a page that fetches a list. This one fetches none, and either of
+    // them here would tell a signatory the agreement they are about to sign does not exist.
+    await expect(page.getByTestId('org-easycla-detail-not-found-state')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-detail-list-loading')).toHaveCount(0);
+  });
+
+  /**
+   * A pasted, bookmarked or linked preview address arrives on a fresh history entry, which carries
+   * no choice — and nothing on the page can rebuild one. Sent back to the list, which is where the
+   * picker is, rather than left on a page headed with a blank name and offering a Start that would
+   * build a request from nothing.
+   *
+   * A reload is *not* this case, which is why it is not the one exercised here: the browser keeps a
+   * history entry's state across a reload, and Angular copies it onto the navigation it synthesises
+   * for one, so a reloaded preview still has the choice it was opened with.
+   */
+  test('sends a preview address that carries no choice back to the list', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await page.goto(`${EASYCLA_URL}/new`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/org\/easycla$/, { timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  /**
+   * The return trip, which is the half of the hand-off no dialog can assert.
+   *
+   * `return_url` is an input to the signing request, so it is fixed before the signature exists and
+   * cannot name it. The signature crosses in `sessionStorage` instead, and this is the test that the
+   * two halves meet: the signatory comes back to the list address and is put on the agreement they
+   * just signed.
+   */
+  test('returns the signatory to the agreement they just signed', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // What EasyCLA does at the end of the ceremony: sends the browser to the address the request
+    // named, which is the list plus the organization the session was opened for.
+    await page.goto(`${EASYCLA_URL}?${ORG_EASYCLA_RETURN_ORG_PARAM}=${MOCK_ACCOUNT_ID}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(new RegExp(`/org/easycla/${STUB_SIGNATURE_ID}$`), { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-detail-title')).toBeVisible();
+  });
+
+  // Single-use, and spent on the visit that finds it. Otherwise an abandoned ceremony leaves a
+  // signature behind that hijacks an ordinary visit to the list — days later, on any return trip.
+  test('does not divert an ordinary visit to the list', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Back to the list without the return parameter — a bookmark, or the signatory navigating there
+    // themselves rather than being sent by EasyCLA.
+    //
+    // Waiting on a card, not on the page shell: the shell arrives in the server-rendered HTML, so
+    // asserting it is satisfied before the client bundle has run — and the stash is read by the
+    // client. Navigating away on the shell alone leaves it unspent and the case asserts nothing. A
+    // card can only come from the list request the client makes.
+    await page.goto(EASYCLA_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('org-easycla-card').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/org\/easycla$/);
+
+    // And spent by that visit, so the genuine return address no longer has one to follow either.
+    await page.goto(`${EASYCLA_URL}?${ORG_EASYCLA_RETURN_ORG_PARAM}=${MOCK_ACCOUNT_ID}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('org-easycla-card').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/org\/easycla$/);
   });
 
   /**
@@ -109,7 +245,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
       if (request.url().includes('/lens/cla-groups/sign') && request.method() === 'POST') signRequests += 1;
     });
 
-    await chooseClaGroup(page);
+    await chooseThenStart(page);
     const continueButton = page.getByTestId('org-easycla-attestation-continue').locator('button');
 
     await expect(continueButton).toBeDisabled();
@@ -143,7 +279,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
       await stubHandoff(p, { sign: { status: 403, body: { error: refusal, code: 'FORBIDDEN' } } });
     });
 
-    await chooseClaGroup(page);
+    await chooseThenStart(page);
     await confirmBoth(page);
     await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
 
@@ -160,7 +296,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
       await stubHandoff(p, { sign: { status: 200, body: { signUrl: '' } } });
     });
 
-    await chooseClaGroup(page);
+    await chooseThenStart(page);
     await confirmBoth(page);
     await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
 
@@ -179,12 +315,15 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
       await stubHandoff(p, { search: signOptionsResponse([multiProject]) });
     });
 
-    await page.getByTestId('org-easycla-sign-cla').click();
+    await page.getByTestId('org-easycla-sign-cla').locator('button').click();
     await groupSearchInput(page).fill('driftwood');
 
     await expect(page.getByTestId(`org-easycla-group-disabled-${multiProject.claGroupId}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
-    await page.getByTestId(`org-easycla-group-select-${multiProject.claGroupId}`).click();
+    // Forced past the actionability check, which reads `aria-disabled` and would simply refuse to
+    // click. Refusing is not the assertion: what has to be proven is that a click that does land —
+    // as one from a pointing device would — still selects nothing.
+    await page.getByTestId(`org-easycla-group-select-${multiProject.claGroupId}`).click({ force: true });
 
     await expect(page.getByTestId('org-easycla-group-continue').locator('button')).toBeDisabled();
     await expect(page.getByTestId('org-easycla-attestation-dialog')).toHaveCount(0);

--- a/apps/lfx-one/e2e/org-easycla-sign.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign.spec.ts
@@ -1,0 +1,192 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Lens EasyCLA corporate self-sign — content E2E (GH-1983).
+ *
+ * The content half of the repository's dual E2E architecture; `org-easycla-sign-robust.spec.ts` is
+ * the structural half. This one walks the chain a signatory walks — Sign CLA, choose a CLA Group,
+ * confirm both statements, hand off — and asserts on the words and the destination.
+ *
+ * The unit tests cover each dialog on its own, with the next one's inputs handed to it directly.
+ * What they cannot cover is the chain: three dialogs opened in sequence by a parent that passes
+ * each one's result into the next, an HTTP round trip in the middle, and a full-page navigation at
+ * the end. Every join in that sequence is real here and stubbed there.
+ *
+ * **Nothing in this file may reach a real signing service.** The request creates a corporate
+ * agreement and a *sent* envelope with no rehearsal mode, so the route that answers it is stubbed,
+ * and the address it answers with is a reserved-domain address that is itself routed and fulfilled
+ * locally. A run that navigated to a genuine address would leave an unsigned agreement behind on
+ * every execution, against a real organization.
+ *
+ * Prerequisites:
+ * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD
+ * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+import {
+  claGroup,
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  fulfillJson,
+  gotoEasyclaList,
+  groupSearchInput,
+  PAGE_LOAD_TIMEOUT,
+  signOption,
+  signOptionsResponse,
+  skipWithoutCredentials,
+  stubHandoff,
+  STUB_SIGN_URL,
+} from './helpers/org-easycla.helper';
+
+const CASCADE = signOption();
+
+function stubList(page: Page) {
+  return fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList([claGroup()]));
+}
+
+/** Opens the picker and chooses the one signable CLA Group, leaving the attestation dialog up. */
+async function chooseClaGroup(page: Page): Promise<void> {
+  await page.getByTestId('org-easycla-sign-cla').click();
+  await expect(page.getByTestId('org-easycla-group-select-dialog')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  await groupSearchInput(page).fill('cascade');
+  await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
+  await page.getByTestId('org-easycla-group-continue').locator('button').click();
+
+  await expect(page.getByTestId('org-easycla-attestation-dialog')).toBeVisible();
+}
+
+/** Ticks both confirmations. The labels are the accessible handles PrimeNG wires to the boxes. */
+async function confirmBoth(page: Page): Promise<void> {
+  await page.locator('label[for="authorityAcked"]').click();
+  await page.locator('label[for="embargoAcked"]').click();
+}
+
+test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test.beforeEach(() => skipWithoutCredentials());
+
+  test('walks the whole chain and hands off to the address the server returned', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseClaGroup(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+
+    // The whole point of the hand-off: the address is the server's, byte for byte, and the
+    // navigation is a full-page one in the same tab rather than a popup or an embedded frame.
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  /**
+   * The attestation gate, driven the way a signatory would.
+   *
+   * This is the assertion the feature exists to make safe. Continuing without both confirmations
+   * would transmit an affirmation the signatory did not make, and produce a legally binding
+   * document that nothing downstream can distinguish from a genuine one.
+   */
+  test('will not continue until both confirmations are given', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    // No request may leave while the gate is shut, so any that does fails the test rather than
+    // being quietly answered by the stub.
+    let signRequests = 0;
+    page.on('request', (request) => {
+      if (request.url().includes('/lens/cla-groups/sign') && request.method() === 'POST') signRequests += 1;
+    });
+
+    await chooseClaGroup(page);
+    const continueButton = page.getByTestId('org-easycla-attestation-continue').locator('button');
+
+    await expect(continueButton).toBeDisabled();
+
+    await page.locator('label[for="authorityAcked"]').click();
+    await expect(continueButton).toBeDisabled();
+
+    await page.locator('label[for="embargoAcked"]').click();
+    await expect(continueButton).toBeEnabled();
+
+    // Withdrawing one closes the gate again, rather than leaving it open on a stale check.
+    await page.locator('label[for="authorityAcked"]').click();
+    await expect(continueButton).toBeDisabled();
+
+    expect(signRequests).toBe(0);
+  });
+
+  /**
+   * A refusal reaches the signatory in the CLA service's own words.
+   *
+   * The trade-compliance refusal is the case this is for: it names the reason and the route to
+   * challenge it, and replacing it with generic copy would leave a signatory with no idea why
+   * their organization cannot sign or who to ask.
+   */
+  test('shows a refusal in the words the CLA service used, not generic failure copy', async ({ page }) => {
+    const refusal = 'This organization requires additional trade compliance review, so the CLA cannot be completed at this time. Contact EasyCLA Support.';
+
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      // The envelope the BFF's error class really serialises to: the sentence under `error`.
+      await stubHandoff(p, { sign: { status: 403, body: { error: refusal, code: 'FORBIDDEN' } } });
+    });
+
+    await chooseClaGroup(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-failed')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-sign-failure-message')).toHaveText(refusal);
+    await expect(page.getByTestId('org-easycla-sign-failure-message')).not.toContainText('We could not prepare this CLA');
+  });
+
+  // A response with no address is how the CLA service says it emailed a named signatory instead —
+  // a shape this flow never asks for. Navigating anyway would send the signer to an empty URL.
+  test('treats a response carrying no signing address as a failure', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p, { sign: { status: 200, body: { signUrl: '' } } });
+    });
+
+    await chooseClaGroup(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-failed')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/org\/easycla/);
+  });
+
+  // A CLA Group with no resolvable project cannot be signed corporately. It stays on screen with
+  // its reason — dropping it would leave the signatory hunting for something they can see in the
+  // legacy console — but it must never become the one a request is built from.
+  test('shows an unsignable CLA group with its reason and refuses to choose it', async ({ page }) => {
+    const multiProject = signOption({ claGroupId: 'bbbbbbbb-2222-4222-8222-222222222222', claGroupName: 'Driftwood Umbrella CLA', projectSfid: undefined });
+
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p, { search: signOptionsResponse([multiProject]) });
+    });
+
+    await page.getByTestId('org-easycla-sign-cla').click();
+    await groupSearchInput(page).fill('driftwood');
+
+    await expect(page.getByTestId(`org-easycla-group-disabled-${multiProject.claGroupId}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await page.getByTestId(`org-easycla-group-select-${multiProject.claGroupId}`).click();
+
+    await expect(page.getByTestId('org-easycla-group-continue').locator('button')).toBeDisabled();
+    await expect(page.getByTestId('org-easycla-attestation-dialog')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { MKTG_OS_AGENTS_ROUTE_SEGMENT } from '@lfx-one/shared/constants';
+import { MKTG_OS_AGENTS_ROUTE_SEGMENT, ORG_EASYCLA_NEW_SEGMENT } from '@lfx-one/shared/constants';
 import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
@@ -169,6 +169,15 @@ export const routes: Routes = [
               {
                 path: '',
                 loadComponent: () => import('./modules/dashboards/org/org-easycla/org-easycla.component').then((m) => m.OrgEasyclaComponent),
+              },
+              {
+                // Ahead of `:signatureId`, which would otherwise match this segment as a signature
+                // id and render the not-found state. The preview reuses the detail component,
+                // sourcing the agreement from the picker's choice in the router state.
+                path: ORG_EASYCLA_NEW_SEGMENT,
+                data: { title: 'Sign a CLA', description: 'Review a CLA before starting the corporate signing process.' },
+                loadComponent: () =>
+                  import('./modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component').then((m) => m.OrgEasyclaDetailComponent),
               },
               {
                 path: ':signatureId',

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
@@ -173,10 +173,11 @@
           </lfx-message>
         }
         <!--
-          The body for an agreement the organization has not signed. Reached from the list, not
-          only from the signing flow: a row's status comes from the producer's `signed` flag, so an
-          unsigned agreement is an ordinary list entry. Without this the tab rendered its heading
-          and then stopped, which reads as a page that failed to load rather than as a state.
+          The body for an agreement the organization has not signed, which on this page means the
+          pre-signing preview: the organization's list draws every row from a signature upstream
+          has already filtered to signed, so it never reaches here. Without this the tab rendered
+          its heading and then stopped, which reads as a page that failed to load rather than as a
+          state.
         -->
         @if (notStarted()) {
           <div class="flex flex-col gap-3" data-testid="org-easycla-detail-not-started">
@@ -237,7 +238,21 @@
         [id]="'org-easycla-detail-tab-panel-' + activeTab()"
         [attr.aria-labelledby]="'org-easycla-detail-tab-trigger-' + activeTab()"
         class="py-8"
-        data-testid="org-easycla-detail-tab-empty"></section>
+        data-testid="org-easycla-detail-tab-empty">
+        <!--
+          The CLA Managers and Approval List tabs on an unsigned agreement, where signing is what
+          creates the content: the signatory becomes the initial CLA Manager, and approval entries
+          are what that manager then maintains. Left bare, the panel reads as a page that failed to
+          load rather than as a state — the same gap the empty Overview had. One lock icon for both,
+          because "locked until signed" is what each panel is actually saying.
+
+          The remaining tabs stay bare. They are unbuilt for every agreement, signed or not, so
+          "once this CLA is signed" would promise content signing does not produce.
+        -->
+        @if (lockedTab(); as locked) {
+          <lfx-empty-state data-testid="org-easycla-detail-tab-locked" icon="fa-light fa-lock" [title]="locked.title" [subtitle]="locked.subtitle" />
+        }
+      </section>
     }
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
@@ -172,6 +172,51 @@
             </ng-template>
           </lfx-message>
         }
+        <!--
+          The body for an agreement the organization has not signed. Reached from the list, not
+          only from the signing flow: a row's status comes from the producer's `signed` flag, so an
+          unsigned agreement is an ordinary list entry. Without this the tab rendered its heading
+          and then stopped, which reads as a page that failed to load rather than as a state.
+        -->
+        @if (notStarted()) {
+          <div class="flex flex-col gap-3" data-testid="org-easycla-detail-not-started">
+            @if (notStartedLead()) {
+              <p class="text-sm text-gray-700" data-testid="org-easycla-detail-not-started-lead">{{ notStartedLead() }}</p>
+            }
+            <p class="font-semibold text-sm text-gray-900">{{ notStartedCopy.stepsHeading }}</p>
+            <!--
+              An ordered list, not three paragraphs as the prototype draws them. The steps are a
+              sequence and are numbered in their own text, so the markup that says so is what lets
+              assistive technology announce the position and count. The prototype's numbering is
+              kept in the visible text rather than generated, so the wording stays verbatim.
+            -->
+            <ol class="flex list-none flex-col gap-2 p-0">
+              @for (step of notStartedCopy.steps; track step.label) {
+                <li class="text-sm text-gray-700">
+                  <span class="font-semibold text-gray-900">{{ step.label }}</span> {{ step.body }}
+                </li>
+              }
+            </ol>
+            <!--
+              Inoperable for now, exactly as the list header's Sign CLA control ships: enabling it
+              belongs to the signing feature, and there is deliberately no click handler to leave
+              behind. The reason is in the accessible name as well as the tooltip, because the
+              tooltip sits on the non-focusable host while the button inside is disabled, so it
+              opens on hover and never on focus — without it, assistive technology announces only
+              "Start the CLA process, disabled" and the viewer cannot tell whether the control is
+              unavailable to them or to everyone.
+            -->
+            <div>
+              <lfx-button
+                [label]="notStartedCopy.startLabel"
+                icon="fa-light fa-file-signature"
+                [disabled]="true"
+                [ariaLabel]="notStartedCopy.startLabel + ' — signing a new CLA from the Organization Lens is coming soon.'"
+                tooltip="Signing a new CLA from the Organization Lens is coming soon."
+                data-testid="org-easycla-detail-start-cla" />
+            </div>
+          </div>
+        }
         @if (canDownload()) {
           <!--
             `severity="secondary"` with `outlined`, the pairing the survey-preview and profile

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
@@ -198,21 +198,17 @@
               }
             </ol>
             <!--
-              Inoperable for now, exactly as the list header's Sign CLA control ships: enabling it
-              belongs to the signing feature, and there is deliberately no click handler to leave
-              behind. The reason is in the accessible name as well as the tooltip, because the
-              tooltip sits on the non-focusable host while the button inside is disabled, so it
-              opens on hover and never on focus — without it, assistive technology announces only
-              "Start the CLA process, disabled" and the viewer cannot tell whether the control is
-              unavailable to them or to everyone.
+              Skips the picker: this page already named the CLA Group. The reason a start is
+              refused lives in the accessible name, not a tooltip — the tooltip host is not
+              focusable while the button is disabled, so it never opens on focus.
             -->
             <div>
               <lfx-button
                 [label]="notStartedCopy.startLabel"
                 icon="fa-light fa-file-signature"
-                [disabled]="true"
-                [ariaLabel]="notStartedCopy.startLabel + ' — signing a new CLA from the Organization Lens is coming soon.'"
-                tooltip="Signing a new CLA from the Organization Lens is coming soon."
+                [disabled]="startDisabled()"
+                [ariaLabel]="startAriaLabel()"
+                (onClick)="startClaProcess()"
                 data-testid="org-easycla-detail-start-cla" />
             </div>
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -254,6 +254,28 @@ describe('OrgEasyclaDetailComponent', () => {
       expect(openDialog.mock.calls[0][0]).toBe(OrgEasyclaAttestationComponent);
     });
 
+    it('offers Start again after the header close tears the dialog down without onClose', async () => {
+      const onClose = new Subject<unknown>();
+      const onDestroy = new Subject<void>();
+      openDialog.mockReturnValue({ onClose, onDestroy, close: vi.fn() });
+      const signable = {
+        ...notStarted,
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      const start = (): HTMLButtonElement | null | undefined => byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      start()?.click();
+      fixture.detectChanges();
+      expect(start()?.disabled).toBe(true);
+
+      onDestroy.next();
+      fixture.detectChanges();
+
+      expect(start()?.disabled).toBe(false);
+    });
+
     it('hands the confirmations to the signing step for this agreement', async () => {
       const attestations = { authorityAcked: true, embargoAcked: true };
       const opened: { component: unknown; config: { data?: unknown; closable?: boolean } }[] = [];

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -283,6 +283,53 @@ describe('OrgEasyclaDetailComponent', () => {
       });
     });
 
+    it('signs a foundation-level agreement against the foundation, not one project it covers', async () => {
+      const opened: { config: { data?: unknown } }[] = [];
+      openDialog.mockImplementation((_component: unknown, config: { data?: unknown } = {}) => {
+        opened.push({ config });
+        return { onClose: of(opened.length === 1 ? { authorityAcked: true, embargoAcked: true } : null), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      // The ordinary shape of an unsigned agreement: one CLA Group covering several projects
+      // under a foundation, each project carrying its own SFID.
+      const foundationLevel = {
+        ...notStarted,
+        claGroupId: 'cla-group-uuid-1',
+        foundationSfid: 'a09410000182dFOUND',
+        projects: [
+          { projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' },
+          { projectName: 'Driftwood', projectSfid: 'a09410000182dD3AAI' },
+        ],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(foundationLevel)] }));
+
+      const fixture = await render();
+      expect(byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.disabled).toBe(false);
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+
+      // The first covered project's SFID would bind the agreement to that project alone, and
+      // nothing downstream would notice: it resolves back to this same CLA Group, so the
+      // response's group-mismatch check sees the id it asked for.
+      expect(opened[1].config.data).toMatchObject({ projectSfid: 'a09410000182dFOUND', claGroupId: 'cla-group-uuid-1' });
+    });
+
+    it('refuses to choose between several covered projects when there is no foundation', async () => {
+      const ambiguous = {
+        ...notStarted,
+        projects: [
+          { projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' },
+          { projectName: 'Driftwood', projectSfid: 'a09410000182dD3AAI' },
+        ],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(ambiguous)] }));
+
+      const fixture = await render();
+
+      // Both projects carry an SFID, so a choice is available — and that is the reason to refuse
+      // it. Search declines to name a project for this shape and the picker greys the row out.
+      expect(byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.disabled).toBe(true);
+    });
+
     it('does not explain the process on a signed agreement', async () => {
       getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -7,7 +7,7 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
-import { ORG_CLA_NOT_STARTED_COPY } from '@lfx-one/shared/constants';
+import { CCLA_SIGN_COPY, ORG_CLA_NOT_STARTED_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -20,6 +20,8 @@ import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OrgEasyclaCoverageDialogComponent } from '../org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
+import { OrgEasyclaAttestationComponent } from '../org-easycla-sign/org-easycla-attestation.component';
+import { OrgEasyclaSignHandoffComponent } from '../org-easycla-sign/org-easycla-sign-handoff.component';
 import { OrgEasyclaDetailComponent } from './org-easycla-detail.component';
 
 describe('OrgEasyclaDetailComponent', () => {
@@ -221,17 +223,64 @@ describe('OrgEasyclaDetailComponent', () => {
       expect(byTestId(fixture, 'org-easycla-detail-not-started')?.querySelector('ol')).not.toBeNull();
     });
 
-    it('offers the start control, and says why it does nothing yet', async () => {
+    it('does not start signing when the agreement has no project to sign against', async () => {
       getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
 
       const fixture = await render();
 
-      // The reason has to be in the accessible name, not the tooltip alone: the tooltip host is
-      // not focusable while the button is disabled, so it never opens on focus.
+      // Same reason the picker leaves a row visible but unselectable: the producer signs by
+      // project, and a row with no project SFID cannot be bound to a request.
       const start = byTestId(fixture, 'org-easycla-detail-start-cla');
       expect(start).not.toBeNull();
       expect(start?.querySelector('button')?.disabled).toBe(true);
-      expect(start?.querySelector('button')?.getAttribute('aria-label')).toContain('coming soon');
+      expect(start?.querySelector('button')?.getAttribute('aria-label')).toContain(CCLA_SIGN_COPY.picker.multiProjectDisabledReason);
+    });
+
+    it('starts the confirmation for this agreement, without asking which CLA group', async () => {
+      openDialog.mockReturnValue({ onClose: of(null), onDestroy: of(undefined), close: vi.fn() });
+      const signable = {
+        ...notStarted,
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      expect(start?.disabled).toBe(false);
+
+      start?.click();
+
+      expect(openDialog).toHaveBeenCalledTimes(1);
+      expect(openDialog.mock.calls[0][0]).toBe(OrgEasyclaAttestationComponent);
+    });
+
+    it('hands the confirmations to the signing step for this agreement', async () => {
+      const attestations = { authorityAcked: true, embargoAcked: true };
+      const opened: { component: unknown; config: { data?: unknown; closable?: boolean } }[] = [];
+      openDialog.mockImplementation((component: unknown, config: { data?: unknown; closable?: boolean } = {}) => {
+        opened.push({ component, config });
+        const result = opened.length === 1 ? attestations : null;
+        return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      const signable = {
+        ...notStarted,
+        claGroupId: 'cla-group-uuid-1',
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+
+      expect(opened).toHaveLength(2);
+      expect(opened[1].component).toBe(OrgEasyclaSignHandoffComponent);
+      expect(opened[1].config.data).toEqual({
+        orgUid: SELECTED_ACCOUNT.uid,
+        projectSfid: 'a09410000182dD2AAI',
+        claGroupId: 'cla-group-uuid-1',
+        attestations,
+      });
     });
 
     it('does not explain the process on a signed agreement', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -7,6 +7,7 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ORG_CLA_NOT_STARTED_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -183,6 +184,73 @@ describe('OrgEasyclaDetailComponent', () => {
     const fixture = await render();
 
     expect(byTestId(fixture, 'org-easycla-detail-ccla-hint')?.textContent?.trim()).toBe("Covers Cascade for Acme's employees.");
+  });
+
+  describe('an agreement the organization has not signed', () => {
+    const notStarted = { status: 'not-started' as const, signed: false, signedOn: undefined };
+
+    it('explains the process instead of leaving the tab empty', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      const panel = byTestId(fixture, 'org-easycla-detail-not-started');
+      expect(panel).not.toBeNull();
+      // All three steps, not merely the heading: the steps are where the consequence of signing —
+      // that the signer becomes the initial CLA Manager — is stated before it happens.
+      expect(panel?.querySelectorAll('li').length).toBe(3);
+      expect(panel?.textContent).toContain(ORG_CLA_NOT_STARTED_COPY.stepsHeading);
+      for (const step of ORG_CLA_NOT_STARTED_COPY.steps) {
+        expect(panel?.textContent).toContain(step.body);
+      }
+    });
+
+    it('names the organization and the agreement it has not signed', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ ...notStarted, claGroupName: 'Cascade CLA' })] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started-lead')?.textContent?.trim()).toBe('Acme has not yet signed a CLA for Cascade CLA.');
+    });
+
+    it('numbers the steps as a list, so their order and count are announced', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')?.querySelector('ol')).not.toBeNull();
+    });
+
+    it('offers the start control, and says why it does nothing yet', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      // The reason has to be in the accessible name, not the tooltip alone: the tooltip host is
+      // not focusable while the button is disabled, so it never opens on focus.
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla');
+      expect(start).not.toBeNull();
+      expect(start?.querySelector('button')?.disabled).toBe(true);
+      expect(start?.querySelector('button')?.getAttribute('aria-label')).toContain('coming soon');
+    });
+
+    it('does not explain the process on a signed agreement', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
+
+    it('does not walk a sanctioned agreement through how to start signing', async () => {
+      // Sanctions take the same status slot, and that viewer's obstacle is not a missing signature
+      // — telling them how to begin would talk past the reason they cannot.
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ status: 'sanctioned', signed: false, signedOn: undefined })] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
   });
 
   it('withholds the download from an agreement that was never signed', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -6,9 +6,9 @@ import '@angular/compiler';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
-import { CCLA_SIGN_COPY, ORG_CLA_NOT_STARTED_COPY } from '@lfx-one/shared/constants';
-import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
+import { ActivatedRoute, convertToParamMap, Navigation, provideRouter, Router } from '@angular/router';
+import { CCLA_SIGN_COPY, ORG_CLA_LOCKED_TAB_COPY, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_SIGN_SELECTION_STATE } from '@lfx-one/shared/constants';
+import type { OrgClaGroup, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
@@ -17,7 +17,7 @@ import { OrgNavigationService } from '@shared/services/org-navigation.service';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 
 import { OrgEasyclaCoverageDialogComponent } from '../org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
 import { OrgEasyclaAttestationComponent } from '../org-easycla-sign/org-easycla-attestation.component';
@@ -39,6 +39,9 @@ describe('OrgEasyclaDetailComponent', () => {
   const addMessage = vi.fn();
   const openDialog = vi.fn();
 
+  /** Where the page tried to go. Installed by `render` on the real router; see the spy there. */
+  let navigate: MockInstance<Router['navigate']>;
+
   function claGroup(overrides: Partial<OrgClaGroup> = {}): OrgClaGroup {
     return {
       id: 'signature-uuid-1',
@@ -56,7 +59,14 @@ describe('OrgEasyclaDetailComponent', () => {
     };
   }
 
-  async function render(): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
+  /**
+   * Renders the page, optionally as the preview the picker navigates to.
+   *
+   * The selection is installed on the navigation rather than passed to the component, because
+   * reading it back out of the navigation is the part under test: the address holds nothing, so a
+   * selection handed in directly would pass on a page that renders blank in the browser.
+   */
+  async function render(previewState?: Record<string, unknown>): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [OrgEasyclaDetailComponent],
@@ -76,6 +86,15 @@ describe('OrgEasyclaDetailComponent', () => {
     TestBed.overrideComponent(OrgEasyclaDetailComponent, {
       set: { providers: [{ provide: DialogService, useValue: { open: openDialog } }] },
     });
+
+    const router = TestBed.inject(Router);
+    // The test module declares no routes, so a real navigation would resolve to nothing and the
+    // assertion would be about the router's failure rather than about where the page tried to go.
+    navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    // Read in a field initializer, so the answer has to be in place before the component exists.
+    vi.spyOn(router, 'getCurrentNavigation').mockReturnValue(
+      previewState === undefined ? null : ({ extras: { state: previewState } } as unknown as Navigation)
+    );
 
     const fixture = TestBed.createComponent(OrgEasyclaDetailComponent);
     fixture.detectChanges();
@@ -368,6 +387,283 @@ describe('OrgEasyclaDetailComponent', () => {
       const fixture = await render();
 
       expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
+  });
+
+  /**
+   * The preview a signatory reads before starting a corporate CLA (#1983), reached from the picker.
+   *
+   * Nothing on this route is fetched. There is no fetch-a-CLA-group-by-id endpoint upstream, so the
+   * page is built entirely from the choice the navigation carried — which is why these cases pass no
+   * `signatureId` and assert that no list is requested.
+   */
+  describe('previewing a CLA Group the picker chose', () => {
+    const CASCADE: OrgClaSignSelection = {
+      claGroupId: 'cla-group-uuid-1',
+      claGroupName: 'Cascade CLA',
+      projectSfid: 'a09410000182dD2AAI',
+      projectName: 'Cascade',
+    };
+
+    function previewing(selection: Partial<OrgClaSignSelection> = {}): Record<string, unknown> {
+      return { [ORG_CLA_SIGN_SELECTION_STATE]: { ...CASCADE, ...selection } };
+    }
+
+    beforeEach(() => {
+      paramMap.next(convertToParamMap({}));
+    });
+
+    it('heads the page with the CLA Group the picker chose', async () => {
+      const fixture = await render(previewing());
+
+      expect(byTestId(fixture, 'org-easycla-detail-title')?.textContent).toContain('Cascade CLA');
+      expect(byTestId(fixture, 'org-easycla-detail-status')?.textContent).toContain('Not started');
+    });
+
+    // The row-shaped states of a page that fetches a list. Neither can be reached without a list in
+    // hand, and `notFound` firing here would tell a signatory the agreement they are about to sign
+    // does not exist.
+    it('asks for no list, and shows neither a skeleton nor a missing agreement', async () => {
+      const fixture = await render(previewing());
+
+      expect(getClaGroups).not.toHaveBeenCalled();
+      expect(byTestId(fixture, 'org-easycla-detail-list-loading')).toBeNull();
+      expect(byTestId(fixture, 'org-easycla-detail-not-found-state')).toBeNull();
+    });
+
+    /**
+     * Start must reach the hand-off from the preview, and against the project the picker resolved.
+     *
+     * This is what the synthesized row is shaped for: one covered project and no foundation SFID, so
+     * `signingChoice` resolves to the picker's own SFID rather than inventing a foundation-level
+     * agreement out of a choice that was made at project level.
+     */
+    it('starts the confirmation against the project the picker resolved', async () => {
+      const opened: { component: unknown; config: { data?: unknown } }[] = [];
+      openDialog.mockImplementation((component: unknown, config: { data?: unknown } = {}) => {
+        opened.push({ component, config });
+        return { onClose: of(opened.length === 1 ? { authorityAcked: true, embargoAcked: true } : null), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      const fixture = await render(previewing());
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      expect(start?.disabled).toBe(false);
+
+      start?.click();
+
+      expect(opened[0].component).toBe(OrgEasyclaAttestationComponent);
+      expect(opened[1].config.data).toMatchObject({ claGroupId: CASCADE.claGroupId, projectSfid: CASCADE.projectSfid });
+    });
+
+    // A pasted, bookmarked or linked preview address arrives with nothing, and nothing here can
+    // rebuild it. The list is where the picker lives, so it is a redirect rather than an empty state.
+    it('leaves for the list when the address carries no selection', async () => {
+      await render();
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+
+    /**
+     * A truncated selection is treated as no selection at all.
+     *
+     * The value comes back out of a history entry, so it can have been written by an earlier
+     * deployment. Trusted, a partial one heads the page with an undefined name and still offers
+     * Start — a missing project SFID only disables signing once something reads it.
+     */
+    it.each([['claGroupId'], ['claGroupName'], ['projectSfid'], ['projectName']] as const)('leaves for the list when %s is missing', async (field) => {
+      await render(previewing({ [field]: '' }));
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+
+    /**
+     * An organization switch invalidates the preview, not merely an open dialog.
+     *
+     * The choice was made under the organization the viewer has just left, and Start would open a
+     * session against the one they arrived at. Nothing here can be re-derived for it either — the CLA
+     * Group named may not be one the new organization can sign.
+     */
+    it('leaves for the list when the viewer switches organization', async () => {
+      const fixture = await render(previewing());
+      expect(navigate).not.toHaveBeenCalled();
+
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+  });
+
+  /**
+   * The two dialogs this page owns, driven with a harness whose closes the test controls.
+   *
+   * The shared `openDialog` stub closes synchronously, which is fine for asserting what gets passed
+   * along and useless for asserting what happens while one is still standing.
+   */
+  describe('the signing dialogs this page owns', () => {
+    interface OpenDialog {
+      component: unknown;
+      config: { data?: unknown; closable?: boolean; closeOnEscape?: boolean; dismissableMask?: boolean };
+      close: ReturnType<typeof vi.fn>;
+      /** Emit to drive this dialog's own close, which is how the flow advances a step. */
+      onClose: Subject<unknown>;
+      /** Emit after `onClose` to finish the leave animation. The next step waits on this. */
+      onDestroy: Subject<void>;
+    }
+
+    const opened: OpenDialog[] = [];
+    const attestations = { authorityAcked: true, embargoAcked: true };
+
+    beforeEach(() => {
+      opened.length = 0;
+      openDialog.mockImplementation((component: unknown, config: OpenDialog['config'] = {}) => {
+        const dialog: OpenDialog = { component, config, close: vi.fn(), onClose: new Subject<unknown>(), onDestroy: new Subject<void>() };
+        opened.push(dialog);
+        return { onClose: dialog.onClose, onDestroy: dialog.onDestroy, close: dialog.close };
+      });
+      getClaGroups.mockReturnValue(
+        of({
+          orgUid: SELECTED_ACCOUNT.uid,
+          claGroups: [
+            claGroup({
+              status: 'not-started',
+              signed: false,
+              signedOn: undefined,
+              projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+            }),
+          ],
+        })
+      );
+    });
+
+    async function start(): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+      return fixture;
+    }
+
+    /**
+     * The hand-off opens locked by all three routes.
+     *
+     * The initial values belong here rather than in the hand-off's own suite, which supplies its own
+     * config and so cannot see what this call site passes. The signing request starts as that dialog
+     * appears and is the call that creates both the signature record and the DocuSign envelope:
+     * dismissed before the address comes back, it leaves an envelope nobody was handed.
+     */
+    it('opens the hand-off with no way to dismiss it', async () => {
+      await start();
+      opened[0].onClose.next(attestations);
+      opened[0].onDestroy.next();
+
+      expect(opened[1].component).toBe(OrgEasyclaSignHandoffComponent);
+      expect(opened[1].config).toMatchObject({ closable: false, closeOnEscape: false, dismissableMask: false });
+    });
+
+    // The step before it is freely dismissable: nothing has been created yet, and trapping someone
+    // in a legal confirmation they want to back out of would be its own problem.
+    it('leaves the attestation dismissable, because nothing exists yet to lose', async () => {
+      await start();
+
+      expect(opened[0].config.closable).toBe(true);
+    });
+
+    /**
+     * The hand-off waits for the attestation to be torn down, not merely closed.
+     *
+     * `close()` emits `onClose` synchronously and starts the leave animation from that same emission,
+     * and the end of that animation drops `p-overflow-hidden` from the body. A dialog opened from
+     * inside `onClose` therefore has its own scroll lock stripped a moment after it appears, and the
+     * page scrolls behind it. The Me-lens hand-off found this first (#2066).
+     */
+    it('opens no hand-off until the attestation has torn down', async () => {
+      await start();
+
+      opened[0].onClose.next(attestations);
+      expect(opened).toHaveLength(1);
+
+      opened[0].onDestroy.next();
+      expect(opened).toHaveLength(2);
+    });
+
+    // Nothing has been created at this point, and the confirmations are about a specific
+    // organization's authority and export position — they cannot carry over to another company.
+    it('closes the attestation on an organization switch, since no signature has been asked for yet', async () => {
+      const fixture = await start();
+      expect(opened).toHaveLength(1);
+
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(opened[0].close).toHaveBeenCalled();
+    });
+
+    /**
+     * The hand-off is deliberately not closed.
+     *
+     * By the time it is open the request has been issued and a signature record and DocuSign envelope
+     * exist for the organization that was selected when the viewer confirmed — which is the one they
+     * meant to sign for. The address that comes back is the only thing that reaches them, so closing
+     * this on a switch would orphan an envelope to save nothing. It is also why the field holding the
+     * closeable ref is named for the uncommitted half.
+     */
+    it('leaves the hand-off standing, because a signing session already exists behind it', async () => {
+      const fixture = await start();
+      opened[0].onClose.next(attestations);
+      opened[0].onDestroy.next();
+      expect(opened).toHaveLength(2);
+
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(opened[1].close).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Why the open tab holds nothing on an agreement nobody has signed, when signing is what fills it.
+   */
+  describe('the tabs signing is what fills', () => {
+    const notStarted = { status: 'not-started' as const, signed: false, signedOn: undefined };
+
+    it.each([['managers'], ['approval']] as const)('explains that the %s tab is waiting on the signature', async (tab) => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+      byTestId(fixture, `org-easycla-detail-tab-${tab}`)?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-detail-tab-locked')?.textContent).toContain(ORG_CLA_LOCKED_TAB_COPY[tab]?.title);
+    });
+
+    // Unbuilt for every agreement, signed or not — so "once this CLA is signed" would promise
+    // content signing does not produce.
+    it.each([['acknowledgments'], ['activity']] as const)('leaves the %s tab bare, since signing does not fill it', async (tab) => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+      byTestId(fixture, `org-easycla-detail-tab-${tab}`)?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-detail-tab-empty')).not.toBeNull();
+      expect(byTestId(fixture, 'org-easycla-detail-tab-locked')).toBeNull();
+    });
+
+    /**
+     * Read from `signed` rather than the status, as the download is and for the same reason:
+     * sanctions occupy the single status slot, so a sanctioned agreement may be signed — and its CLA
+     * Managers are real people who would be told they do not exist yet.
+     */
+    it('does not lock the managers tab on a signed agreement that is also sanctioned', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ status: 'sanctioned' })] }));
+
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-tab-managers')?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-detail-tab-locked')).toBeNull();
     });
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -4,7 +4,7 @@
 import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import type {
   OrgClaCoverageChip,
@@ -14,10 +14,20 @@ import type {
   OrgClaGroupList,
   OrgClaGroupPickerResult,
   OrgClaSignAttestations,
+  OrgClaSignSelection,
   OrgClaStatusDisplay,
 } from '@lfx-one/shared/interfaces';
-import { CCLA_SIGN_COPY, ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
-import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary } from '@lfx-one/shared/utils';
+import {
+  CCLA_SIGN_COPY,
+  ORG_CLA_DETAIL_TABS,
+  ORG_CLA_HEADING_STATUS,
+  ORG_CLA_LOCKED_TAB_COPY,
+  ORG_CLA_NOT_STARTED_COPY,
+  ORG_CLA_SIGN_SELECTION_STATE,
+  ORG_CLA_STATUS_DISPLAY,
+  ORG_EASYCLA_PATH,
+} from '@lfx-one/shared/constants';
+import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary, orgClaPreviewGroup } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -48,6 +58,7 @@ import { OrgEasyclaSignHandoffComponent } from '../org-easycla-sign/org-easycla-
 })
 export class OrgEasyclaDetailComponent {
   private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly accountContext = inject(AccountContextService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
@@ -92,6 +103,22 @@ export class OrgEasyclaDetailComponent {
     { initialValue: (this.route.snapshot.paramMap.get('signatureId') ?? '').trim() }
   );
 
+  /**
+   * The CLA Group the picker chose, when this page was opened as the preview a signatory reads
+   * before starting a corporate CLA (#1983). Null on an ordinary agreement route, and on the server.
+   *
+   * Carried by the navigation rather than by the address because an address holds nothing that
+   * could be resolved: the CLA service exposes no fetch-a-CLA-group-by-id endpoint, so ids in the
+   * URL could not be turned back into the agreement this page has to name, and the names would
+   * have to ride along in the URL for the heading to render at all. Angular copies the non-router
+   * keys of a restored `history.state` onto the navigation it synthesises, so in-app back and
+   * forward arrive here with the choice still attached.
+   */
+  private readonly previewSelection: OrgClaSignSelection | null = this.readPreviewSelection();
+
+  /** Previewing an agreement nobody has signed, so there is no list row to find and none is fetched. */
+  private readonly previewing = !!this.previewSelection;
+
   // Every selection the viewer makes, including clearing it.
   private readonly selectedOrgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(distinctUntilChanged());
 
@@ -123,8 +150,12 @@ export class OrgEasyclaDetailComponent {
     return !data || data.orgUid === this.accountContext.selectedAccount()?.uid;
   });
 
+  // `previewing` first: no list is requested in that mode, so `claData()` stays undefined for the
+  // life of the page and every other term here would hold the skeleton over a page that has
+  // everything it needs.
   protected readonly claLoading = computed(
-    () => this.hasCompany() && (this.claData() === undefined || this.claLoadingState() || !this.claDataIsForSelectedOrg()) && !this.fetchError()
+    () =>
+      !this.previewing && this.hasCompany() && (this.claData() === undefined || this.claLoadingState() || !this.claDataIsForSelectedOrg()) && !this.fetchError()
   );
 
   protected readonly claGroup: Signal<OrgClaGroup | undefined> = computed(() => this.initClaGroup());
@@ -139,9 +170,10 @@ export class OrgEasyclaDetailComponent {
 
   protected readonly coverageHint = computed(() => this.initCoverageHint());
 
-  // Read from `signed` rather than the status: sanctions win the single status slot, so a
-  // `sanctioned` row may be signed or unsigned, and offering the document on an unsigned one
-  // gives the viewer a control that can only fail.
+  // Read from `signed` rather than the status, because this component serves two sources and only
+  // the flag answers both: the preview builds an agreement nobody has signed, and `status` there
+  // is `not-started` while on a sanctioned list row it says nothing about whether a document
+  // exists. Offering the download on an agreement without one is a control that can only fail.
   protected readonly canDownload = computed(() => this.claGroup()?.signed === true);
 
   protected readonly notStartedCopy = ORG_CLA_NOT_STARTED_COPY;
@@ -198,10 +230,26 @@ export class OrgEasyclaDetailComponent {
 
   protected readonly tabs = computed(() => this.initTabs());
 
+  protected readonly lockedTab = computed(() => this.initLockedTab());
+
   public constructor() {
     // Switching organizations does not destroy this component — it re-drives the list fetch — so
     // without this the attestation stays open over a page that has moved on.
-    this.selectedOrgUid$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => this.uncommittedSigningDialog?.close());
+    this.selectedOrgUid$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.uncommittedSigningDialog?.close();
+
+      // On the preview the switch invalidates the page and not merely an open dialog. The choice
+      // was made under the organization the viewer has just left, and Start would open a session
+      // against the one they arrived at; nothing here can be re-derived for it either, since the
+      // CLA Group named may not be one the new organization can sign. So the page leaves rather
+      // than re-render itself under a company the choice was never about.
+      if (this.previewing) this.leaveForList();
+    });
+
+    // A pasted or bookmarked preview address, or one whose selection did not survive the trip.
+    // Nothing can be rehydrated — see `previewSelection` — and the list is where the picker lives,
+    // so this is a redirect rather than an empty state offering to start again.
+    if (isPlatformBrowser(this.platformId) && !this.previewing && !this.signatureId()) this.leaveForList();
   }
 
   protected selectTab(tab: OrgClaDetailTab): void {
@@ -353,6 +401,9 @@ export class OrgEasyclaDetailComponent {
   }
 
   private initClaGroup(): OrgClaGroup | undefined {
+    // The preview's agreement does not exist yet, so there is no row keyed by signature id to find.
+    if (this.previewSelection) return orgClaPreviewGroup(this.previewSelection);
+
     const id = this.signatureId();
     if (!id) return undefined;
     return this.claData()?.claGroups.find((group) => group.id === id);
@@ -421,14 +472,61 @@ export class OrgEasyclaDetailComponent {
     return ORG_CLA_DETAIL_TABS.map((tab) => ({ ...tab, badge: this.tabBadge(tab.id) }));
   }
 
+  /**
+   * Why the open tab holds nothing, when signing is what would fill it. Null on every other tab
+   * and on a signed agreement, where the panel is simply unbuilt.
+   *
+   * Read from `signed` rather than the status, as `canDownload` is and for the same reason:
+   * sanctions occupy the single status slot, so a `sanctioned` agreement may be signed — and its
+   * CLA Managers are real people who would be told they do not exist yet.
+   */
+  private initLockedTab(): { title: string; subtitle: string } | null {
+    const group = this.claGroup();
+    if (!group || group.signed) return null;
+    return ORG_CLA_LOCKED_TAB_COPY[this.activeTab()] ?? null;
+  }
+
   private tabBadge(tab: OrgClaDetailTab): string {
     if (tab === 'managers') return this.managersBadge();
     if (tab === 'approval') return this.approvalBadge();
     return '';
   }
 
+  /**
+   * The picker's choice, validated, or null when this is not the preview route.
+   *
+   * Validated rather than trusted: the value comes back out of a history entry, so it can be a
+   * shape written by an earlier deployment or one truncated on the way. Left unchecked, a partial
+   * selection would head the page with an undefined name — and it would still offer Start, because
+   * a missing project SFID only disables signing once something reads it.
+   */
+  private readPreviewSelection(): OrgClaSignSelection | null {
+    if (!isPlatformBrowser(this.platformId)) return null;
+
+    const state = this.router.getCurrentNavigation()?.extras?.state;
+    const selection = state?.[ORG_CLA_SIGN_SELECTION_STATE] as OrgClaSignSelection | undefined;
+    if (!selection?.claGroupId || !selection.claGroupName || !selection.projectSfid || !selection.projectName) return null;
+
+    return selection;
+  }
+
+  /**
+   * Leaves the preview for the list, replacing the address rather than pushing over it.
+   *
+   * Replacing is what actually closes the page: the choice lives in the history entry, so an entry
+   * left behind is one Back re-renders — under whichever organization is selected by then, which on
+   * the organization-switch path is precisely the wrong one.
+   */
+  private leaveForList(): void {
+    void this.router.navigate([ORG_EASYCLA_PATH], { replaceUrl: true });
+  }
+
   private initClaData(): Signal<OrgClaGroupList | null | undefined> {
-    if (!isPlatformBrowser(this.platformId)) {
+    // Not requested while previewing: `claGroup` comes from the selection, so the response would be
+    // fetched and never read. That absence is also what keeps `notFound` and `fetchError` off this
+    // page — neither can be reached without a list in hand — and `notFound` firing over a preview
+    // would tell a signatory the agreement they are about to sign does not exist.
+    if (this.previewing || !isPlatformBrowser(this.platformId)) {
       return signal<OrgClaGroupList | null | undefined>(undefined);
     }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -157,12 +157,18 @@ export class OrgEasyclaDetailComponent {
   protected readonly notStartedLead = computed(() => this.initNotStartedLead());
 
   /**
-   * The project and CLA Group this page already named, so Start can skip the picker.
+   * The SFID and CLA Group this page already named, so Start can skip the picker.
    *
-   * Any covered project with an SFID is enough: the producer signs by project and resolves the
-   * CLA Group from it. The picker only disables a row when search returned no `projectSfid` at
-   * all; requiring exactly one project here would disable Start on every multi-project group
-   * the list can already show.
+   * Foundation before covered project, and the order is the whole point. A CLA Group covering
+   * several projects is the ordinary case, not an edge one, and the corporate signature is keyed
+   * on the SFID sent with it — so taking the first covered project would open the agreement
+   * against one project of the several the CLA Group covers. That is not caught downstream
+   * either: the sub-project resolves back to this same CLA Group, so the mismatch guard on the
+   * response sees the id it asked for and passes.
+   *
+   * Absent a foundation, only a CLA Group covering a single project is unambiguous. Several
+   * covered projects with no foundation SFID is exactly the case search declines to name a
+   * project for, and the picker greys those rows out for the same reason.
    */
   protected readonly signingChoice = computed(() => this.signingChoiceFrom(this.claGroup()));
 
@@ -242,6 +248,35 @@ export class OrgEasyclaDetailComponent {
     this.confirmThenHandOff(orgUid, chosen);
   }
 
+  protected onDownload(): void {
+    const group = this.claGroup();
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    if (!group || !orgUid || this.downloading()) return;
+
+    this.downloading.set(true);
+    this.claService
+      .getPdfUrl(orgUid, group.id)
+      // `finalize` rather than clearing the flag in each handler: cancellation runs neither, and
+      // would otherwise leave the button spinning for the rest of the page's life.
+      .pipe(
+        finalize(() => this.downloading.set(false)),
+        takeUntil(this.contextChanged$),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: ({ url }) => {
+          downloadFromUrl(url, `${group.claGroupName}-signed.pdf`);
+        },
+        error: () => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Download failed',
+            detail: 'Could not download the signed document. Please try again.',
+          });
+        },
+      });
+  }
+
   private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
     const attestationRef = this.dialogService.open(OrgEasyclaAttestationComponent, {
       header: CCLA_SIGN_COPY.attestation.header,
@@ -285,39 +320,17 @@ export class OrgEasyclaDetailComponent {
   }
 
   private signingChoiceFrom(group: OrgClaGroup | undefined): OrgClaGroupPickerResult | null {
-    if (!group?.claGroupId) return null;
-    const project = group.projects.find((entry) => !!entry.projectSfid);
-    if (!project?.projectSfid) return null;
-    return { claGroupId: group.claGroupId, projectSfid: project.projectSfid, projectName: project.projectName };
-  }
+    const claGroupId = group?.claGroupId;
+    if (!group || !claGroupId) return null;
 
-  protected onDownload(): void {
-    const group = this.claGroup();
-    const orgUid = this.accountContext.selectedAccount()?.uid;
-    if (!group || !orgUid || this.downloading()) return;
+    if (group.foundationSfid) {
+      return { claGroupId, projectSfid: group.foundationSfid, projectName: group.foundationName ?? group.claGroupName };
+    }
 
-    this.downloading.set(true);
-    this.claService
-      .getPdfUrl(orgUid, group.id)
-      // `finalize` rather than clearing the flag in each handler: cancellation runs neither, and
-      // would otherwise leave the button spinning for the rest of the page's life.
-      .pipe(
-        finalize(() => this.downloading.set(false)),
-        takeUntil(this.contextChanged$),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe({
-        next: ({ url }) => {
-          downloadFromUrl(url, `${group.claGroupName}-signed.pdf`);
-        },
-        error: () => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Download failed',
-            detail: 'Could not download the signed document. Please try again.',
-          });
-        },
-      });
+    const [only] = group.projects;
+    if (group.projects.length !== 1 || !only?.projectSfid) return null;
+
+    return { claGroupId, projectSfid: only.projectSfid, projectName: only.projectName };
   }
 
   private initClaGroup(): OrgClaGroup | undefined {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -289,13 +289,7 @@ export class OrgEasyclaDetailComponent {
 
     this.uncommittedSigningDialog = attestationRef;
 
-    attestationRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((attestations: OrgClaSignAttestations | null | undefined) => {
-      this.uncommittedSigningDialog = null;
-      if (!attestations) {
-        this.signingOpen.set(false);
-        return;
-      }
-
+    this.whenSigningDialogEnds(attestationRef, (attestations: OrgClaSignAttestations) => {
       this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
     });
   }
@@ -316,7 +310,32 @@ export class OrgEasyclaDetailComponent {
       data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
     }) as DynamicDialogRef;
 
-    handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
+    this.whenSigningDialogEnds(handoffRef);
+  }
+
+  /**
+   * Releases Start when a dialog ends, unless `onAdvance` is taking the lock to the next step.
+   *
+   * PrimeNG's header close and Escape go through `p-dialog` `onHide` → `DynamicDialogRef.destroy()`.
+   * That never emits `onClose`. A listener that only watches `onClose` therefore leaves
+   * `signingOpen` true after those dismissals, and the control stays disabled until reload.
+   */
+  private whenSigningDialogEnds<T>(dialogRef: DynamicDialogRef, onAdvance?: (value: T) => void): void {
+    let handedOff = false;
+
+    dialogRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: T | null | undefined) => {
+      if (this.uncommittedSigningDialog === dialogRef) this.uncommittedSigningDialog = null;
+      if (value && onAdvance) {
+        handedOff = true;
+        onAdvance(value);
+        return;
+      }
+      this.signingOpen.set(false);
+    });
+
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      if (!handedOff) this.signingOpen.set(false);
+    });
   }
 
   private signingChoiceFrom(group: OrgClaGroup | undefined): OrgClaGroupPickerResult | null {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import type { OrgClaCoverageChip, OrgClaDetailTab, OrgClaDetailTabView, OrgClaGroup, OrgClaGroupList, OrgClaStatusDisplay } from '@lfx-one/shared/interfaces';
-import { ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
+import { ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
 import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -123,6 +123,18 @@ export class OrgEasyclaDetailComponent {
   // gives the viewer a control that can only fail.
   protected readonly canDownload = computed(() => this.claGroup()?.signed === true);
 
+  protected readonly notStartedCopy = ORG_CLA_NOT_STARTED_COPY;
+
+  /**
+   * Read from the status rather than from `signed` being false, unlike `canDownload` above.
+   * Sanctions occupy the same status slot, and a sanctioned agreement carries its own explanatory
+   * body in the design — walking that viewer through how to start signing would talk past the
+   * reason they cannot.
+   */
+  protected readonly notStarted = computed(() => this.claGroup()?.status === 'not-started');
+
+  protected readonly notStartedLead = computed(() => this.initNotStartedLead());
+
   protected readonly signedOnLabel = computed(() => this.initSignedOnLabel());
 
   protected readonly signedByName = computed(() => this.initSignedByName());
@@ -223,6 +235,17 @@ export class OrgEasyclaDetailComponent {
     const summary = orgClaCoverageSummary(group);
     const company = this.companyName();
     return summary && company ? `Covers ${summary} for ${company}'s employees.` : '';
+  }
+
+  /**
+   * Withheld until both names are known rather than filled with a placeholder. The sentence names
+   * the organization being bound and the agreement it would be bound to, so a gap in either is the
+   * part that carries the meaning, and "— has not yet signed a CLA for —" states nothing.
+   */
+  private initNotStartedLead(): string {
+    const group = this.claGroup();
+    const company = this.companyName();
+    return group && company ? this.notStartedCopy.lead(company, group.claGroupName) : '';
   }
 
   private initSignedOnLabel(): string {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -6,13 +6,22 @@ import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATF
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
-import type { OrgClaCoverageChip, OrgClaDetailTab, OrgClaDetailTabView, OrgClaGroup, OrgClaGroupList, OrgClaStatusDisplay } from '@lfx-one/shared/interfaces';
-import { ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
+import type {
+  OrgClaCoverageChip,
+  OrgClaDetailTab,
+  OrgClaDetailTabView,
+  OrgClaGroup,
+  OrgClaGroupList,
+  OrgClaGroupPickerResult,
+  OrgClaSignAttestations,
+  OrgClaStatusDisplay,
+} from '@lfx-one/shared/interfaces';
+import { CCLA_SIGN_COPY, ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
 import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, distinctUntilChanged, filter, finalize, map, of, skip, switchMap, takeUntil, tap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, finalize, map, of, skip, switchMap, take, takeUntil, tap } from 'rxjs';
 
 import { BreadcrumbComponent } from '@components/breadcrumb/breadcrumb.component';
 import { ButtonComponent } from '@components/button/button.component';
@@ -27,6 +36,8 @@ import { OpenIntercomDirective } from '@shared/directives/open-intercom.directiv
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 
 import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from '../org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
+import { OrgEasyclaAttestationComponent } from '../org-easycla-sign/org-easycla-attestation.component';
+import { OrgEasyclaSignHandoffComponent } from '../org-easycla-sign/org-easycla-sign-handoff.component';
 
 @Component({
   selector: 'lfx-org-easycla-detail',
@@ -51,6 +62,16 @@ export class OrgEasyclaDetailComponent {
   protected readonly downloading = signal(false);
   protected readonly fetchError = signal(false);
   private readonly claLoadingState = signal(false);
+
+  /** One hand-off at a time. Also what disables Start while a flow is open. */
+  protected readonly signingOpen = signal(false);
+
+  /**
+   * The attestation dialog, while it is open. Held so an organization switch can close it.
+   * Never holds the hand-off — by then a signing session exists for the organization that was
+   * selected when the viewer confirmed.
+   */
+  private uncommittedSigningDialog: DynamicDialogRef | null = null;
 
   protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
   protected readonly hasCompany = computed(() => !!this.accountContext.selectedAccount()?.uid);
@@ -135,6 +156,30 @@ export class OrgEasyclaDetailComponent {
 
   protected readonly notStartedLead = computed(() => this.initNotStartedLead());
 
+  /**
+   * The project and CLA Group this page already named, so Start can skip the picker.
+   *
+   * Any covered project with an SFID is enough: the producer signs by project and resolves the
+   * CLA Group from it. The picker only disables a row when search returned no `projectSfid` at
+   * all; requiring exactly one project here would disable Start on every multi-project group
+   * the list can already show.
+   */
+  protected readonly signingChoice = computed(() => this.signingChoiceFrom(this.claGroup()));
+
+  protected readonly startDisabled = computed(
+    () => !this.hasCompany() || this.signingOpen() || this.hasNoOrgAccess() || !this.orgContextLoaded() || !this.signingChoice()
+  );
+
+  protected readonly startAriaLabel = computed(() => {
+    const label = this.notStartedCopy.startLabel;
+    if (this.hasNoOrgAccess()) return `${label} — Organization Lens is not available for your account`;
+    if (!this.orgContextLoaded()) return `${label} — checking your organization access`;
+    if (!this.hasCompany()) return `${label} — select an organization first`;
+    if (this.signingOpen()) return `${label} — a signing request is already open`;
+    if (!this.signingChoice()) return `${label} — ${CCLA_SIGN_COPY.picker.multiProjectDisabledReason}`;
+    return label;
+  });
+
   protected readonly signedOnLabel = computed(() => this.initSignedOnLabel());
 
   protected readonly signedByName = computed(() => this.initSignedByName());
@@ -146,6 +191,12 @@ export class OrgEasyclaDetailComponent {
   protected readonly approvalBadge = computed(() => this.initApprovalBadge());
 
   protected readonly tabs = computed(() => this.initTabs());
+
+  public constructor() {
+    // Switching organizations does not destroy this component — it re-drives the list fetch — so
+    // without this the attestation stays open over a page that has moved on.
+    this.selectedOrgUid$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => this.uncommittedSigningDialog?.close());
+  }
 
   protected selectTab(tab: OrgClaDetailTab): void {
     this.activeTab.set(tab);
@@ -174,6 +225,70 @@ export class OrgEasyclaDetailComponent {
     if (!group) return;
 
     this.dialogService.open(OrgEasyclaCoverageDialogComponent, orgClaCoverageDialogConfig(group));
+  }
+
+  /**
+   * Starts the corporate signing flow from this agreement, skipping the picker.
+   *
+   * The page already named the CLA Group. Asking again would be a second source of truth for
+   * which agreement the viewer is looking at, and a chance to hand off a different one.
+   */
+  protected startClaProcess(): void {
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    const chosen = this.signingChoice();
+    if (!orgUid || !chosen || this.signingOpen()) return;
+
+    this.signingOpen.set(true);
+    this.confirmThenHandOff(orgUid, chosen);
+  }
+
+  private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
+    const attestationRef = this.dialogService.open(OrgEasyclaAttestationComponent, {
+      header: CCLA_SIGN_COPY.attestation.header,
+      width: '42rem',
+      style: { maxWidth: '90vw' },
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+    }) as DynamicDialogRef;
+
+    this.uncommittedSigningDialog = attestationRef;
+
+    attestationRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((attestations: OrgClaSignAttestations | null | undefined) => {
+      this.uncommittedSigningDialog = null;
+      if (!attestations) {
+        this.signingOpen.set(false);
+        return;
+      }
+
+      this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
+    });
+  }
+
+  private afterDialogTornDown(dialogRef: DynamicDialogRef, next: () => void): void {
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => next());
+  }
+
+  private openHandOff(orgUid: string, chosen: OrgClaGroupPickerResult, attestations: OrgClaSignAttestations): void {
+    const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
+      header: CCLA_SIGN_COPY.preparing.header,
+      width: '40rem',
+      style: { maxWidth: '90vw' },
+      modal: true,
+      closable: false,
+      closeOnEscape: false,
+      dismissableMask: false,
+      data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
+    }) as DynamicDialogRef;
+
+    handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
+  }
+
+  private signingChoiceFrom(group: OrgClaGroup | undefined): OrgClaGroupPickerResult | null {
+    if (!group?.claGroupId) return null;
+    const project = group.projects.find((entry) => !!entry.projectSfid);
+    if (!project?.projectSfid) return null;
+    return { claGroupId: group.claGroupId, projectSfid: project.projectSfid, projectName: project.projectName };
   }
 
   protected onDownload(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
@@ -24,10 +24,20 @@ This is legal attestation copy: do not hardcode a sentence here, and do not rewo
       control="embargoAcked"
       [label]="copy.embargoLabel"
       labelClass="text-sm text-slate-700"
+      ariaDescribedBy="org-easycla-attestation-conditions"
       data-testid="org-easycla-attestation-embargo" />
   </div>
 
-  <ul class="mt-3 flex list-disc flex-col gap-2 pl-9 text-sm text-slate-700" data-testid="org-easycla-attestation-conditions">
+  <!--
+    Described by, not merely adjacent. The checkbox's own label ends "… is not:", and the terms
+    that finish that sentence are these list items. Without the association a screen-reader user
+    arrives at the control having heard an incomplete sentence and affirms terms never read to
+    them, which is not a defensible way to take a legal attestation.
+  -->
+  <ul
+    id="org-easycla-attestation-conditions"
+    class="mt-3 flex list-disc flex-col gap-2 pl-9 text-sm text-slate-700"
+    data-testid="org-easycla-attestation-conditions">
     @for (condition of copy.embargoConditions; track condition) {
       <li>{{ condition }}</li>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
@@ -2,7 +2,7 @@
 Copyright The Linux Foundation and each contributor to LFX.
 SPDX-License-Identifier: MIT
 
-Every string below is bound from CCLA_SIGN_COPY.attestation, verbatim from the approved design.
+Every string below is bound from CCLA_SIGN_COPY.attestation, verbatim from the M3 prototype.
 This is legal attestation copy: do not hardcode a sentence here, and do not reword one.
 -->
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
@@ -1,0 +1,58 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+
+Every string below is bound from CCLA_SIGN_COPY.attestation, verbatim from the approved design.
+This is legal attestation copy: do not hardcode a sentence here, and do not reword one.
+-->
+
+<div class="flex flex-col" data-testid="org-easycla-attestation-dialog">
+  <p class="text-sm font-semibold text-slate-900">{{ copy.authorityHeading }}</p>
+  <div class="mt-2">
+    <lfx-checkbox
+      [form]="form"
+      control="authorityAcked"
+      [label]="copy.authorityLabel"
+      labelClass="text-sm text-slate-700"
+      data-testid="org-easycla-attestation-authority" />
+  </div>
+
+  <p class="mt-6 text-sm font-semibold text-slate-900">{{ copy.embargoHeading }}</p>
+  <div class="mt-2">
+    <lfx-checkbox
+      [form]="form"
+      control="embargoAcked"
+      [label]="copy.embargoLabel"
+      labelClass="text-sm text-slate-700"
+      data-testid="org-easycla-attestation-embargo" />
+  </div>
+
+  <ul class="mt-3 list-disc space-y-2 pl-9 text-sm text-slate-700" data-testid="org-easycla-attestation-conditions">
+    @for (condition of copy.embargoConditions; track condition) {
+      <li>{{ condition }}</li>
+    }
+    <!--
+      Split rather than listed with the two above because the link sits mid-sentence. `noopener`
+      is on the link because the opened context must not be handed control of this one — this
+      page is mid-way through a legal act.
+    -->
+    <li>
+      {{ copy.embargoSanctionsCondition.before
+      }}<a [href]="copy.embargoSanctionsCondition.linkUrl" target="_blank" rel="noopener noreferrer" class="text-blue-700 underline">{{
+        copy.embargoSanctionsCondition.linkText
+      }}</a
+      >{{ copy.embargoSanctionsCondition.after }}
+    </li>
+  </ul>
+
+  <!--
+    No "I am not authorized" control here, operable or disabled. The designee path it belongs to
+    is not implemented in this feature, and a legal confirmation step is the wrong place to
+    advertise an unavailable route: a signatory who is genuinely not authorized would read a
+    greyed-out control as their answer and stop, having been shown no way forward at all.
+  -->
+  <div class="mt-8 flex justify-end gap-2">
+    <lfx-button [label]="copy.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-attestation-cancel" />
+    <lfx-button [label]="copy.continueLabel" [disabled]="!bothAcked()" (onClick)="onContinue()" data-testid="org-easycla-attestation-continue" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
@@ -27,7 +27,7 @@ This is legal attestation copy: do not hardcode a sentence here, and do not rewo
       data-testid="org-easycla-attestation-embargo" />
   </div>
 
-  <ul class="mt-3 list-disc space-y-2 pl-9 text-sm text-slate-700" data-testid="org-easycla-attestation-conditions">
+  <ul class="mt-3 flex list-disc flex-col gap-2 pl-9 text-sm text-slate-700" data-testid="org-easycla-attestation-conditions">
     @for (condition of copy.embargoConditions; track condition) {
       <li>{{ condition }}</li>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.spec.ts
@@ -1,0 +1,158 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrgEasyclaAttestationComponent } from './org-easycla-attestation.component';
+
+/**
+ * The attestation gate, from the browser's side.
+ *
+ * The controller specs prove the server refuses an unaffirmed request. These prove the two things
+ * only the client can be wrong about: that the control cannot be reached without both boxes, and
+ * that what leaves the dialog is what the signatory actually set rather than a literal written
+ * on the way out.
+ */
+describe('OrgEasyclaAttestationComponent', () => {
+  const close = vi.fn();
+
+  async function render(): Promise<ComponentFixture<OrgEasyclaAttestationComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaAttestationComponent],
+      providers: [{ provide: DynamicDialogRef, useValue: { close } }],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaAttestationComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  /** Reaches the component's own form, which is what the template binds and the click reads. */
+  function form(fixture: ComponentFixture<OrgEasyclaAttestationComponent>) {
+    return (fixture.componentInstance as unknown as { form: { controls: Record<string, { setValue: (v: boolean) => void }> } }).form;
+  }
+
+  function continueButton(fixture: ComponentFixture<OrgEasyclaAttestationComponent>): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('[data-testid="org-easycla-attestation-continue"] button') as HTMLButtonElement;
+  }
+
+  beforeEach(() => close.mockClear());
+
+  it('opens with neither confirmation given', async () => {
+    const fixture = await render();
+
+    const boxes = Array.from(fixture.nativeElement.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+    expect(boxes).toHaveLength(2);
+    expect(boxes.every((box) => !box.checked)).toBe(true);
+  });
+
+  it('cannot be continued with neither confirmation', async () => {
+    const fixture = await render();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it.each([['authorityAcked'], ['embargoAcked']])('cannot be continued with only %s given', async (control) => {
+    const fixture = await render();
+
+    form(fixture).controls[control].setValue(true);
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('can be continued once both are given', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    form(fixture).controls['embargoAcked'].setValue(true);
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(false);
+  });
+
+  // Withdrawal must re-close the gate. A `bothAcked` computed once and cached, or a flag set on
+  // first tick and never cleared, would leave the control live after the signatory changed their
+  // mind — and the request would then carry an affirmation they had visibly retracted.
+  it('cannot be continued again after a confirmation is withdrawn', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    form(fixture).controls['embargoAcked'].setValue(true);
+    fixture.detectChanges();
+    form(fixture).controls['embargoAcked'].setValue(false);
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('closes with both confirmations as the signatory set them', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    form(fixture).controls['embargoAcked'].setValue(true);
+    fixture.detectChanges();
+    continueButton(fixture).click();
+
+    expect(close).toHaveBeenCalledWith({ authorityAcked: true, embargoAcked: true });
+  });
+
+  // The load-bearing one. Invoking continue directly bypasses the disabled attribute, which is
+  // exactly what a regression in the template would do. Nothing must close the dialog with an
+  // affirmation the form does not hold.
+  it('closes with nothing when continue is invoked while a confirmation is withdrawn', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    fixture.detectChanges();
+    (fixture.componentInstance as unknown as { onContinue: () => void }).onContinue();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('closes with nothing when the signatory backs out', async () => {
+    const fixture = await render();
+
+    (fixture.nativeElement.querySelector('[data-testid="org-easycla-attestation-cancel"] button') as HTMLButtonElement).click();
+
+    expect(close).toHaveBeenCalledWith(null);
+  });
+
+  it('renders the approved wording verbatim', async () => {
+    const fixture = await render();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.authorityHeading);
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.authorityLabel);
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.embargoHeading);
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.embargoLabel);
+    for (const condition of CCLA_SIGN_COPY.attestation.embargoConditions) {
+      expect(text).toContain(condition);
+    }
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.embargoSanctionsCondition.linkText);
+  });
+
+  it('links the sanctions authority without handing it control of this page', async () => {
+    const fixture = await render();
+
+    const link = fixture.nativeElement.querySelector('[data-testid="org-easycla-attestation-conditions"] a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe(CCLA_SIGN_COPY.attestation.embargoSanctionsCondition.linkUrl);
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toContain('noopener');
+  });
+
+  // Self-sign only in this feature. A disabled "I am not authorized" control would tell a
+  // signatory who genuinely is not authorized that they have no route at all.
+  it('offers no designee control, neither operable nor disabled', async () => {
+    const fixture = await render();
+    const text = ((fixture.nativeElement as HTMLElement).textContent ?? '').toLowerCase();
+
+    expect(text).not.toContain('i am not authorized');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.spec.ts
@@ -124,7 +124,7 @@ describe('OrgEasyclaAttestationComponent', () => {
     expect(close).toHaveBeenCalledWith(null);
   });
 
-  it('renders the approved wording verbatim', async () => {
+  it('renders the attestation wording verbatim', async () => {
     const fixture = await render();
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.ts
@@ -1,0 +1,74 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup } from '@angular/forms';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import type { OrgClaSignAttestations } from '@lfx-one/shared/interfaces';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+
+/**
+ * The authorization and export-compliance confirmations, ahead of the corporate signing hand-off
+ * (#1983).
+ *
+ * Every string it renders comes from `CCLA_SIGN_COPY.attestation`, verbatim from the approved
+ * design. This is the first attestation the product renders itself — every earlier CLA surface
+ * handed off to another product before any attestation appeared — so the wording is a reviewed
+ * artifact, not copy. Do not paraphrase it here, and do not inline a variant.
+ *
+ * Closes with the two confirmations as the signatory actually left them, or `null` if they backed
+ * out. It deliberately does **not** close with a bare "confirmed" signal: the values are what the
+ * request transmits, and reconstructing them at the caller would mean the caller asserting an
+ * attestation rather than relaying one.
+ */
+@Component({
+  selector: 'lfx-org-easycla-attestation',
+  imports: [ButtonComponent, CheckboxComponent],
+  templateUrl: './org-easycla-attestation.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaAttestationComponent {
+  private readonly ref = inject(DynamicDialogRef);
+
+  protected readonly copy = CCLA_SIGN_COPY.attestation;
+
+  /** Both start unticked. Nothing in this flow pre-affirms either one. */
+  protected readonly form = new FormGroup({
+    authorityAcked: new FormControl<boolean>(false, { nonNullable: true }),
+    embargoAcked: new FormControl<boolean>(false, { nonNullable: true }),
+  });
+
+  /**
+   * Mirrors the form rather than being derived in the template, so withdrawing a confirmation
+   * re-disables the control on the same change that cleared it.
+   */
+  protected readonly bothAcked = signal(false);
+
+  public constructor() {
+    this.form.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.bothAcked.set(this.form.controls.authorityAcked.value === true && this.form.controls.embargoAcked.value === true);
+    });
+  }
+
+  protected onContinue(): void {
+    const authorityAcked = this.form.controls.authorityAcked.value === true;
+    const embargoAcked = this.form.controls.embargoAcked.value === true;
+
+    // Re-read from the controls at the moment of the click rather than trusting the disabled
+    // state that led here. The disabled control is the safeguard; this is the record. If the two
+    // ever disagree, the one that matters legally is what the signatory actually set, and closing
+    // with a literal `true` would make that disagreement undetectable everywhere downstream.
+    if (!authorityAcked || !embargoAcked) return;
+
+    const attestations: OrgClaSignAttestations = { authorityAcked, embargoAcked };
+    this.ref.close(attestations);
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.ts
@@ -15,10 +15,10 @@ import { CheckboxComponent } from '@components/checkbox/checkbox.component';
  * The authorization and export-compliance confirmations, ahead of the corporate signing hand-off
  * (#1983).
  *
- * Every string it renders comes from `CCLA_SIGN_COPY.attestation`, verbatim from the approved
- * design. This is the first attestation the product renders itself — every earlier CLA surface
- * handed off to another product before any attestation appeared — so the wording is a reviewed
- * artifact, not copy. Do not paraphrase it here, and do not inline a variant.
+ * Every string it renders comes from `CCLA_SIGN_COPY.attestation`, verbatim from the M3
+ * prototype. This is the first attestation the product renders itself — every earlier CLA surface
+ * handed off to another product before any attestation appeared — so the wording is a single
+ * defined artifact, not copy. Do not paraphrase it here, and do not inline a variant.
  *
  * Closes with the two confirmations as the signatory actually left them, or `null` if they backed
  * out. It deliberately does **not** close with a bare "confirmed" signal: the values are what the

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -1,0 +1,105 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+-->
+
+<div class="flex flex-col" data-testid="org-easycla-group-select-dialog">
+  <p class="mb-4 text-sm text-slate-600">Choose the project or CLA group you want to sign a corporate CLA for.</p>
+
+  <!--
+    The results list is in flow, not an absolutely positioned overlay: inside a DynamicDialog an
+    overlay contributes no height, so the dialog stays short and its content box crops the list.
+  -->
+  <div>
+    <label for="org-easycla-group-select-search-input" class="sr-only">Search projects and CLA groups</label>
+    <lfx-input-text
+      [id]="'org-easycla-group-select-search-input'"
+      [form]="searchForm"
+      control="query"
+      type="text"
+      size="small"
+      icon="fa-light fa-magnifying-glass"
+      placeholder="Search projects, CLA groups, or organizations…"
+      autocomplete="off"
+      styleClass="w-full"
+      data-testid="org-easycla-group-select-search" />
+
+    <div
+      role="listbox"
+      aria-label="Matching CLA groups"
+      class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg"
+      data-testid="org-easycla-group-select-results">
+      @if (error()) {
+        <div role="alert" class="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600" data-testid="org-easycla-group-select-error">
+          <span>Couldn't load CLA groups.</span>
+          <lfx-button label="Retry" size="small" [text]="true" icon="fa-light fa-arrow-rotate-left" (onClick)="retry()" />
+        </div>
+      } @else if (queryBand() === 'empty') {
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-empty">Search for a project or CLA group.</div>
+      } @else if (queryBand() === 'short') {
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-keep-typing">
+          Keep typing — searching starts at {{ minChars }} characters.
+        </div>
+      } @else if (loading() && options().length === 0) {
+        <div class="flex items-center gap-2 px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-loading">
+          <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+          Searching…
+        </div>
+      } @else if (!loading() && options().length === 0) {
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-no-match">No matching projects or CLA groups.</div>
+      } @else {
+        <!--
+          Results stay on screen while the next search runs, matching the Me-lens picker: a cold
+          producer search is a multi-table scan, so swapping the list for a spinner on every
+          keystroke past the third would flash the modal empty for that whole window.
+        -->
+        @if (loading()) {
+          <div class="flex items-center gap-2 border-b border-slate-100 px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-pending">
+            <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+            Searching…
+          </div>
+        }
+        @for (option of options(); track option.claGroupId) {
+          <!--
+            A row that cannot be signed keeps its place and states why, rather than disappearing.
+            The reason is rendered as visible text and not only as a tooltip, because the row is
+            not focusable when disabled and a tooltip alone would never reach a viewer who cannot
+            hover.
+          -->
+          <div
+            role="option"
+            [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
+            [attr.aria-disabled]="!!option.disabledReason"
+            class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
+            [class.cursor-pointer]="!option.disabledReason"
+            [class.hover:bg-slate-50]="!option.disabledReason"
+            [class.cursor-not-allowed]="!!option.disabledReason"
+            [class.opacity-60]="!!option.disabledReason"
+            [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId"
+            [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
+            (click)="onSelect(option)">
+            <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
+            @if (option.secondaryName) {
+              <span class="block text-xs text-slate-500">{{ option.secondaryName }}</span>
+            }
+            @if (option.disabledReason) {
+              <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
+                {{ option.disabledReason }}
+              </span>
+            }
+          </div>
+        }
+        @if (truncated()) {
+          <div class="px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-truncated">
+            More CLA groups matched than can be shown. Narrow your search.
+          </div>
+        }
+      }
+    </div>
+  </div>
+
+  <div class="mt-6 flex justify-end gap-2">
+    <lfx-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-group-cancel" />
+    <lfx-button label="Continue" [disabled]="!selected()" (onClick)="onContinue()" data-testid="org-easycla-group-continue" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -4,7 +4,9 @@ SPDX-License-Identifier: MIT
 -->
 
 <div class="flex flex-col" data-testid="org-easycla-group-select-dialog">
-  <p class="mb-4 text-sm text-slate-600">Choose the project or CLA group you want to sign a corporate CLA for.</p>
+  <p class="mb-4 text-sm text-slate-600">
+    Choose the project, CLA group, or repository source (GitHub, GitLab, or Gerrit) you want to sign a corporate CLA for.
+  </p>
 
   <!--
     The results list is in flow, not an absolutely positioned overlay: inside a DynamicDialog an
@@ -28,7 +30,7 @@ SPDX-License-Identifier: MIT
       type="text"
       size="small"
       icon="fa-light fa-magnifying-glass"
-      placeholder="Search projects, CLA groups, or organizations…"
+      placeholder="Search projects, CLA groups, repo sources, or paste a repo link…"
       autocomplete="off"
       styleClass="w-full"
       role="combobox"
@@ -101,6 +103,19 @@ SPDX-License-Identifier: MIT
             <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
             @if (option.secondaryName) {
               <span class="block text-xs text-slate-500">{{ option.secondaryName }}</span>
+            }
+            <!--
+              Shown only for a repository match, where the row would otherwise contain nothing the
+              viewer typed: pasting a repo link resolves to the CLA Group covering it, whose project
+              and group names need share no text with the address. Without this the row reads as an
+              unrelated result. It is inside the option, so it is part of the accessible name and is
+              read when the highlight arrives.
+            -->
+            @if (option.matchedRepositoryName) {
+              <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-matched-repo-' + option.claGroupId">
+                <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
+                <span class="truncate">{{ option.matchedRepositoryName }}</span>
+              </span>
             }
             @if (option.disabledReason) {
               <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -12,8 +12,12 @@ SPDX-License-Identifier: MIT
   -->
   <!--
     Keydown is bound here rather than on the rows. The rows are not focusable — focus stays in the
-    text box so the viewer can keep typing while moving the highlight, which is what the listbox's
-    `aria-activedescendant` describes.
+    text box so the viewer can keep typing while moving the highlight.
+
+    The combobox attributes go on the input itself, not on this container and not on the listbox.
+    `aria-activedescendant` is read from whatever holds focus, which is the text box throughout;
+    on the listbox it names the right element and is never announced, because nothing ever focuses
+    the listbox. That failure is invisible on screen, which is how it survived a first pass.
   -->
   <div (keydown)="onKeydown($event)">
     <label for="org-easycla-group-select-search-input" class="sr-only">Search projects and CLA groups</label>
@@ -27,13 +31,17 @@ SPDX-License-Identifier: MIT
       placeholder="Search projects, CLA groups, or organizations…"
       autocomplete="off"
       styleClass="w-full"
+      role="combobox"
+      ariaAutocomplete="list"
+      ariaControls="org-easycla-group-select-results"
+      [ariaExpanded]="listboxOpen()"
+      [ariaActivedescendant]="activeOptionId()"
       data-testid="org-easycla-group-select-search" />
 
     <div
       id="org-easycla-group-select-results"
       role="listbox"
       aria-label="Matching CLA groups"
-      [attr.aria-activedescendant]="highlightedIndex() >= 0 ? 'org-easycla-group-option-' + options()[highlightedIndex()]?.claGroupId : null"
       class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg"
       data-testid="org-easycla-group-select-results">
       @if (error()) {
@@ -59,8 +67,12 @@ SPDX-License-Identifier: MIT
           Results stay on screen while the next search runs, matching the Me-lens picker: a cold
           producer search is a multi-table scan, so swapping the list for a spinner on every
           keystroke past the third would flash the modal empty for that whole window.
+
+          Shown for the debounce as well as the request (`stale`, not just `loading`), because the
+          rows underneath answer the previous term for both — and they are not selectable for
+          either, so the banner is what explains why clicking one does nothing.
         -->
-        @if (loading()) {
+        @if (stale()) {
           <div class="flex items-center gap-2 border-b border-slate-100 px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-pending">
             <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
             Searching…
@@ -77,12 +89,12 @@ SPDX-License-Identifier: MIT
             role="option"
             [id]="'org-easycla-group-option-' + option.claGroupId"
             [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
-            [attr.aria-disabled]="!!option.disabledReason"
+            [attr.aria-disabled]="!!option.disabledReason || stale()"
             class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
-            [class.cursor-pointer]="!option.disabledReason"
-            [class.hover:bg-slate-50]="!option.disabledReason"
-            [class.cursor-not-allowed]="!!option.disabledReason"
-            [class.opacity-60]="!!option.disabledReason"
+            [class.cursor-pointer]="!option.disabledReason && !stale()"
+            [class.hover:bg-slate-50]="!option.disabledReason && !stale()"
+            [class.cursor-not-allowed]="!!option.disabledReason || stale()"
+            [class.opacity-60]="!!option.disabledReason || stale()"
             [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
             [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
             (click)="onSelect(option)">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -4,9 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 
 <div class="flex flex-col" data-testid="org-easycla-group-select-dialog">
-  <p class="mb-4 text-sm text-slate-600">
-    Choose the project, CLA group, or repository source (GitHub, GitLab, or Gerrit) you want to sign a corporate CLA for.
-  </p>
+  <p class="mb-4 text-sm text-slate-600">{{ copy.body }}</p>
 
   <!--
     The results list is in flow, not an absolutely positioned overlay: inside a DynamicDialog an
@@ -22,7 +20,7 @@ SPDX-License-Identifier: MIT
     the listbox. That failure is invisible on screen, which is how it survived a first pass.
   -->
   <div (keydown)="onKeydown($event)">
-    <label for="org-easycla-group-select-search-input" class="sr-only">Search projects and CLA groups</label>
+    <label for="org-easycla-group-select-search-input" class="sr-only">{{ copy.placeholder }}</label>
     <lfx-input-text
       [id]="'org-easycla-group-select-search-input'"
       [form]="searchForm"
@@ -30,7 +28,7 @@ SPDX-License-Identifier: MIT
       type="text"
       size="small"
       icon="fa-light fa-magnifying-glass"
-      placeholder="Search projects, CLA groups, repo sources, or paste a repo link…"
+      [placeholder]="copy.placeholder"
       autocomplete="off"
       styleClass="w-full"
       role="combobox"
@@ -52,7 +50,7 @@ SPDX-License-Identifier: MIT
           <lfx-button label="Retry" size="small" [text]="true" icon="fa-light fa-arrow-rotate-left" (onClick)="retry()" />
         </div>
       } @else if (queryBand() === 'empty') {
-        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-empty">Search for a project or CLA group.</div>
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-empty">{{ copy.empty }}</div>
       } @else if (queryBand() === 'short') {
         <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-keep-typing">
           Keep typing — searching starts at {{ minChars }} characters.
@@ -63,7 +61,7 @@ SPDX-License-Identifier: MIT
           Searching…
         </div>
       } @else if (!loading() && options().length === 0) {
-        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-no-match">No matching projects or CLA groups.</div>
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-no-match">{{ copy.noMatch }}</div>
       } @else {
         <!--
           Results stay on screen while the next search runs, matching the Me-lens picker: a cold
@@ -134,7 +132,7 @@ SPDX-License-Identifier: MIT
   </div>
 
   <div class="mt-6 flex justify-end gap-2">
-    <lfx-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-group-cancel" />
-    <lfx-button label="Continue" [disabled]="!selected()" (onClick)="onContinue()" data-testid="org-easycla-group-continue" />
+    <lfx-button [label]="copy.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-group-cancel" />
+    <lfx-button [label]="copy.continueLabel" [disabled]="!selected()" (onClick)="onContinue()" data-testid="org-easycla-group-continue" />
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -36,7 +36,7 @@ SPDX-License-Identifier: MIT
       ariaControls="org-easycla-group-select-results"
       [ariaExpanded]="listboxOpen()"
       [ariaActivedescendant]="activeOptionId()"
-      data-testid="org-easycla-group-select-search" />
+      dataTest="org-easycla-group-select-search" />
 
     <div
       id="org-easycla-group-select-results"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -10,7 +10,12 @@ SPDX-License-Identifier: MIT
     The results list is in flow, not an absolutely positioned overlay: inside a DynamicDialog an
     overlay contributes no height, so the dialog stays short and its content box crops the list.
   -->
-  <div>
+  <!--
+    Keydown is bound here rather than on the rows. The rows are not focusable — focus stays in the
+    text box so the viewer can keep typing while moving the highlight, which is what the listbox's
+    `aria-activedescendant` describes.
+  -->
+  <div (keydown)="onKeydown($event)">
     <label for="org-easycla-group-select-search-input" class="sr-only">Search projects and CLA groups</label>
     <lfx-input-text
       [id]="'org-easycla-group-select-search-input'"
@@ -25,8 +30,10 @@ SPDX-License-Identifier: MIT
       data-testid="org-easycla-group-select-search" />
 
     <div
+      id="org-easycla-group-select-results"
       role="listbox"
       aria-label="Matching CLA groups"
+      [attr.aria-activedescendant]="highlightedIndex() >= 0 ? 'org-easycla-group-option-' + options()[highlightedIndex()]?.claGroupId : null"
       class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg"
       data-testid="org-easycla-group-select-results">
       @if (error()) {
@@ -59,15 +66,16 @@ SPDX-License-Identifier: MIT
             Searching…
           </div>
         }
-        @for (option of options(); track option.claGroupId) {
+        @for (option of options(); track option.claGroupId; let index = $index) {
           <!--
             A row that cannot be signed keeps its place and states why, rather than disappearing.
-            The reason is rendered as visible text and not only as a tooltip, because the row is
-            not focusable when disabled and a tooltip alone would never reach a viewer who cannot
-            hover.
+            The reason is rendered as visible text and not only as a tooltip, because a tooltip
+            would never reach a viewer who cannot hover. It is inside the option, so the reason is
+            part of the row's accessible name and is read when the highlight arrives.
           -->
           <div
             role="option"
+            [id]="'org-easycla-group-option-' + option.claGroupId"
             [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
             [attr.aria-disabled]="!!option.disabledReason"
             class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
@@ -75,7 +83,7 @@ SPDX-License-Identifier: MIT
             [class.hover:bg-slate-50]="!option.disabledReason"
             [class.cursor-not-allowed]="!!option.disabledReason"
             [class.opacity-60]="!!option.disabledReason"
-            [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId"
+            [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
             [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
             (click)="onSelect(option)">
             <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -1,0 +1,284 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import type { ClaGroupOption, ClaGroupSearchResponse } from '@lfx-one/shared/interfaces';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrgEasyclaGroupSelectComponent } from './org-easycla-group-select.component';
+
+/**
+ * The Organization Lens CLA Group picker.
+ *
+ * The searching itself is the Me-lens picker's debounce and minimum-term behaviour and is covered
+ * there. What is new — and what these specs are for — is that this picker keeps rows it cannot
+ * sign, says why, and refuses to return one.
+ */
+describe('OrgEasyclaGroupSelectComponent', () => {
+  const getSignOptions = vi.fn();
+  const close = vi.fn();
+  const orgUid = '0014100000Te0xxAAC';
+
+  // Not cast. A cast would let a fixture omit a field the shared view mapper reads, and the
+  // failure would surface as an unrelated runtime error rather than a type error here.
+  const signable: ClaGroupOption = {
+    claGroupId: '11111111-1111-4111-8111-111111111111',
+    claGroupName: 'Cascade CLA',
+    projectName: 'Cascade',
+    projectSfid: 'a09410000182dD2AAI',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+  };
+
+  /** A CLA Group covering several projects: the producer cannot be told which one to sign for. */
+  const multiProject: ClaGroupOption = {
+    claGroupId: '22222222-2222-4222-8222-222222222222',
+    claGroupName: 'Driftwood Umbrella CLA',
+    projectName: 'Driftwood Umbrella',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+  };
+
+  /** A CLA Group configured for individual agreements only. */
+  const individualOnly: ClaGroupOption = {
+    claGroupId: '33333333-3333-4333-8333-333333333333',
+    claGroupName: 'Beacon ICLA-only CLA',
+    projectName: 'Beacon',
+    projectSfid: 'a09410000182dD3AAI',
+    cclaEnabled: false,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+  };
+
+  function results(options: ClaGroupOption[], truncated = false, searchTerm = 'cascade'): ClaGroupSearchResponse {
+    return { results: options, truncated, searchTerm, resultCount: options.length };
+  }
+
+  async function render(): Promise<ComponentFixture<OrgEasyclaGroupSelectComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaGroupSelectComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: { orgUid } } },
+        { provide: OrgLensClaService, useValue: { getSignOptions } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaGroupSelectComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  /** Types a searchable term and lets the debounce elapse. */
+  async function search(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, term = 'cascade'): Promise<void> {
+    const form = (fixture.componentInstance as unknown as { searchForm: { controls: { query: { setValue: (v: string) => void } } } }).searchForm;
+    form.controls.query.setValue(term);
+    await vi.advanceTimersByTimeAsync(600);
+    fixture.detectChanges();
+  }
+
+  function testid(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, id: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+  }
+
+  function row(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, option: ClaGroupOption): HTMLElement {
+    return testid(fixture, `org-easycla-group-select-${option.claGroupId}`) as HTMLElement;
+  }
+
+  function continueButton(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLButtonElement {
+    return testid(fixture, 'org-easycla-group-continue')?.querySelector('button') as HTMLButtonElement;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getSignOptions.mockReset();
+    close.mockClear();
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('searches the viewing organization, not the whole platform', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture, 'cascade');
+
+    expect(getSignOptions).toHaveBeenCalledWith(orgUid, 'cascade');
+  });
+
+  it('does not search before the minimum term length', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture, 'ca'.slice(0, CLA_GROUP_SEARCH_MIN_CHARS - 1));
+
+    expect(getSignOptions).not.toHaveBeenCalled();
+    expect(testid(fixture, 'org-easycla-group-select-keep-typing')).not.toBeNull();
+  });
+
+  it('offers a signable CLA group without a reason against it', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(row(fixture, signable)).not.toBeNull();
+    expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('false');
+    expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)).toBeNull();
+  });
+
+  // A row that cannot be signed stays on screen. Filtering it out would leave the viewer
+  // searching again for a CLA Group they can see in the legacy console, with no explanation.
+  it('keeps a multi-project CLA group visible and says why it cannot be signed here', async () => {
+    getSignOptions.mockReturnValue(of(results([multiProject])));
+
+    const fixture = await render();
+    await search(fixture, 'driftwood');
+
+    expect(row(fixture, multiProject).getAttribute('aria-disabled')).toBe('true');
+    expect(testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.multiProjectDisabledReason);
+  });
+
+  it('keeps an individual-only CLA group visible and says why it cannot be signed corporately', async () => {
+    getSignOptions.mockReturnValue(of(results([individualOnly])));
+
+    const fixture = await render();
+    await search(fixture, 'beacon');
+
+    expect(row(fixture, individualOnly).getAttribute('aria-disabled')).toBe('true');
+    expect(testid(fixture, `org-easycla-group-disabled-${individualOnly.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.cclaDisabledReason);
+  });
+
+  // The reason is visible text, not only a tooltip: a disabled row is not focusable, so a
+  // tooltip-only reason never reaches anyone who cannot hover.
+  it('states the reason as text on the row itself', async () => {
+    getSignOptions.mockReturnValue(of(results([multiProject])));
+
+    const fixture = await render();
+    await search(fixture, 'driftwood');
+
+    const reason = testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`);
+    expect(reason?.textContent?.trim()).toBeTruthy();
+    expect(row(fixture, multiProject).contains(reason)).toBe(true);
+  });
+
+  it('cannot be continued before a CLA group is chosen', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('returns the chosen CLA group with the project it will be signed for', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+    row(fixture, signable).click();
+    fixture.detectChanges();
+    continueButton(fixture).click();
+
+    expect(close).toHaveBeenCalledWith({
+      claGroupId: signable.claGroupId,
+      projectSfid: signable.projectSfid,
+      projectName: signable.projectName,
+    });
+  });
+
+  // Clicking a disabled row must not select it. The template's own disabled state is not the only
+  // guard, because a keyboard activation does not consult a CSS class.
+  it('does not choose a CLA group that cannot be signed', async () => {
+    getSignOptions.mockReturnValue(of(results([multiProject])));
+
+    const fixture = await render();
+    await search(fixture, 'driftwood');
+    row(fixture, multiProject).click();
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  // A typed character invalidates the confirmed choice, so the continue control can never
+  // describe a CLA Group the field no longer matches.
+  it('discards the choice when the search is edited', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+    row(fixture, signable).click();
+    fixture.detectChanges();
+    expect(continueButton(fixture).disabled).toBe(false);
+
+    await search(fixture, 'cascade rewritten');
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('distinguishes "nothing matched" from "keep typing"', async () => {
+    getSignOptions.mockReturnValue(of(results([])));
+
+    const fixture = await render();
+    await search(fixture, 'nothingmatches');
+
+    expect(testid(fixture, 'org-easycla-group-select-no-match')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-group-select-keep-typing')).toBeNull();
+  });
+
+  it('says when more matched than it can show', async () => {
+    getSignOptions.mockReturnValue(of(results([signable], true)));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, 'org-easycla-group-select-truncated')).not.toBeNull();
+  });
+
+  it('offers a retry when the search fails rather than reading as no matches', async () => {
+    getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, 'org-easycla-group-select-error')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-group-select-no-match')).toBeNull();
+  });
+
+  it('recovers when a retried search succeeds', async () => {
+    getSignOptions.mockReturnValueOnce(throwError(() => new Error('gateway'))).mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+    (fixture.componentInstance as unknown as { retry: () => void }).retry();
+    await vi.advanceTimersByTimeAsync(600);
+    fixture.detectChanges();
+
+    expect(testid(fixture, 'org-easycla-group-select-error')).toBeNull();
+    expect(row(fixture, signable)).not.toBeNull();
+  });
+
+  it('closes with nothing when the viewer backs out', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-group-cancel')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(close).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -135,6 +135,15 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
   afterEach(() => vi.useRealTimers());
 
+  it('uses the M3 prototype copy, not a paraphrase of it', async () => {
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-group-select-dialog')?.querySelector('p')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.body);
+    expect(testid(fixture, 'org-easycla-group-select-search')?.querySelector('input')?.getAttribute('placeholder')).toBe(CCLA_SIGN_COPY.picker.placeholder);
+    expect(testid(fixture, 'org-easycla-group-select-empty')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.empty);
+    expect(continueButton(fixture).textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.continueLabel);
+  });
+
   it('searches the viewing organization, not the whole platform', async () => {
     getSignOptions.mockReturnValue(of(results([signable])));
 
@@ -284,7 +293,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     const fixture = await render();
     await search(fixture, 'nothingmatches');
 
-    expect(testid(fixture, 'org-easycla-group-select-no-match')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-group-select-no-match')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.noMatch);
     expect(testid(fixture, 'org-easycla-group-select-keep-typing')).toBeNull();
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -103,6 +103,11 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     return testid(fixture, 'org-easycla-group-continue')?.querySelector('button') as HTMLButtonElement;
   }
 
+  /** The focused element, and so the only one whose ARIA state assistive technology announces. */
+  function searchBoxOf(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLInputElement {
+    return fixture.nativeElement.querySelector('#org-easycla-group-select-search-input') as HTMLInputElement;
+  }
+
   beforeEach(() => {
     vi.useFakeTimers();
     getSignOptions.mockReset();
@@ -288,8 +293,11 @@ describe('OrgEasyclaGroupSelectComponent', () => {
    * activation behaviour of their own. Without the handling below there is no way to choose a CLA
    * Group without a pointer — the flow is simply unavailable to a keyboard-only signatory.
    *
-   * The highlight roves from the text box, which keeps focus, so `aria-activedescendant` on the
-   * listbox is what tells a screen reader which row is current.
+   * The highlight roves from the text box, which keeps focus, so the combobox attributes have to
+   * be on the text box: `aria-activedescendant` is read from the focused element, and on the
+   * listbox — which nothing ever focuses — it names the right row and is never announced. These
+   * assertions therefore read the input, not the list. Asserting against the list is how the
+   * first version of this passed while being silent to every screen reader.
    */
   describe('keyboard', () => {
     function press(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, key: string): void {
@@ -317,16 +325,36 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       });
     });
 
+    // The wiring that makes the highlight audible at all. Without `role="combobox"` and
+    // `aria-controls` on the focused input, `aria-activedescendant` on it has nothing to resolve
+    // against and assistive technology has no reason to look for a list.
+    it('declares the input a combobox controlling the results list', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      const input = () => searchBoxOf(fixture);
+
+      expect(input().getAttribute('role')).toBe('combobox');
+      expect(input().getAttribute('aria-autocomplete')).toBe('list');
+      expect(input().getAttribute('aria-controls')).toBe('org-easycla-group-select-results');
+      expect(results_(fixture).id).toBe('org-easycla-group-select-results');
+
+      // Before a search there is nothing to expand into; after one there is.
+      expect(input().getAttribute('aria-expanded')).toBe('false');
+      await search(fixture);
+      expect(input().getAttribute('aria-expanded')).toBe('true');
+    });
+
     it('names the highlighted row so a screen reader can follow the arrow keys', async () => {
       getSignOptions.mockReturnValue(of(results([signable])));
 
       const fixture = await render();
       await search(fixture);
-      expect(results_(fixture).getAttribute('aria-activedescendant')).toBeNull();
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBeNull();
 
       press(fixture, 'ArrowDown');
 
-      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
       expect(row(fixture, signable).id).toBe(`org-easycla-group-option-${signable.claGroupId}`);
     });
 
@@ -337,11 +365,11 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       await search(fixture);
       press(fixture, 'ArrowDown');
       press(fixture, 'ArrowDown');
-      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${individualOnly.claGroupId}`);
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${individualOnly.claGroupId}`);
 
       press(fixture, 'ArrowUp');
 
-      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
     });
 
     // The highlight does stop on a row that cannot be signed, because the reason it cannot is the
@@ -353,7 +381,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       const fixture = await render();
       await search(fixture, 'driftwood');
       press(fixture, 'ArrowDown');
-      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${multiProject.claGroupId}`);
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${multiProject.claGroupId}`);
 
       press(fixture, 'Enter');
 
@@ -373,7 +401,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
       await search(fixture, 'beacon');
 
-      expect(results_(fixture).getAttribute('aria-activedescendant')).toBeNull();
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBeNull();
     });
 
     it('backs out on Escape', async () => {
@@ -395,6 +423,123 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       press(fixture, 'Enter');
 
       expect(close).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The window between a keystroke and the results that answer it.
+   *
+   * The rows for the previous term stay rendered across the debounce and the request that follows
+   * it. If they stay choosable, a viewer can pick one in that window and the response that lands
+   * afterwards swaps the list out from under a selection it never contained — and Continue then
+   * opens a corporate agreement for a project the viewer had already started typing away from.
+   *
+   * These cases interleave typing and choosing deliberately. A test that only advances the clock
+   * and asserts on the final list passes against the broken version, because the bug is not in
+   * what is fetched: `switchMap` cancels the previous request correctly. It is in what remains
+   * clickable while that happens.
+   */
+  describe('a search the viewer has moved on from', () => {
+    /** Types without letting the debounce elapse, leaving the previous rows on screen. */
+    function type(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, term: string): void {
+      const form = (fixture.componentInstance as unknown as { searchForm: { controls: { query: { setValue: (v: string) => void } } } }).searchForm;
+      form.controls.query.setValue(term);
+      fixture.detectChanges();
+    }
+
+    it('refuses a row clicked after the term it belongs to was changed', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      expect(row(fixture, signable)).not.toBeNull();
+
+      // Mid-word. `signable` is still drawn, and is now a result for a term nobody is searching.
+      type(fixture, 'beacon');
+      row(fixture, signable).click();
+      fixture.detectChanges();
+
+      expect(continueButton(fixture).disabled).toBe(true);
+
+      // And it stays refused after the new results land, rather than being resurrected by them.
+      await vi.advanceTimersByTimeAsync(600);
+      fixture.detectChanges();
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    // The keyboard route to the same defect, and it needs the extra ArrowDown to be worth having.
+    // Typing already resets the highlight, so an Enter pressed straight after it is refused for
+    // that reason alone and the case would pass with no staleness handling at all. Re-highlighting
+    // first puts the cursor back on a superseded row, which is the state only the guard refuses.
+    it('refuses a re-highlighted superseded row on Enter, not only on click', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+
+      type(fixture, 'beacon');
+      const key = (name: string) => {
+        testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key: name, bubbles: true }));
+        fixture.detectChanges();
+      };
+      key('ArrowDown');
+      key('Enter');
+
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+      // The highlight is not announced either, so nothing reads out a row that cannot be chosen.
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    it('marks the superseded rows as unavailable while they are still drawn', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('false');
+
+      type(fixture, 'beacon');
+
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('true');
+      // And the viewer is told why the rows stopped responding, rather than left guessing.
+      expect(testid(fixture, 'org-easycla-group-select-pending')).not.toBeNull();
+    });
+
+    it('makes the rows choosable again once the results catch up with the term', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([individualOnly]))).mockReturnValue(of(results([signable], false, 'cascade')));
+
+      const fixture = await render();
+      await search(fixture, 'beacon');
+      type(fixture, 'cascade');
+      await vi.advanceTimersByTimeAsync(600);
+      fixture.detectChanges();
+
+      expect(testid(fixture, 'org-easycla-group-select-pending')).toBeNull();
+      row(fixture, signable).click();
+      fixture.detectChanges();
+      continueButton(fixture).click();
+
+      expect(close).toHaveBeenCalledWith({
+        claGroupId: signable.claGroupId,
+        projectSfid: signable.projectSfid,
+        projectName: signable.projectName,
+      });
+    });
+
+    // Choosing writes the CLA Group's name into the field, which is a value change like any
+    // other. If that were treated as the viewer moving on, every selection would immediately
+    // invalidate itself and Continue would never enable.
+    it('does not treat writing the chosen name into the field as a new search', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      row(fixture, signable).click();
+      fixture.detectChanges();
+
+      expect(continueButton(fixture).disabled).toBe(false);
+      expect(testid(fixture, 'org-easycla-group-select-pending')).toBeNull();
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -163,8 +163,9 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     expect(testid(fixture, `org-easycla-group-disabled-${individualOnly.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.cclaDisabledReason);
   });
 
-  // The reason is visible text, not only a tooltip: a disabled row is not focusable, so a
-  // tooltip-only reason never reaches anyone who cannot hover.
+  // The reason is visible text inside the option, not a tooltip: a tooltip never reaches anyone
+  // who cannot hover, and inside the option it becomes part of the row's accessible name, so it
+  // is read out when the keyboard highlight arrives.
   it('states the reason as text on the row itself', async () => {
     getSignOptions.mockReturnValue(of(results([multiProject])));
 
@@ -280,5 +281,120 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     (testid(fixture, 'org-easycla-group-cancel')?.querySelector('button') as HTMLButtonElement).click();
 
     expect(close).toHaveBeenCalledWith(null);
+  });
+
+  /**
+   * The rows carry `role="option"` on plain elements, which are not focusable and have no
+   * activation behaviour of their own. Without the handling below there is no way to choose a CLA
+   * Group without a pointer — the flow is simply unavailable to a keyboard-only signatory.
+   *
+   * The highlight roves from the text box, which keeps focus, so `aria-activedescendant` on the
+   * listbox is what tells a screen reader which row is current.
+   */
+  describe('keyboard', () => {
+    function press(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, key: string): void {
+      testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      fixture.detectChanges();
+    }
+
+    function results_(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLElement {
+      return testid(fixture, 'org-easycla-group-select-results') as HTMLElement;
+    }
+
+    it('chooses the highlighted CLA group on Enter', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'Enter');
+      continueButton(fixture).click();
+
+      expect(close).toHaveBeenCalledWith({
+        claGroupId: signable.claGroupId,
+        projectSfid: signable.projectSfid,
+        projectName: signable.projectName,
+      });
+    });
+
+    it('names the highlighted row so a screen reader can follow the arrow keys', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+      expect(results_(fixture).getAttribute('aria-activedescendant')).toBeNull();
+
+      press(fixture, 'ArrowDown');
+
+      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+      expect(row(fixture, signable).id).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+    });
+
+    it('moves down and back up through the list', async () => {
+      getSignOptions.mockReturnValue(of(results([signable, individualOnly])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'ArrowDown');
+      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${individualOnly.claGroupId}`);
+
+      press(fixture, 'ArrowUp');
+
+      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+    });
+
+    // The highlight does stop on a row that cannot be signed, because the reason it cannot is the
+    // row's whole payload and skipping past it would keep that from a keyboard-only viewer
+    // entirely. Enter is what refuses.
+    it('highlights a CLA group that cannot be signed but will not choose it', async () => {
+      getSignOptions.mockReturnValue(of(results([multiProject])));
+
+      const fixture = await render();
+      await search(fixture, 'driftwood');
+      press(fixture, 'ArrowDown');
+      expect(results_(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${multiProject.claGroupId}`);
+
+      press(fixture, 'Enter');
+
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    // The highlight is a position in the previous list. Carried across a new search it would let
+    // Enter confirm whichever CLA Group happens to land at that offset.
+    it('drops the highlight when a new search arrives', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable, individualOnly]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'ArrowDown');
+
+      await search(fixture, 'beacon');
+
+      expect(results_(fixture).getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    it('backs out on Escape', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'Escape');
+
+      expect(close).toHaveBeenCalledWith(null);
+    });
+
+    it('ignores Enter when the search failed and the rows are not on screen', async () => {
+      getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'Enter');
+
+      expect(close).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -108,10 +108,16 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     return fixture.nativeElement.querySelector('#org-easycla-group-select-search-input') as HTMLInputElement;
   }
 
+  // jsdom implements no layout, so it ships no `scrollIntoView` at all — an unstubbed arrow press
+  // throws before the assertion is reached. Stubbed on the prototype rather than per element
+  // because the highlight scrolls on every arrow press, not on one deep-linked element.
+  const scrollIntoView = vi.fn();
   beforeEach(() => {
     vi.useFakeTimers();
     getSignOptions.mockReset();
     close.mockClear();
+    scrollIntoView.mockClear();
+    Element.prototype.scrollIntoView = scrollIntoView;
   });
 
   afterEach(() => vi.useRealTimers());
@@ -323,6 +329,24 @@ describe('OrgEasyclaGroupSelectComponent', () => {
         projectSfid: signable.projectSfid,
         projectName: signable.projectName,
       });
+    });
+
+    // Focus stays on the search box throughout the combobox pattern, so the browser scrolls
+    // nothing of its own when the highlight moves. Past the handful of rows the 240px list can
+    // show, a sighted keyboard user would lose sight of which row Enter is about to choose — and
+    // a screen-reader user would notice nothing wrong, which is what makes it easy to ship.
+    it('brings the newly highlighted row into view on each arrow press', async () => {
+      getSignOptions.mockReturnValue(of(results([signable, multiProject])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'ArrowDown');
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      // `nearest` so a row already visible does not scroll; anything else jumps the list under the
+      // reader on every press.
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: 'nearest' });
     });
 
     // The wiring that makes the highlight audible at all. Without `role="combobox"` and

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -50,6 +50,19 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     organizations: [],
   };
 
+  /** Reached by pasting a repository address: nothing in the names carries the term that found it. */
+  const repositoryMatch: ClaGroupOption = {
+    claGroupId: '44444444-4444-4444-8444-444444444444',
+    claGroupName: 'Cascade CLA',
+    projectName: 'Cascade',
+    projectSfid: 'a09410000182dD4AAI',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['repository'],
+    matchedRepositoryName: 'acme-org/waterfall-sdk',
+    organizations: [],
+  };
+
   /** A CLA Group configured for individual agreements only. */
   const individualOnly: ClaGroupOption = {
     claGroupId: '33333333-3333-4333-8333-333333333333',
@@ -186,6 +199,28 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     const reason = testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`);
     expect(reason?.textContent?.trim()).toBeTruthy();
     expect(row(fixture, multiProject).contains(reason)).toBe(true);
+  });
+
+  it('names the repository a pasted address resolved to, on the row it produced', async () => {
+    getSignOptions.mockReturnValue(of(results([repositoryMatch], false, 'https://github.com/acme-org/waterfall-sdk')));
+
+    const fixture = await render();
+    await search(fixture, 'https://github.com/acme-org/waterfall-sdk');
+
+    // On the row, not merely somewhere in the dialog: it has to be part of the option's accessible
+    // name, so the highlight reads it out along with the names it does not resemble.
+    const matched = testid(fixture, `org-easycla-group-matched-repo-${repositoryMatch.claGroupId}`);
+    expect(matched?.textContent).toContain('acme-org/waterfall-sdk');
+    expect(row(fixture, repositoryMatch).contains(matched)).toBe(true);
+  });
+
+  it('does not claim a repository match on a row found by name', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, `org-easycla-group-matched-repo-${signable.claGroupId}`)).toBeNull();
   });
 
   it('cannot be continued before a CLA group is chosen', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -6,7 +6,7 @@ import '@angular/compiler';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
-import type { ClaGroupOption, ClaGroupSearchResponse } from '@lfx-one/shared/interfaces';
+import type { ClaGroupOption, ClaGroupSearchResponse, OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { of, throwError } from 'rxjs';
@@ -79,14 +79,28 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     return { results: options, truncated, searchTerm, resultCount: options.length };
   }
 
-  async function render(): Promise<ComponentFixture<OrgEasyclaGroupSelectComponent>> {
+  /** One row of the organization's own CLA list, as the page hands it down. */
+  function held(claGroupId: string): OrgClaGroup {
+    return {
+      id: 'signature-uuid-1',
+      claGroupId,
+      claGroupName: 'Cascade CLA',
+      projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      signed: true,
+      status: 'signed',
+      needsClaManager: false,
+      claManagersCount: 1,
+    };
+  }
+
+  async function render(claGroups: OrgClaGroup[] = []): Promise<ComponentFixture<OrgEasyclaGroupSelectComponent>> {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [OrgEasyclaGroupSelectComponent],
       providers: [
         provideNoopAnimations(),
         { provide: DynamicDialogRef, useValue: { close } },
-        { provide: DynamicDialogConfig, useValue: { data: { orgUid } } },
+        { provide: DynamicDialogConfig, useValue: { data: { orgUid, claGroups } } },
         { provide: OrgLensClaService, useValue: { getSignOptions } },
       ],
     }).compileComponents();
@@ -139,7 +153,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     const fixture = await render();
 
     expect(testid(fixture, 'org-easycla-group-select-dialog')?.querySelector('p')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.body);
-    expect(testid(fixture, 'org-easycla-group-select-search')?.querySelector('input')?.getAttribute('placeholder')).toBe(CCLA_SIGN_COPY.picker.placeholder);
+    expect(searchBoxOf(fixture).getAttribute('placeholder')).toBe(CCLA_SIGN_COPY.picker.placeholder);
     expect(testid(fixture, 'org-easycla-group-select-empty')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.empty);
     expect(continueButton(fixture).textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.continueLabel);
   });
@@ -194,6 +208,83 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
     expect(row(fixture, individualOnly).getAttribute('aria-disabled')).toBe('true');
     expect(testid(fixture, `org-easycla-group-disabled-${individualOnly.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.cclaDisabledReason);
+  });
+
+  /**
+   * A CLA Group the organization already holds a corporate agreement for.
+   *
+   * Left selectable, Continue carries the viewer to a preview headed "«Org» has not yet signed a
+   * CLA for «Group»" — a false statement about an agreement that exists — and offers to sign it
+   * again. The refusal is what stops that, so these cases assert the row, the reason, and that
+   * neither pointer nor keyboard can get past it.
+   */
+  describe('a CLA group the organization has already signed', () => {
+    it('keeps the row visible and says the organization already holds one', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(signable.claGroupId)]);
+      await search(fixture);
+
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('true');
+      expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.alreadySignedDisabledReason);
+    });
+
+    it('cannot be chosen by pointer or by keyboard', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(signable.claGroupId)]);
+      await search(fixture);
+      row(fixture, signable).click();
+      testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    /**
+     * EasyCLA accepts hyphenated, unhyphenated and mixed-case spellings of the same UUID, and the
+     * two sides of this comparison come from different endpoints — the organization's CLA list and
+     * the CLA Group search. A raw `===` passes every test written with one spelling on both sides
+     * and misses the real match in production, which is the whole failure this guards.
+     */
+    it('matches the held agreement across UUID spellings, not by string equality', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(signable.claGroupId.replaceAll('-', '').toUpperCase())]);
+      await search(fixture);
+
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('true');
+      expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.alreadySignedDisabledReason);
+    });
+
+    // The other half of the check: holding *an* agreement must not refuse every row, or the
+    // picker becomes unusable for any organization that has signed anything.
+    it('leaves a CLA group the organization does not hold selectable', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(individualOnly.claGroupId)]);
+      await search(fixture);
+      row(fixture, signable).click();
+      fixture.detectChanges();
+
+      expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)).toBeNull();
+      expect(continueButton(fixture).disabled).toBe(false);
+    });
+
+    // Answered before "covers several projects", which is the less useful of the two: a CLA Group
+    // signed through the legacy console can still be one this flow could not have signed itself.
+    it('names the held agreement ahead of the reason this flow could not have signed it', async () => {
+      getSignOptions.mockReturnValue(of(results([multiProject])));
+
+      const fixture = await render([held(multiProject.claGroupId)]);
+      await search(fixture, 'driftwood');
+
+      const reason = testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`)?.textContent;
+      expect(reason).toContain(CCLA_SIGN_COPY.picker.alreadySignedDisabledReason);
+      expect(reason).not.toContain(CCLA_SIGN_COPY.picker.multiProjectDisabledReason);
+    });
   });
 
   // The reason is visible text inside the option, not a tooltip: a tooltip never reaches anyone
@@ -254,7 +345,27 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       claGroupId: signable.claGroupId,
       projectSfid: signable.projectSfid,
       projectName: signable.projectName,
+      claGroupName: signable.claGroupName,
     });
+  });
+
+  /**
+   * The name the preview page heads itself with, when search named no CLA Group.
+   *
+   * That page cannot look it up again — there is no fetch-a-CLA-group-by-id endpoint — so a blank
+   * here becomes a preview headed by nothing, offering to start a legal agreement it cannot name.
+   */
+  it('falls back to the row’s own primary line when search named no CLA Group', async () => {
+    const unnamed: ClaGroupOption = { ...signable, claGroupName: undefined };
+    getSignOptions.mockReturnValue(of(results([unnamed])));
+
+    const fixture = await render();
+    await search(fixture);
+    row(fixture, unnamed).click();
+    fixture.detectChanges();
+    continueButton(fixture).click();
+
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ claGroupName: unnamed.projectName }));
   });
 
   // Clicking a disabled row must not select it. The template's own disabled state is not the only
@@ -372,6 +483,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
         claGroupId: signable.claGroupId,
         projectSfid: signable.projectSfid,
         projectName: signable.projectName,
+        claGroupName: signable.claGroupName,
       });
     });
 
@@ -592,6 +704,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
         claGroupId: signable.claGroupId,
         projectSfid: signable.projectSfid,
         projectName: signable.projectName,
+        claGroupName: signable.claGroupName,
       });
     });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -9,10 +9,10 @@ import type {
   ClaGroupOption,
   ClaGroupSearchResponse,
   OrgClaGroupOptionView,
-  OrgClaGroupPickerResult,
   OrgClaGroupSelectDialogData,
+  OrgClaSignSelection,
 } from '@lfx-one/shared/interfaces';
-import { toClaGroupOptionView } from '@lfx-one/shared/utils';
+import { isSameClaGroup, toClaGroupOptionView } from '@lfx-one/shared/utils';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs';
@@ -25,11 +25,13 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
  *
  * **A deliberate second picker, not an oversight.** The Me-lens `ClaGroupSelectComponent` was
  * considered and rejected as a base. It reads its results from `MyClasService` — a route that is
- * neither dark-launch gated for this section nor organization-scoped — and it takes the
- * contributor's own held agreements as dialog input so it can annotate rows they have already
- * signed. Neither applies here, and the annotation this picker needs is the inverse: why a row
- * *cannot* be signed corporately. Parameterising the data source, the annotation source and the
- * selectability rule would rewrite the component the Me-lens signing flow depends on, inside a
+ * neither dark-launch gated for this section nor organization-scoped — and where a contributor
+ * already holds an agreement it annotates the row and leaves it choosable, because signing the
+ * same CLA Group under a second identity is something a contributor legitimately does. Both
+ * pickers are handed the already-held agreements; they disagree about what the overlap means.
+ * Here it is a refusal, because this flow signs as one party — the selected organization — and
+ * offers no second identity to sign as. Parameterising the data source, the annotation source and
+ * the selectability rule would rewrite the component the Me-lens signing flow depends on, inside a
  * slice whose risk is already spent on a write path and legal copy.
  *
  * What is genuinely shared is shared: the debounce and minimum-term constants, and
@@ -51,6 +53,9 @@ export class OrgEasyclaGroupSelectComponent {
   private readonly config = inject<DynamicDialogConfig<OrgClaGroupSelectDialogData>>(DynamicDialogConfig);
 
   private readonly orgUid = this.config.data?.orgUid ?? '';
+
+  /** The organization's corporate CLAs, against which a search hit is refused as already signed. */
+  private readonly heldClaGroups = this.config.data?.claGroups ?? [];
 
   protected readonly copy = CCLA_SIGN_COPY.picker;
   protected readonly minChars = CLA_GROUP_SEARCH_MIN_CHARS;
@@ -257,10 +262,14 @@ export class OrgEasyclaGroupSelectComponent {
     // being asserted is the key of a request that creates a legal document.
     if (!option?.projectSfid) return;
 
-    const result: OrgClaGroupPickerResult = {
+    const result: OrgClaSignSelection = {
       claGroupId: option.claGroupId,
       projectSfid: option.projectSfid,
       projectName: option.primaryName,
+      // The CLA Group's own name where search gave one, and the primary line otherwise — the project
+      // name, or the unnamed literal when search could name neither. The preview page heads itself
+      // with this and cannot look it up again, so it must never come through blank.
+      claGroupName: option.claGroupName || option.primaryName,
     };
     this.ref.close(result);
   }
@@ -306,12 +315,29 @@ export class OrgEasyclaGroupSelectComponent {
    * A row that cannot be signed stays on screen with its reason, rather than being filtered out.
    *
    * Dropping it would leave a viewer searching repeatedly for a CLA Group they can see in the
-   * legacy console, with nothing to explain the absence. Leaving it selectable would send a
-   * request that is certain to fail.
+   * legacy console, with nothing to explain the absence. Leaving it selectable would carry the
+   * viewer into a preview that states something untrue about the agreement, and from there into a
+   * request that either fails or duplicates one the organization already has.
    */
   private toOrgOptionView(option: ClaGroupOption): OrgClaGroupOptionView {
     const view = toClaGroupOptionView(option);
 
+    // Ahead of the two below because it is the more useful answer where both apply: a CLA Group
+    // signed through the legacy console can still be one this flow could not have signed itself.
+    //
+    // Matched canonically, not with `===`. EasyCLA accepts hyphenated, unhyphenated and mixed-case
+    // spellings of the same UUID, so a raw string compare silently misses real matches — and a
+    // missed match here is the failure this check exists to prevent.
+    //
+    // The refusal is narrower than it looks. The upstream grain is (signing entity x CLA Group), so
+    // an organization can legitimately hold two rows for one CLA Group under different signing
+    // entities, and signing this group again for a *different* legal entity would be a real flow.
+    // It is safe to refuse today only because this flow always signs for the selected organization
+    // — `company_sfid` is the grant-checked `orgUid` — and offers no signing-entity choice. The day
+    // it does, this becomes a check on the entity rather than on the group.
+    if (this.heldClaGroups.some((held) => isSameClaGroup(held.claGroupId, option.claGroupId))) {
+      return { ...view, disabledReason: this.copy.alreadySignedDisabledReason };
+    }
     if (!option.projectSfid) {
       return { ...view, disabledReason: this.copy.multiProjectDisabledReason };
     }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -66,6 +66,9 @@ export class OrgEasyclaGroupSelectComponent {
 
   private readonly query = signal('');
 
+  /** Position of the keyboard highlight in `options`, or -1 when nothing is highlighted. */
+  protected readonly highlightedIndex = signal(-1);
+
   /**
    * Which "the list is empty" answer applies, so the template never infers one from a zero
    * length — which cannot tell "you have not typed yet" from "keep going" from "no matches".
@@ -111,6 +114,9 @@ export class OrgEasyclaGroupSelectComponent {
         if (!response) return;
         this.options.set(response.results.map((option) => this.toOrgOptionView(option)));
         this.truncated.set(response.truncated);
+        // The highlight is a position in the previous list; carrying it over would let Enter
+        // confirm whichever CLA Group happens to land at that offset in the new one.
+        this.highlightedIndex.set(-1);
       });
 
     this.searchForm.controls.query.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
@@ -120,10 +126,57 @@ export class OrgEasyclaGroupSelectComponent {
       }
 
       // A typed character invalidates the confirmed choice, so the summary and the continue
-      // control can never describe a CLA Group the text no longer matches.
+      // control can never describe a CLA Group the text no longer matches. The highlight is a
+      // position in the previous list, so it has to drop here rather than after the debounce —
+      // Enter during the request window would otherwise confirm a CLA Group the text no longer
+      // describes.
       this.selected.set(null);
+      this.highlightedIndex.set(-1);
       this.pushSearch(value ?? '');
     });
+  }
+
+  /**
+   * Arrow keys, Enter and Escape on the results list, matching the Me-lens picker.
+   *
+   * Bound at the field's container rather than on each row, and the rows are not focusable: focus
+   * stays in the text box so the viewer can keep typing while moving the highlight, which is what
+   * `aria-activedescendant` on the listbox describes.
+   *
+   * The highlight does stop on a row that cannot be signed. Skipping those would be the obvious
+   * reading of "disabled", and it is the wrong one here — the reason a CLA Group cannot be signed
+   * corporately is the row's whole payload, and a keyboard-only viewer who cannot reach the row
+   * never hears it. `onSelect` is what refuses; arriving is allowed.
+   */
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.ref.close(null);
+      return;
+    }
+
+    const options = this.options();
+    // Match the template: the error and keep-typing panels replace the rows, so the keyboard must
+    // not treat a leftover list as still on screen.
+    if (this.error() || this.queryBand() !== 'searchable' || options.length === 0) return;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        // Otherwise the caret jumps to the end of the field on every step.
+        event.preventDefault();
+        this.highlightedIndex.set((this.highlightedIndex() + 1) % options.length);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.highlightedIndex.set((this.highlightedIndex() - 1 + options.length) % options.length);
+        break;
+      case 'Enter': {
+        const highlighted = options[this.highlightedIndex()];
+        if (!highlighted) return;
+        event.preventDefault();
+        this.onSelect(highlighted);
+        break;
+      }
+    }
   }
 
   protected retry(): void {
@@ -164,9 +217,11 @@ export class OrgEasyclaGroupSelectComponent {
     this.search$.next(value);
   }
 
+  /** Drops a list the template is no longer drawing, so Arrow/Enter cannot confirm a hidden row. */
   private clearResults(): void {
     this.options.set([]);
     this.truncated.set(false);
+    this.highlightedIndex.set(-1);
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -66,8 +66,48 @@ export class OrgEasyclaGroupSelectComponent {
 
   private readonly query = signal('');
 
+  /**
+   * The search term `options` came back for, or null when they came back for nothing yet.
+   *
+   * Compared against the live query to decide whether the list on screen still describes what the
+   * viewer has typed. See `stale`.
+   */
+  private readonly resultsFor = signal<string | null>(null);
+
+  /**
+   * Whether the rows on screen belong to a term the viewer has since changed.
+   *
+   * There is a window — the debounce, plus the request — in which the previous term's rows are
+   * still rendered under new text in the field. Left selectable, a click in that window sets
+   * `selected` to a CLA Group that was never a result for the current query, and the response
+   * that lands afterwards replaces the visible list without touching the selection. Continue
+   * would then open a corporate agreement for whichever project the viewer had abandoned
+   * mid-word, which is not a UI blemish on this flow — it is the wrong legal document.
+   *
+   * `switchMap` does not cover this: it cancels the previous request only once the debounce has
+   * elapsed and the new term reaches it, and cancelling a request was never what protected the
+   * selection anyway.
+   */
+  protected readonly stale: Signal<boolean> = computed(() => this.resultsFor() !== this.query().trim());
+
   /** Position of the keyboard highlight in `options`, or -1 when nothing is highlighted. */
   protected readonly highlightedIndex = signal(-1);
+
+  /** Whether rows are on screen, for the input's `aria-expanded`. */
+  protected readonly listboxOpen: Signal<boolean> = computed(() => !this.error() && this.queryBand() === 'searchable' && this.options().length > 0);
+
+  /**
+   * The highlighted row's element id, for the input's `aria-activedescendant`, or null.
+   *
+   * Null while the list is stale as well as while nothing is highlighted: pointing focus at a row
+   * from a superseded search would have a screen reader announce a CLA Group that is on its way
+   * off the screen and cannot be chosen.
+   */
+  protected readonly activeOptionId: Signal<string | null> = computed(() => {
+    const option = this.options()[this.highlightedIndex()];
+    if (!option || this.stale()) return null;
+    return `org-easycla-group-option-${option.claGroupId}`;
+  });
 
   /**
    * Which "the list is empty" answer applies, so the template never infers one from a zero
@@ -94,26 +134,33 @@ export class OrgEasyclaGroupSelectComponent {
             this.loading.set(false);
             this.error.set(false);
             this.clearResults();
-            return of<ClaGroupSearchResponse | null>(null);
+            return of<{ searchTerm: string; response: ClaGroupSearchResponse | null } | null>(null);
           }
 
           this.loading.set(true);
           this.error.set(false);
           return this.claService.getSignOptions(this.orgUid, searchTerm).pipe(
+            // Paired with its own term all the way through, so the handler can say which query
+            // the rows it is about to render actually answer. Reading the live query there
+            // instead would be the same race one layer down.
+            map((response) => ({ searchTerm, response: response as ClaGroupSearchResponse | null })),
             catchError(() => {
               this.error.set(true);
               this.clearResults();
-              return of<ClaGroupSearchResponse | null>(null);
+              return of<{ searchTerm: string; response: ClaGroupSearchResponse | null } | null>(null);
             })
           );
         }),
         takeUntilDestroyed()
       )
-      .subscribe((response) => {
+      .subscribe((emission) => {
         this.loading.set(false);
-        if (!response) return;
-        this.options.set(response.results.map((option) => this.toOrgOptionView(option)));
-        this.truncated.set(response.truncated);
+        if (!emission?.response) return;
+        this.options.set(emission.response.results.map((option) => this.toOrgOptionView(option)));
+        this.truncated.set(emission.response.truncated);
+        // Records which term these rows answer, which is what clears `stale` and makes them
+        // selectable again.
+        this.resultsFor.set(emission.searchTerm);
         // The highlight is a position in the previous list; carrying it over would let Enter
         // confirm whichever CLA Group happens to land at that offset in the new one.
         this.highlightedIndex.set(-1);
@@ -137,11 +184,13 @@ export class OrgEasyclaGroupSelectComponent {
   }
 
   /**
-   * Arrow keys, Enter and Escape on the results list, matching the Me-lens picker.
+   * Arrow keys, Enter and Escape on the results list.
    *
    * Bound at the field's container rather than on each row, and the rows are not focusable: focus
    * stays in the text box so the viewer can keep typing while moving the highlight, which is what
-   * `aria-activedescendant` on the listbox describes.
+   * `aria-activedescendant` *on the input* describes. The Me-lens picker puts that attribute on
+   * the listbox instead, where it is never announced; that is a real defect in that component and
+   * is not fixed here, but it is deliberately not copied.
    *
    * The highlight does stop on a row that cannot be signed. Skipping those would be the obvious
    * reading of "disabled", and it is the wrong one here — the reason a CLA Group cannot be signed
@@ -188,6 +237,11 @@ export class OrgEasyclaGroupSelectComponent {
     // signed must not become the chosen one through a keyboard activation either.
     if (option.disabledReason) return;
 
+    // A row from a superseded search cannot be chosen, however it was reached. The template also
+    // marks these rows non-interactive, but the guard belongs here as well: this is the last
+    // point before a CLA Group becomes the one a corporate agreement gets opened for.
+    if (this.stale()) return;
+
     this.selected.set(option);
     this.suppressNextEmit = true;
     this.searchForm.controls.query.setValue(option.secondaryName ? `${option.primaryName} — ${option.secondaryName}` : option.primaryName);
@@ -222,6 +276,7 @@ export class OrgEasyclaGroupSelectComponent {
     this.options.set([]);
     this.truncated.set(false);
     this.highlightedIndex.set(-1);
+    this.resultsFor.set(null);
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
@@ -45,6 +45,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OrgEasyclaGroupSelectComponent {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly ref = inject(DynamicDialogRef);
   private readonly claService = inject(OrgLensClaService);
   private readonly config = inject<DynamicDialogConfig<OrgClaGroupSelectDialogData>>(DynamicDialogConfig);
@@ -213,10 +214,12 @@ export class OrgEasyclaGroupSelectComponent {
         // Otherwise the caret jumps to the end of the field on every step.
         event.preventDefault();
         this.highlightedIndex.set((this.highlightedIndex() + 1) % options.length);
+        this.revealHighlighted(options);
         break;
       case 'ArrowUp':
         event.preventDefault();
         this.highlightedIndex.set((this.highlightedIndex() - 1 + options.length) % options.length);
+        this.revealHighlighted(options);
         break;
       case 'Enter': {
         const highlighted = options[this.highlightedIndex()];
@@ -264,6 +267,26 @@ export class OrgEasyclaGroupSelectComponent {
 
   protected onCancel(): void {
     this.ref.close(null);
+  }
+
+  /**
+   * Brings the highlighted row into the scrolling list.
+   *
+   * Focus never leaves the search box — the combobox pattern puts `aria-activedescendant` there —
+   * so the browser does no scrolling of its own when the highlight moves. Past the few rows the
+   * list can show, the highlight would otherwise travel off-screen and a sighted keyboard user
+   * would have no way to tell which row Enter is about to choose. A screen reader is unaffected
+   * either way, which is why this is easy to miss.
+   *
+   * `nearest` so a highlight already in view does not scroll, which would make every arrow press
+   * jump the list under the reader.
+   */
+  private revealHighlighted(options: readonly OrgClaGroupOptionView[]): void {
+    const option = options[this.highlightedIndex()];
+    if (!option) return;
+
+    const row = this.host.nativeElement.querySelector(`#org-easycla-group-option-${CSS.escape(option.claGroupId)}`);
+    row?.scrollIntoView({ block: 'nearest' });
   }
 
   private pushSearch(value: string): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -21,7 +21,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 
 /**
- * "Sign a Corporate CLA" CLA Group picker for the Organization Lens (#1983).
+ * "Sign a CLA" CLA Group picker for the Organization Lens (#1983).
  *
  * **A deliberate second picker, not an oversight.** The Me-lens `ClaGroupSelectComponent` was
  * considered and rejected as a base. It reads its results from `MyClasService` — a route that is

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -1,0 +1,190 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import type {
+  ClaGroupOption,
+  ClaGroupSearchResponse,
+  OrgClaGroupOptionView,
+  OrgClaGroupPickerResult,
+  OrgClaGroupSelectDialogData,
+} from '@lfx-one/shared/interfaces';
+import { toClaGroupOptionView } from '@lfx-one/shared/utils';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+
+/**
+ * "Sign a Corporate CLA" CLA Group picker for the Organization Lens (#1983).
+ *
+ * **A deliberate second picker, not an oversight.** The Me-lens `ClaGroupSelectComponent` was
+ * considered and rejected as a base. It reads its results from `MyClasService` — a route that is
+ * neither dark-launch gated for this section nor organization-scoped — and it takes the
+ * contributor's own held agreements as dialog input so it can annotate rows they have already
+ * signed. Neither applies here, and the annotation this picker needs is the inverse: why a row
+ * *cannot* be signed corporately. Parameterising the data source, the annotation source and the
+ * selectability rule would rewrite the component the Me-lens signing flow depends on, inside a
+ * slice whose risk is already spent on a write path and legal copy.
+ *
+ * What is genuinely shared is shared: the debounce and minimum-term constants, and
+ * `toClaGroupOptionView`. If the two pickers later converge, that is the moment for a common
+ * base — not now, when they disagree about what a row means.
+ *
+ * Closes with the chosen group, or `null` if the viewer backs out.
+ */
+@Component({
+  selector: 'lfx-org-easycla-group-select',
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent],
+  templateUrl: './org-easycla-group-select.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaGroupSelectComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly claService = inject(OrgLensClaService);
+  private readonly config = inject<DynamicDialogConfig<OrgClaGroupSelectDialogData>>(DynamicDialogConfig);
+
+  private readonly orgUid = this.config.data?.orgUid ?? '';
+
+  protected readonly copy = CCLA_SIGN_COPY.picker;
+  protected readonly minChars = CLA_GROUP_SEARCH_MIN_CHARS;
+
+  protected readonly searchForm = new FormGroup({
+    query: new FormControl(''),
+  });
+
+  protected readonly options = signal<OrgClaGroupOptionView[]>([]);
+  protected readonly loading = signal(false);
+  protected readonly error = signal(false);
+  protected readonly selected = signal<OrgClaGroupOptionView | null>(null);
+  protected readonly truncated = signal(false);
+
+  private readonly query = signal('');
+
+  /**
+   * Which "the list is empty" answer applies, so the template never infers one from a zero
+   * length — which cannot tell "you have not typed yet" from "keep going" from "no matches".
+   */
+  protected readonly queryBand: Signal<'empty' | 'short' | 'searchable'> = computed(() => {
+    const length = this.query().trim().length;
+    if (length === 0) return 'empty';
+    return length < CLA_GROUP_SEARCH_MIN_CHARS ? 'short' : 'searchable';
+  });
+
+  private readonly search$ = new Subject<string>();
+
+  /** Set while writing the chosen group's name back into the field, so it is not re-searched. */
+  private suppressNextEmit = false;
+
+  public constructor() {
+    this.search$
+      .pipe(
+        debounceTime(CLA_GROUP_SEARCH_DEBOUNCE_MS),
+        map((query) => query.trim()),
+        switchMap((searchTerm) => {
+          if (searchTerm.length < CLA_GROUP_SEARCH_MIN_CHARS) {
+            this.loading.set(false);
+            this.error.set(false);
+            this.clearResults();
+            return of<ClaGroupSearchResponse | null>(null);
+          }
+
+          this.loading.set(true);
+          this.error.set(false);
+          return this.claService.getSignOptions(this.orgUid, searchTerm).pipe(
+            catchError(() => {
+              this.error.set(true);
+              this.clearResults();
+              return of<ClaGroupSearchResponse | null>(null);
+            })
+          );
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((response) => {
+        this.loading.set(false);
+        if (!response) return;
+        this.options.set(response.results.map((option) => this.toOrgOptionView(option)));
+        this.truncated.set(response.truncated);
+      });
+
+    this.searchForm.controls.query.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
+      if (this.suppressNextEmit) {
+        this.suppressNextEmit = false;
+        return;
+      }
+
+      // A typed character invalidates the confirmed choice, so the summary and the continue
+      // control can never describe a CLA Group the text no longer matches.
+      this.selected.set(null);
+      this.pushSearch(value ?? '');
+    });
+  }
+
+  protected retry(): void {
+    this.pushSearch(this.searchForm.controls.query.value ?? '');
+  }
+
+  protected onSelect(option: OrgClaGroupOptionView): void {
+    // Belt and braces with the template's disabled state: a row that names why it cannot be
+    // signed must not become the chosen one through a keyboard activation either.
+    if (option.disabledReason) return;
+
+    this.selected.set(option);
+    this.suppressNextEmit = true;
+    this.searchForm.controls.query.setValue(option.secondaryName ? `${option.primaryName} — ${option.secondaryName}` : option.primaryName);
+  }
+
+  protected onContinue(): void {
+    const option = this.selected();
+    // `projectSfid` is what makes a row selectable in the first place, so this is unreachable
+    // through the UI. It is here because the alternative to checking is asserting, and the value
+    // being asserted is the key of a request that creates a legal document.
+    if (!option?.projectSfid) return;
+
+    const result: OrgClaGroupPickerResult = {
+      claGroupId: option.claGroupId,
+      projectSfid: option.projectSfid,
+      projectName: option.primaryName,
+    };
+    this.ref.close(result);
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+
+  private pushSearch(value: string): void {
+    this.query.set(value);
+    this.search$.next(value);
+  }
+
+  private clearResults(): void {
+    this.options.set([]);
+    this.truncated.set(false);
+  }
+
+  /**
+   * A row that cannot be signed stays on screen with its reason, rather than being filtered out.
+   *
+   * Dropping it would leave a viewer searching repeatedly for a CLA Group they can see in the
+   * legacy console, with nothing to explain the absence. Leaving it selectable would send a
+   * request that is certain to fail.
+   */
+  private toOrgOptionView(option: ClaGroupOption): OrgClaGroupOptionView {
+    const view = toClaGroupOptionView(option);
+
+    if (!option.projectSfid) {
+      return { ...view, disabledReason: this.copy.multiProjectDisabledReason };
+    }
+    if (option.cclaEnabled !== true) {
+      return { ...view, disabledReason: this.copy.cclaDisabledReason };
+    }
+    return { ...view, disabledReason: null };
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
@@ -1,0 +1,48 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+-->
+
+<div class="flex flex-col" data-testid="org-easycla-sign-handoff-dialog">
+  @switch (state()) {
+    @case ('preparing') {
+      <div class="flex flex-col items-center gap-3 py-6 text-center" data-testid="org-easycla-sign-preparing">
+        <i class="fa-light fa-spinner-third fa-spin text-3xl text-slate-400" aria-hidden="true"></i>
+        <p class="text-sm text-slate-600">{{ copy.preparing.body }}</p>
+        <!-- Stated before the signatory commits, not after: becoming the initial CLA Manager is a
+             standing responsibility, and learning it afterwards is learning it too late. -->
+        <p class="text-sm font-medium text-slate-900" data-testid="org-easycla-sign-manager-notice">{{ copy.preparing.consequence }}</p>
+      </div>
+    }
+
+    @case ('ready') {
+      <div class="flex flex-col gap-4" data-testid="org-easycla-sign-ready">
+        <div class="flex items-center gap-2 text-emerald-700">
+          <i class="fa-light fa-circle-check text-2xl" aria-hidden="true"></i>
+          <span class="text-sm font-semibold">{{ copy.ready.header }}</span>
+        </div>
+        <p class="text-sm text-slate-600">{{ copy.ready.body }}</p>
+        <div class="mt-2 flex justify-end gap-2">
+          <lfx-button [label]="copy.ready.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-sign-cancel" />
+          <lfx-button [label]="copy.ready.continueLabel" (onClick)="onReviewAndSign()" data-testid="org-easycla-sign-review" />
+        </div>
+      </div>
+    }
+
+    @case ('failed') {
+      <div class="flex flex-col gap-4" role="alert" data-testid="org-easycla-sign-failed">
+        <div class="flex items-center gap-2 text-red-700">
+          <i class="fa-light fa-triangle-exclamation text-2xl" aria-hidden="true"></i>
+          <span class="text-sm font-semibold">{{ copy.failure.header }}</span>
+        </div>
+        <!-- The CLA service's own sentence when it refused in words; the generic copy otherwise.
+             A trade-compliance refusal names the reason and how to challenge it, which nothing
+             written here could reproduce and keep current. -->
+        <p class="text-sm text-slate-600" data-testid="org-easycla-sign-failure-message">{{ failureMessage() }}</p>
+        <div class="mt-2 flex justify-end">
+          <lfx-button label="Close" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-sign-failed-close" />
+        </div>
+      </div>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
@@ -16,12 +16,13 @@ SPDX-License-Identifier: MIT
     }
 
     @case ('ready') {
+      <!-- The state's name is the dialog's title, set from the component, and is deliberately not
+           repeated here: it used to be, which put "Review CCLA" on screen twice. -->
       <div class="flex flex-col gap-4" data-testid="org-easycla-sign-ready">
-        <div class="flex items-center gap-2 text-emerald-700">
-          <i class="fa-light fa-circle-check text-2xl" aria-hidden="true"></i>
-          <span class="text-sm font-semibold">{{ copy.ready.header }}</span>
+        <div class="flex items-start gap-2">
+          <i class="fa-light fa-circle-check mt-0.5 text-xl text-emerald-700" aria-hidden="true"></i>
+          <p class="text-sm text-slate-600">{{ copy.ready.body }}</p>
         </div>
-        <p class="text-sm text-slate-600">{{ copy.ready.body }}</p>
         <div class="mt-2 flex justify-end gap-2">
           <lfx-button [label]="copy.ready.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-sign-cancel" />
           <lfx-button [label]="copy.ready.continueLabel" (onClick)="onReviewAndSign()" data-testid="org-easycla-sign-review" />
@@ -31,14 +32,14 @@ SPDX-License-Identifier: MIT
 
     @case ('failed') {
       <div class="flex flex-col gap-4" role="alert" data-testid="org-easycla-sign-failed">
-        <div class="flex items-center gap-2 text-red-700">
-          <i class="fa-light fa-triangle-exclamation text-2xl" aria-hidden="true"></i>
-          <span class="text-sm font-semibold">{{ copy.failure.header }}</span>
-        </div>
         <!-- The CLA service's own sentence when it refused in words; the generic copy otherwise.
              A trade-compliance refusal names the reason and how to challenge it, which nothing
-             written here could reproduce and keep current. -->
-        <p class="text-sm text-slate-600" data-testid="org-easycla-sign-failure-message">{{ failureMessage() }}</p>
+             written here could reproduce and keep current. The state's name is the dialog's
+             title, set from the component, so it is not repeated alongside the message. -->
+        <div class="flex items-start gap-2">
+          <i class="fa-light fa-triangle-exclamation mt-0.5 text-xl text-red-700" aria-hidden="true"></i>
+          <p class="text-sm text-slate-600" data-testid="org-easycla-sign-failure-message">{{ failureMessage() }}</p>
+        </div>
         <div class="mt-2 flex justify-end">
           <lfx-button label="Close" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-sign-failed-close" />
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
@@ -39,8 +39,7 @@ SPDX-License-Identifier: MIT
           <i class="fa-light fa-circle-check mt-0.5 text-xl text-emerald-700" aria-hidden="true"></i>
           <p class="text-sm text-slate-600">{{ copy.ready.body }}</p>
         </div>
-        <div class="mt-2 flex justify-end gap-2">
-          <lfx-button [label]="copy.ready.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-sign-cancel" />
+        <div class="mt-2 flex justify-end">
           <lfx-button [label]="copy.ready.continueLabel" (onClick)="onReviewAndSign()" data-testid="org-easycla-sign-review" />
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
@@ -3,7 +3,23 @@ Copyright The Linux Foundation and each contributor to LFX.
 SPDX-License-Identifier: MIT
 -->
 
-<div class="flex flex-col" data-testid="org-easycla-sign-handoff-dialog">
+<!--
+  A polite live region around the whole switch, because the state changes on its own: the signing
+  request is issued as the dialog opens, and when it lands the message is replaced and the Review
+  CCLA control appears. Sighted users see that happen. Without this, a screen-reader user is told
+  the dialog is preparing and then nothing further — the controls arrive silently, and there is no
+  event to prompt them to go looking.
+
+  Focus is deliberately NOT moved to Review CCLA when it appears. That control opens the signing
+  session in this same tab, so auto-focusing it puts a page-leaving action under the next Enter or
+  Space the user happens to press, and it would also cut off the announcement that just told them
+  why focus moved. The dialog already holds focus, so the polite announcement is enough to say the
+  control now exists and can be reached by Tab.
+
+  The failure branch below keeps its own role="alert" and so stays assertive: it interrupts, which
+  a refusal should, and a nested live region overrides this one for its own subtree.
+-->
+<div class="flex flex-col" role="status" aria-live="polite" data-testid="org-easycla-sign-handoff-dialog">
   @switch (state()) {
     @case ('preparing') {
       <div class="flex flex-col items-center gap-3 py-6 text-center" data-testid="org-easycla-sign-preparing">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -236,14 +236,17 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     expect(shown).not.toContain('Http failure response');
   });
 
-  it('closes without a result when the signatory backs out of an open session', async () => {
+  // By the time this state is reached the agreement and its DocuSign envelope exist upstream, and
+  // the address on screen is the only way anyone reaches them. A back-out here would strand a real
+  // agreement that this application cannot cancel or reuse, so the state offers no way back.
+  it('offers no way out of an open session except continuing to sign it', async () => {
     requestCorporateSignature.mockReturnValue(of(response));
 
     const fixture = await render();
-    (testid(fixture, 'org-easycla-sign-cancel')?.querySelector('button') as HTMLButtonElement).click();
 
-    expect(close).toHaveBeenCalledWith(null);
-    expect(location.href).toBe('https://example.test/org/easycla');
+    expect(testid(fixture, 'org-easycla-sign-cancel')).toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-review')).not.toBeNull();
+    expect(close).not.toHaveBeenCalled();
   });
 
   it('fails closed when it is opened without a selection', async () => {
@@ -269,11 +272,23 @@ describe('OrgEasyclaSignHandoffComponent', () => {
       expect(config.closeOnEscape).toBe(false);
     });
 
-    it.each([
-      ['ready', () => of(response)],
-      ['failed', () => throwError(() => bffError(500, { error: 'nope' }))],
-    ])('can be dismissed again once it reaches %s', async (_state, source) => {
-      requestCorporateSignature.mockReturnValue(source());
+    // Still sealed on success, not just in flight. The envelope exists by then and the address on
+    // screen is the only copy, so an Escape here abandons a real agreement — and `ready` waits for
+    // a person, where the request itself usually answers in under a second. Sealing only the
+    // in-flight window would close the smaller of the two holes.
+    it('still cannot be dismissed once the session is open', async () => {
+      requestCorporateSignature.mockReturnValue(of(response));
+
+      await render();
+
+      expect(config.closable).toBe(false);
+      expect(config.closeOnEscape).toBe(false);
+    });
+
+    // The one dismissible state: no envelope to strand, and trapping someone in a dialog that
+    // reports a failure would leave them no way out at all.
+    it('can be dismissed once it reaches failed', async () => {
+      requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
 
       await render();
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -283,6 +283,50 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   });
 
   /**
+   * The preparing → ready transition happens on its own, with no user action behind it: the
+   * request is issued as the dialog opens and the panel is rewritten when it lands. A sighted
+   * user watches the spinner become a Review CCLA button. Without a live region a screen-reader
+   * user hears the preparing message and then nothing at all, so the control that carries the
+   * whole flow forward arrives with no event to announce it.
+   */
+  describe('announcing the asynchronous transition', () => {
+    it('holds the dialog content in a polite live region', async () => {
+      requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
+
+      const fixture = await render();
+
+      const panel = testid(fixture, 'org-easycla-sign-handoff-dialog');
+      expect(panel?.getAttribute('aria-live')).toBe('polite');
+      expect(panel?.getAttribute('role')).toBe('status');
+    });
+
+    // The region has to be the container that survives the switch. Placed on a per-state branch it
+    // would be created at the same moment as the content it is meant to announce, and a live
+    // region that appears together with its text announces nothing.
+    it('keeps the region mounted across the transition, so the change is what is announced', async () => {
+      requestCorporateSignature.mockReturnValue(of(response));
+
+      const fixture = await render();
+
+      const panel = testid(fixture, 'org-easycla-sign-handoff-dialog');
+      expect(panel?.getAttribute('aria-live')).toBe('polite');
+      expect(testid(fixture, 'org-easycla-sign-ready')).toBeTruthy();
+      // The ready branch itself must not carry a competing region, or the swap is announced twice.
+      expect(testid(fixture, 'org-easycla-sign-ready')?.getAttribute('aria-live')).toBeNull();
+    });
+
+    // A refusal interrupts rather than waits its turn, and the nested role overrides the polite
+    // ancestor for its own subtree.
+    it('leaves the failure branch assertive', async () => {
+      requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
+
+      const fixture = await render();
+
+      expect(testid(fixture, 'org-easycla-sign-failed')?.getAttribute('role')).toBe('alert');
+    });
+  });
+
+  /**
    * The shell dialog's title is PrimeNG's, and it is a static string at the call site. Left alone
    * it keeps saying "Configuring CLA Manager Settings…" above a panel that says the session is
    * ready, or that it failed.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -6,7 +6,7 @@ import '@angular/compiler';
 import { DOCUMENT } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import { CCLA_SIGN_COPY, ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -40,6 +40,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
 
   const response: OrgClaSignResponse = {
     signUrl: 'https://demo.docusign.net/Signing/StartInSession.aspx?t=abc123',
+    signatureId: '7f1c2f5e-0d44-4a2b-9d61-2c9b8a7e4f30',
   };
 
   // Explicit rather than defaulted: a defaulted parameter would substitute the real selection for
@@ -104,7 +105,10 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   beforeEach(() => {
     requestCorporateSignature.mockReset();
     close.mockClear();
-    setHref.mockClear();
+    // Reset, not clear: one case installs an implementation that reads the stash mid-navigation, and
+    // leaving it in place would have it run for every later case.
+    setHref.mockReset();
+    sessionStorage.clear();
   });
 
   it('opens the signing session as the dialog opens', async () => {
@@ -185,6 +189,39 @@ describe('OrgEasyclaSignHandoffComponent', () => {
 
     expect(testid(fixture, 'org-easycla-sign-failed')).not.toBeNull();
     expect(location.href).toBe('https://example.test/org/easycla');
+  });
+
+  /**
+   * The signatory returns through a cross-site redirect to an address that was composed before this
+   * signature existed, so this dialog is the last place in the browser that knows which agreement
+   * they are about to sign. Stashing it is what lets the return land on that agreement instead of
+   * the list.
+   */
+  it('stashes the signature before leaving, so the return can land on the agreement', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+    // Read at the moment of the navigation rather than after it. No code of ours runs once the
+    // browser has left, so a stash written afterwards would never be written at all — and reading it
+    // at the end of the test cannot tell the two orders apart.
+    let stashedOnLeaving: string | null = null;
+    setHref.mockImplementation(() => {
+      stashedOnLeaving = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
+    });
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-review')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(setHref).toHaveBeenCalledWith(response.signUrl);
+    expect(stashedOnLeaving).toBe(response.signatureId);
+  });
+
+  // A stash with no hand-off behind it would send the next visit to the list into a detail page for
+  // an agreement nobody was ever handed.
+  it('stashes nothing when the session came back without an address', async () => {
+    requestCorporateSignature.mockReturnValue(of({ ...response, signUrl: '' }));
+
+    await render();
+
+    expect(sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY)).toBeNull();
   });
 
   // A trade-compliance hold is explained upstream, names how to challenge it, and will change

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -1,0 +1,216 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { DOCUMENT } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Observable, of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrgEasyclaSignHandoffComponent } from './org-easycla-sign-handoff.component';
+
+/**
+ * The hand-off, from the browser's side.
+ *
+ * Three things are worth a test here and the rest is markup: that the attestations the signatory
+ * gave are the ones sent, that the address the CLA service returned is the one navigated to, and
+ * that a refusal it explained in words reaches the signatory in those words.
+ */
+describe('OrgEasyclaSignHandoffComponent', () => {
+  const requestCorporateSignature = vi.fn();
+  const close = vi.fn();
+  // Assignment goes through a spy so the ordering of close-then-navigate is observable, not just
+  // the final value.
+  const setHref = vi.fn();
+  let location: { href: string };
+
+  const data: OrgClaSignHandoffDialogData = {
+    orgUid: '0014100000Te0xxAAC',
+    projectSfid: 'a09410000182dD2AAI',
+    claGroupId: 'd5d3f4f0-1a2b-4c3d-8e9f-0a1b2c3d4e5f',
+    attestations: { authorityAcked: true, embargoAcked: true },
+  };
+
+  const response: OrgClaSignResponse = {
+    signUrl: 'https://demo.docusign.net/Signing/StartInSession.aspx?t=abc123',
+  };
+
+  // Explicit rather than defaulted: a defaulted parameter would substitute the real selection for
+  // the `undefined` the missing-data test means to pass, and that test would silently assert
+  // nothing.
+  async function renderWith(dialogData: OrgClaSignHandoffDialogData | undefined): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
+    let href = 'https://example.test/org/easycla';
+    location = {
+      get href() {
+        return href;
+      },
+      set href(value: string) {
+        setHref(value);
+        href = value;
+      },
+    };
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaSignHandoffComponent],
+      providers: [
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: dialogData } },
+        { provide: OrgLensClaService, useValue: { requestCorporateSignature } },
+        // Only `location` is swapped. TestBed renders through DOCUMENT, so replacing it wholesale
+        // breaks the fixture; jsdom also refuses a direct `document.location` assignment. Methods
+        // are bound to the real document — called on the proxy they would fail on internal slots.
+        {
+          provide: DOCUMENT,
+          useFactory: () =>
+            new Proxy(globalThis.document, {
+              get: (target, prop) => {
+                if (prop === 'location') return location;
+                const value = Reflect.get(target, prop);
+                return typeof value === 'function' ? value.bind(target) : value;
+              },
+            }),
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaSignHandoffComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function render(): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
+    return renderWith(data);
+  }
+
+  function testid(fixture: ComponentFixture<OrgEasyclaSignHandoffComponent>, id: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+  }
+
+  beforeEach(() => {
+    requestCorporateSignature.mockReset();
+    close.mockClear();
+    setHref.mockClear();
+  });
+
+  it('opens the signing session as the dialog opens', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    await render();
+
+    expect(requestCorporateSignature).toHaveBeenCalledWith(data.orgUid, {
+      projectSfid: data.projectSfid,
+      claGroupId: data.claGroupId,
+      authorityAcked: true,
+      embargoAcked: true,
+    });
+  });
+
+  // The client-side half of the attestation contract. The component must relay what the
+  // attestation step recorded, so that a regression which lets an unaffirmed request through the
+  // dialog is refused by the server rather than laundered into a `true` on the way out.
+  it('relays a withdrawn confirmation as withdrawn', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    await renderWith({ ...data, attestations: { authorityAcked: true, embargoAcked: false } });
+
+    expect(requestCorporateSignature).toHaveBeenCalledWith(data.orgUid, {
+      projectSfid: data.projectSfid,
+      claGroupId: data.claGroupId,
+      authorityAcked: true,
+      embargoAcked: false,
+    });
+  });
+
+  it('tells the signatory they will become the initial CLA Manager before they commit', async () => {
+    requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-preparing')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-manager-notice')?.textContent).toContain(CCLA_SIGN_COPY.preparing.consequence);
+  });
+
+  it('offers the signing control once the session is open', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-ready')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-preparing')).toBeNull();
+  });
+
+  // Navigated to exactly as returned, and in this tab. A new context would leave the signatory's
+  // return from EasyCLA stranded on a second tab behind the console they started from.
+  it('navigates this tab to the address the CLA service returned', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-review')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(location.href).toBe(response.signUrl);
+  });
+
+  // A full-page navigation is not a teardown. Back out of DocuSign can restore this page from
+  // bfcache with the flow still marked open, which disables Sign CLA until a manual reload — so
+  // the dialog must release before it navigates, not after.
+  it('releases the flow before navigating away', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-review')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(setHref).toHaveBeenCalledWith(response.signUrl);
+    expect(close.mock.invocationCallOrder[0]).toBeLessThan(setHref.mock.invocationCallOrder[0]);
+  });
+
+  it('does not navigate when the session came back without an address', async () => {
+    requestCorporateSignature.mockReturnValue(of({ ...response, signUrl: '' }));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failed')).not.toBeNull();
+    expect(location.href).toBe('https://example.test/org/easycla');
+  });
+
+  // A trade-compliance hold is explained upstream, names how to challenge it, and will change
+  // when that process does. Replacing it with this application's generic sentence would drop the
+  // only part of the message the signatory could act on.
+  it("shows a refusal in the CLA service's own words", async () => {
+    const refusal = 'This company is subject to a trade-compliance hold. Contact support to review the determination.';
+    requestCorporateSignature.mockReturnValue(throwError(() => ({ status: 403, error: { message: refusal } })));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(refusal);
+  });
+
+  it('shows the generic failure when the refusal was not explained', async () => {
+    requestCorporateSignature.mockReturnValue(throwError(() => ({ status: 500, error: { message: 'signature service unavailable' } })));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(CCLA_SIGN_COPY.failure.body);
+  });
+
+  it('closes without a result when the signatory backs out of an open session', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-cancel')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(close).toHaveBeenCalledWith(null);
+    expect(location.href).toBe('https://example.test/org/easycla');
+  });
+
+  it('fails closed when it is opened without a selection', async () => {
+    const fixture = await renderWith(undefined);
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(testid(fixture, 'org-easycla-sign-failed')).not.toBeNull();
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -4,6 +4,7 @@
 import '@angular/compiler';
 
 import { DOCUMENT } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
@@ -28,6 +29,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   // the final value.
   const setHref = vi.fn();
   let location: { href: string };
+  let config: DynamicDialogConfig<OrgClaSignHandoffDialogData>;
 
   const data: OrgClaSignHandoffDialogData = {
     orgUid: '0014100000Te0xxAAC',
@@ -54,12 +56,15 @@ describe('OrgEasyclaSignHandoffComponent', () => {
         href = value;
       },
     };
+    // The real shape and the real initial values from the call site, because the component drives
+    // three of these and a bare `{ data }` stub would let a wrong initial value pass unnoticed.
+    config = { data: dialogData, header: CCLA_SIGN_COPY.preparing.header, closable: false, closeOnEscape: false };
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [OrgEasyclaSignHandoffComponent],
       providers: [
         { provide: DynamicDialogRef, useValue: { close } },
-        { provide: DynamicDialogConfig, useValue: { data: dialogData } },
+        { provide: DynamicDialogConfig, useValue: config },
         { provide: OrgLensClaService, useValue: { requestCorporateSignature } },
         // Only `location` is swapped. TestBed renders through DOCUMENT, so replacing it wholesale
         // breaks the fixture; jsdom also refuses a direct `document.location` assignment. Methods
@@ -89,6 +94,11 @@ describe('OrgEasyclaSignHandoffComponent', () => {
 
   function testid(fixture: ComponentFixture<OrgEasyclaSignHandoffComponent>, id: string): HTMLElement | null {
     return fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+  }
+
+  /** What `HttpClient` actually rejects with: a real `HttpErrorResponse` over this BFF's body. */
+  function bffError(status: number, body: unknown): HttpErrorResponse {
+    return new HttpErrorResponse({ status, statusText: 'x', url: '/api/orgs/x/lens/cla-groups/sign', error: body });
   }
 
   beforeEach(() => {
@@ -180,9 +190,25 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   // A trade-compliance hold is explained upstream, names how to challenge it, and will change
   // when that process does. Replacing it with this application's generic sentence would drop the
   // only part of the message the signatory could act on.
+  //
+  // The fixtures below are real `HttpErrorResponse`s carrying the body this BFF actually sends.
+  // `BaseApiError#toResponse` puts the message under `error`, and the validation replies put it
+  // under `message`; an earlier version of this suite invented `{ error: { message } }`, which is
+  // neither, and passed against a component that could not read either one.
   it("shows a refusal in the CLA service's own words", async () => {
     const refusal = 'This company is subject to a trade-compliance hold. Contact support to review the determination.';
-    requestCorporateSignature.mockReturnValue(throwError(() => ({ status: 403, error: { message: refusal } })));
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(403, { error: refusal, code: 'UPSTREAM_ERROR' })));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(refusal);
+  });
+
+  // The BFF's own validation replies answer with `message`, so the relay has to read both spellings
+  // — a reader that knows only one drops half of what the server says.
+  it("shows a refusal the server sent under 'message'", async () => {
+    const refusal = 'Both the authorization and compliance confirmations are required';
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(403, { message: refusal })));
 
     const fixture = await render();
 
@@ -190,11 +216,24 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   });
 
   it('shows the generic failure when the refusal was not explained', async () => {
-    requestCorporateSignature.mockReturnValue(throwError(() => ({ status: 500, error: { message: 'signature service unavailable' } })));
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'signature service unavailable' })));
 
     const fixture = await render();
 
     expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(CCLA_SIGN_COPY.failure.body);
+  });
+
+  // Angular synthesizes a non-empty `HttpErrorResponse.message` ("Http failure response for …")
+  // for every failure, so a reader that falls back to it puts an HTTP debugging string in front of
+  // a signatory who was refused.
+  it('shows the generic failure rather than Angular’s synthesized message when the body is empty', async () => {
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(403, null)));
+
+    const fixture = await render();
+
+    const shown = testid(fixture, 'org-easycla-sign-failure-message')?.textContent;
+    expect(shown).toContain(CCLA_SIGN_COPY.failure.body);
+    expect(shown).not.toContain('Http failure response');
   });
 
   it('closes without a result when the signatory backs out of an open session', async () => {
@@ -212,5 +251,64 @@ describe('OrgEasyclaSignHandoffComponent', () => {
 
     expect(requestCorporateSignature).not.toHaveBeenCalled();
     expect(testid(fixture, 'org-easycla-sign-failed')).not.toBeNull();
+  });
+
+  /**
+   * The signing request runs while this dialog is on screen, and it is the call that creates both
+   * the signature record and the DocuSign envelope. Dismissing the dialog destroys the component
+   * and its subscription, so the address that comes back is discarded and the envelope is left
+   * with nobody holding it. Neither exit is available until there is something to lose.
+   */
+  describe('while the signing request is in flight', () => {
+    it('cannot be dismissed by the header control or by Escape', async () => {
+      requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
+
+      await render();
+
+      expect(config.closable).toBe(false);
+      expect(config.closeOnEscape).toBe(false);
+    });
+
+    it.each([
+      ['ready', () => of(response)],
+      ['failed', () => throwError(() => bffError(500, { error: 'nope' }))],
+    ])('can be dismissed again once it reaches %s', async (_state, source) => {
+      requestCorporateSignature.mockReturnValue(source());
+
+      await render();
+
+      expect(config.closable).toBe(true);
+      expect(config.closeOnEscape).toBe(true);
+    });
+  });
+
+  /**
+   * The shell dialog's title is PrimeNG's, and it is a static string at the call site. Left alone
+   * it keeps saying "Configuring CLA Manager Settings…" above a panel that says the session is
+   * ready, or that it failed.
+   */
+  describe('the dialog title', () => {
+    it.each([
+      ['preparing', () => new Observable<OrgClaSignResponse>(() => undefined), CCLA_SIGN_COPY.preparing.header],
+      ['ready', () => of(response), CCLA_SIGN_COPY.ready.header],
+      ['failed', () => throwError(() => bffError(500, { error: 'nope' })), CCLA_SIGN_COPY.failure.header],
+    ])('names the %s state', async (_state, source, expected) => {
+      requestCorporateSignature.mockReturnValue(source());
+
+      await render();
+
+      expect(config.header).toBe(expected);
+    });
+
+    // Would have been the whole bug: the title is set once at the call site and the panel moves on
+    // without it.
+    it('does not leave the preparing title above a ready panel', async () => {
+      requestCorporateSignature.mockReturnValue(of(response));
+
+      const fixture = await render();
+
+      expect(testid(fixture, 'org-easycla-sign-ready')).not.toBeNull();
+      expect(config.header).not.toBe(CCLA_SIGN_COPY.preparing.header);
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -60,19 +60,22 @@ export class OrgEasyclaSignHandoffComponent {
     // this config object on every change-detection pass — so driving them from state here is what
     // keeps the frame honest, rather than fixing them at the call site that cannot see the state.
     //
-    // While the request is in flight the dialog cannot be dismissed by either route. Closing it
-    // then destroys this component and its subscription, and the signing address that comes back
-    // is the only copy: the signature record and the DocuSign envelope are created by that same
-    // call, so a dismissal mid-flight leaves a real envelope nobody was handed. Both exits open
-    // again on `ready` and `failed`, where there is either an address on screen or nothing left
-    // to lose.
+    // The dialog cannot be dismissed while the request is in flight, and still cannot once it
+    // succeeds. The signature record and the DocuSign envelope are created by that one call, and
+    // the address it returns is the only copy — so every exit before the signatory follows it
+    // abandons a real agreement upstream, which this application has no way to cancel or reuse.
+    // Sealing only the in-flight window would close the smaller of the two holes: the request
+    // usually answers in under a second, while `ready` waits for a person.
+    //
+    // `failed` is the one dismissible state. There is no envelope to strand, and trapping someone
+    // in a dialog that reports a failure would leave them no way out at all.
     effect(() => {
       const state = this.state();
-      const inFlight = state === 'preparing';
+      const dismissible = state === 'failed';
 
       this.config.header = this.headerFor[state];
-      this.config.closable = !inFlight;
-      this.config.closeOnEscape = !inFlight;
+      this.config.closable = dismissible;
+      this.config.closeOnEscape = dismissible;
     });
 
     const data = this.config.data;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { DOCUMENT } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { serverAuthoredMessage } from '@shared/utils/http-error.utils';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
@@ -46,7 +48,33 @@ export class OrgEasyclaSignHandoffComponent {
 
   private readonly prepared = signal<OrgClaSignResponse | null>(null);
 
+  /** Shell-dialog title per state, so the frame never contradicts the panel inside it. */
+  private readonly headerFor: Record<'preparing' | 'ready' | 'failed', string> = {
+    preparing: CCLA_SIGN_COPY.preparing.header,
+    ready: CCLA_SIGN_COPY.ready.header,
+    failed: CCLA_SIGN_COPY.failure.header,
+  };
+
   public constructor() {
+    // The shell dialog is PrimeNG's, and it re-reads `header`, `closable` and `closeOnEscape` from
+    // this config object on every change-detection pass — so driving them from state here is what
+    // keeps the frame honest, rather than fixing them at the call site that cannot see the state.
+    //
+    // While the request is in flight the dialog cannot be dismissed by either route. Closing it
+    // then destroys this component and its subscription, and the signing address that comes back
+    // is the only copy: the signature record and the DocuSign envelope are created by that same
+    // call, so a dismissal mid-flight leaves a real envelope nobody was handed. Both exits open
+    // again on `ready` and `failed`, where there is either an address on screen or nothing left
+    // to lose.
+    effect(() => {
+      const state = this.state();
+      const inFlight = state === 'preparing';
+
+      this.config.header = this.headerFor[state];
+      this.config.closable = !inFlight;
+      this.config.closeOnEscape = !inFlight;
+    });
+
     const data = this.config.data;
     if (!data) {
       this.state.set('failed');
@@ -113,14 +141,14 @@ export class OrgEasyclaSignHandoffComponent {
    * both are more useful than anything this layer could write — the compliance wording in
    * particular is maintained upstream and will change when the process does. Everything else
    * shares one message, because there is nothing in it the signatory could act on differently.
+   *
+   * Read through the shared helper rather than by hand. The BFF answers a relayed refusal with
+   * the sentence under `error` (`BaseApiError#toResponse`) and its own validation replies with it
+   * under `message`, so a reader that reaches for one spelling drops the other — and dropping
+   * `error` is dropping every refusal this relay exists for.
    */
   private messageFor(error: unknown): string {
-    const message = (error as { error?: { message?: unknown } } | null)?.error?.message;
-    const status = (error as { status?: unknown } | null)?.status;
-
-    if (status === 403 && typeof message === 'string' && message.trim()) {
-      return message.trim();
-    }
-    return CCLA_SIGN_COPY.failure.body;
+    if (!(error instanceof HttpErrorResponse) || error.status !== 403) return CCLA_SIGN_COPY.failure.body;
+    return serverAuthoredMessage(error, CCLA_SIGN_COPY.failure.body).trim();
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -1,0 +1,126 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DOCUMENT } from '@angular/common';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+import { ButtonComponent } from '@components/button/button.component';
+
+/**
+ * Opens the corporate signing session, then hands the signatory off to it (#1983).
+ *
+ * The request is made when this dialog opens — that is, on the signatory's Continue from the
+ * attestation step — rather than on the Review and Sign control below. It is not a rehearsal: the
+ * CLA service persists a signature record and opens a DocuSign envelope in the same call, and
+ * there is no shape of the request that yields a signing address without doing so. Given that,
+ * every failure it can produce is better surfaced *before* the signatory's final commitment than
+ * after it. Waiting would not avoid the envelope; it would only mean telling somebody who has
+ * just pressed "sign" that nothing happened.
+ *
+ * The consequence is that backing out here leaves a sent envelope behind. That belongs to the CLA
+ * service, which already voids them, and is not cleaned up from this side.
+ */
+@Component({
+  selector: 'lfx-org-easycla-sign-handoff',
+  imports: [ButtonComponent],
+  templateUrl: './org-easycla-sign-handoff.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaSignHandoffComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly claService = inject(OrgLensClaService);
+  private readonly document = inject(DOCUMENT);
+  private readonly config = inject<DynamicDialogConfig<OrgClaSignHandoffDialogData>>(DynamicDialogConfig);
+
+  protected readonly copy = CCLA_SIGN_COPY;
+
+  protected readonly state = signal<'preparing' | 'ready' | 'failed'>('preparing');
+  /** The CLA service's own words for a refusal it explained; the generic copy otherwise. */
+  protected readonly failureMessage = signal<string>(CCLA_SIGN_COPY.failure.body);
+
+  private readonly prepared = signal<OrgClaSignResponse | null>(null);
+
+  public constructor() {
+    const data = this.config.data;
+    if (!data) {
+      this.state.set('failed');
+      return;
+    }
+
+    this.claService
+      .requestCorporateSignature(data.orgUid, {
+        projectSfid: data.projectSfid,
+        claGroupId: data.claGroupId,
+        // Relayed exactly as the attestation step recorded them. Writing `true` here would make
+        // the client's own disabled state the only record that the signatory ever confirmed
+        // anything, and would keep sending an affirmation after that state regressed.
+        authorityAcked: data.attestations.authorityAcked,
+        embargoAcked: data.attestations.embargoAcked,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          // The server already rejects an empty address as a failed hand-off; this is the second
+          // line, because the cost of being wrong is navigating to this application's own root
+          // and reading as a completed signature.
+          if (!response.signUrl) {
+            this.state.set('failed');
+            return;
+          }
+          this.prepared.set(response);
+          this.state.set('ready');
+        },
+        error: (error: unknown) => {
+          this.failureMessage.set(this.messageFor(error));
+          this.state.set('failed');
+        },
+      });
+  }
+
+  /**
+   * A full navigation, not a new context: EasyCLA returns the signatory to the Organization Lens
+   * afterwards, which only reads as one flow if they never left this tab.
+   */
+  protected onReviewAndSign(): void {
+    const prepared = this.prepared();
+    if (!prepared?.signUrl) return;
+
+    // Closed before the navigation, which releases the page's single-flight flag. A full-page
+    // navigation is not a teardown: a Back out of DocuSign can restore this page from bfcache
+    // exactly as it left it, and a flag still set there disables Sign CLA until a manual reload.
+    this.ref.close(prepared);
+
+    // Navigated to as returned. Composing this from a console base and the identifiers would
+    // ignore the session the request just opened.
+    this.document.location.href = prepared.signUrl;
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+
+  /**
+   * A refusal the CLA service explained is shown in its own words.
+   *
+   * It answers a trade-compliance hold with a sentence naming the reason and the support route,
+   * and a missing signing authority with a statement about the caller's scope. Both are 403s, and
+   * both are more useful than anything this layer could write — the compliance wording in
+   * particular is maintained upstream and will change when the process does. Everything else
+   * shares one message, because there is nothing in it the signatory could act on differently.
+   */
+  private messageFor(error: unknown): string {
+    const message = (error as { error?: { message?: unknown } } | null)?.error?.message;
+    const status = (error as { status?: unknown } | null)?.status;
+
+    if (status === 403 && typeof message === 'string' && message.trim()) {
+      return message.trim();
+    }
+    return CCLA_SIGN_COPY.failure.body;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -9,6 +9,7 @@ import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { serverAuthoredMessage } from '@shared/utils/http-error.utils';
+import { stashSignedSignatureId } from '@shared/utils/org-cla-signed-signature.util';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
@@ -121,6 +122,12 @@ export class OrgEasyclaSignHandoffComponent {
   protected onReviewAndSign(): void {
     const prepared = this.prepared();
     if (!prepared?.signUrl) return;
+
+    // Stashed before the navigation, because after it there is no code of ours left running. The
+    // signatory returns to `/org/easycla` through a cross-site redirect whose address was fixed
+    // before this signature existed, so this is the only moment at which anything in the browser
+    // knows which agreement they are about to sign.
+    stashSignedSignatureId(prepared.signatureId);
 
     // Closed before the navigation, which releases the page's single-flight flag. A full-page
     // navigation is not a teardown: a Back out of DocuSign can restore this page from bfcache

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -19,6 +19,11 @@
          Org Lens access, since every request the flow makes would be refused by the server and the
          page is already saying the module is unavailable beneath this control.
 
+         Also disabled until the org context has settled. `hasNoOrgAccess()` reads false while the
+         grants and persona are still loading, so without this a viewer with no grant can start the
+         flow inside the loading window and reach a refusal the page would otherwise have prevented.
+         The page body below gates on the same signal.
+
          Deliberately not disabled for a viewer who lacks signing authority: that is a different
          thing and not known here. The CLA service is the only party that knows, it decides per
          project and organization, and it explains its refusal in words worth reading. Hiding the
@@ -27,7 +32,7 @@
     <lfx-button
       label="Sign CLA"
       icon="fa-light fa-file-signature"
-      [disabled]="!hasCompany() || signingOpen() || hasNoOrgAccess()"
+      [disabled]="!hasCompany() || signingOpen() || hasNoOrgAccess() || !orgContextLoaded()"
       [ariaLabel]="signClaAriaLabel()"
       styleClass="shrink-0"
       (onClick)="startSigning()"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -14,22 +14,19 @@
       <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization holds across Linux Foundation projects.</p>
     </div>
 
-    <!-- Rendered but not yet operable: the signing hand-off ships separately. It is here now
-         because the no-CLAs empty state tells the viewer to use it, and disabled reads as
-         "not yet available" where an enabled control wired to nothing reads as broken. There is
-         deliberately no click handler to leave behind — enabling it is the signing feature's job. -->
-    <!-- The reason is in the accessible name as well as the tooltip, because the tooltip alone
-         cannot reach everyone it needs to: the directive sits on the non-focusable `<p-button>`
-         host while the button inside it is disabled, so it opens on hover and never on focus.
-         Without this, assistive technology announces only "Sign CLA, disabled" and the viewer is
-         left to guess whether the control is unavailable to them or unavailable to everyone. -->
+    <!-- Disabled only while no organization is selected — there would be nothing to sign for —
+         and while a hand-off is already open, which is the single-flight guard.
+
+         Deliberately not disabled for a viewer who lacks signing authority: the CLA service is
+         the only party that knows, it decides per project and organization, and it explains its
+         refusal in words worth reading. Hiding the control for those viewers is #1980. -->
     <lfx-button
       label="Sign CLA"
       icon="fa-light fa-file-signature"
-      [disabled]="true"
-      ariaLabel="Sign CLA — signing a new CLA from the Organization Lens is coming soon."
-      tooltip="Signing a new CLA from the Organization Lens is coming soon."
+      [disabled]="!hasCompany() || signingOpen()"
+      [ariaLabel]="signClaAriaLabel()"
       styleClass="shrink-0"
+      (onClick)="startSigning()"
       data-testid="org-easycla-sign-cla" />
   </header>
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -14,16 +14,20 @@
       <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization holds across Linux Foundation projects.</p>
     </div>
 
-    <!-- Disabled only while no organization is selected — there would be nothing to sign for —
-         and while a hand-off is already open, which is the single-flight guard.
+    <!-- Disabled while no organization is selected — there would be nothing to sign for — while a
+         hand-off is already open, which is the single-flight guard, and while the viewer has no
+         Org Lens access, since every request the flow makes would be refused by the server and the
+         page is already saying the module is unavailable beneath this control.
 
-         Deliberately not disabled for a viewer who lacks signing authority: the CLA service is
-         the only party that knows, it decides per project and organization, and it explains its
-         refusal in words worth reading. Hiding the control for those viewers is #1980. -->
+         Deliberately not disabled for a viewer who lacks signing authority: that is a different
+         thing and not known here. The CLA service is the only party that knows, it decides per
+         project and organization, and it explains its refusal in words worth reading. Hiding the
+         control for those viewers is #1980. Lacking Org Lens access is known locally, which is
+         why it belongs in this expression and signing authority does not. -->
     <lfx-button
       label="Sign CLA"
       icon="fa-light fa-file-signature"
-      [disabled]="!hasCompany() || signingOpen()"
+      [disabled]="!hasCompany() || signingOpen() || hasNoOrgAccess()"
       [ariaLabel]="signClaAriaLabel()"
       styleClass="shrink-0"
       (onClick)="startSigning()"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -3,10 +3,10 @@
 
 import '@angular/compiler';
 
-import { signal } from '@angular/core';
+import { ApplicationRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -944,6 +944,119 @@ describe('OrgEasyclaComponent', () => {
       await switchOrg(fixture);
 
       expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 1–8 of 11');
+    });
+  });
+  /**
+   * Returning from DocuSign, where the organization is named on the address.
+   *
+   * The signatory comes back through a cross-site navigation carrying only a `SameSite=Lax`
+   * cookie; when it does not come back, bootstrap selects the first organization in their list, so
+   * signing for one company returns them looking at another.
+   */
+  describe('when EasyCLA returns the signatory with an organization named on the address', () => {
+    const MICROSOFT = { uid: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation', accountId: 'acct-microsoft' };
+    const CONTAINERSHIP = { uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.', accountId: 'acct-containership' };
+
+    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT]) {
+      const setAccount = vi.fn();
+      const navigate = vi.fn();
+      const availableAccounts = signal(authorized);
+
+      selectedAccount.set(CONTAINERSHIP);
+      getClaGroups.mockReturnValue(of({ orgUid: CONTAINERSHIP.uid, claGroups: [] }));
+
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [OrgEasyclaComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts, setAccount } },
+          { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+          { provide: PersonaService, useValue: { personaLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+          { provide: OrgLensClaService, useValue: { getClaGroups } },
+          { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(namedOrg ? { org: namedOrg } : {}) } } },
+          MessageService,
+        ],
+      })
+        .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: openDialog } }] } })
+        .compileComponents();
+
+      const fixture = TestBed.createComponent(OrgEasyclaComponent);
+      vi.spyOn(TestBed.inject(Router), 'navigate').mockImplementation(navigate);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      return { fixture, setAccount, navigate, availableAccounts };
+    }
+
+    it('selects the organization the signature was made for, not the first in the list', async () => {
+      const { setAccount } = await renderReturnedFrom(MICROSOFT.uid);
+
+      // `setAccount` also rewrites the cookie, so the selection that went missing is repaired.
+      expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+    });
+
+    /**
+     * The parameter names an organization; it does not grant one.
+     *
+     * A crafted link must not select a company the viewer does not hold — and specifically must
+     * not render its name, which is what building a stub from the value (the way the cookie path
+     * hydrates an id it trusts) would do.
+     */
+    it('ignores an organization the viewer does not hold rather than selecting it', async () => {
+      const { setAccount, fixture } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).not.toContain('0014100000TeZZZAAA');
+    });
+
+    it('strips the parameter once adopted, so a reload or a copied link cannot pin a stale organization', async () => {
+      const { navigate } = await renderReturnedFrom(MICROSOFT.uid);
+
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null }, replaceUrl: true }));
+    });
+
+    // Left in place it would keep re-asserting an organization the viewer cannot have, on a page
+    // that has already settled without it.
+    it('strips the parameter even when it named an organization it could not use', async () => {
+      const { navigate } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(navigate).toHaveBeenCalled();
+    });
+
+    // The list arrives after this page is constructed, so resolving against the empty list it starts
+    // with would throw away a legitimate hand-off.
+    it('waits for the authorized list rather than discarding the hand-off against an empty one', async () => {
+      navLoaded.set(false);
+      const { setAccount, availableAccounts } = await renderReturnedFrom(MICROSOFT.uid, []);
+
+      expect(setAccount).not.toHaveBeenCalled();
+
+      availableAccounts.set([CONTAINERSHIP, MICROSOFT]);
+      navLoaded.set(true);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+    });
+
+    // The mirror of the wait above: once the organization list has genuinely settled without it,
+    // there is nothing left to wait for and the page stops trying.
+    it('gives up once the organization context has settled without that organization', async () => {
+      const { setAccount, navigate } = await renderReturnedFrom(MICROSOFT.uid, []);
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalled();
+    });
+
+    it('touches nothing on an ordinary visit that carries no organization', async () => {
+      const { setAccount, navigate } = await renderReturnedFrom(null);
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -979,7 +979,7 @@ describe('OrgEasyclaComponent', () => {
     const MICROSOFT = { uid: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation', accountId: 'acct-microsoft' };
     const CONTAINERSHIP = { uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.', accountId: 'acct-containership' };
 
-    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT], currentUrl?: string) {
+    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT]) {
       const setAccount = vi.fn();
       const navigate = vi.fn();
       const availableAccounts = signal(authorized);
@@ -1008,9 +1008,6 @@ describe('OrgEasyclaComponent', () => {
       const fixture = TestBed.createComponent(OrgEasyclaComponent);
       const router = TestBed.inject(Router);
       vi.spyOn(router, 'navigate').mockImplementation(navigate);
-      // Stands in for a navigation that has already happened, since `navigate` is stubbed and the
-      // router's own address therefore never moves in these cases.
-      if (currentUrl) vi.spyOn(router, 'url', 'get').mockReturnValue(currentUrl);
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -1063,12 +1060,6 @@ describe('OrgEasyclaComponent', () => {
      * There is nothing left to strip in that case either: the agreement's address carries no
      * parameter.
      */
-    it('leaves the address alone once the signatory has already been landed on their agreement', async () => {
-      const { navigate } = await renderReturnedFrom(MICROSOFT.uid, [CONTAINERSHIP, MICROSOFT], '/org/easycla/signature-uuid-1');
-
-      expect(navigate).not.toHaveBeenCalled();
-    });
-
     // The list arrives after this page is constructed, so resolving against the empty list it starts
     // with would throw away a legitimate hand-off.
     it('waits for the authorized list rather than discarding the hand-off against an empty one', async () => {
@@ -1196,6 +1187,41 @@ describe('OrgEasyclaComponent', () => {
       const { navigate } = await renderAfterSigning({ stash: '' });
 
       expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+    });
+
+    /**
+     * Both return flows navigate, and Angular cancels an in-flight navigation when another begins,
+     * so the address has to be arbitrated rather than stripped by both. Landing wins; the parameter
+     * leaves with the route it sat on.
+     *
+     * Asserted as the ONLY navigation, because the defect this pins was not a wrong destination. It
+     * was a second, entirely correct-looking strip back to the list, which cancelled the landing and
+     * left the signatory exactly where they would have been with no feature at all. Asserting only
+     * that the landing was requested passes against it — the request was always made.
+     */
+    it('does not strip the address back to the list while landing on the agreement', async () => {
+      const { navigate } = await renderAfterSigning();
+
+      expect(navigate).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+    });
+
+    // The other flow stands down as soon as a landing is intended, so once this one decides to stay
+    // on the list the parameter is its to remove — otherwise it survives the visit, which is the one
+    // thing it must not do.
+    it('removes the organization from the address when it stays on the list', async () => {
+      const { navigate } = await renderAfterSigning({ claGroups: [] });
+
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
+    });
+
+    // No list is ever fetched for an organization the viewer does not hold, so waiting on one would
+    // wait for ever and strand the organization on the address.
+    it('gives up, and still clears the address, when the named organization is not the viewer’s', async () => {
+      const { navigate } = await renderAfterSigning({ org: 'not-an-organization-they-hold' });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -195,7 +195,9 @@ describe('OrgEasyclaComponent', () => {
       const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
         opened.push({ component, config });
         const result = closeResults[opened.length - 1];
-        return { onClose: of(result), close: vi.fn() };
+        // `onDestroy` as well as `onClose`: the flow waits for teardown between steps, so a stub
+        // that only closes would stall it at the first dialog.
+        return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
       });
       return { opened, open };
     }
@@ -328,14 +330,16 @@ describe('OrgEasyclaComponent', () => {
         close: ReturnType<typeof vi.fn>;
         /** Emit to drive this dialog's own close, which is how the flow advances a step. */
         onClose: Subject<unknown>;
+        /** Emit after `onClose` to finish the leave animation. The next step waits on this. */
+        onDestroy: Subject<void>;
       }
 
       function openDialogHarness() {
         const opened: OpenDialog[] = [];
         const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
-          const dialog: OpenDialog = { component, config, close: vi.fn(), onClose: new Subject<unknown>() };
+          const dialog: OpenDialog = { component, config, close: vi.fn(), onClose: new Subject<unknown>(), onDestroy: new Subject<void>() };
           opened.push(dialog);
-          return { onClose: dialog.onClose, close: dialog.close };
+          return { onClose: dialog.onClose, onDestroy: dialog.onDestroy, close: dialog.close };
         });
         return { opened, open };
       }
@@ -416,8 +420,9 @@ describe('OrgEasyclaComponent', () => {
         const { fixture, harness } = await renderWithOpenDialogs();
 
         byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-        // Choosing a CLA group closes the picker and opens the attestation dialog behind it.
+        // Choosing a CLA group closes the picker and, once it has torn down, opens the attestation.
         harness.opened[0].onClose.next(chosen);
+        harness.opened[0].onDestroy.next();
         expect(harness.opened).toHaveLength(2);
 
         selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
@@ -425,6 +430,49 @@ describe('OrgEasyclaComponent', () => {
         await fixture.whenStable();
 
         expect(harness.opened[1].close).toHaveBeenCalled();
+      });
+
+      /**
+       * Each step waits for the previous dialog to be torn down, not merely closed.
+       *
+       * `close()` emits `onClose` synchronously and starts the leave animation from that same
+       * emission, and the end of that animation drops `p-overflow-hidden` from the body. A dialog
+       * opened from inside `onClose` therefore has its own scroll lock stripped a moment after it
+       * appears, and the page scrolls behind it. The Me-lens hand-off found this first (#2066);
+       * this chain opens two dialogs from inside a close, so it had the defect twice.
+       */
+      it.each([
+        { index: 0, step: 'attestation' },
+        { index: 1, step: 'hand-off' },
+      ])('opens no $step dialog until the previous one has torn down', async ({ index }) => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        for (let i = 0; i < index; i++) {
+          harness.opened[i].onClose.next(i === 0 ? chosen : { authorityAcked: true, embargoAcked: true });
+          harness.opened[i].onDestroy.next();
+        }
+
+        const before = harness.opened.length;
+        harness.opened[index].onClose.next(index === 0 ? chosen : { authorityAcked: true, embargoAcked: true });
+        expect(harness.opened).toHaveLength(before);
+
+        harness.opened[index].onDestroy.next();
+        expect(harness.opened).toHaveLength(before + 1);
+      });
+
+      // The gap between one dialog tearing down and the next opening is a window in which the
+      // control is live. It stays disabled across it, or a second click starts a parallel flow.
+      it('starts no second flow in the gap between a teardown and the next dialog', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        harness.opened[0].onClose.next(chosen);
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        harness.opened[0].onDestroy.next();
+
+        expect(harness.opened).toHaveLength(2);
       });
 
       /**
@@ -441,7 +489,9 @@ describe('OrgEasyclaComponent', () => {
 
         byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
         harness.opened[0].onClose.next(chosen);
+        harness.opened[0].onDestroy.next();
         harness.opened[1].onClose.next({ authorityAcked: true, embargoAcked: true });
+        harness.opened[1].onDestroy.next();
         expect(harness.opened).toHaveLength(3);
 
         selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -461,6 +461,24 @@ describe('OrgEasyclaComponent', () => {
         expect(harness.opened).toHaveLength(before + 1);
       });
 
+      /**
+       * PrimeNG's header X and Escape go through `p-dialog` `onHide` → `destroy()`, never `close()`.
+       * `onClose` therefore never fires. The lock has to drop on that teardown, or Sign CLA stays
+       * disabled until reload.
+       */
+      it('offers the control again after the header close tears the dialog down without onClose', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        fixture.detectChanges();
+        expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(true);
+
+        harness.opened[0].onDestroy.next();
+        fixture.detectChanges();
+
+        expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(false);
+      });
+
       // The gap between one dialog tearing down and the next opening is a window in which the
       // control is live. It stays disabled across it, or a second click starts a parallel flow.
       it('starts no second flow in the gap between a teardown and the next dialog', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -148,6 +148,21 @@ describe('OrgEasyclaComponent', () => {
       expect(button?.getAttribute('aria-label')).toContain('select an organization first');
     });
 
+    // `hasNoOrgAccess()` reads false while the grants and persona are still resolving, so without
+    // this gate a viewer holding no grant can start the flow inside the loading window and reach a
+    // refusal the page would otherwise have prevented.
+    it('cannot be used while the organization context is still resolving', async () => {
+      grantsLoaded.set(false);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      // Every reason the control is disabled needs its own wording, or the announcement is just
+      // "disabled" with nothing behind it.
+      expect(button?.getAttribute('aria-label')).toContain('checking your organization access');
+    });
+
     // Not disabled for a viewer who lacks signing authority. The CLA service decides that per
     // project and organization and explains its refusal in words; this layer cannot know it, and
     // guessing would hide the control from people who do hold the authority.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -7,6 +7,7 @@ import { ApplicationRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -178,8 +179,15 @@ describe('OrgEasyclaComponent', () => {
   // The component's own job in the signing flow is only to sequence three dialogs and carry each
   // one's result to the next. What is worth proving is that it carries rather than reconstructs:
   // the attestations reaching the hand-off must be the ones the attestation dialog closed with.
+  /**
+   * The picker, and the hand-over to the preview page.
+   *
+   * This page's part of the signing flow ends at the choice. The attestation and the hand-off belong
+   * to the preview the choice is carried to — that is the arrangement the M3 prototype draws, and it
+   * puts the two legally operative steps on a page that names the agreement they apply to.
+   */
   describe('corporate signing flow', () => {
-    const chosen = { claGroupId: 'cla-group-uuid-1', projectSfid: 'a09410000182dD2AAI', projectName: 'Cascade' };
+    const chosen = { claGroupId: 'cla-group-uuid-1', projectSfid: 'a09410000182dD2AAI', projectName: 'Cascade', claGroupName: 'Cascade CLA' };
 
     /** Only the four the flow actually sets. The rest of DynamicDialogConfig is PrimeNG's default. */
     interface DialogHarnessConfig {
@@ -195,8 +203,8 @@ describe('OrgEasyclaComponent', () => {
       const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
         opened.push({ component, config });
         const result = closeResults[opened.length - 1];
-        // `onDestroy` as well as `onClose`: the flow waits for teardown between steps, so a stub
-        // that only closes would stall it at the first dialog.
+        // `onDestroy` as well as `onClose`: the navigation waits for teardown, so a stub that only
+        // closes would never reach it.
         return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
       });
       return { opened, open };
@@ -210,6 +218,7 @@ describe('OrgEasyclaComponent', () => {
         providers: [
           provideRouter([]),
           provideNoopAnimations(),
+          { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap({}) } } },
           { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
@@ -223,11 +232,15 @@ describe('OrgEasyclaComponent', () => {
         .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: harness.open } }] } })
         .compileComponents();
 
+      // The test module declares no routes, so a real navigation would resolve to nothing and the
+      // assertion would be about the router's failure rather than about where the page tried to go.
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
       const fixture = TestBed.createComponent(OrgEasyclaComponent);
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
-      return { fixture, harness };
+      return { fixture, harness, navigate };
     }
 
     it('asks which CLA group to sign for, scoped to the selected organization', async () => {
@@ -236,73 +249,88 @@ describe('OrgEasyclaComponent', () => {
       byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
 
       expect(harness.opened).toHaveLength(1);
-      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid });
+      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] });
     });
 
-    it('does not ask for a confirmation when no CLA group was chosen', async () => {
+    /**
+     * The picker refuses a CLA Group the organization already holds an agreement for, and this is
+     * where it learns which those are.
+     *
+     * Handed down rather than fetched: this page has the list on screen, and a second request would
+     * be a second answer to the same question. Nothing else here can supply it, so an omission is
+     * silent — the picker simply refuses nothing and the preview goes on to tell the signatory their
+     * organization has not signed an agreement it has.
+     */
+    it('hands the picker the agreements the organization already holds', async () => {
+      const groups = [claGroup()];
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: groups }));
       const { fixture, harness } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid, claGroups: groups });
+    });
+
+    // Keyed on the `orgUid` the server echoed, not on a response merely being in hand. The previous
+    // organization's list stays loaded for a cycle after a switch, and passing it would refuse rows
+    // this organization has never signed — a refusal with no way for the viewer to discover it is
+    // wrong. Empty is the safe reading, and it is what the picker did before this check existed.
+    it('withholds a CLA list that belongs to a different organization', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: '0014100000Zq8xbAAB', claGroups: [claGroup()] }));
+      const { fixture, harness } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] });
+    });
+
+    /**
+     * The hand-over, and the load-bearing one on this page.
+     *
+     * The choice travels in the navigation's state rather than the address, because an address holds
+     * nothing that could be resolved: there is no fetch-a-CLA-group-by-id endpoint, so the preview
+     * would have to render its heading from text taken out of the URL. Everything the preview needs
+     * has to be in this object, including the display name — a selection missing one of these fields
+     * is one the preview refuses and redirects away from.
+     */
+    it('carries the choice to the preview page in the navigation state', async () => {
+      const { fixture, navigate } = await renderWithDialogs([chosen]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      // The key is spelled out rather than taken from the constant, deliberately. It is written into
+      // a history entry that outlives the deployment that wrote it, so renaming it silently breaks
+      // in-app back and forward into a preview opened before the deploy.
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla', 'new'], { state: { orgClaSignSelection: chosen } });
+    });
+
+    it('goes nowhere when no CLA group was chosen', async () => {
+      const { fixture, harness, navigate } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(1);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    // Only the picker. The attestation and the hand-off are the preview page's, so a second dialog
+    // opened here would be this page running a flow it no longer owns.
+    it('opens no dialog of its own beyond the picker', async () => {
+      const { fixture, harness } = await renderWithDialogs([chosen]);
 
       byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
 
       expect(harness.opened).toHaveLength(1);
     });
 
-    it('does not hand off when the confirmation step was dismissed', async () => {
-      const { fixture, harness } = await renderWithDialogs([chosen, null]);
+    // Freely dismissable: nothing has been created yet, and trapping someone in a legal
+    // confirmation they want to back out of would be its own problem.
+    it('leaves the CLA group picker dismissable, because nothing exists yet to lose', async () => {
+      const { fixture, harness } = await renderWithDialogs([chosen]);
 
       byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
 
-      expect(harness.opened).toHaveLength(2);
-    });
-
-    // The load-bearing one. Whatever the attestation dialog closed with is what the hand-off is
-    // given — not a `true` written here, and not an inference from the dialog having closed at
-    // all. A regression that hardcoded these would make the signatory's confirmation unfalsifiable
-    // from this side.
-    it('hands the confirmations to the signing step exactly as the signatory gave them', async () => {
-      const attestations = { authorityAcked: true, embargoAcked: true };
-      const { fixture, harness } = await renderWithDialogs([chosen, attestations, null]);
-
-      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-
-      expect(harness.opened).toHaveLength(3);
-      expect(harness.opened[2].config.data).toEqual({
-        orgUid: SELECTED_ACCOUNT.uid,
-        projectSfid: chosen.projectSfid,
-        claGroupId: chosen.claGroupId,
-        attestations,
-      });
-    });
-
-    /**
-     * The hand-off opens locked by all three routes, and the component reopens them once the
-     * request has landed.
-     *
-     * The initial values belong here rather than in the hand-off's own suite, which supplies its
-     * own config and so cannot see what this call site passes. The signing request starts as that
-     * dialog appears and is the call that creates both the signature record and the DocuSign
-     * envelope: dismissed before the address comes back, it leaves an envelope nobody was handed.
-     */
-    it('opens the hand-off with no way to dismiss it', async () => {
-      const attestations = { authorityAcked: true, embargoAcked: true };
-      const { fixture, harness } = await renderWithDialogs([chosen, attestations, null]);
-
-      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-
-      expect(harness.opened[2].config).toMatchObject({ closable: false, closeOnEscape: false, dismissableMask: false });
-    });
-
-    // The two steps before it are freely dismissable: nothing has been created yet, and trapping
-    // someone in a legal confirmation they want to back out of would be its own problem.
-    it.each([
-      [0, 'CLA group picker'],
-      [1, 'attestation step'],
-    ])('leaves the %s dismissable, because nothing exists yet to lose', async (index) => {
-      const { fixture, harness } = await renderWithDialogs([chosen, { authorityAcked: true, embargoAcked: true }, null]);
-
-      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-
-      expect(harness.opened[index].config.closable).toBe(true);
+      expect(harness.opened[0].config.closable).toBe(true);
     });
 
     // A dismissed flow must release the control, or the page needs a reload to try again.
@@ -316,12 +344,39 @@ describe('OrgEasyclaComponent', () => {
     });
 
     /**
-     * Switching organizations with a signing flow part-way open.
+     * The lock spans the navigation, not just the dialog.
      *
-     * These need dialogs that stay open, so they use a harness whose `onClose` is a Subject the
-     * test controls. The one above emits synchronously, which closes every dialog the instant it
-     * opens — fine for asserting what gets passed along, useless for asserting what happens while
-     * one is still standing.
+     * Between the picker tearing down and the preview being reached the control is on screen and
+     * live, so releasing at the close would let a second click start a parallel flow in that gap.
+     * Releasing at the navigation instead also covers the case where it never lands — refused by a
+     * guard, or superseded — which would otherwise leave Sign CLA disabled until a reload.
+     */
+    it('holds the control through the navigation and releases it when that settles', async () => {
+      const { fixture, navigate } = await renderWithDialogs([chosen]);
+      let arrive: (landed: boolean) => void = () => undefined;
+      navigate.mockReturnValue(new Promise<boolean>((resolve) => (arrive = resolve)));
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+      fixture.detectChanges();
+      const control = (): HTMLButtonElement | null | undefined => byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(control()?.disabled).toBe(true);
+
+      // Refused, which is the case the release has to cover: on a landing navigation this page is
+      // already gone and nothing here would be observable either way.
+      arrive(false);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(control()?.disabled).toBe(false);
+    });
+
+    /**
+     * Switching organizations with the picker part-way open.
+     *
+     * These need a dialog that stays open, so they use a harness whose `onClose` is a Subject the
+     * test controls. The one above emits synchronously, which closes the dialog the instant it opens
+     * — fine for asserting what gets passed along, useless for asserting what happens while it is
+     * still standing.
      */
     describe('when the organization changes part-way through', () => {
       interface OpenDialog {
@@ -363,20 +418,22 @@ describe('OrgEasyclaComponent', () => {
           .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: harness.open } }] } })
           .compileComponents();
 
+        const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
         const fixture = TestBed.createComponent(OrgEasyclaComponent);
         fixture.detectChanges();
         await fixture.whenStable();
         fixture.detectChanges();
-        return { fixture, harness };
+        return { fixture, harness, navigate };
       }
 
       /**
        * The load-bearing one, and the reason the close exists at all.
        *
-       * `orgUid` is read once when the flow starts and carried through all three dialogs, and
+       * `orgUid` is read once when the flow starts and handed to the picker as dialog data, and
        * switching organizations does not destroy this component. So a picker left standing lists
-       * the previous organization's CLA groups, and choosing one would open a signing session
-       * against a company the viewer is no longer looking at — the detail page's stale-download
+       * the previous organization's CLA groups, and choosing one would carry that company into a
+       * signing session for the one the viewer is now looking at — the detail page's stale-download
        * failure, arriving at a corporate legal agreement instead of a PDF.
        */
       it('closes the CLA group picker rather than letting it sign for the organization just left', async () => {
@@ -414,51 +471,24 @@ describe('OrgEasyclaComponent', () => {
         expect(harness.opened[0].close).toHaveBeenCalled();
       });
 
-      // Nothing has been created at this point either, and the confirmations are about a specific
-      // organization's authority and export position — they cannot carry over to another company.
-      it('closes the attestation step as well, since no signature has been asked for yet', async () => {
-        const { fixture, harness } = await renderWithOpenDialogs();
-
-        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-        // Choosing a CLA group closes the picker and, once it has torn down, opens the attestation.
-        harness.opened[0].onClose.next(chosen);
-        harness.opened[0].onDestroy.next();
-        expect(harness.opened).toHaveLength(2);
-
-        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        expect(harness.opened[1].close).toHaveBeenCalled();
-      });
-
       /**
-       * Each step waits for the previous dialog to be torn down, not merely closed.
+       * The navigation waits for the picker to be torn down, not merely closed.
        *
        * `close()` emits `onClose` synchronously and starts the leave animation from that same
-       * emission, and the end of that animation drops `p-overflow-hidden` from the body. A dialog
-       * opened from inside `onClose` therefore has its own scroll lock stripped a moment after it
-       * appears, and the page scrolls behind it. The Me-lens hand-off found this first (#2066);
-       * this chain opens two dialogs from inside a close, so it had the defect twice.
+       * emission, and the end of that animation drops `p-overflow-hidden` from the body. Leaving
+       * from inside `onClose` therefore races that teardown against a page change, and the Me-lens
+       * hand-off found the dialog half of this first (#2066).
        */
-      it.each([
-        { index: 0, step: 'attestation' },
-        { index: 1, step: 'hand-off' },
-      ])('opens no $step dialog until the previous one has torn down', async ({ index }) => {
-        const { fixture, harness } = await renderWithOpenDialogs();
+      it('does not leave for the preview until the picker has torn down', async () => {
+        const { fixture, harness, navigate } = await renderWithOpenDialogs();
 
         byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-        for (let i = 0; i < index; i++) {
-          harness.opened[i].onClose.next(i === 0 ? chosen : { authorityAcked: true, embargoAcked: true });
-          harness.opened[i].onDestroy.next();
-        }
 
-        const before = harness.opened.length;
-        harness.opened[index].onClose.next(index === 0 ? chosen : { authorityAcked: true, embargoAcked: true });
-        expect(harness.opened).toHaveLength(before);
+        harness.opened[0].onClose.next(chosen);
+        expect(navigate).not.toHaveBeenCalled();
 
-        harness.opened[index].onDestroy.next();
-        expect(harness.opened).toHaveLength(before + 1);
+        harness.opened[0].onDestroy.next();
+        expect(navigate).toHaveBeenCalledTimes(1);
       });
 
       /**
@@ -479,9 +509,9 @@ describe('OrgEasyclaComponent', () => {
         expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(false);
       });
 
-      // The gap between one dialog tearing down and the next opening is a window in which the
-      // control is live. It stays disabled across it, or a second click starts a parallel flow.
-      it('starts no second flow in the gap between a teardown and the next dialog', async () => {
+      // The gap between the picker tearing down and the preview being reached is a window in which
+      // the control is live. It stays disabled across it, or a second click opens a second picker.
+      it('starts no second flow in the gap between the teardown and the navigation', async () => {
         const { fixture, harness } = await renderWithOpenDialogs();
 
         byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
@@ -490,33 +520,7 @@ describe('OrgEasyclaComponent', () => {
         byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
         harness.opened[0].onDestroy.next();
 
-        expect(harness.opened).toHaveLength(2);
-      });
-
-      /**
-       * The hand-off is deliberately not closed.
-       *
-       * By the time it is open the request has been issued and a signature record and DocuSign
-       * envelope exist for the organization that was selected when the viewer confirmed — which
-       * is the one they meant to sign for. The address that comes back is the only thing that
-       * reaches them, so closing this on a switch would orphan an envelope to save nothing. It is
-       * also why the field holding the closeable ref is named for the uncommitted half.
-       */
-      it('leaves the hand-off standing, because a signing session already exists behind it', async () => {
-        const { fixture, harness } = await renderWithOpenDialogs();
-
-        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
-        harness.opened[0].onClose.next(chosen);
-        harness.opened[0].onDestroy.next();
-        harness.opened[1].onClose.next({ authorityAcked: true, embargoAcked: true });
-        harness.opened[1].onDestroy.next();
-        expect(harness.opened).toHaveLength(3);
-
-        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        expect(harness.opened[2].close).not.toHaveBeenCalled();
+        expect(harness.opened).toHaveLength(1);
       });
     });
   });
@@ -975,7 +979,7 @@ describe('OrgEasyclaComponent', () => {
     const MICROSOFT = { uid: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation', accountId: 'acct-microsoft' };
     const CONTAINERSHIP = { uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.', accountId: 'acct-containership' };
 
-    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT]) {
+    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT], currentUrl?: string) {
       const setAccount = vi.fn();
       const navigate = vi.fn();
       const availableAccounts = signal(authorized);
@@ -1002,7 +1006,11 @@ describe('OrgEasyclaComponent', () => {
         .compileComponents();
 
       const fixture = TestBed.createComponent(OrgEasyclaComponent);
-      vi.spyOn(TestBed.inject(Router), 'navigate').mockImplementation(navigate);
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockImplementation(navigate);
+      // Stands in for a navigation that has already happened, since `navigate` is stubbed and the
+      // router's own address therefore never moves in these cases.
+      if (currentUrl) vi.spyOn(router, 'url', 'get').mockReturnValue(currentUrl);
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -1046,6 +1054,21 @@ describe('OrgEasyclaComponent', () => {
       expect(navigate).toHaveBeenCalled();
     });
 
+    /**
+     * The strip and the landing on the signed agreement race each other — this one waits on the
+     * authorized accounts, the other on the CLA list — and this one navigates *relative to this
+     * route*. Arriving second, it would take the signatory straight back off the agreement they
+     * had just been landed on, which reads as the landing being broken rather than the strip.
+     *
+     * There is nothing left to strip in that case either: the agreement's address carries no
+     * parameter.
+     */
+    it('leaves the address alone once the signatory has already been landed on their agreement', async () => {
+      const { navigate } = await renderReturnedFrom(MICROSOFT.uid, [CONTAINERSHIP, MICROSOFT], '/org/easycla/signature-uuid-1');
+
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
     // The list arrives after this page is constructed, so resolving against the empty list it starts
     // with would throw away a legitimate hand-off.
     it('waits for the authorized list rather than discarding the hand-off against an empty one', async () => {
@@ -1075,6 +1098,104 @@ describe('OrgEasyclaComponent', () => {
 
       expect(setAccount).not.toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Landing on the agreement just signed, rather than on the list the signatory left.
+   *
+   * The return address cannot name it: `return_url` is an input to the upstream signing request and
+   * so is fixed before a signature exists. The signature crosses in `sessionStorage` instead, and
+   * this page spends it.
+   */
+  describe('when EasyCLA returns the signatory after a signing ceremony', () => {
+    const SIGNED = ['/org/easycla', 'signature-uuid-1'];
+
+    async function renderAfterSigning(options: { stash?: string; org?: string | null; listOrgUid?: string; claGroups?: OrgClaGroup[] } = {}) {
+      const { stash = 'signature-uuid-1', org = SELECTED_ACCOUNT.uid, listOrgUid = SELECTED_ACCOUNT.uid, claGroups = [claGroup()] } = options;
+
+      if (stash) sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, stash);
+      selectedAccount.set(SELECTED_ACCOUNT);
+      getClaGroups.mockReturnValue(of({ orgUid: listOrgUid, claGroups }));
+
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [OrgEasyclaComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          {
+            provide: AccountContextService,
+            useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts: signal([SELECTED_ACCOUNT]), setAccount: vi.fn() },
+          },
+          { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+          { provide: PersonaService, useValue: { personaLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+          { provide: OrgLensClaService, useValue: { getClaGroups } },
+          { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(org ? { org } : {}) } } },
+          MessageService,
+        ],
+      })
+        .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: openDialog } }] } })
+        .compileComponents();
+
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      const fixture = TestBed.createComponent(OrgEasyclaComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      return { fixture, navigate };
+    }
+
+    beforeEach(() => sessionStorage.clear());
+
+    // Replaces rather than pushes: the address left behind is the return address, and an entry for
+    // it is one Back re-enters — spending nothing and stripping a parameter all over again.
+    it('lands on the agreement just signed, without leaving the return address in history', async () => {
+      const { navigate } = await renderAfterSigning();
+
+      expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+    });
+
+    /**
+     * EasyCLA may not have finished processing the DocuSign callback by the time the signatory is
+     * back. Navigating blind would land them on "This CLA was not found", which is strictly worse
+     * than the list — the list shows the agreement as soon as it appears.
+     */
+    it('stays on the list when the signed agreement is not in it yet', async () => {
+      const { navigate } = await renderAfterSigning({ claGroups: [] });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+    });
+
+    /**
+     * Whichever organization was selected at boot settles first and cannot contain the new
+     * agreement, so a decision taken against that list would spend the trip on a row that was never
+     * going to be in it.
+     */
+    it('waits for the named organization’s own list rather than deciding on the one in hand', async () => {
+      const { navigate } = await renderAfterSigning({ listOrgUid: '0014100000Te2QjAAJ' });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+    });
+
+    // Otherwise an abandoned ceremony leaves a signature behind that hijacks an ordinary visit to
+    // the list, days later, on whatever return trip finds it.
+    it('does not divert an ordinary visit, and spends the signature anyway', async () => {
+      const { navigate } = await renderAfterSigning({ org: null });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+      // Spent either way, which is what makes it single-use whichever visit finds it.
+      expect(sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY)).toBeNull();
+    });
+
+    it('stays on the list when no ceremony left a signature behind', async () => {
+      const { navigate } = await renderAfterSigning({ stash: '' });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -297,6 +297,145 @@ describe('OrgEasyclaComponent', () => {
 
       expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(false);
     });
+
+    /**
+     * Switching organizations with a signing flow part-way open.
+     *
+     * These need dialogs that stay open, so they use a harness whose `onClose` is a Subject the
+     * test controls. The one above emits synchronously, which closes every dialog the instant it
+     * opens — fine for asserting what gets passed along, useless for asserting what happens while
+     * one is still standing.
+     */
+    describe('when the organization changes part-way through', () => {
+      interface OpenDialog {
+        component: unknown;
+        config: DialogHarnessConfig;
+        close: ReturnType<typeof vi.fn>;
+        /** Emit to drive this dialog's own close, which is how the flow advances a step. */
+        onClose: Subject<unknown>;
+      }
+
+      function openDialogHarness() {
+        const opened: OpenDialog[] = [];
+        const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
+          const dialog: OpenDialog = { component, config, close: vi.fn(), onClose: new Subject<unknown>() };
+          opened.push(dialog);
+          return { onClose: dialog.onClose, close: dialog.close };
+        });
+        return { opened, open };
+      }
+
+      async function renderWithOpenDialogs() {
+        const harness = openDialogHarness();
+        TestBed.resetTestingModule();
+        await TestBed.configureTestingModule({
+          imports: [OrgEasyclaComponent],
+          providers: [
+            provideRouter([]),
+            provideNoopAnimations(),
+            { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
+            { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+            { provide: PersonaService, useValue: { personaLoaded } },
+            { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+            { provide: OrgLensClaService, useValue: { getClaGroups } },
+            MessageService,
+          ],
+        })
+          .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: harness.open } }] } })
+          .compileComponents();
+
+        const fixture = TestBed.createComponent(OrgEasyclaComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+        return { fixture, harness };
+      }
+
+      /**
+       * The load-bearing one, and the reason the close exists at all.
+       *
+       * `orgUid` is read once when the flow starts and carried through all three dialogs, and
+       * switching organizations does not destroy this component. So a picker left standing lists
+       * the previous organization's CLA groups, and choosing one would open a signing session
+       * against a company the viewer is no longer looking at — the detail page's stale-download
+       * failure, arriving at a corporate legal agreement instead of a PDF.
+       */
+      it('closes the CLA group picker rather than letting it sign for the organization just left', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        expect(harness.opened).toHaveLength(1);
+
+        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(harness.opened[0].close).toHaveBeenCalled();
+      });
+
+      /**
+       * Clearing the organization, not just switching to another one.
+       *
+       * This is the half the detail page's download stream originally missed: the cancellation
+       * derived from the non-empty selection, so clearing emitted nothing and the stale request
+       * survived. The same filter sits in this component's `orgUid$`, which is why the signing
+       * close listens on the unfiltered stream instead. Without that, this case leaves a picker
+       * open over a page showing no organization at all.
+       */
+      it('closes the picker when the organization is cleared, not only when it is switched', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        expect(harness.opened).toHaveLength(1);
+
+        selectedAccount.set(null);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(harness.opened[0].close).toHaveBeenCalled();
+      });
+
+      // Nothing has been created at this point either, and the confirmations are about a specific
+      // organization's authority and export position — they cannot carry over to another company.
+      it('closes the attestation step as well, since no signature has been asked for yet', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        // Choosing a CLA group closes the picker and opens the attestation dialog behind it.
+        harness.opened[0].onClose.next(chosen);
+        expect(harness.opened).toHaveLength(2);
+
+        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(harness.opened[1].close).toHaveBeenCalled();
+      });
+
+      /**
+       * The hand-off is deliberately not closed.
+       *
+       * By the time it is open the request has been issued and a signature record and DocuSign
+       * envelope exist for the organization that was selected when the viewer confirmed — which
+       * is the one they meant to sign for. The address that comes back is the only thing that
+       * reaches them, so closing this on a switch would orphan an envelope to save nothing. It is
+       * also why the field holding the closeable ref is named for the uncommitted half.
+       */
+      it('leaves the hand-off standing, because a signing session already exists behind it', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        harness.opened[0].onClose.next(chosen);
+        harness.opened[1].onClose.next({ authorityAcked: true, embargoAcked: true });
+        expect(harness.opened).toHaveLength(3);
+
+        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(harness.opened[2].close).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('access and org-selection states', () => {
@@ -310,6 +449,26 @@ describe('OrgEasyclaComponent', () => {
 
       expect(byTestId(fixture, 'org-easycla-no-access-state')).toBeTruthy();
       expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    /**
+     * The organization stays selected here on purpose.
+     *
+     * That combination is what the page actually renders for a caller whose account carries a
+     * company but no Org Lens grant, and it is the one the other no-access cases miss by clearing
+     * `selectedAccount` — which disables the control for the unrelated reason that there is
+     * nothing to sign for. With the company left in place, only an access term can disable it.
+     * Without one, the page offered "Organization Lens is not available" and a live Sign CLA
+     * button together, and every request the flow made would be refused by the server.
+     */
+    it('does not offer Sign CLA to a caller with a company but no org access', async () => {
+      hasOrgSelectorAccess.set(false);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      expect(button?.getAttribute('aria-label')).toContain('Organization Lens is not available');
     });
 
     it('withholds both answers until the grant and persona fetches have returned', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -129,22 +129,134 @@ describe('OrgEasyclaComponent', () => {
       expect(byTestId(fixture, 'org-easycla-title')?.textContent).not.toContain('—');
     });
 
-    it('renders the Sign CLA control, disabled, so the empty-state copy points at something real', async () => {
+    it('offers the Sign CLA control once an organization is selected', async () => {
       const fixture = await render();
       const signCla = byTestId(fixture, 'org-easycla-sign-cla');
 
       expect(signCla).toBeTruthy();
-      expect(signCla?.querySelector('button')?.disabled).toBe(true);
+      expect(signCla?.querySelector('button')?.disabled).toBe(false);
     });
 
-    // The tooltip carrying the reason opens on hover only: its directive is on the non-focusable
-    // host while the button inside is disabled. The accessible name is the path that reaches a
-    // screen reader, which would otherwise hear "Sign CLA, disabled" and no reason for it.
-    it('names the reason the Sign CLA control is disabled, not just that it is', async () => {
+    it('cannot be used before an organization resolves, because there is nothing to sign for', async () => {
+      selectedAccount.set(null);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      // A disabled control must say why, or a screen reader hears only "disabled".
+      expect(button?.getAttribute('aria-label')).toContain('select an organization first');
+    });
+
+    // Not disabled for a viewer who lacks signing authority. The CLA service decides that per
+    // project and organization and explains its refusal in words; this layer cannot know it, and
+    // guessing would hide the control from people who do hold the authority.
+    it('offers the control without pre-judging the viewer’s signing authority', async () => {
       const fixture = await render();
       const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
 
-      expect(button?.getAttribute('aria-label')).toContain('coming soon');
+      expect(button?.disabled).toBe(false);
+      expect(button?.getAttribute('aria-label')).toBe('Sign a corporate CLA');
+    });
+  });
+
+  // The component's own job in the signing flow is only to sequence three dialogs and carry each
+  // one's result to the next. What is worth proving is that it carries rather than reconstructs:
+  // the attestations reaching the hand-off must be the ones the attestation dialog closed with.
+  describe('corporate signing flow', () => {
+    const chosen = { claGroupId: 'cla-group-uuid-1', projectSfid: 'a09410000182dD2AAI', projectName: 'Cascade' };
+
+    /** Each `open` closes with the next queued result, so a whole flow can be driven in order. */
+    function dialogHarness(closeResults: unknown[]) {
+      const opened: { component: unknown; config: { data?: unknown } }[] = [];
+      const open = vi.fn((component: unknown, config: { data?: unknown } = {}) => {
+        opened.push({ component, config });
+        const result = closeResults[opened.length - 1];
+        return { onClose: of(result), close: vi.fn() };
+      });
+      return { opened, open };
+    }
+
+    async function renderWithDialogs(closeResults: unknown[]) {
+      const harness = dialogHarness(closeResults);
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [OrgEasyclaComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
+          { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+          { provide: PersonaService, useValue: { personaLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+          { provide: OrgLensClaService, useValue: { getClaGroups } },
+          MessageService,
+        ],
+      })
+        // The component provides DialogService itself, so the component-level provider is the one
+        // that has to be replaced; a module-level override would not be seen.
+        .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: harness.open } }] } })
+        .compileComponents();
+
+      const fixture = TestBed.createComponent(OrgEasyclaComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      return { fixture, harness };
+    }
+
+    it('asks which CLA group to sign for, scoped to the selected organization', async () => {
+      const { fixture, harness } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(1);
+      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid });
+    });
+
+    it('does not ask for a confirmation when no CLA group was chosen', async () => {
+      const { fixture, harness } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(1);
+    });
+
+    it('does not hand off when the confirmation step was dismissed', async () => {
+      const { fixture, harness } = await renderWithDialogs([chosen, null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(2);
+    });
+
+    // The load-bearing one. Whatever the attestation dialog closed with is what the hand-off is
+    // given — not a `true` written here, and not an inference from the dialog having closed at
+    // all. A regression that hardcoded these would make the signatory's confirmation unfalsifiable
+    // from this side.
+    it('hands the confirmations to the signing step exactly as the signatory gave them', async () => {
+      const attestations = { authorityAcked: true, embargoAcked: true };
+      const { fixture, harness } = await renderWithDialogs([chosen, attestations, null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(3);
+      expect(harness.opened[2].config.data).toEqual({
+        orgUid: SELECTED_ACCOUNT.uid,
+        projectSfid: chosen.projectSfid,
+        claGroupId: chosen.claGroupId,
+        attestations,
+      });
+    });
+
+    // A dismissed flow must release the control, or the page needs a reload to try again.
+    it('offers the control again after a dismissed flow', async () => {
+      const { fixture } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(false);
     });
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -67,7 +67,7 @@ describe('OrgEasyclaComponent', () => {
         { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
         { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
         { provide: PersonaService, useValue: { personaLoaded } },
-        { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+        { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
         { provide: OrgLensClaService, useValue: { getClaGroups } },
         MessageService,
       ],
@@ -222,7 +222,7 @@ describe('OrgEasyclaComponent', () => {
           { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
-          { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
           { provide: OrgLensClaService, useValue: { getClaGroups } },
           MessageService,
         ],
@@ -410,7 +410,7 @@ describe('OrgEasyclaComponent', () => {
             { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
             { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
             { provide: PersonaService, useValue: { personaLoaded } },
-            { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+            { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
             { provide: OrgLensClaService, useValue: { getClaGroups } },
             MessageService,
           ],
@@ -981,6 +981,7 @@ describe('OrgEasyclaComponent', () => {
 
     async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT]) {
       const setAccount = vi.fn();
+      const resetAndReload = vi.fn();
       const navigate = vi.fn();
       const availableAccounts = signal(authorized);
 
@@ -996,7 +997,7 @@ describe('OrgEasyclaComponent', () => {
           { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts, setAccount } },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
-          { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload } },
           { provide: OrgLensClaService, useValue: { getClaGroups } },
           { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(namedOrg ? { org: namedOrg } : {}) } } },
           MessageService,
@@ -1013,7 +1014,7 @@ describe('OrgEasyclaComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      return { fixture, setAccount, navigate, availableAccounts };
+      return { fixture, setAccount, resetAndReload, navigate, availableAccounts };
     }
 
     it('selects the organization the signature was made for, not the first in the list', async () => {
@@ -1021,6 +1022,29 @@ describe('OrgEasyclaComponent', () => {
 
       // `setAccount` also rewrites the cookie, so the selection that went missing is repaired.
       expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+    });
+
+    /**
+     * Selecting it is not enough to keep it.
+     *
+     * The org selector requests its first page for whichever organization was current at bootstrap,
+     * which on a cold return is still the stale cookie. When that page lands, the pending default
+     * selection reassigns to its first row unless the current selection is on it — so adopting
+     * without re-pinning is overwritten a beat later by a page requested before the adoption
+     * happened, and the signatory lands back on the organization they did not sign for.
+     */
+    it('re-pins the catalogue on the adopted organization, so the pending default selection cannot reassign it', async () => {
+      const { resetAndReload } = await renderReturnedFrom(MICROSOFT.uid);
+
+      expect(resetAndReload).toHaveBeenCalledWith(MICROSOFT.uid);
+    });
+
+    // The mirror of ignoring it above: an organization that was not adopted must not be pinned
+    // either, or a crafted link would reorder the viewer's catalogue around a company it named.
+    it('does not re-pin an organization the viewer does not hold', async () => {
+      const { resetAndReload } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(resetAndReload).not.toHaveBeenCalled();
     });
 
     /**
@@ -1121,7 +1145,7 @@ describe('OrgEasyclaComponent', () => {
           },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
-          { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
           { provide: OrgLensClaService, useValue: { getClaGroups } },
           { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(org ? { org } : {}) } } },
           MessageService,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -166,10 +166,18 @@ describe('OrgEasyclaComponent', () => {
   describe('corporate signing flow', () => {
     const chosen = { claGroupId: 'cla-group-uuid-1', projectSfid: 'a09410000182dD2AAI', projectName: 'Cascade' };
 
+    /** Only the four the flow actually sets. The rest of DynamicDialogConfig is PrimeNG's default. */
+    interface DialogHarnessConfig {
+      data?: unknown;
+      closable?: boolean;
+      closeOnEscape?: boolean;
+      dismissableMask?: boolean;
+    }
+
     /** Each `open` closes with the next queued result, so a whole flow can be driven in order. */
     function dialogHarness(closeResults: unknown[]) {
-      const opened: { component: unknown; config: { data?: unknown } }[] = [];
-      const open = vi.fn((component: unknown, config: { data?: unknown } = {}) => {
+      const opened: { component: unknown; config: DialogHarnessConfig }[] = [];
+      const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
         opened.push({ component, config });
         const result = closeResults[opened.length - 1];
         return { onClose: of(result), close: vi.fn() };
@@ -247,6 +255,37 @@ describe('OrgEasyclaComponent', () => {
         claGroupId: chosen.claGroupId,
         attestations,
       });
+    });
+
+    /**
+     * The hand-off opens locked by all three routes, and the component reopens them once the
+     * request has landed.
+     *
+     * The initial values belong here rather than in the hand-off's own suite, which supplies its
+     * own config and so cannot see what this call site passes. The signing request starts as that
+     * dialog appears and is the call that creates both the signature record and the DocuSign
+     * envelope: dismissed before the address comes back, it leaves an envelope nobody was handed.
+     */
+    it('opens the hand-off with no way to dismiss it', async () => {
+      const attestations = { authorityAcked: true, embargoAcked: true };
+      const { fixture, harness } = await renderWithDialogs([chosen, attestations, null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened[2].config).toMatchObject({ closable: false, closeOnEscape: false, dismissableMask: false });
+    });
+
+    // The two steps before it are freely dismissable: nothing has been created yet, and trapping
+    // someone in a legal confirmation they want to back out of would be its own problem.
+    it.each([
+      [0, 'CLA group picker'],
+      [1, 'attestation step'],
+    ])('leaves the %s dismissable, because nothing exists yet to lose', async (index) => {
+      const { fixture, harness } = await renderWithDialogs([chosen, { authorityAcked: true, embargoAcked: true }, null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened[index].config.closable).toBe(true);
     });
 
     // A dismissed flow must release the control, or the page needs a reload to try again.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -278,12 +278,7 @@ export class OrgEasyclaComponent {
 
     this.uncommittedSigningDialog = pickerRef;
 
-    pickerRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((chosen: OrgClaGroupPickerResult | null | undefined) => {
-      this.uncommittedSigningDialog = null;
-      if (!chosen) {
-        this.signingOpen.set(false);
-        return;
-      }
+    this.whenSigningDialogEnds(pickerRef, (chosen: OrgClaGroupPickerResult) => {
       // The choice comes from `onClose`, which carries it; the next dialog waits for teardown.
       // `signingOpen` stays true across that gap, so the control cannot start a second flow in it.
       this.afterDialogTornDown(pickerRef, () => this.confirmThenHandOff(orgUid, chosen));
@@ -339,13 +334,7 @@ export class OrgEasyclaComponent {
 
     this.uncommittedSigningDialog = attestationRef;
 
-    attestationRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((attestations: OrgClaSignAttestations | null | undefined) => {
-      this.uncommittedSigningDialog = null;
-      if (!attestations) {
-        this.signingOpen.set(false);
-        return;
-      }
-
+    this.whenSigningDialogEnds(attestationRef, (attestations: OrgClaSignAttestations) => {
       this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
     });
   }
@@ -370,7 +359,33 @@ export class OrgEasyclaComponent {
       data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
     }) as DynamicDialogRef;
 
-    handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
+    // No successor, so any teardown — `close()` or PrimeNG's header/Escape `destroy()` — releases.
+    this.whenSigningDialogEnds(handoffRef);
+  }
+
+  /**
+   * Releases Sign CLA when a dialog ends, unless `onAdvance` is taking the lock to the next step.
+   *
+   * PrimeNG's header close and Escape go through `p-dialog` `onHide` → `DynamicDialogRef.destroy()`.
+   * That never emits `onClose`. A listener that only watches `onClose` therefore leaves
+   * `signingOpen` true after those dismissals, and the control stays disabled until reload.
+   */
+  private whenSigningDialogEnds<T>(dialogRef: DynamicDialogRef, onAdvance?: (value: T) => void): void {
+    let handedOff = false;
+
+    dialogRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: T | null | undefined) => {
+      if (this.uncommittedSigningDialog === dialogRef) this.uncommittedSigningDialog = null;
+      if (value && onAdvance) {
+        handedOff = true;
+        onAdvance(value);
+        return;
+      }
+      this.signingOpen.set(false);
+    });
+
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      if (!handedOff) this.signingOpen.set(false);
+    });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -5,13 +5,13 @@ import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
-import { RouterLink } from '@angular/router';
-import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
-import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupPickerResult, OrgClaSignAttestations } from '@lfx-one/shared/interfaces';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { CCLA_SIGN_COPY, ORG_EASYCLA_RETURN_ORG_PARAM } from '@lfx-one/shared/constants';
+import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaGroupPickerResult, OrgClaSignAttestations } from '@lfx-one/shared/interfaces';
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, filter, of, skip, switchMap, take, tap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, skip, switchMap, take, tap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -48,6 +48,8 @@ export class OrgEasyclaComponent {
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   /** One hand-off at a time. Also what disables the Sign CLA control while a flow is open. */
   protected readonly signingOpen = signal(false);
@@ -226,6 +228,8 @@ export class OrgEasyclaComponent {
     // Separate from the reset above because it listens on the unfiltered stream: a cleared
     // selection has no list to re-filter but does have a signing flow to abandon.
     this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonUncommittedSigning());
+
+    this.adoptOrganizationFromReturnAddress();
   }
 
   protected changePage(delta: number): void {
@@ -367,6 +371,54 @@ export class OrgEasyclaComponent {
     }) as DynamicDialogRef;
 
     handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
+  }
+
+  /**
+   * Selects the organization EasyCLA named on the return address after a corporate signing.
+   *
+   * The signatory comes back through a cross-site navigation, and which organization is selected
+   * survives that only in a `SameSite=Lax` cookie. When it does not come back, bootstrap falls to
+   * the first organization in the viewer's list — so signing for one company returns them looking
+   * at another, with their new agreement nowhere in sight. The return address names the
+   * organization the session was opened for so this page does not have to guess.
+   *
+   * **The parameter names an organization; it does not grant one.** It is resolved against the
+   * viewer's own authorized accounts and anything absent from that list is ignored, so a crafted
+   * link cannot select a company they do not hold. Deliberately no stub is built from the value —
+   * that is how the cookie path hydrates an id it trusts, and doing it here would render an
+   * arbitrary organization's name from the URL.
+   */
+  private adoptOrganizationFromReturnAddress(): void {
+    // The address is only followed in a browser, and the strip below is a browser navigation.
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const named = this.route.snapshot.queryParamMap.get(ORG_EASYCLA_RETURN_ORG_PARAM);
+    if (!named) return;
+
+    // The authorized list arrives after this component is constructed, so resolving immediately
+    // would discard a legitimate hand-off against an empty list. Waits for whichever comes first:
+    // the organization appearing, or the org context settling without it.
+    combineLatest([toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
+      .pipe(
+        map(([accounts, loaded]) => ({ match: accounts.find((account: Account) => account.uid === named) ?? null, loaded })),
+        filter(({ match, loaded }) => !!match || loaded),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ match }) => {
+        // `setAccount` also rewrites the cookie, so the round trip repairs the selection that went
+        // missing rather than leaving the next reload to fall back all over again.
+        if (match) this.accountContext.setAccount(match);
+
+        // Stripped whether or not it matched. Left in place it would pin a stale organization on
+        // reload and on any copied link, and would contradict the viewer the moment they switch.
+        void this.router.navigate([], {
+          relativeTo: this.route,
+          queryParams: { [ORG_EASYCLA_RETURN_ORG_PARAM]: null },
+          queryParamsHandling: 'merge',
+          replaceUrl: true,
+        });
+      });
   }
 
   private initSearchTerm(): Signal<string> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -428,7 +428,20 @@ export class OrgEasyclaComponent {
       .subscribe(({ match }) => {
         // `setAccount` also rewrites the cookie, so the round trip repairs the selection that went
         // missing rather than leaving the next reload to fall back all over again.
-        if (match) this.accountContext.setAccount(match);
+        //
+        // Selecting it is not enough to keep it. The org selector bootstraps its catalogue with
+        // whichever organization was current at the time, which on a cold return is still the stale
+        // cookie — so the first page comes back pinned to that one. When it lands, the pending
+        // default selection asks whether the *current* selection is on the page it received, and
+        // reassigns to the first row when it is not. Adopting early therefore gets overwritten a
+        // beat later by a page that was requested before the adoption happened.
+        //
+        // Re-pinning refetches that page for the organization actually selected, which both
+        // supersedes the in-flight one and satisfies the check when the replacement arrives.
+        if (match) {
+          this.accountContext.setAccount(match);
+          this.orgNavigation.resetAndReload(match.uid);
+        }
 
         // Not when a landing is intended. `landOnSignedAgreement` navigates off this route, and the
         // navigation below is relative to it, so both in flight means Angular cancels whichever

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -52,6 +52,13 @@ export class OrgEasyclaComponent {
   /** One hand-off at a time. Also what disables the Sign CLA control while a flow is open. */
   protected readonly signingOpen = signal(false);
 
+  /**
+   * Whichever signing dialog is open before a signature has been asked for — the picker, then the
+   * attestation. Held so an organization switch can close it; see `abandonUncommittedSigning`.
+   * Never holds the hand-off, which is why the field is named for the uncommitted half.
+   */
+  private uncommittedSigningDialog: DynamicDialogRef | null = null;
+
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
 
@@ -69,9 +76,13 @@ export class OrgEasyclaComponent {
 
   /**
    * Names the reason when Sign CLA is disabled, so a screen reader hears one instead of a bare
-   * "disabled". Computed rather than a template ternary — the control has two distinct reasons.
+   * "disabled". Computed rather than a template ternary — the control has three distinct reasons.
+   *
+   * No-access is checked first: it is the one reason the viewer can do nothing about, and it also
+   * subsumes the others, since a viewer without access has no organization to select either.
    */
   protected readonly signClaAriaLabel = computed(() => {
+    if (this.hasNoOrgAccess()) return 'Sign a corporate CLA — Organization Lens is not available for your account';
     if (!this.hasCompany()) return 'Sign a corporate CLA — select an organization first';
     if (this.signingOpen()) return 'Sign a corporate CLA — a signing request is already open';
     return 'Sign a corporate CLA';
@@ -107,11 +118,22 @@ export class OrgEasyclaComponent {
   // ── Data ──────────────────────────────────────────────────────────────────
   private readonly searchTerm: Signal<string> = this.initSearchTerm();
 
+  // Every selection the viewer makes, including clearing it.
+  private readonly selectedOrgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(distinctUntilChanged());
+
   // Shared with the constructor's org-switch reset below — mirrors org-groups' orgUid$.
-  private readonly orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(
-    filter((uid): uid is string => !!uid),
-    distinctUntilChanged()
-  );
+  private readonly orgUid$ = this.selectedOrgUid$.pipe(filter((uid): uid is string => !!uid));
+
+  /**
+   * Emits when the viewer leaves the organization a signing flow was started for, skipping the
+   * value present at subscribe time.
+   *
+   * Derived from the unfiltered stream, not `orgUid$`, for the reason the CLA Group detail page
+   * found on its download stream: clearing the selection empties the page just as switching does,
+   * and the non-empty filter would swallow it — leaving exactly the stale thing the stream exists
+   * to cancel. Here that stale thing is a signing flow still pointed at the previous company.
+   */
+  private readonly orgChanged$ = this.selectedOrgUid$.pipe(skip(1));
 
   private readonly claData: Signal<OrgClaGroupList | null | undefined> = this.initClaData();
 
@@ -196,6 +218,10 @@ export class OrgEasyclaComponent {
       this.filterForm.reset({ search: '' });
       this.page.set(0);
     });
+
+    // Separate from the reset above because it listens on the unfiltered stream: a cleared
+    // selection has no list to re-filter but does have a signing flow to abandon.
+    this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonUncommittedSigning());
   }
 
   protected changePage(delta: number): void {
@@ -239,13 +265,35 @@ export class OrgEasyclaComponent {
       data: { orgUid },
     }) as DynamicDialogRef;
 
+    this.uncommittedSigningDialog = pickerRef;
+
     pickerRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((chosen: OrgClaGroupPickerResult | null | undefined) => {
+      this.uncommittedSigningDialog = null;
       if (!chosen) {
         this.signingOpen.set(false);
         return;
       }
       this.confirmThenHandOff(orgUid, chosen);
     });
+  }
+
+  /**
+   * Closes a signing flow that has not yet asked for a signature, on an organization switch.
+   *
+   * `orgUid` is read once when the flow starts and threaded through all three dialogs, and
+   * switching organizations does not destroy this component — it re-drives the list fetch. So
+   * without this, the picker and the attestation dialog stay open over a page that has moved on,
+   * still carrying the organization the viewer left, and confirming would open a signing session
+   * against that company's legal position. This is the download path's stale-response failure on
+   * the detail page, arriving at a legal agreement instead of a PDF.
+   *
+   * Only the two dialogs before the request is issued. The hand-off is deliberately left alone:
+   * by the time it is open a signing session exists for the organization that was selected when
+   * the viewer confirmed, which is the one they meant, and the address it returns is the only
+   * thing that reaches them. Closing it on a switch would orphan an envelope to save nothing.
+   */
+  private abandonUncommittedSigning(): void {
+    this.uncommittedSigningDialog?.close();
   }
 
   private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
@@ -257,7 +305,10 @@ export class OrgEasyclaComponent {
       dismissableMask: true,
     }) as DynamicDialogRef;
 
+    this.uncommittedSigningDialog = attestationRef;
+
     attestationRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((attestations: OrgClaSignAttestations | null | undefined) => {
+      this.uncommittedSigningDialog = null;
       if (!attestations) {
         this.signingOpen.set(false);
         return;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -11,7 +11,7 @@ import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupPickerResult, OrgClaSignA
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, filter, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, of, skip, switchMap, take, tap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -280,7 +280,9 @@ export class OrgEasyclaComponent {
         this.signingOpen.set(false);
         return;
       }
-      this.confirmThenHandOff(orgUid, chosen);
+      // The choice comes from `onClose`, which carries it; the next dialog waits for teardown.
+      // `signingOpen` stays true across that gap, so the control cannot start a second flow in it.
+      this.afterDialogTornDown(pickerRef, () => this.confirmThenHandOff(orgUid, chosen));
     });
   }
 
@@ -301,6 +303,22 @@ export class OrgEasyclaComponent {
    */
   private abandonUncommittedSigning(): void {
     this.uncommittedSigningDialog?.close();
+  }
+
+  /**
+   * Runs `next` once a dialog is not merely closed but torn down.
+   *
+   * `DynamicDialogRef.close()` emits `onClose` synchronously and starts the leave animation from
+   * that same emission, and the end of that animation is what drops `p-overflow-hidden` from the
+   * body. A dialog opened from inside `onClose` therefore has its own scroll lock stripped a
+   * moment after it appears, and the page scrolls behind it. `onDestroy` fires after that
+   * teardown, which is the boundary a follow-on step has to wait for.
+   *
+   * The Me-lens hand-off found this first (#2066) and carries the same helper. This chain opens
+   * two dialogs from inside a close, so it had the defect twice.
+   */
+  private afterDialogTornDown(dialogRef: DynamicDialogRef, next: () => void): void {
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => next());
   }
 
   private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
@@ -324,26 +342,31 @@ export class OrgEasyclaComponent {
         return;
       }
 
-      const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
-        // Opened locked, and the component unlocks it — including this header, which it keeps in
-        // step with the state it is showing. A real signing session is opened behind this dialog
-        // as it appears, and the address it returns is the only thing that reaches the signatory:
-        // dismissing it before then, by mask, header control or Escape, leaves an envelope that
-        // exists and that nobody was handed. These three are the initial values only.
-        header: CCLA_SIGN_COPY.preparing.header,
-        width: '40rem',
-        // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
-        // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
-        style: { maxWidth: '90vw' },
-        modal: true,
-        closable: false,
-        closeOnEscape: false,
-        dismissableMask: false,
-        data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
-      }) as DynamicDialogRef;
-
-      handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
+      this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
     });
+  }
+
+  /** The last step, opened only once the attestation dialog has finished tearing down. */
+  private openHandOff(orgUid: string, chosen: OrgClaGroupPickerResult, attestations: OrgClaSignAttestations): void {
+    const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
+      // Opened locked, and the component unlocks it — including this header, which it keeps in
+      // step with the state it is showing. A real signing session is opened behind this dialog
+      // as it appears, and the address it returns is the only thing that reaches the signatory:
+      // dismissing it before then, by mask, header control or Escape, leaves an envelope that
+      // exists and that nobody was handed. These three are the initial values only.
+      header: CCLA_SIGN_COPY.preparing.header,
+      width: '40rem',
+      // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
+      // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
+      style: { maxWidth: '90vw' },
+      modal: true,
+      closable: false,
+      closeOnEscape: false,
+      dismissableMask: false,
+      data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
+    }) as DynamicDialogRef;
+
+    handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
   }
 
   private initSearchTerm(): Signal<string> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -6,8 +6,14 @@ import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATF
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { CCLA_SIGN_COPY, ORG_EASYCLA_RETURN_ORG_PARAM } from '@lfx-one/shared/constants';
-import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaGroupPickerResult, OrgClaSignAttestations } from '@lfx-one/shared/interfaces';
+import {
+  CCLA_SIGN_COPY,
+  ORG_CLA_SIGN_SELECTION_STATE,
+  ORG_EASYCLA_NEW_SEGMENT,
+  ORG_EASYCLA_PATH,
+  ORG_EASYCLA_RETURN_ORG_PARAM,
+} from '@lfx-one/shared/constants';
+import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -22,12 +28,11 @@ import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
+import { takeStashedSignedSignatureId } from '@shared/utils/org-cla-signed-signature.util';
 
 import { OrgEasyclaCardComponent } from './org-easycla-card/org-easycla-card.component';
 import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from './org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
-import { OrgEasyclaAttestationComponent } from './org-easycla-sign/org-easycla-attestation.component';
 import { OrgEasyclaGroupSelectComponent } from './org-easycla-sign/org-easycla-group-select.component';
-import { OrgEasyclaSignHandoffComponent } from './org-easycla-sign/org-easycla-sign-handoff.component';
 
 @Component({
   selector: 'lfx-org-easycla',
@@ -55,11 +60,14 @@ export class OrgEasyclaComponent {
   protected readonly signingOpen = signal(false);
 
   /**
-   * Whichever signing dialog is open before a signature has been asked for — the picker, then the
-   * attestation. Held so an organization switch can close it; see `abandonUncommittedSigning`.
-   * Never holds the hand-off, which is why the field is named for the uncommitted half.
+   * The CLA Group picker, while it is open. Held so an organization switch can close it; see
+   * `abandonOpenPicker`.
+   *
+   * The only signing dialog this page owns. The steps that follow — the attestation and the
+   * hand-off — belong to the preview page the picker navigates to, which names the agreement they
+   * are about.
    */
-  private uncommittedSigningDialog: DynamicDialogRef | null = null;
+  private openPickerDialog: DynamicDialogRef | null = null;
 
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
@@ -227,9 +235,10 @@ export class OrgEasyclaComponent {
 
     // Separate from the reset above because it listens on the unfiltered stream: a cleared
     // selection has no list to re-filter but does have a signing flow to abandon.
-    this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonUncommittedSigning());
+    this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonOpenPicker());
 
     this.adoptOrganizationFromReturnAddress();
+    this.landOnSignedAgreement();
   }
 
   protected changePage(delta: number): void {
@@ -248,14 +257,13 @@ export class OrgEasyclaComponent {
   }
 
   /**
-   * Starts the corporate signing flow (#1983): pick a CLA Group, confirm authorization and export
-   * compliance, then hand off.
+   * Starts the corporate signing flow (#1983): pick a CLA Group, then hand that choice to the
+   * preview page, where the signatory reads what they are about to sign.
    *
-   * Three dialogs in sequence rather than one stepped component, matching the Me-lens hand-off:
-   * each step closes with what the next one needs, so no step can read a value another step was
-   * responsible for collecting. In particular the attestation dialog closes with the two
-   * confirmations themselves, and this method passes them straight through — it never
-   * reconstructs them from the fact that the dialog closed with something.
+   * This page stops at the picker. The attestation and the hand-off follow on the preview page,
+   * which is the arrangement the M3 prototype draws and also the one that puts the two legally
+   * operative steps — the confirmations, and the request that opens a real envelope — on a page
+   * that names the agreement they apply to rather than in a dialog stack over a list.
    */
   protected startSigning(): void {
     const orgUid = this.accountContext.selectedAccount()?.uid;
@@ -263,6 +271,16 @@ export class OrgEasyclaComponent {
     if (!orgUid || this.signingOpen()) return;
 
     this.signingOpen.set(true);
+
+    // The agreements this organization already holds, so the picker can refuse a CLA Group it has
+    // one for. Handed down rather than fetched: this page has the list, and a second request would
+    // be a second answer to the same question.
+    //
+    // Keyed on the `orgUid` the server echoed, not on the response merely being present. A response
+    // that belongs to the organization the viewer just left would refuse rows this organization has
+    // never signed, and an empty list is the safe reading of "not known yet".
+    const claData = this.claData();
+    const claGroups = claData?.orgUid === orgUid ? claData.claGroups : [];
 
     const pickerRef = this.dialogService.open(OrgEasyclaGroupSelectComponent, {
       header: CCLA_SIGN_COPY.picker.header,
@@ -273,35 +291,52 @@ export class OrgEasyclaComponent {
       modal: true,
       closable: true,
       dismissableMask: true,
-      data: { orgUid },
+      data: { orgUid, claGroups },
     }) as DynamicDialogRef;
 
-    this.uncommittedSigningDialog = pickerRef;
+    this.openPickerDialog = pickerRef;
 
-    this.whenSigningDialogEnds(pickerRef, (chosen: OrgClaGroupPickerResult) => {
-      // The choice comes from `onClose`, which carries it; the next dialog waits for teardown.
+    this.whenSigningDialogEnds(pickerRef, (chosen: OrgClaSignSelection) => {
+      // The choice comes from `onClose`, which carries it; the navigation waits for teardown.
       // `signingOpen` stays true across that gap, so the control cannot start a second flow in it.
-      this.afterDialogTornDown(pickerRef, () => this.confirmThenHandOff(orgUid, chosen));
+      this.afterDialogTornDown(pickerRef, () => this.openPreview(chosen));
     });
   }
 
   /**
-   * Closes a signing flow that has not yet asked for a signature, on an organization switch.
+   * Closes the CLA Group picker on an organization switch.
    *
-   * `orgUid` is read once when the flow starts and threaded through all three dialogs, and
-   * switching organizations does not destroy this component — it re-drives the list fetch. So
-   * without this, the picker and the attestation dialog stay open over a page that has moved on,
-   * still carrying the organization the viewer left, and confirming would open a signing session
-   * against that company's legal position. This is the download path's stale-response failure on
-   * the detail page, arriving at a legal agreement instead of a PDF.
+   * The picker is opened for one organization — `orgUid` is read once when the flow starts and
+   * handed to it as dialog data — and switching organizations does not destroy this component; it
+   * re-drives the list fetch. So without this the picker stays open over a page that has moved on,
+   * still listing the previous organization's CLA Groups, and choosing one would carry that company
+   * into a signing session. This is the download path's stale-response failure on the detail page,
+   * arriving at a legal agreement instead of a PDF.
    *
-   * Only the two dialogs before the request is issued. The hand-off is deliberately left alone:
-   * by the time it is open a signing session exists for the organization that was selected when
-   * the viewer confirmed, which is the one they meant, and the address it returns is the only
-   * thing that reaches them. Closing it on a switch would orphan an envelope to save nothing.
+   * The steps that can actually create something are past the navigation and are not this page's to
+   * close: the preview page leaves for the list on a switch of its own accord, and the hand-off is
+   * deliberately left standing once a session exists behind it.
    */
-  private abandonUncommittedSigning(): void {
-    this.uncommittedSigningDialog?.close();
+  private abandonOpenPicker(): void {
+    this.openPickerDialog?.close();
+  }
+
+  /**
+   * Hands the chosen CLA Group to the preview page.
+   *
+   * The choice travels in the navigation's state rather than the address. The CLA service exposes
+   * no fetch-a-CLA-group-by-id endpoint, so ids in a URL could not be resolved back into the
+   * agreement the preview has to name — the display names would have to ride along in the URL too,
+   * leaving that page to render its heading from text taken out of the address.
+   */
+  private openPreview(selection: OrgClaSignSelection): void {
+    void this.router
+      .navigate([ORG_EASYCLA_PATH, ORG_EASYCLA_NEW_SEGMENT], { state: { [ORG_CLA_SIGN_SELECTION_STATE]: selection } })
+      // Released at the navigation rather than at the dialog's close, so the control stays disabled
+      // across the teardown gap and a navigation that never lands — refused by a guard, or
+      // superseded by another — cannot leave Sign CLA disabled until a reload. On the ordinary path
+      // this page is already gone by the time this runs.
+      .finally(() => this.signingOpen.set(false));
   }
 
   /**
@@ -320,49 +355,6 @@ export class OrgEasyclaComponent {
     dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => next());
   }
 
-  private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
-    const attestationRef = this.dialogService.open(OrgEasyclaAttestationComponent, {
-      header: CCLA_SIGN_COPY.attestation.header,
-      width: '42rem',
-      // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
-      // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
-      style: { maxWidth: '90vw' },
-      modal: true,
-      closable: true,
-      dismissableMask: true,
-    }) as DynamicDialogRef;
-
-    this.uncommittedSigningDialog = attestationRef;
-
-    this.whenSigningDialogEnds(attestationRef, (attestations: OrgClaSignAttestations) => {
-      this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
-    });
-  }
-
-  /** The last step, opened only once the attestation dialog has finished tearing down. */
-  private openHandOff(orgUid: string, chosen: OrgClaGroupPickerResult, attestations: OrgClaSignAttestations): void {
-    const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
-      // Opened locked, and the component unlocks it — including this header, which it keeps in
-      // step with the state it is showing. A real signing session is opened behind this dialog
-      // as it appears, and the address it returns is the only thing that reaches the signatory:
-      // dismissing it before then, by mask, header control or Escape, leaves an envelope that
-      // exists and that nobody was handed. These three are the initial values only.
-      header: CCLA_SIGN_COPY.preparing.header,
-      width: '40rem',
-      // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
-      // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
-      style: { maxWidth: '90vw' },
-      modal: true,
-      closable: false,
-      closeOnEscape: false,
-      dismissableMask: false,
-      data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
-    }) as DynamicDialogRef;
-
-    // No successor, so any teardown — `close()` or PrimeNG's header/Escape `destroy()` — releases.
-    this.whenSigningDialogEnds(handoffRef);
-  }
-
   /**
    * Releases Sign CLA when a dialog ends, unless `onAdvance` is taking the lock to the next step.
    *
@@ -374,7 +366,7 @@ export class OrgEasyclaComponent {
     let handedOff = false;
 
     dialogRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: T | null | undefined) => {
-      if (this.uncommittedSigningDialog === dialogRef) this.uncommittedSigningDialog = null;
+      if (this.openPickerDialog === dialogRef) this.openPickerDialog = null;
       if (value && onAdvance) {
         handedOff = true;
         onAdvance(value);
@@ -425,6 +417,13 @@ export class OrgEasyclaComponent {
         // missing rather than leaving the next reload to fall back all over again.
         if (match) this.accountContext.setAccount(match);
 
+        // Not once the signatory is already on their signed agreement. `landOnSignedAgreement`
+        // races this — it waits on the CLA list where this waits on the authorized accounts, and
+        // either can settle first — and the address it leaves for carries no parameter to strip.
+        // The navigation below is relative to this route, so arriving second it would take them
+        // straight back off the agreement they had just been landed on.
+        if (this.router.url.startsWith(`${ORG_EASYCLA_PATH}/`)) return;
+
         // Stripped whether or not it matched. Left in place it would pin a stale organization on
         // reload and on any copied link, and would contradict the viewer the moment they switch.
         void this.router.navigate([], {
@@ -433,6 +432,54 @@ export class OrgEasyclaComponent {
           queryParamsHandling: 'merge',
           replaceUrl: true,
         });
+      });
+  }
+
+  /**
+   * Lands the signatory on the agreement they just signed, instead of the list they left.
+   *
+   * The return address cannot name it: `return_url` is an *input* to the upstream signing request
+   * and so is fixed before a signature exists, while the signature id only comes back on the
+   * response. The client carries it across the trip in `sessionStorage`, and this spends it.
+   *
+   * Three conditions, each of which is a way of not being wrong:
+   *
+   * - **Only when the return parameter is present**, so an abandoned ceremony followed by an
+   *   ordinary visit to the list does not teleport the viewer into a detail page. The stash is
+   *   spent either way, which is what makes it single-use whichever visit finds it.
+   * - **Only once the named organization's own list has landed.** Whichever organization was
+   *   selected at boot settles first and cannot contain the new agreement, so a decision taken
+   *   against that list would spend the trip on a row that was never going to be in it.
+   * - **Only if the row is actually there.** EasyCLA may not have finished processing the DocuSign
+   *   callback by the time the signatory is back, and navigating blind would land them on "This CLA
+   *   was not found" — strictly worse than the list, which shows the agreement once it appears.
+   *
+   * Matching the row by the CLA Group instead would need none of the stash, and is not equivalent:
+   * the upstream grain is (signing entity x CLA Group), so one organization can hold two rows for
+   * the same CLA Group, and the match is ambiguous exactly where it matters.
+   */
+  private landOnSignedAgreement(): void {
+    // Same browser-only boundary the return-address adoption above documents: `sessionStorage` is
+    // one, and the navigation below is the other.
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const signatureId = takeStashedSignedSignatureId();
+    const named = this.route.snapshot.queryParamMap.get(ORG_EASYCLA_RETURN_ORG_PARAM);
+    if (!signatureId || !named) return;
+
+    toObservable(this.claData)
+      .pipe(
+        filter((data): data is OrgClaGroupList => data?.orgUid === named),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data) => {
+        if (!data.claGroups.some((group) => group.id === signatureId)) return;
+
+        // Replaces rather than pushes: the address being left behind is the return address, and an
+        // entry for it in the viewer's history is one Back re-enters, spending nothing and stripping
+        // a parameter all over again.
+        void this.router.navigate([ORG_EASYCLA_PATH, signatureId], { replaceUrl: true });
       });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import type { OrgClaGroup, OrgClaGroupList } from '@lfx-one/shared/interfaces';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupPickerResult, OrgClaSignAttestations } from '@lfx-one/shared/interfaces';
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, filter, of, skip, switchMap, tap } from 'rxjs';
 
@@ -24,6 +25,9 @@ import { OrgNavigationService } from '@shared/services/org-navigation.service';
 
 import { OrgEasyclaCardComponent } from './org-easycla-card/org-easycla-card.component';
 import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from './org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
+import { OrgEasyclaAttestationComponent } from './org-easycla-sign/org-easycla-attestation.component';
+import { OrgEasyclaGroupSelectComponent } from './org-easycla-sign/org-easycla-group-select.component';
+import { OrgEasyclaSignHandoffComponent } from './org-easycla-sign/org-easycla-sign-handoff.component';
 
 @Component({
   selector: 'lfx-org-easycla',
@@ -41,8 +45,12 @@ export class OrgEasyclaComponent {
   private readonly personaService = inject(PersonaService);
   private readonly orgNavigation = inject(OrgNavigationService);
   private readonly claService = inject(OrgLensClaService);
-  private readonly platformId = inject(PLATFORM_ID);
   private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  /** One hand-off at a time. Also what disables the Sign CLA control while a flow is open. */
+  protected readonly signingOpen = signal(false);
 
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
@@ -58,6 +66,16 @@ export class OrgEasyclaComponent {
   // ── Org context ───────────────────────────────────────────────────────────
   protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
   protected readonly hasCompany = computed(() => !!this.accountContext.selectedAccount()?.uid);
+
+  /**
+   * Names the reason when Sign CLA is disabled, so a screen reader hears one instead of a bare
+   * "disabled". Computed rather than a template ternary — the control has two distinct reasons.
+   */
+  protected readonly signClaAriaLabel = computed(() => {
+    if (!this.hasCompany()) return 'Sign a corporate CLA — select an organization first';
+    if (this.signingOpen()) return 'Sign a corporate CLA — a signing request is already open';
+    return 'Sign a corporate CLA';
+  });
 
   /**
    * True once both grant fetches have returned and the caller holds no org access. The route guard
@@ -193,6 +211,72 @@ export class OrgEasyclaComponent {
    */
   protected openCoverage(claGroup: OrgClaGroup): void {
     this.dialogService.open(OrgEasyclaCoverageDialogComponent, orgClaCoverageDialogConfig(claGroup));
+  }
+
+  /**
+   * Starts the corporate signing flow (#1983): pick a CLA Group, confirm authorization and export
+   * compliance, then hand off.
+   *
+   * Three dialogs in sequence rather than one stepped component, matching the Me-lens hand-off:
+   * each step closes with what the next one needs, so no step can read a value another step was
+   * responsible for collecting. In particular the attestation dialog closes with the two
+   * confirmations themselves, and this method passes them straight through — it never
+   * reconstructs them from the fact that the dialog closed with something.
+   */
+  protected startSigning(): void {
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    // Single-flight: the control is disabled while a flow is open, and this is the second line.
+    if (!orgUid || this.signingOpen()) return;
+
+    this.signingOpen.set(true);
+
+    const pickerRef = this.dialogService.open(OrgEasyclaGroupSelectComponent, {
+      header: CCLA_SIGN_COPY.picker.header,
+      width: '40rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { orgUid },
+    }) as DynamicDialogRef;
+
+    pickerRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((chosen: OrgClaGroupPickerResult | null | undefined) => {
+      if (!chosen) {
+        this.signingOpen.set(false);
+        return;
+      }
+      this.confirmThenHandOff(orgUid, chosen);
+    });
+  }
+
+  private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
+    const attestationRef = this.dialogService.open(OrgEasyclaAttestationComponent, {
+      header: CCLA_SIGN_COPY.attestation.header,
+      width: '42rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+    }) as DynamicDialogRef;
+
+    attestationRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((attestations: OrgClaSignAttestations | null | undefined) => {
+      if (!attestations) {
+        this.signingOpen.set(false);
+        return;
+      }
+
+      const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
+        header: CCLA_SIGN_COPY.preparing.header,
+        width: '40rem',
+        modal: true,
+        // Not dismissable by clicking away: a real signing session is opened behind this dialog,
+        // and its address is the only thing that reaches the signatory. Losing it to a stray
+        // click means an envelope exists that nobody was handed.
+        closable: true,
+        dismissableMask: false,
+        data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
+      }) as DynamicDialogRef;
+
+      handoffRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.signingOpen.set(false));
+    });
   }
 
   private initSearchTerm(): Signal<string> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -259,6 +259,9 @@ export class OrgEasyclaComponent {
     const pickerRef = this.dialogService.open(OrgEasyclaGroupSelectComponent, {
       header: CCLA_SIGN_COPY.picker.header,
       width: '40rem',
+      // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
+      // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
+      style: { maxWidth: '90vw' },
       modal: true,
       closable: true,
       dismissableMask: true,
@@ -300,6 +303,9 @@ export class OrgEasyclaComponent {
     const attestationRef = this.dialogService.open(OrgEasyclaAttestationComponent, {
       header: CCLA_SIGN_COPY.attestation.header,
       width: '42rem',
+      // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
+      // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
+      style: { maxWidth: '90vw' },
       modal: true,
       closable: true,
       dismissableMask: true,
@@ -322,6 +328,9 @@ export class OrgEasyclaComponent {
         // exists and that nobody was handed. These three are the initial values only.
         header: CCLA_SIGN_COPY.preparing.header,
         width: '40rem',
+        // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
+        // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
+        style: { maxWidth: '90vw' },
         modal: true,
         closable: false,
         closeOnEscape: false,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -83,6 +83,10 @@ export class OrgEasyclaComponent {
    */
   protected readonly signClaAriaLabel = computed(() => {
     if (this.hasNoOrgAccess()) return 'Sign a corporate CLA — Organization Lens is not available for your account';
+    // Every reason the control is disabled needs a branch here, or assistive technology announces
+    // "disabled" with no explanation. Loading sits above the company check because it is why the
+    // company is not known yet.
+    if (!this.orgContextLoaded()) return 'Sign a corporate CLA — checking your organization access';
     if (!this.hasCompany()) return 'Sign a corporate CLA — select an organization first';
     if (this.signingOpen()) return 'Sign a corporate CLA — a signing request is already open';
     return 'Sign a corporate CLA';

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -264,13 +264,16 @@ export class OrgEasyclaComponent {
       }
 
       const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
+        // Opened locked, and the component unlocks it — including this header, which it keeps in
+        // step with the state it is showing. A real signing session is opened behind this dialog
+        // as it appears, and the address it returns is the only thing that reaches the signatory:
+        // dismissing it before then, by mask, header control or Escape, leaves an envelope that
+        // exists and that nobody was handed. These three are the initial values only.
         header: CCLA_SIGN_COPY.preparing.header,
         width: '40rem',
         modal: true,
-        // Not dismissable by clicking away: a real signing session is opened behind this dialog,
-        // and its address is the only thing that reaches the signatory. Losing it to a stray
-        // click means an envelope exists that nobody was handed.
-        closable: true,
+        closable: false,
+        closeOnEscape: false,
         dismissableMask: false,
         data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
       }) as DynamicDialogRef;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -69,6 +69,19 @@ export class OrgEasyclaComponent {
    */
   private openPickerDialog: DynamicDialogRef | null = null;
 
+  /**
+   * Whether this page load is a return from a signing ceremony that intends to land on an
+   * agreement, which makes the return organization on the address `landOnSignedAgreement`'s to
+   * remove rather than `adoptOrganizationFromReturnAddress`'s.
+   *
+   * Both flows start in the constructor and both navigate, and Angular cancels an in-flight
+   * navigation when another begins — so unarbitrated they take turns cancelling each other and the
+   * signatory stays on the list. The committed address cannot arbitrate them, being still the return
+   * address at the moment either decides; this is set synchronously instead, before anything is
+   * awaited, so it reads true no matter which of them resolves first.
+   */
+  private returnLandingPending = false;
+
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
 
@@ -417,22 +430,34 @@ export class OrgEasyclaComponent {
         // missing rather than leaving the next reload to fall back all over again.
         if (match) this.accountContext.setAccount(match);
 
-        // Not once the signatory is already on their signed agreement. `landOnSignedAgreement`
-        // races this — it waits on the CLA list where this waits on the authorized accounts, and
-        // either can settle first — and the address it leaves for carries no parameter to strip.
-        // The navigation below is relative to this route, so arriving second it would take them
-        // straight back off the agreement they had just been landed on.
-        if (this.router.url.startsWith(`${ORG_EASYCLA_PATH}/`)) return;
+        // Not when a landing is intended. `landOnSignedAgreement` navigates off this route, and the
+        // navigation below is relative to it, so both in flight means Angular cancels whichever
+        // started first — leaving the signatory on the list either way.
+        //
+        // A flag rather than a look at `this.router.url`, which is the *committed* address: both
+        // flows start from this constructor and `navigate` resolves later, so at this point the
+        // committed address is still the return address whichever one goes on to win. The flag is
+        // set synchronously, before anything is awaited, so it is already true here. Removing the
+        // parameter then belongs to the landing, which does it if it declines to navigate.
+        if (this.returnLandingPending) return;
 
-        // Stripped whether or not it matched. Left in place it would pin a stale organization on
-        // reload and on any copied link, and would contradict the viewer the moment they switch.
-        void this.router.navigate([], {
-          relativeTo: this.route,
-          queryParams: { [ORG_EASYCLA_RETURN_ORG_PARAM]: null },
-          queryParamsHandling: 'merge',
-          replaceUrl: true,
-        });
+        this.stripReturnOrganizationFromAddress();
       });
+  }
+
+  /**
+   * Takes the organization back off the address once it has been acted on.
+   *
+   * Whether or not it matched: left in place it would pin a stale organization on reload and on any
+   * copied link, and would contradict the viewer the moment they switch.
+   */
+  private stripReturnOrganizationFromAddress(): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { [ORG_EASYCLA_RETURN_ORG_PARAM]: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   /**
@@ -457,6 +482,15 @@ export class OrgEasyclaComponent {
    * Matching the row by the CLA Group instead would need none of the stash, and is not equivalent:
    * the upstream grain is (signing entity x CLA Group), so one organization can hold two rows for
    * the same CLA Group, and the match is ambiguous exactly where it matters.
+   *
+   * Waiting on that list also has to be able to give up. No list is ever fetched for an organization
+   * the viewer does not hold, so a crafted or stale return address would otherwise wait for one
+   * forever and leave the organization on the address — which is the one thing FR-027a says must not
+   * survive the visit. Settling without the organization is therefore an outcome, not a hang.
+   *
+   * From the moment a landing is intended this method owns that parameter: it removes it itself when
+   * it decides to stay on the list, because `adoptOrganizationFromReturnAddress` stands down as soon
+   * as the intent is claimed. Leaving both to strip it is what made the two cancel each other.
    */
   private landOnSignedAgreement(): void {
     // Same browser-only boundary the return-address adoption above documents: `sessionStorage` is
@@ -467,18 +501,35 @@ export class OrgEasyclaComponent {
     const named = this.route.snapshot.queryParamMap.get(ORG_EASYCLA_RETURN_ORG_PARAM);
     if (!signatureId || !named) return;
 
-    toObservable(this.claData)
+    // Claimed before anything is awaited, so the sibling flow above sees it however the two
+    // interleave. From here the parameter is this method's to remove.
+    this.returnLandingPending = true;
+
+    combineLatest([toObservable(this.claData), toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
       .pipe(
-        filter((data): data is OrgClaGroupList => data?.orgUid === named),
+        map(([data, accounts, loaded]) => ({
+          list: data?.orgUid === named ? data : null,
+          // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
+          // context has settled without it there is no list coming and waiting on one would leave
+          // the parameter on the address for good.
+          unreachable: loaded && !accounts.some((account: Account) => account.uid === named),
+        })),
+        filter(({ list, unreachable }) => !!list || unreachable),
         take(1),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((data) => {
-        if (!data.claGroups.some((group) => group.id === signatureId)) return;
+      .subscribe(({ list }) => {
+        if (!list?.claGroups.some((group) => group.id === signatureId)) {
+          // Staying on the list, so the address still has to be cleaned up — the sibling flow stood
+          // down on the strength of the flag and will not do it.
+          this.stripReturnOrganizationFromAddress();
+          return;
+        }
 
         // Replaces rather than pushes: the address being left behind is the return address, and an
         // entry for it in the viewer's history is one Back re-enters, spending nothing and stripping
-        // a parameter all over again.
+        // a parameter all over again. The parameter needs no separate removal — this leaves the
+        // route it sits on, and query parameters are not carried across.
         void this.router.navigate([ORG_EASYCLA_PATH, signatureId], { replaceUrl: true });
       });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@lfx-one/shared/constants';
 import type { OrgCanonicalRecord, OrgProfileEditableFields, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
 import { httpsUrlValidator } from '@lfx-one/shared/validators';
-import { extractErrorMessage } from '@shared/utils/http-error.utils';
+import { serverAuthoredMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -338,40 +338,14 @@ export class OrgProfileEditComponent implements OnInit {
       return {
         severity: 'error',
         summary: 'Logo rejected',
-        detail: this.logoErrorDetail(error, 'This image could not be used. Try a different file.'),
+        detail: serverAuthoredMessage(error, 'This image could not be used. Try a different file.'),
         life: 8000,
       };
     }
     if (status === 404 || status === 409) {
-      return { severity: 'error', summary: 'Upload failed', detail: this.logoErrorDetail(error, 'Unable to upload logo. Please try again.'), life: 5000 };
+      return { severity: 'error', summary: 'Upload failed', detail: serverAuthoredMessage(error, 'Unable to upload logo. Please try again.'), life: 5000 };
     }
     return { severity: 'error', summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.', life: 5000 };
-  }
-
-  /**
-   * Server-authored reason for a failed upload, or the caller's fallback.
-   *
-   * `extractErrorMessage` ends with `error.message || fallback`, and Angular always synthesizes a
-   * non-empty `error.message` ("Http failure response for …"), so its fallback is unreachable for a
-   * body-less response. Checking for a server-authored body first keeps that HTTP debugging string
-   * out of the toast.
-   */
-  private logoErrorDetail(error: unknown, fallback: string): string {
-    return this.hasServerMessage(error) ? extractErrorMessage(error, fallback) : fallback;
-  }
-
-  /** Whether the response body carries a message the server wrote, in any shape the BFF emits. */
-  private hasServerMessage(error: unknown): boolean {
-    const body = error instanceof HttpErrorResponse ? error.error : null;
-    if (typeof body === 'string') return body.trim().length > 0;
-    if (!body || typeof body !== 'object') return false;
-
-    const { message, error: errorText, errors } = body as { message?: unknown; error?: unknown; errors?: unknown };
-    const hasTopLevel = [message, errorText].some((value) => typeof value === 'string' && value.trim().length > 0);
-    const hasFieldDetail =
-      Array.isArray(errors) &&
-      errors.some((entry) => typeof (entry as { message?: unknown })?.message === 'string' && (entry as { message: string }).message.trim().length > 0);
-    return hasTopLevel || hasFieldDetail;
   }
 
   private refreshFieldFlags(): void {

--- a/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.html
+++ b/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.html
@@ -8,6 +8,7 @@
       [binary]="binary()"
       [inputId]="inputId() || control()"
       [ariaLabelledBy]="ariaLabelledBy()"
+      [pt]="{ input: { 'aria-describedby': ariaDescribedBy() || null } }"
       [styleClass]="styleClass()"
       class="flex" />
     @if (label()) {

--- a/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.ts
+++ b/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.ts
@@ -16,6 +16,12 @@ export class CheckboxComponent {
   public readonly inputId = input<string>();
   /** Id of the element naming this checkbox — use when the consent text is richer than `label` allows. */
   public readonly ariaLabelledBy = input<string>();
+  /**
+   * Id of the element carrying the terms this checkbox affirms, for a label that does not stand
+   * alone. `p-checkbox` has no `ariaDescribedBy` of its own, so this is applied to the rendered
+   * input through `pt`.
+   */
+  public readonly ariaDescribedBy = input<string>();
   public readonly label = input<string>('');
   public readonly binary = input<boolean>(true);
   public readonly disabled = input<boolean>(false);

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
@@ -28,6 +28,11 @@
         [attr.maxlength]="maxlength()"
         [attr.aria-describedby]="describedBy() || null"
         [attr.aria-invalid]="invalid() ? true : null"
+        [attr.role]="role() ?? null"
+        [attr.aria-controls]="ariaControls() ?? null"
+        [attr.aria-activedescendant]="ariaActivedescendant() ?? null"
+        [attr.aria-expanded]="ariaExpanded() ?? null"
+        [attr.aria-autocomplete]="ariaAutocomplete() ?? null"
         [attr.data-test]="dataTest()" />
     </p-iconfield>
   } @else {
@@ -45,6 +50,11 @@
       [attr.maxlength]="maxlength()"
       [attr.aria-describedby]="describedBy() || null"
       [attr.aria-invalid]="invalid() ? true : null"
+      [attr.role]="role() ?? null"
+      [attr.aria-controls]="ariaControls() ?? null"
+      [attr.aria-activedescendant]="ariaActivedescendant() ?? null"
+      [attr.aria-expanded]="ariaExpanded() ?? null"
+      [attr.aria-autocomplete]="ariaAutocomplete() ?? null"
       [attr.data-test]="dataTest()" />
   }
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.ts
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.ts
@@ -32,4 +32,22 @@ export class InputTextComponent {
   public describedBy = input<string>();
   /** Marks the control invalid for assistive tech; the visible error text is the caller's. */
   public invalid = input<boolean>(false);
+
+  /**
+   * Combobox wiring, for the typeahead pickers that put a results list under this field.
+   *
+   * These belong on the `<input>` and nowhere else. `aria-activedescendant` in particular is read
+   * from the element that holds focus, and focus stays in the text box while the arrow keys move
+   * a highlight through the list — so the same attribute placed on the list container, which is
+   * never focused, announces nothing at all. That is a silent failure: the highlight looks right
+   * on screen and a screen reader hears none of it.
+   *
+   * All optional and null by default, so a field that is not a combobox emits no ARIA it has no
+   * business claiming.
+   */
+  public role = input<string>();
+  public ariaControls = input<string>();
+  public ariaActivedescendant = input<string | null>();
+  public ariaExpanded = input<boolean>();
+  public ariaAutocomplete = input<string>();
 }

--- a/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import type { OrgClaGroupList, PdfUrlResponse } from '@lfx-one/shared/interfaces';
+import type { ClaGroupSearchResponse, OrgClaGroupList, OrgClaSignRequest, OrgClaSignResponse, PdfUrlResponse } from '@lfx-one/shared/interfaces';
 import { Observable } from 'rxjs';
 
 /**
@@ -26,5 +26,23 @@ export class OrgLensClaService {
 
   public getPdfUrl(orgUid: string, signatureId: string): Observable<PdfUrlResponse> {
     return this.http.get<PdfUrlResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups/${encodeURIComponent(signatureId)}/pdf-url`);
+  }
+
+  /** CLA Groups the organization could sign a corporate CLA for (#1983). One call per typed term. */
+  public getSignOptions(orgUid: string, searchTerm: string): Observable<ClaGroupSearchResponse> {
+    const params = new HttpParams().set('search', searchTerm);
+    return this.http.get<ClaGroupSearchResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups/sign-options`, { params });
+  }
+
+  /**
+   * Opens the corporate signing session (#1983).
+   *
+   * `request` carries the signatory's two attestations as they actually stood when they
+   * continued. Nothing on this path substitutes a literal for them, and nothing should: the
+   * server compares against `true` and refuses anything else, which is only meaningful if what
+   * arrives is what the signatory set.
+   */
+  public requestCorporateSignature(orgUid: string, request: OrgClaSignRequest): Observable<OrgClaSignResponse> {
+    return this.http.post<OrgClaSignResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups/sign`, request);
   }
 }

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,7 +5,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { extractErrorMessage, isTransientHttpError, retryTransientHttpError } from './http-error.utils';
+import { extractErrorMessage, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });
@@ -145,5 +145,49 @@ describe('extractErrorMessage', () => {
   it('handles a plain Error and an unknown value', () => {
     expect(extractErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
     expect(extractErrorMessage('not an error', 'fallback')).toBe('fallback');
+  });
+});
+
+/**
+ * The composition for anywhere the fallback is user-facing copy rather than a debugging default.
+ * `extractErrorMessage` alone cannot serve that case: it ends with `error.message || fallback`,
+ * and Angular synthesizes a non-empty `.message` for every failure, so its fallback is unreachable
+ * and "Http failure response for /api/…" reaches the screen instead.
+ */
+describe('serverAuthoredMessage', () => {
+  // Two spellings because the server has two paths: `BaseApiError#toResponse` answers with the
+  // message under `error`, and a controller that validates and replies directly uses `message`. A
+  // reader that knows only one silently loses half the server's replies.
+  it.each([
+    ['error', { error: 'This organization requires additional review' }],
+    ['message', { message: 'This organization requires additional review' }],
+  ])('reads the message the server sent under %s', (_key, body) => {
+    expect(serverAuthoredMessage(httpErrorWithBody(403, body), 'fallback')).toBe('This organization requires additional review');
+  });
+
+  it('prefers a field-level detail, exactly as extractErrorMessage does', () => {
+    const error = httpErrorWithBody(400, { error: 'Validation failed', errors: [{ message: 'The real detail' }] });
+
+    expect(serverAuthoredMessage(error, 'fallback')).toBe('The real detail');
+  });
+
+  it('returns a plain string body directly', () => {
+    expect(serverAuthoredMessage(httpErrorWithBody(502, 'upstream down'), 'fallback')).toBe('upstream down');
+  });
+
+  // The whole reason this exists, and the case `extractErrorMessage` gets wrong.
+  it.each([[{}], [null], [{ code: 'FORBIDDEN' }], [{ message: '   ' }], [{ errors: 'not an array' }], ['   ']])(
+    'answers the fallback, not Angular’s synthesized message, for %p',
+    (body) => {
+      const shown = serverAuthoredMessage(httpErrorWithBody(403, body), 'fallback');
+
+      expect(shown).toBe('fallback');
+      expect(shown).not.toContain('Http failure response');
+    }
+  );
+
+  it('answers the fallback for anything that is not an HTTP failure', () => {
+    expect(serverAuthoredMessage(new Error('boom'), 'fallback')).toBe('fallback');
+    expect(serverAuthoredMessage(undefined, 'fallback')).toBe('fallback');
   });
 });

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -75,8 +75,16 @@ export function serverAuthoredMessage(error: unknown, fallback: string): string 
  * Whether the response body carries a message the server wrote, in any shape this BFF emits.
  *
  * There are two, because the server has two paths: `BaseApiError#toResponse` answers with the
- * message under `error`, while a controller that validates and replies directly answers with it
- * under `message`. A reader that knows only one of them silently loses half the server's replies.
+ * message under `error`, while a controller that answers `res.status(...).json({ message })`
+ * directly answers with it under `message`. A reader that knows only one of them silently loses
+ * half the server's replies.
+ *
+ * **Both are still live and this must stay tolerant of both.** The org-lens sign route was moved
+ * onto the error-class path so it emits only the first, and the temptation is then to narrow this
+ * to `error`. Don't: the second shape is emitted by roughly two dozen surviving call sites across
+ * `clas`, `crowdfunding`, `profile` and `org-lens-project-detail`, including the sibling Me-lens
+ * CLA controller. Narrowing would turn every one of their messages into the generic fallback.
+ * Converting them is worth doing and is not this feature's to do.
  */
 function hasServerAuthoredMessage(error: unknown): boolean {
   const body = error instanceof HttpErrorResponse ? error.error : null;

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -60,6 +60,38 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
 }
 
 /**
+ * The message the server wrote, or `fallback` when it wrote none.
+ *
+ * `extractErrorMessage` ends with `error.message || fallback`, and Angular always synthesizes a
+ * non-empty `HttpErrorResponse.message` ("Http failure response for …"), so its own fallback is
+ * unreachable for a body-less response — the HTTP debugging string reaches the screen instead.
+ * Anywhere the fallback is user-facing copy, this is the composition that is actually wanted.
+ */
+export function serverAuthoredMessage(error: unknown, fallback: string): string {
+  return hasServerAuthoredMessage(error) ? extractErrorMessage(error, fallback) : fallback;
+}
+
+/**
+ * Whether the response body carries a message the server wrote, in any shape this BFF emits.
+ *
+ * There are two, because the server has two paths: `BaseApiError#toResponse` answers with the
+ * message under `error`, while a controller that validates and replies directly answers with it
+ * under `message`. A reader that knows only one of them silently loses half the server's replies.
+ */
+function hasServerAuthoredMessage(error: unknown): boolean {
+  const body = error instanceof HttpErrorResponse ? error.error : null;
+  if (typeof body === 'string') return body.trim().length > 0;
+  if (!body || typeof body !== 'object') return false;
+
+  const { message, error: errorText, errors } = body as { message?: unknown; error?: unknown; errors?: unknown };
+  const hasTopLevel = [message, errorText].some((value) => typeof value === 'string' && value.trim().length > 0);
+  const hasFieldDetail =
+    Array.isArray(errors) &&
+    errors.some((entry) => typeof (entry as { message?: unknown })?.message === 'string' && (entry as { message: string }).message.trim().length > 0);
+  return hasTopLevel || hasFieldDetail;
+}
+
+/**
  * Whether an error is worth retrying — a beat of time could plausibly fix a network drop (0),
  * rate limit (429), request timeout (408), or upstream 5xx, but not a client error like an
  * expired session (401) or a permission/not-found response (403/404).

--- a/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
+
+/**
+ * The signature a corporate signing session created, carried across the DocuSign round trip so the
+ * signatory returns to the agreement they signed rather than to the list (#1983).
+ *
+ * `sessionStorage` because nothing lighter survives the trip: the return is a cross-site
+ * navigation, so neither an in-memory value nor a history entry's state comes back with it. Scoped
+ * to the tab that made the request, which is the tab the signatory returns in.
+ *
+ * SSR-safe: both functions no-op when `sessionStorage` is unavailable, as the sibling
+ * `clearPendingProfileSave` does.
+ */
+export function stashSignedSignatureId(signatureId: string): void {
+  if (typeof sessionStorage === 'undefined') return;
+  sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, signatureId);
+}
+
+/**
+ * Reads the stashed signature and clears it in the same breath.
+ *
+ * Single-use by construction rather than by the caller remembering to clean up. A signature id
+ * left behind is a pointer to a named organization's agreement that outlives the trip it was for,
+ * and it would send the *next* visit to the list into a detail page nobody asked for.
+ */
+export function takeStashedSignedSignatureId(): string {
+  if (typeof sessionStorage === 'undefined') return '';
+
+  const signatureId = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY) ?? '';
+  sessionStorage.removeItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
+  return signatureId.trim();
+}

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -7,7 +7,7 @@
 // EasyCLA re-verifies each key belongs to the caller and owns the signature, so the
 // upstream endpoint — not this controller — is the ownership authorization boundary.
 
-import { CLA_GROUP_SEARCH_MIN_CHARS, CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
+import { CLA_GROUP_ID_PATTERN, CLA_GROUP_SEARCH_MIN_CHARS, CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
 import type { ClaManagerRequestType } from '@lfx-one/shared/interfaces';
 import { codePointLength, sanitizePlainText } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
@@ -17,10 +17,6 @@ import { getStringQueryParam } from '../helpers/validation.helper';
 import { ClaService } from '../services/cla.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
-
-// A CLA Group UUID, hyphenated or not — the two spellings the producer's own pattern accepts.
-// Anchored with fixed-length runs, so it cannot backtrack.
-const CLA_GROUP_ID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 
 /**
  * Every recipient must already be a non-empty string. Coercing mixed arrays would turn

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
@@ -328,6 +328,18 @@ describe('OrgClasController.requestCorporateSignature', () => {
     expect(requestCorporateSignature).not.toHaveBeenCalled();
   });
 
+  // Shape-checked, not just non-empty. A malformed identifier that only fails an emptiness test
+  // reaches EasyCLA's project-and-organization authorization check and returns as a 403 — which
+  // this route relays in the producer's words, so the signatory is told their signing authority
+  // was refused when the real fault was a bad request this boundary could have named.
+  it.each([['nimbus'], ['not a salesforce id'], ['a0941000002wBz2AAE-extra'], ['../../etc/passwd']])(
+    'rejects a malformed project identifier %p before calling upstream',
+    async (projectSfid) => {
+      expect((await rejectionOf({ projectSfid })).statusCode).toBe(400);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+    }
+  );
+
   it('rejects a CLA group identifier that is not a UUID', async () => {
     expect((await rejectionOf({ claGroupId: 'nimbus-foundation' })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
@@ -27,7 +27,7 @@ const { loggerMock } = vi.hoisted(() => ({
 }));
 vi.mock('../services/logger.service', () => ({ logger: loggerMock }));
 
-import { AuthenticationError } from '../errors';
+import { AuthenticationError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { OrgClasController } from './org-clas.controller';
 
@@ -152,6 +152,25 @@ function signReq(body: Record<string, unknown> = {}) {
   } as any;
 }
 
+/**
+ * Runs the sign controller and returns what it rejected with.
+ *
+ * The rejections go to `next(error)` rather than to `res.status(400).json(...)`, so the shared
+ * error handler owns the envelope and the severity — client input that fails validation is a
+ * WARN, and logging it as an ERROR inflates the signal this service is watched by. Asserting
+ * through `next` rather than through `res` is what keeps that true: a branch that answered
+ * directly would leave `next` uncalled and fail here.
+ */
+async function rejectionOf(body: Record<string, unknown>): Promise<{ statusCode: number; code: string; response: Record<string, any> }> {
+  const next = vi.fn();
+  await new OrgClasController().requestCorporateSignature(signReq(body), buildRes(), next);
+
+  const error = next.mock.calls[0]?.[0] as ServiceValidationError | undefined;
+  expect(error, 'expected the controller to reject via next(error)').toBeInstanceOf(ServiceValidationError);
+
+  return { statusCode: error!.statusCode, code: error!.code, response: error!.toResponse() };
+}
+
 describe('OrgClasController.getSignOptions', () => {
   it('returns 401 (via next) when there is no authenticated user', async () => {
     getUsernameFromAuth.mockResolvedValue(null);
@@ -207,77 +226,72 @@ describe('OrgClasController.getSignOptions', () => {
  */
 describe('OrgClasController.requestCorporateSignature — the attestations', () => {
   it('refuses when the authorization confirmation is false, and never calls upstream', async () => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: false }), res, vi.fn());
-
+    expect((await rejectionOf({ authorityAcked: false })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('refuses when the compliance confirmation is false, and never calls upstream', async () => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ embargoAcked: false }), res, vi.fn());
-
+    expect((await rejectionOf({ embargoAcked: false })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('refuses when both are false', async () => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: false, embargoAcked: false }), res, vi.fn());
-
+    expect((await rejectionOf({ authorityAcked: false, embargoAcked: false })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('refuses when either is absent', async () => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: undefined }), res, vi.fn());
-
+    expect((await rejectionOf({ authorityAcked: undefined })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   // The specific failure this guards: `Boolean(body.authorityAcked)` or `!!body.authorityAcked`
   // would accept every one of these and record an attestation nobody made.
   it.each([['true'], [1], [{}], [[]], ['yes']])('refuses the truthy non-boolean %p rather than coercing it', async (value) => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: value }), res, vi.fn());
-
+    expect((await rejectionOf({ authorityAcked: value })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   // An operation opened and never terminated reads on a dashboard as a request still in flight.
-  // Every rejection below the `startOperation` has to close it.
+  // The error handler is what terminates these now, so what this asserts is that the rejection
+  // actually reaches it — a branch that answered on `res` directly would strand the operation.
   it.each([
     ['a withdrawn confirmation', { embargoAcked: false }],
     ['a missing project', { projectSfid: '' }],
     ['a malformed CLA group id', { claGroupId: 'not-a-uuid' }],
-  ])('closes the operation it opened when rejecting %s', async (_case, body) => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq(body), res, vi.fn());
-
-    expect(res.status).toHaveBeenCalledWith(400);
+  ])('hands the rejection to the error handler when rejecting %s', async (_case, body) => {
+    expect((await rejectionOf(body)).statusCode).toBe(400);
     expect(loggerMock.startOperation).toHaveBeenCalledTimes(1);
-    expect(loggerMock.error).toHaveBeenCalledTimes(1);
-    expect(loggerMock.error.mock.calls[0][1]).toBe('request_org_cla_corporate_signature');
+    // Not logged here at all: bad client input is not an operational error, and the handler
+    // classifies a 400 as a warning. A `logger.error` on this path is the defect.
+    expect(loggerMock.error).not.toHaveBeenCalled();
   });
 
-  // The types, not the values: a log line is not a place to record a legal assertion.
-  it('records that a non-boolean arrived without recording what it was', async () => {
-    const res = buildRes();
+  // A log line — and a response — is not a place to record a legal assertion. Naming which of the
+  // two confirmations was withheld would record exactly that, so neither the value nor the field
+  // is reported: the rejection is about the pair.
+  it('says a confirmation is missing without saying which one, or what arrived instead', async () => {
+    const { code, response } = await rejectionOf({ embargoAcked: 'yes please' });
 
-    await new OrgClasController().requestCorporateSignature(signReq({ embargoAcked: 'yes please' }), res, vi.fn());
+    expect(code).toBe('VALIDATION_ERROR');
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain('yes please');
+    expect(serialized).not.toContain('embargoAcked');
+    expect(serialized).not.toContain('authorityAcked');
+    expect(response['error']).toBe('Both the authorization and compliance confirmations are required');
+  });
 
-    expect(loggerMock.error.mock.calls[0][4]).toMatchObject({ embargo_acked_type: 'string' });
-    expect(JSON.stringify(loggerMock.error.mock.calls[0][4])).not.toContain('yes please');
+  // The whole point of D: one envelope. Every rejection from this route carries the standard
+  // `error` + `code` shape rather than the bare `{ message }` a direct `res.json` produced.
+  it.each([
+    ['a missing project', { projectSfid: '' }],
+    ['a malformed CLA group id', { claGroupId: 'not-a-uuid' }],
+    ['a withdrawn confirmation', { embargoAcked: false }],
+  ])('answers %s in the standard error envelope', async (_case, body) => {
+    const { response } = await rejectionOf(body);
+
+    expect(response).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(typeof response['error']).toBe('string');
   });
 
   it('passes both confirmations through as the booleans that arrived, not as literals', async () => {
@@ -310,21 +324,13 @@ describe('OrgClasController.requestCorporateSignature', () => {
   });
 
   it('rejects a missing project identifier before calling upstream', async () => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ projectSfid: '   ' }), res, vi.fn());
-
+    expect((await rejectionOf({ projectSfid: '   ' })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it('rejects a CLA group identifier that is not a UUID', async () => {
-    const res = buildRes();
-
-    await new OrgClasController().requestCorporateSignature(signReq({ claGroupId: 'nimbus-foundation' }), res, vi.fn());
-
+    expect((await rejectionOf({ claGroupId: 'nimbus-foundation' })).statusCode).toBe(400);
     expect(requestCorporateSignature).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   // The organization is the grant-checked path segment. A body that names a different one is

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
@@ -6,18 +6,26 @@ import '@angular/compiler';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { getUsernameFromAuth } = vi.hoisted(() => ({ getUsernameFromAuth: vi.fn<() => Promise<string | null>>() }));
-const { listClaGroups, getPdfUrl } = vi.hoisted(() => ({ listClaGroups: vi.fn(), getPdfUrl: vi.fn() }));
+const { listClaGroups, getPdfUrl, getSignOptions, requestCorporateSignature } = vi.hoisted(() => ({
+  listClaGroups: vi.fn(),
+  getPdfUrl: vi.fn(),
+  getSignOptions: vi.fn(),
+  requestCorporateSignature: vi.fn(),
+}));
 
 vi.mock('../utils/auth-helper', () => ({ getUsernameFromAuth }));
 vi.mock('../services/org-cla.service', () => ({
   OrgClaService: class {
     public listClaGroups = listClaGroups;
     public getPdfUrl = getPdfUrl;
+    public getSignOptions = getSignOptions;
+    public requestCorporateSignature = requestCorporateSignature;
   },
 }));
-vi.mock('../services/logger.service', () => ({
-  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
+vi.mock('../services/logger.service', () => ({ logger: loggerMock }));
 
 import { AuthenticationError } from '../errors';
 import { logger } from '../services/logger.service';
@@ -124,5 +132,231 @@ describe('OrgClasController.getPdfUrl', () => {
     expect(getPdfUrl).toHaveBeenCalledWith(req, '0014100000Te2ovAAB', 'signature-uuid-1');
     expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     expect(res.json).toHaveBeenCalledWith({ url: 'https://s3.example.org/ccla.pdf', expiresInSeconds: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corporate signing hand-off (#1983)
+// ---------------------------------------------------------------------------
+
+const ORG_UID = '0014100000Te2ovAAB';
+const CLA_GROUP_ID = '7f3a1c22-9d51-4a8e-b0c6-2e4f81d9a733';
+const PROJECT_SFID = 'a09410000182dD3AAI';
+
+/** A request whose attestations are both genuinely affirmed. Cases override only what they test. */
+function signReq(body: Record<string, unknown> = {}) {
+  return {
+    params: { orgUid: ORG_UID },
+    query: {},
+    body: { projectSfid: PROJECT_SFID, claGroupId: CLA_GROUP_ID, authorityAcked: true, embargoAcked: true, ...body },
+  } as any;
+}
+
+describe('OrgClasController.getSignOptions', () => {
+  it('returns 401 (via next) when there is no authenticated user', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: 'nimbus' }, body: {} } as any, res, next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+    expect(getSignOptions).not.toHaveBeenCalled();
+  });
+
+  it('answers a term below the minimum with an empty set rather than an error', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: 'ni' }, body: {} } as any, res, vi.fn());
+
+    expect(getSignOptions).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ searchTerm: 'ni', resultCount: 0, truncated: false, results: [] });
+  });
+
+  it('trims the term before measuring it, so whitespace cannot buy the minimum', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: '  n  ' }, body: {} } as any, res, vi.fn());
+
+    expect(getSignOptions).not.toHaveBeenCalled();
+  });
+
+  it('passes a searchable term through and answers with the envelope', async () => {
+    getSignOptions.mockResolvedValue({ searchTerm: 'nimbus', resultCount: 1, truncated: false, results: [] });
+    const res = buildRes();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: 'nimbus' }, body: {} } as any, res, vi.fn());
+
+    expect(getSignOptions).toHaveBeenCalledWith(expect.anything(), 'nimbus');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+});
+
+/**
+ * The attestation gate.
+ *
+ * These are the highest-value assertions in this feature. Every other failure it can have is
+ * visible — a wrong URL, a missing field, a broken layout. This one is not: a request that
+ * transmits an affirmation the signatory did not make succeeds at every layer and produces a
+ * legally binding document, and nothing downstream can tell it apart from a genuine one.
+ *
+ * So the tests are written from the negative side. `false` surviving as `false` matters more
+ * than `true` surviving as `true`, because the code that would break the first is the same
+ * plausible-looking code — a literal, a default, a `??`, a truthiness check — that would let the
+ * second keep passing.
+ */
+describe('OrgClasController.requestCorporateSignature — the attestations', () => {
+  it('refuses when the authorization confirmation is false, and never calls upstream', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: false }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('refuses when the compliance confirmation is false, and never calls upstream', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ embargoAcked: false }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('refuses when both are false', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: false, embargoAcked: false }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('refuses when either is absent', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: undefined }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  // The specific failure this guards: `Boolean(body.authorityAcked)` or `!!body.authorityAcked`
+  // would accept every one of these and record an attestation nobody made.
+  it.each([['true'], [1], [{}], [[]], ['yes']])('refuses the truthy non-boolean %p rather than coercing it', async (value) => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ authorityAcked: value }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  // An operation opened and never terminated reads on a dashboard as a request still in flight.
+  // Every rejection below the `startOperation` has to close it.
+  it.each([
+    ['a withdrawn confirmation', { embargoAcked: false }],
+    ['a missing project', { projectSfid: '' }],
+    ['a malformed CLA group id', { claGroupId: 'not-a-uuid' }],
+  ])('closes the operation it opened when rejecting %s', async (_case, body) => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq(body), res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(loggerMock.startOperation).toHaveBeenCalledTimes(1);
+    expect(loggerMock.error).toHaveBeenCalledTimes(1);
+    expect(loggerMock.error.mock.calls[0][1]).toBe('request_org_cla_corporate_signature');
+  });
+
+  // The types, not the values: a log line is not a place to record a legal assertion.
+  it('records that a non-boolean arrived without recording what it was', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ embargoAcked: 'yes please' }), res, vi.fn());
+
+    expect(loggerMock.error.mock.calls[0][4]).toMatchObject({ embargo_acked_type: 'string' });
+    expect(JSON.stringify(loggerMock.error.mock.calls[0][4])).not.toContain('yes please');
+  });
+
+  it('passes both confirmations through as the booleans that arrived, not as literals', async () => {
+    requestCorporateSignature.mockResolvedValue({ signUrl: 'https://docusign.example.org/session/1' });
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, vi.fn());
+
+    // The whole request, not a subset: the service requires `projectSfid` and `claGroupId` too,
+    // and a subset matcher cannot see a field that is absent.
+    expect(requestCorporateSignature).toHaveBeenCalledWith(expect.anything(), ORG_UID, {
+      projectSfid: PROJECT_SFID,
+      claGroupId: CLA_GROUP_ID,
+      authorityAcked: true,
+      embargoAcked: true,
+    });
+  });
+});
+
+describe('OrgClasController.requestCorporateSignature', () => {
+  it('returns 401 (via next) when there is no authenticated user', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing project identifier before calling upstream', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ projectSfid: '   ' }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a CLA group identifier that is not a UUID', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ claGroupId: 'nimbus-foundation' }), res, vi.fn());
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  // The organization is the grant-checked path segment. A body that names a different one is
+  // ignored rather than honoured — otherwise the path parameter is decorative and any viewer with
+  // org-lens access anywhere could open a signing session against another company.
+  it('takes the organization from the path, ignoring one supplied in the body', async () => {
+    requestCorporateSignature.mockResolvedValue({ signUrl: 'https://docusign.example.org/session/1' });
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ companySfid: '0014100000OtherAAA', orgUid: '0014100000OtherAAA' }), res, vi.fn());
+
+    expect(requestCorporateSignature).toHaveBeenCalledWith(expect.anything(), ORG_UID, expect.anything());
+  });
+
+  it('answers with the signing session and forbids caching it', async () => {
+    requestCorporateSignature.mockResolvedValue({ signUrl: 'https://docusign.example.org/session/1' });
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, vi.fn());
+
+    expect(res.json).toHaveBeenCalledWith({ signUrl: 'https://docusign.example.org/session/1' });
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+
+  it('passes an upstream failure to the error handler rather than answering', async () => {
+    requestCorporateSignature.mockRejectedValue(new Error('upstream refused'));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.ts
@@ -144,23 +144,23 @@ export class OrgClasController {
       // verbatim, so a client-supplied one would turn the hand-off into an open redirect.
       const body = req.body as { projectSfid?: unknown; claGroupId?: unknown; authorityAcked?: unknown; embargoAcked?: unknown } | undefined;
 
-      // Each rejection below closes the operation it opened. A bare `return` would leave a
-      // `started` entry with no terminator and no duration, so a dashboard pairing the two would
-      // read every rejected request as an operation still in flight.
+      // Each rejection below throws rather than answering directly, so the shared error handler
+      // classifies it: one response envelope, WARN rather than ERROR (bad client input is not an
+      // operational fault, and logging it as one inflates the error signal this service is
+      // watched by), and the operation terminated on the same path as every other failure. The
+      // sibling `getPdfUrl` above already does this; these three were the outliers.
       const projectSfid = String(body?.projectSfid ?? '').trim();
       if (!projectSfid) {
-        const message = 'A project identifier is required';
-        logger.error(req, 'request_org_cla_corporate_signature', startTime, new Error(message), { org_uid: orgUid });
-        res.status(400).json({ message });
-        return;
+        throw ServiceValidationError.fromFieldErrors({ projectSfid: 'A project identifier is required' }, 'A project identifier is required', {
+          operation: 'request_org_cla_corporate_signature',
+        });
       }
 
       const claGroupId = String(body?.claGroupId ?? '').trim();
       if (!CLA_GROUP_ID_PATTERN.test(claGroupId)) {
-        const message = 'A CLA group identifier is required';
-        logger.error(req, 'request_org_cla_corporate_signature', startTime, new Error(message), { org_uid: orgUid });
-        res.status(400).json({ message });
-        return;
+        throw ServiceValidationError.fromFieldErrors({ claGroupId: 'A CLA group identifier is required' }, 'A CLA group identifier is required', {
+          operation: 'request_org_cla_corporate_signature',
+        });
       }
 
       // Compared against the literal `true`, not coerced. These two carry the legal weight of the
@@ -168,17 +168,14 @@ export class OrgClasController {
       // never made, and the failure would be invisible everywhere downstream because upstream
       // sees only the boolean that arrives. Upstream refuses a false as well; answering it here
       // spends no round trip to learn that a signatory who withdrew a confirmation cannot sign.
+      //
+      // Reported against `attestations` rather than against whichever of the two failed. Naming
+      // the failing one would record, in a log line and in the response, that this signatory did
+      // not affirm that specific statement — which is the legal assertion itself, and the reason
+      // the values are not logged either.
       if (body?.authorityAcked !== true || body?.embargoAcked !== true) {
         const message = 'Both the authorization and compliance confirmations are required';
-        // The types, never the values: what is useful in a log is whether something non-boolean
-        // arrived, and recording an attestation's value would put a legal assertion in a log line.
-        logger.error(req, 'request_org_cla_corporate_signature', startTime, new Error(message), {
-          org_uid: orgUid,
-          authority_acked_type: typeof body?.authorityAcked,
-          embargo_acked_type: typeof body?.embargoAcked,
-        });
-        res.status(400).json({ message });
-        return;
+        throw ServiceValidationError.fromFieldErrors({ attestations: message }, message, { operation: 'request_org_cla_corporate_signature' });
       }
 
       const result = await this.orgClaService.requestCorporateSignature(req, orgUid, {

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.ts
@@ -1,13 +1,21 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, ServiceValidationError } from '../errors';
+import { getStringQueryParam } from '../helpers/validation.helper';
 import { assertOrgUid } from '../helpers/org-uid.helper';
 import { OrgClaService } from '../services/org-cla.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
+
+/**
+ * Same UUID shape the Me-lens hand-off validates, hyphens optional because the producer's own
+ * pattern allows both spellings.
+ */
+const CLA_GROUP_ID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 
 export class OrgClasController {
   private readonly orgClaService = new OrgClaService();
@@ -71,6 +79,118 @@ export class OrgClasController {
 
       logger.success(req, 'get_org_cla_pdf_url', startTime, { org_uid: orgUid, signature_id: signatureId, found: true });
       res.json(pdf);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // GET /api/orgs/:orgUid/lens/cla-groups/sign-options?search=<term>
+  // CLA Groups the organization could sign a corporate CLA for (#1983). A read: impersonation
+  // stays allowed, exactly as on the Me-lens picker. The write is next door.
+  public async getSignOptions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_cla_sign_options');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_cla_sign_options' });
+      }
+
+      const orgUid = req.params['orgUid'];
+      assertOrgUid(orgUid, 'get_org_cla_sign_options');
+
+      const searchTerm = (getStringQueryParam(req, 'search') ?? '').trim();
+
+      // Upstream requires three characters and 400s below that. The picker gates on the same
+      // length; this is the second line, so a caller that skips the picker gets an empty set
+      // rather than an error describing a mistake nobody made.
+      if (searchTerm.length < CLA_GROUP_SEARCH_MIN_CHARS) {
+        logger.success(req, 'get_org_cla_sign_options', startTime, { result_count: 0, term_too_short: true });
+        res.setHeader('Cache-Control', 'no-store');
+        res.json({ searchTerm, resultCount: 0, truncated: false, results: [] });
+        return;
+      }
+
+      const envelope = await this.orgClaService.getSignOptions(req, searchTerm);
+
+      logger.success(req, 'get_org_cla_sign_options', startTime, { org_uid: orgUid, result_count: envelope.resultCount });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(envelope);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // POST /api/orgs/:orgUid/lens/cla-groups/sign
+  // Opens the corporate signing session and answers with the address EasyCLA returned. Nothing
+  // here composes that address, and nothing here decides whether the caller may sign — the CLA
+  // service checks signing authority and trade compliance on every request, and its refusal is
+  // relayed in its own words rather than pre-empted.
+  //
+  // Blocked during impersonation at the route, so there is no impersonation branch here.
+  public async requestCorporateSignature(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'request_org_cla_corporate_signature');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'request_org_cla_corporate_signature' });
+      }
+
+      const orgUid = req.params['orgUid'];
+      assertOrgUid(orgUid, 'request_org_cla_corporate_signature');
+
+      // The chosen project and CLA group are the only things taken from the body besides the two
+      // attestations. The organization is the grant-checked path parameter, and the return
+      // address is derived from the request — EasyCLA stores that value and redirects to it
+      // verbatim, so a client-supplied one would turn the hand-off into an open redirect.
+      const body = req.body as { projectSfid?: unknown; claGroupId?: unknown; authorityAcked?: unknown; embargoAcked?: unknown } | undefined;
+
+      // Each rejection below closes the operation it opened. A bare `return` would leave a
+      // `started` entry with no terminator and no duration, so a dashboard pairing the two would
+      // read every rejected request as an operation still in flight.
+      const projectSfid = String(body?.projectSfid ?? '').trim();
+      if (!projectSfid) {
+        const message = 'A project identifier is required';
+        logger.error(req, 'request_org_cla_corporate_signature', startTime, new Error(message), { org_uid: orgUid });
+        res.status(400).json({ message });
+        return;
+      }
+
+      const claGroupId = String(body?.claGroupId ?? '').trim();
+      if (!CLA_GROUP_ID_PATTERN.test(claGroupId)) {
+        const message = 'A CLA group identifier is required';
+        logger.error(req, 'request_org_cla_corporate_signature', startTime, new Error(message), { org_uid: orgUid });
+        res.status(400).json({ message });
+        return;
+      }
+
+      // Compared against the literal `true`, not coerced. These two carry the legal weight of the
+      // request: a truthy non-boolean accepted here would record an attestation the signatory
+      // never made, and the failure would be invisible everywhere downstream because upstream
+      // sees only the boolean that arrives. Upstream refuses a false as well; answering it here
+      // spends no round trip to learn that a signatory who withdrew a confirmation cannot sign.
+      if (body?.authorityAcked !== true || body?.embargoAcked !== true) {
+        const message = 'Both the authorization and compliance confirmations are required';
+        // The types, never the values: what is useful in a log is whether something non-boolean
+        // arrived, and recording an attestation's value would put a legal assertion in a log line.
+        logger.error(req, 'request_org_cla_corporate_signature', startTime, new Error(message), {
+          org_uid: orgUid,
+          authority_acked_type: typeof body?.authorityAcked,
+          embargo_acked_type: typeof body?.embargoAcked,
+        });
+        res.status(400).json({ message });
+        return;
+      }
+
+      const result = await this.orgClaService.requestCorporateSignature(req, orgUid, {
+        projectSfid,
+        claGroupId,
+        authorityAcked: body.authorityAcked,
+        embargoAcked: body.embargoAcked,
+      });
+
+      logger.success(req, 'request_org_cla_corporate_signature', startTime, { org_uid: orgUid });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(result);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import { CLA_GROUP_ID_PATTERN, CLA_GROUP_SEARCH_MIN_CHARS, SALESFORCE_ID_PATTERN } from '@lfx-one/shared/constants';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, ServiceValidationError } from '../errors';
@@ -10,12 +10,6 @@ import { assertOrgUid } from '../helpers/org-uid.helper';
 import { OrgClaService } from '../services/org-cla.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
-
-/**
- * Same UUID shape the Me-lens hand-off validates, hyphens optional because the producer's own
- * pattern allows both spellings.
- */
-const CLA_GROUP_ID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 
 export class OrgClasController {
   private readonly orgClaService = new OrgClaService();
@@ -149,8 +143,12 @@ export class OrgClasController {
       // operational fault, and logging it as one inflates the error signal this service is
       // watched by), and the operation terminated on the same path as every other failure. The
       // sibling `getPdfUrl` above already does this; these three were the outliers.
+      // Shape-checked, not merely non-empty. A malformed identifier that is only checked for
+      // emptiness travels upstream and comes back as a 403 from the project-and-organization
+      // authorization check — which relays to the signatory as a refusal about their signing
+      // authority, when the real fault is a bad request this boundary could have named.
       const projectSfid = String(body?.projectSfid ?? '').trim();
-      if (!projectSfid) {
+      if (!SALESFORCE_ID_PATTERN.test(projectSfid)) {
         throw ServiceValidationError.fromFieldErrors({ projectSfid: 'A project identifier is required' }, 'A project identifier is required', {
           operation: 'request_org_cla_corporate_signature',
         });

--- a/apps/lfx-one/src/server/errors/base.error.ts
+++ b/apps/lfx-one/src/server/errors/base.error.ts
@@ -2,6 +2,22 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Where a client-visible message is kept, when it must differ from `message`.
+ *
+ * A symbol, not a string key, and that is the whole mechanism. Two log paths read an error by
+ * enumerating its string keys — `customErrorSerializer` copies everything `Object.keys` returns
+ * onto the log payload, and anything reached by `JSON.stringify` does the same — so a plain
+ * `public clientMessage` would be written into the log line by both, which is the thing this
+ * exists to prevent. Symbol-keyed properties are invisible to `Object.keys`, `JSON.stringify`
+ * and spread alike, so the value cannot reach a log through the generic paths at all.
+ *
+ * Non-enumerable would also work and would be one line shorter. It is rejected because it is a
+ * flag on a property that a later `Object.assign`, clone or refactor can silently drop, whereas
+ * a symbol key cannot be un-symboled by accident.
+ */
+const CLIENT_MESSAGE = Symbol('BaseApiError.clientMessage');
+
+/**
  * Base error class for all API errors with structured metadata
  */
 export abstract class BaseApiError extends Error {
@@ -26,6 +42,7 @@ export abstract class BaseApiError extends Error {
       metadata?: Record<string, any>;
       originalError?: Error;
       transportFailure?: boolean;
+      clientMessage?: string;
     } = {}
   ) {
     super(message);
@@ -40,9 +57,28 @@ export abstract class BaseApiError extends Error {
     this.originalError = options.originalError;
     this.transportFailure = options.transportFailure;
 
+    if (options.clientMessage) {
+      (this as Record<symbol, unknown>)[CLIENT_MESSAGE] = options.clientMessage;
+    }
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
+  }
+
+  /**
+   * The message written for the client, when that differs from `message`.
+   *
+   * A getter on the prototype rather than an own property, so it is doubly out of reach of the
+   * key-enumerating log paths described at CLIENT_MESSAGE: not an own key to begin with, and its
+   * backing store is keyed by a symbol.
+   *
+   * Set this whenever the sentence the client should read is not one that may be logged —
+   * an upstream refusal that names the caller or their organization's compliance standing being
+   * the case this was built for. `message` then stays generic and is what the log records.
+   */
+  public get clientMessage(): string | undefined {
+    return (this as Record<symbol, unknown>)[CLIENT_MESSAGE] as string | undefined;
   }
 
   /**
@@ -79,7 +115,9 @@ export abstract class BaseApiError extends Error {
    */
   public toResponse(): Record<string, any> {
     return {
-      error: this.message,
+      // `clientMessage` when the throwing site set one, `message` otherwise — so the only errors
+      // whose response text differs from their log text are the ones that asked for it.
+      error: this.clientMessage ?? this.message,
       code: this.code,
       // Whether the BFF raised this as a TRANSPORT failure, declared explicitly by the site that
       // threw it -- not inferred from `originalError`.

--- a/apps/lfx-one/src/server/errors/microservice.error.ts
+++ b/apps/lfx-one/src/server/errors/microservice.error.ts
@@ -24,6 +24,7 @@ export class MicroserviceError extends BaseApiError {
       originalMessage?: string;
       originalError?: Error;
       transportFailure?: boolean;
+      clientMessage?: string;
     } = {}
   ) {
     super(message, statusCode, code, {
@@ -32,6 +33,7 @@ export class MicroserviceError extends BaseApiError {
       path: options.path,
       originalError: options.originalError,
       transportFailure: options.transportFailure,
+      clientMessage: options.clientMessage,
     });
 
     this.errorBody = options.errorBody;

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.spec.ts
@@ -159,4 +159,84 @@ describe('gatewayFetch log-only redaction', () => {
 
     expect(error.errorBody).toBeUndefined();
   });
+
+  /**
+   * A 2xx whose body does not parse.
+   *
+   * The option was written for refusals and so was only ever consulted on the non-OK branch,
+   * which left it silently unhonoured on the one path where the *success* payload is the
+   * sensitive thing. On the corporate signing call that body is the signing address and the
+   * signature identifier, so a single malformed response wrote both to the logs of a caller that
+   * had explicitly opted out of exactly that.
+   *
+   * Both surfaces are asserted, because the body reaches the logs by two routes: the helper's own
+   * warning, and `getLogContext()` on the thrown error, which the API error handler logs. Closing
+   * only the first moves the leak one layer up instead of fixing it — which is how the same
+   * finding came back twice before.
+   */
+  describe('a 2xx whose body does not parse', () => {
+    const SIGN_URL = 'https://demo.docusign.example/signing/envelope-SENSITIVE-ADDRESS';
+    const SIGNATURE_ID = 'signature-SENSITIVE-IDENTIFIER';
+
+    function malformedSuccess(): void {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(`{"sign_url":"${SIGN_URL}","signature_id":"${SIGNATURE_ID}" <<truncated`, { status: 200 }))
+      );
+    }
+
+    it('keeps the unparsed body out of the log line', async () => {
+      malformedSuccess();
+
+      await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch(() => undefined);
+
+      const emitted = JSON.stringify(logger.warning.mock.calls);
+      expect(emitted).not.toContain('SENSITIVE-ADDRESS');
+      expect(emitted).not.toContain('SENSITIVE-IDENTIFIER');
+      expect(emitted).not.toContain('docusign');
+    });
+
+    /**
+     * The redaction must not cost the diagnosis — but the parse message cannot be what preserves
+     * it. V8 quotes the offending input (`Unexpected token 'S', "SECRET-COUPON" is not valid
+     * JSON`), so logging the message hands over the leading edge of the very body being withheld.
+     * The exception name carries the useful half without the payload.
+     */
+    it('still says what happened and on which operation, without quoting the body', async () => {
+      malformedSuccess();
+
+      await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch(() => undefined);
+
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'org_cla_request_corporate_signature',
+        'Upstream returned invalid JSON response',
+        expect.objectContaining({ status: 200, body_redacted: true, error_name: 'SyntaxError' })
+      );
+    });
+
+    // Nothing relays a producer sentence out of a malformed success, so unlike the non-OK branch
+    // there is nothing here to keep the body for — and keeping it would re-log it at the handler.
+    it('does not carry the body out on the thrown error either', async () => {
+      malformedSuccess();
+
+      const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch((caught: unknown) => caught)) as MicroserviceError;
+
+      expect(error.errorBody).toBeUndefined();
+      expect(JSON.stringify(error.getLogContext())).not.toContain('SENSITIVE-ADDRESS');
+      expect(JSON.stringify(error.getLogContext())).not.toContain('SENSITIVE-IDENTIFIER');
+    });
+
+    // The counterpart: a caller that has not opted out still gets the body, or this change would
+    // have quietly removed a diagnostic from every other consumer of the helper.
+    it('leaves the body in place for a caller that did not ask for redaction', async () => {
+      malformedSuccess();
+
+      const plain = { ...options, redactResponseBodyFromLogs: false };
+      const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', plain).catch((caught: unknown) => caught)) as MicroserviceError;
+
+      expect(error.errorBody).toContain('SENSITIVE-ADDRESS');
+      expect(JSON.stringify(logger.warning.mock.calls)).toContain('SENSITIVE-ADDRESS');
+    });
+  });
 });

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.spec.ts
@@ -97,3 +97,66 @@ describe('gatewayFetch sensitive response redaction', () => {
     expect(JSON.stringify(logger.warning.mock.calls)).not.toContain('SECRET-COUPON');
   });
 });
+
+/**
+ * The narrower option, for callers whose upstream refusals are written for the user: the sentence
+ * only exists in the body, so discarding the body outright would discard the message with it.
+ *
+ * Keeping the body on the error is half a control, not a whole one — `MicroserviceError` puts
+ * `errorBody` in its log context, and the API error handler logs that. The caller owes a
+ * `withoutUpstreamBody` after taking the message out. Documented on the option, and the reason
+ * these two behaviours are pinned separately.
+ */
+describe('gatewayFetch log-only redaction', () => {
+  const req = { apiGatewayToken: 'gateway-token' } as Request;
+  const options = {
+    operation: 'org_cla_request_corporate_signature',
+    service: 'org_cla_service',
+    errorMessage: 'Failed to request the corporate CLA signature',
+    errorCode: 'UPSTREAM_ERROR',
+    method: 'POST' as const,
+    redactResponseBodyFromLogs: true,
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('keeps a non-OK body out of the log', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'refused', lf_username: 'SENSITIVE-HANDLE' }), { status: 403 }))
+    );
+
+    await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch(() => undefined);
+
+    expect(JSON.stringify(logger.warning.mock.calls)).not.toContain('SENSITIVE-HANDLE');
+    expect(logger.warning.mock.calls[0]?.[3]).toMatchObject({ status: 403, body_redacted: true });
+  });
+
+  it('still attaches the body to the error, so the refusal sentence can be relayed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'refused' }), { status: 403 }))
+    );
+
+    const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch((caught: unknown) => caught)) as MicroserviceError;
+
+    expect(error.errorBody).toContain('refused');
+  });
+
+  // Otherwise a caller that set both would quietly get the weaker of the two.
+  it('is superseded by full redaction rather than overriding it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'refused' }), { status: 403 }))
+    );
+
+    const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', { ...options, redactResponseBody: true }).catch(
+      (caught: unknown) => caught
+    )) as MicroserviceError;
+
+    expect(error.errorBody).toBeUndefined();
+  });
+});

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
@@ -29,6 +29,13 @@ export interface GatewayFetchOptions {
    * the error handler's own log line. A caller using this owes it to drop the body once it has
    * taken the message out (`withoutUpstreamBody`), or the leak simply moves one layer up.
    *
+   * Also covers a 2xx whose body does not parse. Nothing relays a refusal from that path — there
+   * is no producer sentence in a malformed success — so the body is dropped there rather than
+   * attached, from the log line and from the thrown error alike. It has to be both: leaving it on
+   * the error would put it back in the log through `getLogContext`. This matters most on the one
+   * call where the *success* payload is the sensitive thing, the corporate signing hand-off, whose
+   * body carries the signing address and the signature identifier.
+   *
    * Ignored when `redactResponseBody` is set, which discards the body outright.
    */
   redactResponseBodyFromLogs?: boolean;
@@ -134,11 +141,22 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
     return JSON.parse(rawBody) as T;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    const truncatedBody = options.redactResponseBody ? undefined : rawBody.slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+    // Either option withholds the body here. `redactResponseBodyFromLogs` keeps a non-OK body on
+    // the error so a refusal can be relayed, but a malformed 2xx has no refusal in it and nothing
+    // reads this one — so it is dropped from the error as well, not merely from the line below.
+    // Kept on the error, `getLogContext` would log it at the handler and undo the redaction.
+    const withheldBody = options.redactResponseBody || options.redactResponseBodyFromLogs;
+    const truncatedBody = withheldBody ? undefined : rawBody.slice(0, UPSTREAM_ERROR_BODY_LIMIT);
     const logContext = {
       status: upstream.status,
       status_text: upstream.statusText,
-      ...(truncatedBody === undefined ? { body_redacted: true } : { body: truncatedBody, error: message }),
+      // Under redaction the parse message is withheld along with the body, because it quotes the
+      // body: V8 reports `Unexpected token 'S', "SECRET-COUPON" is not valid JSON`, so logging it
+      // would hand over the first of exactly the content being redacted. The exception name is
+      // safe — it is a class name — and still distinguishes a parse failure from anything else.
+      ...(truncatedBody === undefined
+        ? { body_redacted: true, error_name: error instanceof Error ? error.name : 'Error' }
+        : { body: truncatedBody, error: message }),
     };
 
     logger.warning(req, options.operation, 'Upstream returned invalid JSON response', logContext);

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
@@ -20,6 +20,18 @@ export interface GatewayFetchOptions {
   bearerToken?: string;
   /** Suppresses upstream response bodies from logs and client-visible error metadata. */
   redactResponseBody?: boolean;
+  /**
+   * Keeps a non-OK upstream body out of the log while still attaching it to the thrown error, for
+   * the callers that must relay a producer-authored refusal to the user — the body is the only
+   * place that sentence exists, so `redactResponseBody` would discard the message along with it.
+   *
+   * Attaching is not the end of the story: `MicroserviceError#getLogContext` puts `errorBody` in
+   * the error handler's own log line. A caller using this owes it to drop the body once it has
+   * taken the message out (`withoutUpstreamBody`), or the leak simply moves one layer up.
+   *
+   * Ignored when `redactResponseBody` is set, which discards the body outright.
+   */
+  redactResponseBodyFromLogs?: boolean;
 }
 
 /**
@@ -84,10 +96,11 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
     const body = options.redactResponseBody
       ? await discardResponseBody(upstream.body)
       : (await upstream.text().catch(() => '')).slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+    const loggableBody = options.redactResponseBodyFromLogs ? undefined : body;
     const logContext = {
       status: upstream.status,
       status_text: upstream.statusText,
-      ...(body === undefined ? { body_redacted: true } : { body }),
+      ...(loggableBody === undefined ? { body_redacted: true } : { body: loggableBody }),
     };
 
     logger.warning(req, options.operation, 'Upstream returned non-OK response', logContext);

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -451,3 +451,24 @@ export function validateRequestBody<T>(body: T | undefined, req: Request, next: 
 
   return true;
 }
+
+/**
+ * Whether a string is an absolute `https:` URL.
+ *
+ * For destinations this application hands to the browser to navigate to. An address that arrives
+ * from upstream and is assigned to `location.href` is executable if its scheme says so — a
+ * `javascript:` value runs in this origin, with this session — so the scheme has to be checked
+ * before the value is passed on, not merely its presence.
+ *
+ * Parsed rather than matched against the text. The browser normalizes before it reads the scheme
+ * — it trims leading whitespace and C0 control characters, and the scheme is case-insensitive —
+ * so `" javascript:…"` and `"JaVaScRiPt:…"` both execute while failing a written-out comparison.
+ * Handing the same parser the value is how this stays in step with what will act on it.
+ */
+export function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/apps/lfx-one/src/server/middleware/error-handler.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/error-handler.middleware.spec.ts
@@ -1,0 +1,161 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * What the API error handler writes to the log, and what it writes to the client.
+ *
+ * These are separate questions for exactly one class of error, and this suite exists for that
+ * class: an upstream refusal whose sentence must be shown to the person who triggered it and must
+ * not be recorded anywhere. The CLA service answers a signing-scope refusal with a body naming the
+ * caller, and a trade-compliance refusal with a body naming the organization's standing. Both are
+ * 403s, both are relayed verbatim to the signatory by design (#1983), and neither may appear in a
+ * log line.
+ *
+ * The assertions below deliberately search the *whole* emitted payload rather than named fields.
+ * This leak has been reported fixed twice while still being live, both times because the fix was
+ * verified by inspecting the field that had been cleaned rather than the line that gets written —
+ * and the refusal was still arriving through a different one. Serializing the payload and
+ * searching it for the sentence is the only assertion that cannot pass while the leak is open.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/logger.service', () => ({
+  logger: { getLastOperation: vi.fn(() => undefined), info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { apiErrorHandler } = await import('./error-handler.middleware');
+const { logger } = await import('../services/logger.service');
+const { MicroserviceError } = await import('../errors');
+const { withoutUpstreamBody, withProducerRefusalMessage } = await import('../services/cla.service');
+const { customErrorSerializer } = await import('../helpers/error-serializer');
+
+/**
+ * Shaped like the real thing and synthetic in every part: a scope refusal names the caller, so a
+ * fixture copied from a real one would put a real person's LF username in this file.
+ */
+const REFUSAL = 'user contributor-xyz is not authorized for project acme-motors-example on behalf of Vendor Corp';
+
+/** The generic sentence `gatewayFetch` builds for a non-OK response, before any relay runs. */
+const GENERIC = 'Failed to request corporate signature: 403 Forbidden';
+
+/** The error the sign path throws: relay the refusal to the client, drop the body it came from. */
+function refusedSigningError(): unknown {
+  const upstream = new MicroserviceError(GENERIC, 403, 'FORBIDDEN', {
+    operation: 'org_cla_request_corporate_signature',
+    service: 'easycla',
+    errorBody: JSON.stringify({ message: REFUSAL }),
+  });
+
+  return withoutUpstreamBody(withProducerRefusalMessage(upstream, 'org_cla_request_corporate_signature', 'easycla'));
+}
+
+function buildReq(): Request {
+  return { id: 'req-1', path: '/api/orgs/acme/lens/cla-groups/sign', method: 'POST', get: () => 'vitest' } as unknown as Request;
+}
+
+function buildRes(): Response & { statusCode?: number; body?: Record<string, unknown> } {
+  const res = {
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body: Record<string, unknown>) {
+      res.body = body;
+      return res;
+    },
+  } as unknown as Response & { statusCode?: number; body?: Record<string, unknown> };
+
+  return res;
+}
+
+function handle(error: unknown): { res: ReturnType<typeof buildRes> } {
+  const res = buildRes();
+  apiErrorHandler(error as Error, buildReq(), res, vi.fn() as unknown as NextFunction);
+  return { res };
+}
+
+/**
+ * Everything the log line would contain, as one searchable string.
+ *
+ * `err` is run through the real Pino serializer rather than stringified directly, because that
+ * serializer is what turns an Error into loggable fields — and it is the component that would
+ * copy a plain public property back onto the payload the handler had just been careful about.
+ * Skipping it would test a payload nobody emits.
+ */
+function emittedLogText(): string {
+  const warning = vi.mocked(logger.warning).mock.calls.at(-1);
+  expect(warning, 'expected a warning to have been logged for a 4xx').toBeDefined();
+
+  const [, operation, message, metadata] = warning as [unknown, string, string, Record<string, unknown>];
+  const { err, ...rest } = metadata;
+
+  return JSON.stringify({ operation, message, err: customErrorSerializer(err), rest });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('apiErrorHandler — a relayed upstream refusal', () => {
+  it('shows the signatory the refusal in the CLA service’s own words', () => {
+    const { res } = handle(refusedSigningError());
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body?.['error']).toBe(REFUSAL);
+  });
+
+  it('writes none of the refusal to the log', () => {
+    handle(refusedSigningError());
+
+    expect(emittedLogText()).not.toContain(REFUSAL);
+  });
+
+  // The two identifiers inside the sentence, asserted on their own. A future refusal format that
+  // this suite's fixture does not predict would still have to get these two past the assertion.
+  it('writes neither the named caller nor the named organization to the log', () => {
+    handle(refusedSigningError());
+
+    const logged = emittedLogText();
+    expect(logged).not.toContain('contributor-xyz');
+    expect(logged).not.toContain('Vendor Corp');
+  });
+
+  it('logs the generic upstream sentence instead, so the failure is still diagnosable', () => {
+    handle(refusedSigningError());
+
+    const logged = emittedLogText();
+    expect(logged).toContain(GENERIC);
+    expect(logged).toContain('org_cla_request_corporate_signature');
+  });
+
+  // The raw body is a second copy of the same sentence, reached by a different route: the handler
+  // spreads `getLogContext()` (which returns `error_body`) and the serializer enumerates the
+  // error's own keys. Dropping the body closes both.
+  it('writes no upstream response body to the log', () => {
+    handle(refusedSigningError());
+
+    expect(emittedLogText()).not.toContain('errorBody');
+    expect(emittedLogText()).not.toContain('error_body":"{');
+  });
+});
+
+describe('apiErrorHandler — errors that set no client message', () => {
+  // The fallback the rest of the app relies on. `toResponse` serving `clientMessage` must not
+  // change what any error that never sets one puts on the wire.
+  it('answers with `message`, exactly as before', () => {
+    const { res } = handle(new MicroserviceError('Upstream is unavailable', 503, 'SERVICE_UNAVAILABLE', { operation: 'op', service: 'svc' }));
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body?.['error']).toBe('Upstream is unavailable');
+  });
+
+  // A 403 the CLA service refused without a usable body: there is nothing to relay, so the
+  // generic sentence is both logged and shown. Proves the relay is not silently swallowing text.
+  it('shows the generic sentence when the refusal carried no message to relay', () => {
+    const bare = new MicroserviceError(GENERIC, 403, 'FORBIDDEN', { operation: 'op', service: 'easycla', errorBody: '<html>gateway</html>' });
+    const { res } = handle(withoutUpstreamBody(withProducerRefusalMessage(bare, 'op', 'easycla')));
+
+    expect(res.body?.['error']).toBe(GENERIC);
+  });
+});

--- a/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
@@ -7,12 +7,19 @@ import express from 'express';
 import type { Server } from 'node:http';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { listClaGroups, getPdfUrl } = vi.hoisted(() => ({ listClaGroups: vi.fn(), getPdfUrl: vi.fn() }));
+const { listClaGroups, getPdfUrl, getSignOptions, requestCorporateSignature } = vi.hoisted(() => ({
+  listClaGroups: vi.fn(),
+  getPdfUrl: vi.fn(),
+  getSignOptions: vi.fn(),
+  requestCorporateSignature: vi.fn(),
+}));
 
 vi.mock('../controllers/org-clas.controller', () => ({
   OrgClasController: class {
     public listClaGroups = listClaGroups;
     public getPdfUrl = getPdfUrl;
+    public getSignOptions = getSignOptions;
+    public requestCorporateSignature = requestCorporateSignature;
   },
 }));
 
@@ -23,7 +30,10 @@ vi.mock('../services/org-role-grants.service', () => ({
     public getAccessAwareOrgs = getAccessAwareOrgs;
   },
 }));
-vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => 'alice', isImpersonating: () => false }));
+// `isImpersonating` is a spy rather than a literal so the write route's guard can be driven from
+// a test. `blockDuringImpersonation` reads it, and it is the only input that guard has.
+const isImpersonating = vi.fn(() => false);
+vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => 'alice', isImpersonating: () => isImpersonating() }));
 vi.mock('../services/logger.service', () => ({
   logger: {
     info: vi.fn(),
@@ -72,9 +82,16 @@ afterAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  isImpersonating.mockReturnValue(false);
   listClaGroups.mockImplementation(ok);
   getPdfUrl.mockImplementation((_req: express.Request, res: express.Response) => {
     res.json({ url: 'https://s3.example.org/ccla.pdf' });
+  });
+  getSignOptions.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ searchTerm: 'cascade', resultCount: 0, truncated: false, results: [] });
+  });
+  requestCorporateSignature.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ signUrl: 'https://signing.example.org/session/1' });
   });
   getAccessAwareOrgs.mockResolvedValue({ resolved: new Map([[GRANTED, { roleSource: 'direct-writer' }]]), upstreamFailed: false });
 });
@@ -118,5 +135,99 @@ describe('org-clas router', () => {
     expect(res.status).toBe(200);
     expect(getPdfUrl).toHaveBeenCalled();
     expect(await res.json()).toEqual({ url: 'https://s3.example.org/ccla.pdf' });
+  });
+});
+
+/**
+ * The corporate signing routes (#1983).
+ *
+ * These assert the guards that stand between a request and a legal document, at the layer where
+ * they are actually wired. A controller test cannot see any of this: it is handed a request that
+ * has already passed everything the router put in front of it, so a guard deleted from the route
+ * line leaves every controller test green.
+ *
+ * There is no environment gate to assert. The module's server-side feature flag was removed
+ * before this work merged, leaving the LaunchDarkly flag as the only gate — and that one hides
+ * the route and the nav without closing the BFF. So what protects these two routes is entirely
+ * what is asserted here: the Org Lens grant on both, and on the write the impersonation guard,
+ * with the CLA service's own signing-authority check beyond them. That is a shorter list than it
+ * was, which makes these cases more load-bearing rather than less.
+ */
+describe('org-clas router — the corporate signing routes', () => {
+  it('refuses the CLA Group search for an org the caller holds no grant on', async () => {
+    const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+    expect(res.status).toBe(403);
+    expect(getSignOptions).not.toHaveBeenCalled();
+  });
+
+  it('admits the CLA Group search for a granted org', async () => {
+    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+    expect(res.status).toBe(200);
+    expect(getSignOptions).toHaveBeenCalled();
+  });
+
+  it('refuses the signature request for an org the caller holds no grant on', async () => {
+    const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}/lens/cla-groups/sign`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectSfid: 'a09410000182dD2AAI', claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111', authorityAcked: true, embargoAcked: true }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The one that matters most on this router.
+   *
+   * The request carries no signatory in its payload — the CLA service records whoever the token
+   * names. Under impersonation that is the wrong person, on a document that cannot be unsigned.
+   * So the guard has to run *before* the controller, not inside it: `not.toHaveBeenCalled()` is
+   * the assertion, and a version that rejected after doing the work would fail it.
+   */
+  it('refuses the signature request while impersonating, before the controller runs', async () => {
+    isImpersonating.mockReturnValue(true);
+
+    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectSfid: 'a09410000182dD2AAI', claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111', authorityAcked: true, embargoAcked: true }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  // The asymmetry is deliberate: choosing a CLA Group is a read and stays available to someone
+  // supporting a customer. Only the write is withheld.
+  it('leaves the CLA Group search available while impersonating', async () => {
+    isImpersonating.mockReturnValue(true);
+
+    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+    expect(res.status).toBe(200);
+    expect(getSignOptions).toHaveBeenCalled();
+  });
+
+  it('admits the signature request for a granted, non-impersonating caller', async () => {
+    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectSfid: 'a09410000182dD2AAI', claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111', authorityAcked: true, embargoAcked: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(requestCorporateSignature).toHaveBeenCalled();
+  });
+
+  // `/sign` and `/sign-options` are literal segments declared ahead of `/:signatureId/pdf-url`.
+  // Declared after it, both would be captured as a signature id and answered by the wrong handler.
+  it('does not let the pdf-url route capture the literal signing segments', async () => {
+    await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+    expect(getSignOptions).toHaveBeenCalled();
+    expect(getPdfUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
@@ -93,6 +93,12 @@ beforeEach(() => {
   requestCorporateSignature.mockImplementation((_req: express.Request, res: express.Response) => {
     res.json({ signUrl: 'https://signing.example.org/session/1' });
   });
+  getSignOptions.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ searchTerm: 'cascade', resultCount: 0, truncated: false, results: [] });
+  });
+  requestCorporateSignature.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ signUrl: 'https://docusign.example.org/session/1' });
+  });
   getAccessAwareOrgs.mockResolvedValue({ resolved: new Map([[GRANTED, { roleSource: 'direct-writer' }]]), upstreamFailed: false });
 });
 
@@ -229,5 +235,113 @@ describe('org-clas router — the corporate signing routes', () => {
 
     expect(getSignOptions).toHaveBeenCalled();
     expect(getPdfUrl).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Choosing a CLA Group to sign for. A read, so impersonation stays allowed — exactly as on the
+   * Me-lens picker, and unlike the write next door.
+   *
+   * The literal `sign-options` segment also has to beat the `:signatureId` route declared after
+   * it; if the declaration order ever flipped, this would arrive at `getPdfUrl` instead.
+   */
+  describe('sign-options', () => {
+    it('refuses a search for an org the caller holds no grant on', async () => {
+      const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(403);
+      expect(getSignOptions).not.toHaveBeenCalled();
+    });
+
+    it('admits a search for a granted org, and not as a signature id', async () => {
+      const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(200);
+      expect(getSignOptions).toHaveBeenCalled();
+      expect(getPdfUrl).not.toHaveBeenCalled();
+    });
+
+    it('refuses a search when the server flag is off, before any grant lookup', async () => {
+      delete process.env['LFX_ORG_LENS_CLA_M3_ENABLED'];
+
+      const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(409);
+      expect(getSignOptions).not.toHaveBeenCalled();
+      expect(getAccessAwareOrgs).not.toHaveBeenCalled();
+    });
+
+    it('stays available while impersonating, because it reads nothing and writes nothing', async () => {
+      isImpersonating.mockReturnValue(true);
+
+      const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(200);
+      expect(getSignOptions).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Opening the signing session: the one write in this router, and the one that creates a
+   * signature record and a DocuSign envelope against a company's legal position.
+   *
+   * Each guard is asserted to run *before* the next thing, not merely to be present. The payload
+   * below is a valid one throughout, so nothing here can pass by being rejected for its shape.
+   */
+  describe('sign', () => {
+    const body = {
+      projectSfid: 'a09410000182dD2AAI',
+      claGroupId: '11111111-1111-4111-8111-111111111111',
+      authorityAcked: true,
+      embargoAcked: true,
+    };
+
+    function sign(orgUid: string): Promise<Response> {
+      return fetch(`${baseUrl}/api/orgs/${orgUid}/lens/cla-groups/sign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it('refuses a signing request for an org the caller holds no grant on', async () => {
+      const res = await sign(UNGRANTED);
+
+      expect(res.status).toBe(403);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+    });
+
+    it('admits a signing request for a granted org', async () => {
+      const res = await sign(GRANTED);
+
+      expect(res.status).toBe(200);
+      expect(requestCorporateSignature).toHaveBeenCalled();
+    });
+
+    // The kill switch has to cover the write, not only the reads: a flag that hides the page while
+    // leaving this route live would let a signature be created in an environment it is off in.
+    it('refuses a signing request when the server flag is off, before any grant lookup', async () => {
+      delete process.env['LFX_ORG_LENS_CLA_M3_ENABLED'];
+
+      const res = await sign(GRANTED);
+
+      expect(res.status).toBe(409);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+      expect(getAccessAwareOrgs).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The payload carries no caller identity — the signatory is whoever the gateway token names.
+     * Under impersonation that is the wrong person, on a corporate agreement, and there is nothing
+     * in the record afterwards to say so. Refused before the controller runs, so no part of the
+     * request is acted on.
+     */
+    it('refuses a signing request while impersonating, before the controller runs', async () => {
+      isImpersonating.mockReturnValue(true);
+
+      const res = await sign(GRANTED);
+
+      expect(res.status).toBe(403);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
@@ -142,100 +142,20 @@ describe('org-clas router', () => {
     expect(getPdfUrl).toHaveBeenCalled();
     expect(await res.json()).toEqual({ url: 'https://s3.example.org/ccla.pdf' });
   });
-});
-
-/**
- * The corporate signing routes (#1983).
- *
- * These assert the guards that stand between a request and a legal document, at the layer where
- * they are actually wired. A controller test cannot see any of this: it is handed a request that
- * has already passed everything the router put in front of it, so a guard deleted from the route
- * line leaves every controller test green.
- *
- * There is no environment gate to assert. The module's server-side feature flag was removed
- * before this work merged, leaving the LaunchDarkly flag as the only gate — and that one hides
- * the route and the nav without closing the BFF. So what protects these two routes is entirely
- * what is asserted here: the Org Lens grant on both, and on the write the impersonation guard,
- * with the CLA service's own signing-authority check beyond them. That is a shorter list than it
- * was, which makes these cases more load-bearing rather than less.
- */
-describe('org-clas router — the corporate signing routes', () => {
-  it('refuses the CLA Group search for an org the caller holds no grant on', async () => {
-    const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}/lens/cla-groups/sign-options?search=cascade`);
-
-    expect(res.status).toBe(403);
-    expect(getSignOptions).not.toHaveBeenCalled();
-  });
-
-  it('admits the CLA Group search for a granted org', async () => {
-    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
-
-    expect(res.status).toBe(200);
-    expect(getSignOptions).toHaveBeenCalled();
-  });
-
-  it('refuses the signature request for an org the caller holds no grant on', async () => {
-    const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}/lens/cla-groups/sign`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectSfid: 'a09410000182dD2AAI', claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111', authorityAcked: true, embargoAcked: true }),
-    });
-
-    expect(res.status).toBe(403);
-    expect(requestCorporateSignature).not.toHaveBeenCalled();
-  });
 
   /**
-   * The one that matters most on this router.
+   * The corporate signing routes (#1983), asserted at the layer where their guards are wired. A
+   * controller test cannot see any of this: it is handed a request that has already passed
+   * everything the router put in front of it, so a guard deleted from a route line would leave
+   * every controller test green.
    *
-   * The request carries no signatory in its payload — the CLA service records whoever the token
-   * names. Under impersonation that is the wrong person, on a document that cannot be unsigned.
-   * So the guard has to run *before* the controller, not inside it: `not.toHaveBeenCalled()` is
-   * the assertion, and a version that rejected after doing the work would fail it.
+   * There is no environment gate to assert. The module's server-side flag was removed on the
+   * parent branch, leaving the LaunchDarkly `org-lens-cla-m3-enabled` flag as the only one — and
+   * that hides the route and the nav without closing the BFF. So what stands in front of these
+   * two routes is exactly what is asserted below: the Org Lens grant on both, the impersonation
+   * guard on the write, and the CLA service's own signing-authority check past them. A shorter
+   * list than it was, which makes each of these cases more load-bearing rather than less.
    */
-  it('refuses the signature request while impersonating, before the controller runs', async () => {
-    isImpersonating.mockReturnValue(true);
-
-    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectSfid: 'a09410000182dD2AAI', claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111', authorityAcked: true, embargoAcked: true }),
-    });
-
-    expect(res.status).toBe(403);
-    expect(requestCorporateSignature).not.toHaveBeenCalled();
-  });
-
-  // The asymmetry is deliberate: choosing a CLA Group is a read and stays available to someone
-  // supporting a customer. Only the write is withheld.
-  it('leaves the CLA Group search available while impersonating', async () => {
-    isImpersonating.mockReturnValue(true);
-
-    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
-
-    expect(res.status).toBe(200);
-    expect(getSignOptions).toHaveBeenCalled();
-  });
-
-  it('admits the signature request for a granted, non-impersonating caller', async () => {
-    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectSfid: 'a09410000182dD2AAI', claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111', authorityAcked: true, embargoAcked: true }),
-    });
-
-    expect(res.status).toBe(200);
-    expect(requestCorporateSignature).toHaveBeenCalled();
-  });
-
-  // `/sign` and `/sign-options` are literal segments declared ahead of `/:signatureId/pdf-url`.
-  // Declared after it, both would be captured as a signature id and answered by the wrong handler.
-  it('does not let the pdf-url route capture the literal signing segments', async () => {
-    await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
-
-    expect(getSignOptions).toHaveBeenCalled();
-    expect(getPdfUrl).not.toHaveBeenCalled();
-  });
 
   /**
    * Choosing a CLA Group to sign for. A read, so impersonation stays allowed — exactly as on the
@@ -258,16 +178,6 @@ describe('org-clas router — the corporate signing routes', () => {
       expect(res.status).toBe(200);
       expect(getSignOptions).toHaveBeenCalled();
       expect(getPdfUrl).not.toHaveBeenCalled();
-    });
-
-    it('refuses a search when the server flag is off, before any grant lookup', async () => {
-      delete process.env['LFX_ORG_LENS_CLA_M3_ENABLED'];
-
-      const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
-
-      expect(res.status).toBe(409);
-      expect(getSignOptions).not.toHaveBeenCalled();
-      expect(getAccessAwareOrgs).not.toHaveBeenCalled();
     });
 
     it('stays available while impersonating, because it reads nothing and writes nothing', async () => {
@@ -315,18 +225,6 @@ describe('org-clas router — the corporate signing routes', () => {
 
       expect(res.status).toBe(200);
       expect(requestCorporateSignature).toHaveBeenCalled();
-    });
-
-    // The kill switch has to cover the write, not only the reads: a flag that hides the page while
-    // leaving this route live would let a signature be created in an environment it is off in.
-    it('refuses a signing request when the server flag is off, before any grant lookup', async () => {
-      delete process.env['LFX_ORG_LENS_CLA_M3_ENABLED'];
-
-      const res = await sign(GRANTED);
-
-      expect(res.status).toBe(409);
-      expect(requestCorporateSignature).not.toHaveBeenCalled();
-      expect(getAccessAwareOrgs).not.toHaveBeenCalled();
     });
 
     /**

--- a/apps/lfx-one/src/server/routes/org-clas.route.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.ts
@@ -21,11 +21,21 @@ router.get('/:orgUid/lens/cla-groups', requireOrgLensAccess, (req, res, next) =>
 // caller identity in the payload — the signatory is whoever the token names, which under
 // impersonation is the wrong person and cannot be corrected afterwards.
 //
-// No server-side environment gate on either route, including the write. The module's only gate is
-// the LaunchDarkly `org-lens-cla-m3-enabled` flag, which hides the route and the nav but does not
-// close the BFF; what protects these two is the Org Lens grant, and on the write the
-// impersonation guard and the CLA service's own signing-authority check. An env gate here was
-// removed deliberately for costing a GitOps round-trip per rollout while withholding nothing.
+// Neither route carries a server-side environment gate, including the write, and the LaunchDarkly
+// `org-lens-cla-m3-enabled` flag is not one either: it is an Angular `canMatch` guard, so it hides
+// the route and the nav in the browser and leaves the BFF mounted. These two are protected by the
+// session, the Org Lens grant on the organization, `blockDuringImpersonation` on the write, and
+// the CLA service's own signing-authority and trade-compliance checks.
+//
+// A server-side flag check on the write was considered when this landed and deliberately not
+// added. It is not an authorization boundary: the same corporate signature can be requested by the
+// same caller through the ACS-authorized EasyCLA v4 API and through the Corporate CLA Console, so
+// a check here withholds no capability — and it would cost a GitOps round-trip and a pod roll per
+// rollout, which is why the env gate was removed with the detail page in the first place.
+//
+// The consequence to know, because it is operational rather than theoretical: the flag is not a
+// complete kill switch for this path. Turning it off stops the UI reaching the route; it does not
+// stop a direct call. Only a deliberate caller who already holds the grant can make that matter.
 router.get('/:orgUid/lens/cla-groups/sign-options', requireOrgLensAccess, (req, res, next) => orgClasController.getSignOptions(req, res, next));
 router.post('/:orgUid/lens/cla-groups/sign', requireOrgLensAccess, blockDuringImpersonation, (req, res, next) =>
   orgClasController.requestCorporateSignature(req, res, next)

--- a/apps/lfx-one/src/server/routes/org-clas.route.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.ts
@@ -4,12 +4,33 @@
 import { Router } from 'express';
 
 import { OrgClasController } from '../controllers/org-clas.controller';
+import { blockDuringImpersonation } from '../middleware/impersonation-readonly.middleware';
 import { requireOrgLensAccess } from '../middleware/require-org-lens-access.middleware';
 
 const router = Router();
 const orgClasController = new OrgClasController();
 
 router.get('/:orgUid/lens/cla-groups', requireOrgLensAccess, (req, res, next) => orgClasController.listClaGroups(req, res, next));
+
+// Corporate CLA signing hand-off (#1983). Declared ahead of the `:signatureId` routes below so
+// the literal segments are not captured as a signature id.
+//
+// Picking the CLA Group is a read and stays available while impersonating. Opening the signing
+// session is guarded, and for the plainest form of the reason the read-only rule exists: it
+// creates a signature record and a DocuSign envelope against a company's legal position, with no
+// caller identity in the payload — the signatory is whoever the token names, which under
+// impersonation is the wrong person and cannot be corrected afterwards.
+//
+// No server-side environment gate on either route, including the write. The module's only gate is
+// the LaunchDarkly `org-lens-cla-m3-enabled` flag, which hides the route and the nav but does not
+// close the BFF; what protects these two is the Org Lens grant, and on the write the
+// impersonation guard and the CLA service's own signing-authority check. An env gate here was
+// removed deliberately for costing a GitOps round-trip per rollout while withholding nothing.
+router.get('/:orgUid/lens/cla-groups/sign-options', requireOrgLensAccess, (req, res, next) => orgClasController.getSignOptions(req, res, next));
+router.post('/:orgUid/lens/cla-groups/sign', requireOrgLensAccess, blockDuringImpersonation, (req, res, next) =>
+  orgClasController.requestCorporateSignature(req, res, next)
+);
+
 router.get('/:orgUid/lens/cla-groups/:signatureId/pdf-url', requireOrgLensAccess, (req, res, next) => orgClasController.getPdfUrl(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -46,6 +46,7 @@ import {
   recordedGithubIdentity,
   toClaGroupSearchResponse,
   toMyClaAgreement,
+  withoutUpstreamBody,
 } from './cla.service';
 
 const req = {} as unknown as Request;
@@ -1405,5 +1406,67 @@ describe('producerMessageFrom', () => {
     expect(producerMessageFrom(JSON.stringify({ code: '403' }))).toBeNull();
     expect(producerMessageFrom(JSON.stringify({ message: '   ' }))).toBeNull();
     expect(producerMessageFrom({ message: 'an object, not the raw text gatewayFetch carries' })).toBeNull();
+  });
+});
+
+/**
+ * The counterpart to reading a message out of an upstream body: getting rid of the body once the
+ * message has been taken out of it.
+ *
+ * It exists because `MicroserviceError#getLogContext` returns `error_body`, and the API error
+ * handler spreads that into the line it logs. An error that still carries an upstream body
+ * therefore logs it wherever it is finally handled, no matter how the fetch that produced it was
+ * configured — so the drop has to happen on the error, not only at the fetch.
+ */
+describe('withoutUpstreamBody', () => {
+  it('keeps the message, status and code while dropping the body', () => {
+    const error = new MicroserviceError('This organization requires additional review', 403, 'UPSTREAM_ERROR', {
+      operation: 'org_cla_request_corporate_signature',
+      service: 'org_cla_service',
+      path: '/v4/self-serve/request-corporate-signature',
+      originalMessage: 'HTTP 403: Forbidden',
+      errorBody: JSON.stringify({ message: 'This organization requires additional review', lf_username: 'SENSITIVE-HANDLE' }),
+    });
+
+    const scrubbed = withoutUpstreamBody(error) as MicroserviceError;
+
+    expect(scrubbed.message).toBe('This organization requires additional review');
+    expect(scrubbed.statusCode).toBe(403);
+    expect(scrubbed.code).toBe('UPSTREAM_ERROR');
+    expect(scrubbed.operation).toBe('org_cla_request_corporate_signature');
+    expect(scrubbed.service).toBe('org_cla_service');
+    expect(scrubbed.path).toBe('/v4/self-serve/request-corporate-signature');
+    expect(scrubbed.originalMessage).toBe('HTTP 403: Forbidden');
+    expect(scrubbed.errorBody).toBeUndefined();
+  });
+
+  // The log line the error handler emits is the thing this protects, so that is what is asserted —
+  // not merely the absence of the field.
+  it('leaves nothing from the body in the log context', () => {
+    const error = new MicroserviceError('Refused', 403, 'UPSTREAM_ERROR', {
+      errorBody: JSON.stringify({ sanction_status: 'pending_review' }),
+    });
+
+    expect(JSON.stringify(error.getLogContext())).toContain('pending_review');
+    expect(JSON.stringify((withoutUpstreamBody(error) as MicroserviceError).getLogContext())).not.toContain('pending_review');
+  });
+
+  // A transport failure is declared by the site that threw it and is read by the client as "our
+  // connection broke" — rebuilding the error must not silently reclassify that.
+  it('preserves a declared transport failure', () => {
+    const error = new MicroserviceError('Gateway unreachable', 502, 'NETWORK_ERROR', {
+      errorBody: 'connection reset',
+      transportFailure: true,
+    });
+
+    expect((withoutUpstreamBody(error) as MicroserviceError).toResponse()['transport']).toBe(true);
+  });
+
+  it('returns anything without a body untouched, rather than rebuilding it', () => {
+    const withoutBody = new MicroserviceError('Refused', 403, 'UPSTREAM_ERROR', { service: 'org_cla_service' });
+    const notOurs = new Error('boom');
+
+    expect(withoutUpstreamBody(withoutBody)).toBe(withoutBody);
+    expect(withoutUpstreamBody(notOurs)).toBe(notOurs);
   });
 });

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -1190,7 +1190,32 @@ describe('ClaService.prepareSign', () => {
 
     // The endpoint ships no reason code, so its prose is the only thing there is to say. Relaying
     // "403 Forbidden" instead would tell the contributor nothing they can act on.
-    await expect(new ClaService().prepareSign(prepareReq, '12345', CLA_GROUP_ID)).rejects.toMatchObject({ statusCode: 403, message: refusal });
+    //
+    // It arrives as `clientMessage`, not `message`. The sentence is a statement about who the
+    // caller is, and `message` is what the API error handler formats into its log line — so the
+    // relay writes the part that is shown and leaves the part that is recorded generic.
+    await expect(new ClaService().prepareSign(prepareReq, '12345', CLA_GROUP_ID)).rejects.toMatchObject({
+      statusCode: 403,
+      clientMessage: refusal,
+    });
+  });
+
+  it('keeps the relayed refusal out of the message the log line is built from', async () => {
+    const refusal = 'the provided identity does not belong to the authenticated user';
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to prepare the CLA signing session: 403 Forbidden', 403, 'FORBIDDEN', {
+        service: 'cla_service',
+        errorBody: JSON.stringify({ code: '403', message: refusal }),
+      })
+    );
+
+    const thrown = await new ClaService()
+      .prepareSign(prepareReq, '12345', CLA_GROUP_ID)
+      .then(() => null)
+      .catch((error: unknown) => error as Error);
+
+    expect(thrown?.message).not.toContain(refusal);
+    expect(thrown?.message).toBe('Failed to prepare the CLA signing session: 403 Forbidden');
   });
 
   it('does not derive a reason code from the refusal prose', async () => {

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -172,6 +172,36 @@ describe('claReturnUrl', () => {
   it('refuses a protocol that is neither http nor https', () => {
     expect(() => claReturnUrl(reqWithHost('app.lfx.dev', 'javascript'))).toThrow(MicroserviceError);
   });
+
+  it('leaves the URL unchanged when no query is asked for', () => {
+    expect(claReturnUrl(reqWithHost('app.lfx.dev'), '/org/easycla')).toBe('https://app.lfx.dev/org/easycla');
+  });
+
+  it('names the organization on the address, so the page does not have to guess it', () => {
+    expect(claReturnUrl(reqWithHost('app.lfx.dev'), '/org/easycla', { org: '0014100000Te0OKAAZ' })).toBe(
+      'https://app.lfx.dev/org/easycla?org=0014100000Te0OKAAZ'
+    );
+  });
+
+  // The whole point of routing this through `searchParams` rather than concatenating: EasyCLA
+  // stores the value and later redirects to it verbatim, so a value that could close the query and
+  // append its own path would turn the hand-off into an open redirect a second way.
+  it.each([
+    ['0014100000Te0OKAAZ#@evil.example.com', 'evil.example.com'],
+    ['0014100000Te0OKAAZ&next=https://evil.example.com', 'evil.example.com'],
+    ['../../evil', 'evil'],
+  ])('encodes %p so it cannot break out of the query string', (value, smuggled) => {
+    const url = claReturnUrl(reqWithHost('app.lfx.dev'), '/org/easycla', { org: value });
+
+    expect(new URL(url).origin).toBe('https://app.lfx.dev');
+    expect(new URL(url).pathname).toBe('/org/easycla');
+    expect(new URL(url).searchParams.get('org')).toBe(value);
+    expect(url).not.toContain(`/${smuggled}`);
+  });
+
+  it('still refuses an untrusted host when a query is supplied', () => {
+    expect(() => claReturnUrl(reqWithHost('evil.example.com'), '/org/easycla', { org: '0014100000Te0OKAAZ' })).toThrow(MicroserviceError);
+  });
 });
 
 describe('normalizeGithubId', () => {

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -161,8 +161,16 @@ const PREVIEW_RETURN_HOSTNAME = /^ui-pr-\d{1,10}\.dev\.v2\.cluster\.linuxfound\.
  * EasyCLA page for the corporate hand-off (#1983). A parameter rather than a second function
  * because the host check above is the security-critical part, and it must exist exactly once.
  * Callers pass a shared path constant, never a request-derived value.
+ *
+ * `query` is the one place a request-derived value may enter, and it is kept out of `path`
+ * deliberately: the corporate hand-off has to name the organization it was opened for, because the
+ * signer comes back through a cross-site navigation and the selected organization survives only in
+ * a `SameSite=Lax` cookie. A bare path leaves the page to guess, and it guesses the first
+ * organization in the viewer's list. Written through `searchParams`, so a value cannot break out of
+ * the query string and append a path or a second origin to a URL that EasyCLA stores and later
+ * redirects to verbatim.
  */
-export function claReturnUrl(req: Request, path: string = MY_CLAS_PATH): string {
+export function claReturnUrl(req: Request, path: string = MY_CLAS_PATH, query?: Readonly<Record<string, string>>): string {
   const host = req.get('host');
   if (!host) {
     throw new MicroserviceError('Cannot derive the CLA return URL: request has no Host header', 500, 'RETURN_URL_UNRESOLVABLE', { service: SERVICE });
@@ -185,7 +193,12 @@ export function claReturnUrl(req: Request, path: string = MY_CLAS_PATH): string 
     throw new MicroserviceError('Cannot derive the CLA return URL: untrusted Host header', 500, 'RETURN_URL_UNTRUSTED', { service: SERVICE });
   }
 
-  return `${req.protocol}://${host}${path}`;
+  const url = new URL(`${req.protocol}://${host}${path}`);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  return url.toString();
 }
 
 // Identity keys the CLA service reports as `"<type>:<value>"`, both in the verified `identity`

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -389,12 +389,20 @@ export function producerMessageFrom(errorBody: unknown): string | null {
 }
 
 /**
- * Re-labels an ownership refusal with the message the CLA service sent, so that message —
- * rather than "403 Forbidden" — is what the contributor is shown.
+ * Carries the CLA service's refusal to the client as `clientMessage`, so that sentence — rather
+ * than "403 Forbidden" — is what the contributor is shown.
  *
  * Scoped to 403 on purpose. That is the one status whose body is a statement about the
  * contributor's own identity and therefore worth repeating verbatim; relaying the prose of a
  * 500 would put upstream internals on screen for something they can do nothing about.
+ *
+ * **`message` is deliberately left alone**, and that is the point of the field. The refusal is
+ * exactly the text that must not be logged — a scope refusal names the caller, a trade-compliance
+ * refusal names the organization's standing — and `message` is logged three ways over: the error
+ * handler formats `API error: ${error.message}`, passes the error itself as `err`, and Pino's
+ * serializer reads `.message` off it. Writing the refusal into `message` therefore published it
+ * to the log line no matter what was done to the body afterwards. `clientMessage` reaches
+ * `toResponse` and nothing else; see `BaseApiError`.
  *
  * Exported for the corporate hand-off (#1983), which lands in the same window: the CLA service
  * answers a trade-compliance refusal with a 403 whose body names the reason and the support
@@ -407,24 +415,29 @@ export function withProducerRefusalMessage(error: unknown, operation = 'cla_prep
   const message = producerMessageFrom(error.errorBody);
   if (!message) return error;
 
-  return new MicroserviceError(message, error.statusCode, error.code, {
+  return new MicroserviceError(error.message, error.statusCode, error.code, {
     operation,
     service,
     errorBody: error.errorBody,
+    clientMessage: message,
   });
 }
 
 /**
- * The same error with the raw upstream body dropped, keeping its message, status and code.
+ * The same error with the raw upstream body dropped, keeping its status, code and client message.
  *
- * `MicroserviceError#getLogContext` returns `error_body`, and the API error handler spreads that
- * into its log line — so an error carrying an upstream body logs that body wherever it is finally
- * handled, however carefully the fetch that produced it was configured. Compose this after
- * anything that needed to read the body (`withProducerRefusalMessage`) and before the throw, on
- * the paths whose upstream refusals name a person or an organization's compliance standing.
+ * `MicroserviceError#getLogContext` returns `error_body` and the API error handler spreads that
+ * into its log line; Pino's error serializer copies it a second time, since it enumerates the
+ * error's own string keys. So an error carrying an upstream body logs that body wherever it is
+ * finally handled, however carefully the fetch that produced it was configured. Compose this
+ * after anything that needed to read the body (`withProducerRefusalMessage`) and before the
+ * throw, on the paths whose upstream refusals name a person or an organization's standing.
  *
- * The message survives, which is the point: the sentence written for the user is kept and the
- * record it was extracted from is not.
+ * This drops the body only. It is not on its own sufficient to keep a refusal out of the logs,
+ * because the sentence extracted from the body is the sensitive part and dropping its container
+ * does nothing about it — `withProducerRefusalMessage` putting that sentence in `clientMessage`
+ * rather than `message` is the half that handles it. Both are needed: one for the record, one
+ * for the sentence.
  */
 export function withoutUpstreamBody(error: unknown): unknown {
   if (!(error instanceof MicroserviceError) || error.errorBody === undefined) return error;
@@ -435,6 +448,7 @@ export function withoutUpstreamBody(error: unknown): unknown {
     path: error.path,
     originalMessage: error.originalMessage,
     transportFailure: error.transportFailure,
+    clientMessage: error.clientMessage,
   });
 }
 

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -414,6 +414,30 @@ export function withProducerRefusalMessage(error: unknown, operation = 'cla_prep
   });
 }
 
+/**
+ * The same error with the raw upstream body dropped, keeping its message, status and code.
+ *
+ * `MicroserviceError#getLogContext` returns `error_body`, and the API error handler spreads that
+ * into its log line — so an error carrying an upstream body logs that body wherever it is finally
+ * handled, however carefully the fetch that produced it was configured. Compose this after
+ * anything that needed to read the body (`withProducerRefusalMessage`) and before the throw, on
+ * the paths whose upstream refusals name a person or an organization's compliance standing.
+ *
+ * The message survives, which is the point: the sentence written for the user is kept and the
+ * record it was extracted from is not.
+ */
+export function withoutUpstreamBody(error: unknown): unknown {
+  if (!(error instanceof MicroserviceError) || error.errorBody === undefined) return error;
+
+  return new MicroserviceError(error.message, error.statusCode, error.code, {
+    operation: error.operation,
+    service: error.service,
+    path: error.path,
+    originalMessage: error.originalMessage,
+    transportFailure: error.transportFailure,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -76,8 +76,15 @@ export { claServiceBaseUrl };
 const KNOWN_MATCH_TYPES = new Set<string>(['claGroup', 'project', 'organization', 'repository']);
 const KNOWN_ORG_SOURCES = new Set<string>(['github', 'gitlab', 'gerrit']);
 
-/** Maps one upstream search result onto the option the picker and the hand-off consume. */
-function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
+/**
+ * Maps one upstream search result onto the option the picker and the hand-off consume.
+ *
+ * Exported for the Org Lens sign-options route (#1983), which wraps rather than replaces it: it
+ * calls this for the shared shape and appends `projectSfid` afterwards, so the Me-lens response
+ * stays byte-identical. Do not add an Org-Lens-only field here — see the note on Salesforce ids
+ * in `toClaGroupSearchResponse` below.
+ */
+export function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
   return {
     claGroupId: result.claGroupID ?? '',
     projectName: result.projectName || undefined,
@@ -103,8 +110,14 @@ function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
  * The envelope is mirrored rather than flattened to an array because `truncated` describes the
  * result *set* — a cap cannot ride inside one of the results. The one field renamed is the
  * identifier (`claGroupID` → `claGroupId`), so Angular is not made to carry two spellings of the
- * same UUID. Salesforce ids are deliberately not carried across. ICLA/CCLA enablement flags are
- * forwarded for Gerrit contract-type routing (#2066); the GitHub prepare-sign path does not branch on them.
+ * same UUID. ICLA/CCLA enablement flags are forwarded for Gerrit contract-type routing (#2066);
+ * the GitHub prepare-sign path does not branch on them.
+ *
+ * Salesforce ids are not carried across *here*, because this envelope's consumer — the Me-lens
+ * picker and its hand-off — is keyed on `claGroupId` alone, and an unread field still ships to
+ * the browser inside the transferred state. The corporate hand-off does need the project id, and
+ * carries it on its own path: `OrgClaService.getSignOptions` appends `projectSfid` after calling
+ * `toClaGroupOption`. Moving it in here would put it in this response too, for no consumer.
  *
  * `searchTerm` falls back to the term the BFF actually sent, so the client can always tell which
  * query a set belongs to even if the producer echoes nothing.
@@ -143,8 +156,13 @@ const PREVIEW_RETURN_HOSTNAME = /^ui-pr-\d{1,10}\.dev\.v2\.cluster\.linuxfound\.
  * Because that makes the origin request-controlled, the host is checked against our own origins
  * before it is handed onward: EasyCLA stores this value and later redirects to it verbatim, so an
  * unchecked forged Host would turn a trusted hand-off into an open redirect.
+ *
+ * `path` selects where the signer lands: the contributor's own CLAs by default, or the Org Lens
+ * EasyCLA page for the corporate hand-off (#1983). A parameter rather than a second function
+ * because the host check above is the security-critical part, and it must exist exactly once.
+ * Callers pass a shared path constant, never a request-derived value.
  */
-export function claReturnUrl(req: Request): string {
+export function claReturnUrl(req: Request, path: string = MY_CLAS_PATH): string {
   const host = req.get('host');
   if (!host) {
     throw new MicroserviceError('Cannot derive the CLA return URL: request has no Host header', 500, 'RETURN_URL_UNRESOLVABLE', { service: SERVICE });
@@ -167,7 +185,7 @@ export function claReturnUrl(req: Request): string {
     throw new MicroserviceError('Cannot derive the CLA return URL: untrusted Host header', 500, 'RETURN_URL_UNTRUSTED', { service: SERVICE });
   }
 
-  return `${req.protocol}://${host}${MY_CLAS_PATH}`;
+  return `${req.protocol}://${host}${path}`;
 }
 
 // Identity keys the CLA service reports as `"<type>:<value>"`, both in the verified `identity`
@@ -377,16 +395,21 @@ export function producerMessageFrom(errorBody: unknown): string | null {
  * Scoped to 403 on purpose. That is the one status whose body is a statement about the
  * contributor's own identity and therefore worth repeating verbatim; relaying the prose of a
  * 500 would put upstream internals on screen for something they can do nothing about.
+ *
+ * Exported for the corporate hand-off (#1983), which lands in the same window: the CLA service
+ * answers a trade-compliance refusal with a 403 whose body names the reason and the support
+ * route, and answers a missing signing authority with a 403 too. `operation` and `service` are
+ * parameters so the relabelled error keeps the caller's own log identity.
  */
-function withProducerRefusalMessage(error: unknown): unknown {
+export function withProducerRefusalMessage(error: unknown, operation = 'cla_prepare_sign', service = SERVICE): unknown {
   if (!(error instanceof MicroserviceError) || error.statusCode !== 403) return error;
 
   const message = producerMessageFrom(error.errorBody);
   if (!message) return error;
 
   return new MicroserviceError(message, error.statusCode, error.code, {
-    operation: 'cla_prepare_sign',
-    service: SERVICE,
+    operation,
+    service,
     errorBody: error.errorBody,
   });
 }

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Request } from 'express';
 
+import type * as ClaIdentifierUtils from '../../../../../packages/shared/src/utils/cla-identifier.utils';
 import type { MicroserviceError as MicroserviceErrorType } from '../errors';
 import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
 
@@ -13,6 +14,15 @@ const { gatewayFetch, isImpersonating, loggerWarning } = vi.hoisted(() => ({
   isImpersonating: vi.fn(() => false),
   loggerWarning: vi.fn(),
 }));
+
+// The shared utils barrel reaches Angular through unrelated siblings (form/meeting/vote), which the
+// node test environment cannot compile. Only the real identifier helper is wanted here — pulled
+// from its own module via `importActual` rather than restated, so the comparison under test is the
+// one that ships. Same approach `rewards-subject.spec.ts` uses for the Salesforce pattern.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await vi.importActual<typeof ClaIdentifierUtils>('../../../../../packages/shared/src/utils/cla-identifier.utils');
+  return { isSameClaGroup: actual.isSameClaGroup, canonicalClaGroupId: actual.canonicalClaGroupId };
+});
 
 vi.mock('../helpers/gateway-fetch.helper', () => ({ gatewayFetch }));
 vi.mock('../helpers/cla-service-url.helper', () => ({ claServiceBaseUrl: () => 'https://gw.example.org/cla-service' }));
@@ -818,6 +828,20 @@ describe('OrgClaService.requestCorporateSignature', () => {
     gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: 'a-different-cla-group-uuid' });
 
     await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/different CLA Group/);
+  });
+
+  // The request boundary accepts hyphenated and unhyphenated spellings in either case; the producer
+  // answers in its own. Comparing raw refuses a perfectly valid session after the envelope exists,
+  // which is worse than not checking at all — so the accepted spellings are pinned here.
+  it.each([
+    ['unhyphenated request', CLA_GROUP_ID.replaceAll('-', '')],
+    ['upper-case request', CLA_GROUP_ID.toUpperCase()],
+  ])('accepts the canonical echo against an %s', async (_label, claGroupId) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: CLA_GROUP_ID });
+
+    expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest({ claGroupId }))).toEqual({
+      signUrl: 'https://docusign.example.org/session/1',
+    });
   });
 
   it('does not hand back the signing address when the CLA Group does not match', async () => {

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -817,7 +817,18 @@ describe('OrgClaService.requestCorporateSignature', () => {
     });
     gatewayFetch.mockRejectedValueOnce(refusal);
 
-    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/trade compliance review/);
+    const thrown = await new OrgClaService()
+      .requestCorporateSignature(signReq(), ORG_UID, signRequest())
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    // `clientMessage`, not `message`: the sentence is what the signatory reads and `toResponse`
+    // serves it, while `message` — the one the error handler formats into its log line — stays
+    // generic. Asserting `rejects.toThrow(/…/)` here would match on `message` and so would pass
+    // for the version of this code that logged the refusal.
+    expect((thrown as MicroserviceErrorType).clientMessage).toMatch(/trade compliance review/);
+    expect((thrown as MicroserviceErrorType).toResponse()['error']).toMatch(/trade compliance review/);
+    expect((thrown as MicroserviceErrorType).message).not.toMatch(/trade compliance review/);
   });
 
   /**
@@ -856,10 +867,16 @@ describe('OrgClaService.requestCorporateSignature', () => {
       .then(() => null)
       .catch((error: unknown) => error);
 
-    expect((thrown as MicroserviceErrorType).message).toBe(refusal);
+    expect((thrown as MicroserviceErrorType).clientMessage).toBe(refusal);
     expect((thrown as MicroserviceErrorType).errorBody).toBeUndefined();
     // The API error handler spreads this into its log line, so it is the thing that must be clean.
     expect(JSON.stringify((thrown as MicroserviceErrorType).getLogContext())).not.toContain('sanction_status');
+    // And the sentence itself, which the log line carries separately as `API error: ${message}`.
+    expect((thrown as MicroserviceErrorType).message).not.toContain(refusal);
+    // The whole error as any key-enumerating serializer would see it — `customErrorSerializer`
+    // copies every own string key onto the log payload, so a client message held under one would
+    // be written straight back into the line the two assertions above just cleaned.
+    expect(JSON.stringify({ ...(thrown as object), message: (thrown as Error).message })).not.toContain(refusal);
   });
 
   // Nothing about the body-dropping is 403-specific: a 5xx body from this endpoint is no more

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -814,6 +814,37 @@ describe('OrgClaService.requestCorporateSignature', () => {
     await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/no usable corporate signing session/);
   });
 
+  // The client assigns this value to `document.location.href`, so a scheme that executes rather
+  // than navigates would run in this origin at the moment the signatory expects to be sent away.
+  // The whitespace and mixed-case entries are the ones a written-out comparison misses: the
+  // browser trims and lowercases the scheme before acting on it, so both of those execute.
+  it.each([
+    ['javascript:alert(document.cookie)'],
+    ['  javascript:alert(1)'],
+    ['\tjavascript:alert(1)'],
+    ['JaVaScRiPt:alert(1)'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['http://docusign.example.org/session/1'],
+    ['/session/1'],
+    ['not a url at all'],
+  ])('refuses a signing address of %p rather than handing it to the browser', async (signUrl) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: signUrl });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/unusable corporate signing address/);
+  });
+
+  // The address is a capability — it opens a named person's agreement — and a hostile one should
+  // not be written anywhere either. Only its scheme is recorded.
+  it('keeps the refused address out of the logs', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: 'javascript:alert(document.cookie)' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow();
+
+    const logged = JSON.stringify(loggerWarning.mock.calls);
+    expect(logged).not.toContain('alert(document.cookie)');
+    expect(logged).toContain('javascript');
+  });
+
   it('fails when upstream returned no signature identifier', async () => {
     gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, signature_id: '' });
 

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -8,13 +8,17 @@ import type { Request } from 'express';
 import type { MicroserviceError as MicroserviceErrorType } from '../errors';
 import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
 
-const { gatewayFetch, isImpersonating } = vi.hoisted(() => ({ gatewayFetch: vi.fn(), isImpersonating: vi.fn(() => false) }));
+const { gatewayFetch, isImpersonating, loggerWarning } = vi.hoisted(() => ({
+  gatewayFetch: vi.fn(),
+  isImpersonating: vi.fn(() => false),
+  loggerWarning: vi.fn(),
+}));
 
 vi.mock('../helpers/gateway-fetch.helper', () => ({ gatewayFetch }));
 vi.mock('../helpers/cla-service-url.helper', () => ({ claServiceBaseUrl: () => 'https://gw.example.org/cla-service' }));
 vi.mock('../utils/auth-helper', () => ({ isImpersonating }));
 vi.mock('./logger.service', () => ({
-  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: loggerWarning, error: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
 
 const { OrgClaService } = await import('./org-cla.service');
@@ -804,6 +808,36 @@ describe('OrgClaService.requestCorporateSignature', () => {
     gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, signature_id: '' });
 
     await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/no usable corporate signing session/);
+  });
+
+  // The agreement is requested by project; the upstream input has no CLA Group field, so the group
+  // the signatory chose cannot be bound to the request and the echoed one is the only way to tell
+  // whether the session that came back is for the agreement they picked. Handing over a mismatched
+  // session would have them sign the wrong corporate agreement with nothing recording it.
+  it('refuses a session opened for a different CLA Group than the one chosen', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: 'a-different-cla-group-uuid' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/different CLA Group/);
+  });
+
+  it('does not hand back the signing address when the CLA Group does not match', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: 'a-different-cla-group-uuid' });
+
+    const outcome = await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest()).catch((error: unknown) => error);
+
+    expect(JSON.stringify(outcome)).not.toContain('docusign.example.org');
+  });
+
+  // Absence is not a mismatch. The field is declared always-present upstream, so losing it is an
+  // upstream regression rather than evidence of a wrong group, and failing here would dead-end
+  // every hand-off the moment it were dropped.
+  it.each([[''], ['   '], [undefined]])('proceeds, warning, when the echoed CLA Group is %p', async (claGroupId) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: claGroupId });
+
+    expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).toEqual({
+      signUrl: 'https://docusign.example.org/session/1',
+    });
+    expect(JSON.stringify(loggerWarning.mock.calls)).toContain('could not verify');
   });
 
   // The trade-compliance refusal is a 403 whose body is a sentence written for the signatory,

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -292,9 +292,10 @@ describe('OrgClaService.listClaGroups — status', () => {
     expect(row.status).toBe('signed');
   });
 
-  // The producer passes the signature's own signed flag through and its tests pin a returned
-  // row whose flag is false, so this list is not exclusively signed agreements. Calling one
-  // signed would state that an organization has signed something it has not.
+  // Upstream's query filters to signed signatures, so this payload is not one the live list
+  // produces — it pins the mapper's rule, not a reachable list state. Worth pinning anyway: the
+  // rule is what makes the same mapper safe for a producer that relaxes the filter, and calling
+  // an unsigned agreement signed would state that an organization has signed something it has not.
   it('maps an unsigned agreement to not-started rather than to signed', async () => {
     gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: false, sanctioned: false })));
 
@@ -813,11 +814,13 @@ describe('OrgClaService.requestCorporateSignature', () => {
   it('maps the upstream response onto the shape the client consumes', async () => {
     gatewayFetch.mockResolvedValueOnce(upstreamOk);
 
-    // Just the address. Upstream also returns the signature, CLA group, project and company
-    // identifiers; none has a client consumer, and the signature id points at a named person's
-    // agreement, so none of them crosses to the browser.
+    // The address and the signature it belongs to, and nothing else. Upstream also returns the CLA
+    // group, project and company identifiers, and none of those has a client consumer. The signature
+    // id does: the return address is an input to this request and so cannot name the signature, which
+    // leaves the client as the only place the two are held together.
     expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).toEqual({
       signUrl: 'https://docusign.example.org/session/1',
+      signatureId: 'signature-uuid-1',
     });
   });
 
@@ -888,6 +891,7 @@ describe('OrgClaService.requestCorporateSignature', () => {
 
     expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest({ claGroupId }))).toEqual({
       signUrl: 'https://docusign.example.org/session/1',
+      signatureId: 'signature-uuid-1',
     });
   });
 
@@ -907,6 +911,7 @@ describe('OrgClaService.requestCorporateSignature', () => {
 
     expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).toEqual({
       signUrl: 'https://docusign.example.org/session/1',
+      signatureId: 'signature-uuid-1',
     });
     expect(JSON.stringify(loggerWarning.mock.calls)).toContain('could not verify');
   });

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Request } from 'express';
 
+import type { MicroserviceError as MicroserviceErrorType } from '../errors';
 import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
 
 const { gatewayFetch, isImpersonating } = vi.hoisted(() => ({ gatewayFetch: vi.fn(), isImpersonating: vi.fn(() => false) }));
@@ -817,6 +818,67 @@ describe('OrgClaService.requestCorporateSignature', () => {
     gatewayFetch.mockRejectedValueOnce(refusal);
 
     await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/trade compliance review/);
+  });
+
+  /**
+   * A refusal from this endpoint names the caller's LF username when it is about scope, and the
+   * organization's trade-compliance standing when it is about sanctions. Neither belongs in an
+   * application log.
+   *
+   * Full redaction is not available here: `gatewayFetch` discards the body under that option, and
+   * the body is the only place the refusal sentence exists — the relay above would go with it. So
+   * the body is kept out of the log at the fetch, and dropped from the error afterwards, once its
+   * message has been taken out. Both halves are needed, and the second is the easier one to miss:
+   * without it the error reaches the API error handler still carrying the body, and that handler
+   * logs `getLogContext()`, which includes it.
+   */
+  it('keeps the upstream refusal body out of the logs', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledWith(expect.anything(), expect.any(String), expect.objectContaining({ redactResponseBodyFromLogs: true }));
+  });
+
+  it('relays the refusal sentence without carrying the body that held it', async () => {
+    const refusal = 'This organization requires additional trade compliance review. Contact support to review the determination.';
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Forbidden', 403, 'UPSTREAM_ERROR', {
+        service: 'org_cla_service',
+        // The shape upstream actually sends on a sanctions refusal: the sentence, alongside fields
+        // that identify the organization's standing and must not survive into a log line.
+        errorBody: JSON.stringify({ message: refusal, company_sfid: ORG_UID, sanction_status: 'pending_review' }),
+      })
+    );
+
+    const thrown = await new OrgClaService()
+      .requestCorporateSignature(signReq(), ORG_UID, signRequest())
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    expect((thrown as MicroserviceErrorType).message).toBe(refusal);
+    expect((thrown as MicroserviceErrorType).errorBody).toBeUndefined();
+    // The API error handler spreads this into its log line, so it is the thing that must be clean.
+    expect(JSON.stringify((thrown as MicroserviceErrorType).getLogContext())).not.toContain('sanction_status');
+  });
+
+  // Nothing about the body-dropping is 403-specific: a 5xx body from this endpoint is no more
+  // loggable, and it is not relayed either, so it has no reason to survive the throw.
+  it('carries no upstream body on a failure it did not relay', async () => {
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to request the corporate CLA signature', 500, 'UPSTREAM_ERROR', {
+        service: 'org_cla_service',
+        errorBody: JSON.stringify({ message: 'panic in signature repository', lf_username: 'someone' }),
+      })
+    );
+
+    const thrown = await new OrgClaService()
+      .requestCorporateSignature(signReq(), ORG_UID, signRequest())
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    expect((thrown as MicroserviceErrorType).errorBody).toBeUndefined();
+    expect(JSON.stringify((thrown as MicroserviceErrorType).getLogContext())).not.toContain('lf_username');
   });
 
   // Scoped to 403 for the reason the helper documents: a 500's prose is about upstream internals,

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -17,6 +17,7 @@ vi.mock('./logger.service', () => ({
 }));
 
 const { OrgClaService } = await import('./org-cla.service');
+const { MicroserviceError } = await import('../errors');
 
 const ORG_UID = '0014100000Te2ovAAB';
 
@@ -636,5 +637,210 @@ describe('OrgClaService.getPdfUrl — the organization scope gate', () => {
       `https://gw.example.org/cla-service/v4/company/external/${ORG_UID}/cla-groups`,
       expect.objectContaining({ operation: 'org_cla_list_cla_groups' })
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corporate signing hand-off (#1983)
+// ---------------------------------------------------------------------------
+
+const CLA_GROUP_ID = '7f3a1c22-9d51-4a8e-b0c6-2e4f81d9a733';
+const PROJECT_SFID = 'a09410000182dD3AAI';
+
+/** A request the CLA service would accept. Cases override only what they are about. */
+function signRequest(overrides: Record<string, unknown> = {}) {
+  return { projectSfid: PROJECT_SFID, claGroupId: CLA_GROUP_ID, authorityAcked: true, embargoAcked: true, ...overrides } as any;
+}
+
+/** A request carrying the Host the return address is derived from. */
+function signReq(): Request {
+  return { protocol: 'https', get: (header: string) => (header === 'host' ? 'app.lfx.dev' : undefined) } as unknown as Request;
+}
+
+describe('OrgClaService.getSignOptions', () => {
+  it('carries the project Salesforce id upstream sent, which is what the corporate request is keyed on', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      searchTerm: 'nimbus',
+      resultCount: 1,
+      results: [{ claGroupID: CLA_GROUP_ID, claGroupName: 'Nimbus Foundation CLA', projectName: 'Cascade', projectSFID: PROJECT_SFID, cclaEnabled: true }],
+    });
+
+    const envelope = await new OrgClaService().getSignOptions(req(), 'nimbus');
+
+    expect(envelope.results[0]).toMatchObject({ claGroupId: CLA_GROUP_ID, projectSfid: PROJECT_SFID, cclaEnabled: true });
+  });
+
+  // Upstream leaves the id unset for a CLA group spanning several projects with no
+  // foundation-level row. Defaulting it to an empty string would make the row look signable and
+  // produce a request that cannot succeed; the picker needs to see the absence.
+  it('omits the project id entirely when upstream resolved none, rather than defaulting it', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      searchTerm: 'nimbus',
+      resultCount: 1,
+      results: [{ claGroupID: CLA_GROUP_ID, claGroupName: 'Nimbus Foundation CLA', cclaEnabled: true }],
+    });
+
+    const envelope = await new OrgClaService().getSignOptions(req(), 'nimbus');
+
+    expect(envelope.results[0]).not.toHaveProperty('projectSfid');
+  });
+
+  it('treats a blank project id as no project id', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      searchTerm: 'nimbus',
+      resultCount: 1,
+      results: [{ claGroupID: CLA_GROUP_ID, projectSFID: '   ', cclaEnabled: true }],
+    });
+
+    expect(await new OrgClaService().getSignOptions(req(), 'nimbus')).toMatchObject({ results: [expect.not.objectContaining({ projectSfid: '   ' })] });
+  });
+
+  it('preserves the envelope fields the picker reads', async () => {
+    gatewayFetch.mockResolvedValueOnce({ searchTerm: 'nimbus', resultCount: 40, truncated: true, results: [] });
+
+    expect(await new OrgClaService().getSignOptions(req(), 'nimbus')).toMatchObject({ searchTerm: 'nimbus', resultCount: 40, truncated: true });
+  });
+});
+
+describe('OrgClaService.requestCorporateSignature', () => {
+  const upstreamOk = {
+    signature_id: 'signature-uuid-1',
+    sign_url: 'https://docusign.example.org/session/1',
+    cla_group_id: CLA_GROUP_ID,
+    project_sfid: PROJECT_SFID,
+    company_id: 'company-uuid-1',
+    company_sfid: ORG_UID,
+  };
+
+  // snake_case on this upstream, unlike the Me-lens prepare-sign next door, which is camelCase in
+  // both directions. Getting this wrong fails silently: go-swagger ignores unknown keys, so a
+  // camelCase body would arrive as a request with no project and no attestations.
+  it('sends the body in snake_case, with the organization from the grant-checked path', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      'https://gw.example.org/cla-service/v4/self-serve/request-corporate-signature',
+      expect.objectContaining({
+        method: 'POST',
+        // The whole body. A subset matcher would not notice a required field going missing, and
+        // would not notice a designee field being added either.
+        body: {
+          project_sfid: PROJECT_SFID,
+          company_sfid: ORG_UID,
+          return_url: 'https://app.lfx.dev/org/easycla',
+          authority_acked: true,
+          embargo_acked: true,
+        },
+      })
+    );
+  });
+
+  // The counterpart to the controller's gate, one layer down: even reached directly, this method
+  // relays what it was given. A literal here would mean the controller's check was the only thing
+  // standing between a withdrawn confirmation and a signed agreement.
+  it('relays a withdrawn confirmation as withdrawn rather than substituting true', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest({ embargoAcked: false }));
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ authority_acked: true, embargo_acked: false }) })
+    );
+  });
+
+  it('derives the return address server-side, pointing at the Organization Lens rather than the profile CLAs', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ return_url: 'https://app.lfx.dev/org/easycla' }) })
+    );
+  });
+
+  // The endpoint accepts these four for the send-by-email and designee paths. This feature
+  // implements neither, and `send_as_email` in particular changes what the response means.
+  it('sends none of the designee or send-by-email fields', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    const body = gatewayFetch.mock.calls[0][2].body;
+    expect(body).not.toHaveProperty('send_as_email');
+    expect(body).not.toHaveProperty('authority_name');
+    expect(body).not.toHaveProperty('authority_email');
+    expect(body).not.toHaveProperty('signing_entity_name');
+  });
+
+  it('maps the upstream response onto the shape the client consumes', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    // Just the address. Upstream also returns the signature, CLA group, project and company
+    // identifiers; none has a client consumer, and the signature id points at a named person's
+    // agreement, so none of them crosses to the browser.
+    expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).toEqual({
+      signUrl: 'https://docusign.example.org/session/1',
+    });
+  });
+
+  // An empty signing address is how upstream reports that it emailed a named signatory instead —
+  // a shape this route never asks for. Returning it as success would navigate the signatory to
+  // this application's own root and read as a completed hand-off.
+  it.each([[''], ['   '], [undefined]])('fails rather than succeeding when the signing address is %p', async (signUrl) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: signUrl });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/no usable corporate signing session/);
+  });
+
+  it('fails when upstream returned no signature identifier', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, signature_id: '' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/no usable corporate signing session/);
+  });
+
+  // The trade-compliance refusal is a 403 whose body is a sentence written for the signatory,
+  // naming the reason and the support route. Showing "403 Forbidden" instead discards it.
+  it("re-labels a 403 with the CLA service's own words", async () => {
+    const refusal = new MicroserviceError('Forbidden', 403, 'UPSTREAM_ERROR', {
+      service: 'org_cla_service',
+      errorBody: JSON.stringify({
+        message: 'We are sorry, but this organization requires additional trade compliance review, so the CLA cannot be completed at this time.',
+      }),
+    });
+    gatewayFetch.mockRejectedValueOnce(refusal);
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/trade compliance review/);
+  });
+
+  // Scoped to 403 for the reason the helper documents: a 500's prose is about upstream internals,
+  // not about the caller, and putting it on screen helps nobody.
+  it('leaves a 500 with its own message rather than relaying upstream prose', async () => {
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to request the corporate CLA signature', 500, 'UPSTREAM_ERROR', {
+        service: 'org_cla_service',
+        errorBody: JSON.stringify({ message: 'panic: nil pointer dereference in signature repository' }),
+      })
+    );
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/Failed to request the corporate CLA/);
+  });
+
+  // No pre-gate on the organization's compliance status: the CLA service screens on every
+  // request, and the status on an existing agreement row cannot answer for an organization that
+  // holds none — which is the population this flow exists for.
+  it('never reads the organization CLA list before requesting the signature', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledTimes(1);
+    expect(gatewayFetch).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('/cla-groups'), expect.anything());
   });
 });

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -745,7 +745,7 @@ describe('OrgClaService.requestCorporateSignature', () => {
         body: {
           project_sfid: PROJECT_SFID,
           company_sfid: ORG_UID,
-          return_url: 'https://app.lfx.dev/org/easycla',
+          return_url: `https://app.lfx.dev/org/easycla?org=${ORG_UID}`,
           authority_acked: true,
           embargo_acked: true,
         },
@@ -776,8 +776,24 @@ describe('OrgClaService.requestCorporateSignature', () => {
     expect(gatewayFetch).toHaveBeenCalledWith(
       expect.anything(),
       expect.any(String),
-      expect.objectContaining({ body: expect.objectContaining({ return_url: 'https://app.lfx.dev/org/easycla' }) })
+      expect.objectContaining({ body: expect.objectContaining({ return_url: `https://app.lfx.dev/org/easycla?org=${ORG_UID}` }) })
     );
+  });
+
+  // Without this the signatory returns through a cross-site navigation carrying only a
+  // `SameSite=Lax` cookie, and when it does not come back the page selects the first organization
+  // in their list — so signing for one company lands them looking at another.
+  it('names the organization on the return address rather than leaving the page to guess it', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    const body = gatewayFetch.mock.calls[0][2].body as { return_url: string };
+    const returned = new URL(body.return_url);
+
+    expect(returned.pathname).toBe('/org/easycla');
+    // The organization the grant check cleared and the request was made for, not a client value.
+    expect(returned.searchParams.get('org')).toBe(ORG_UID);
   });
 
   // The endpoint accepts these four for the send-by-email and designee paths. This feature

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -66,8 +66,8 @@ const SERVICE = 'org_cla_service';
  * status. `status` remains the single slot the template reads, because sanctions outrank
  * signing there and a consumer forming its own opinion from the two booleans would present a
  * sanctioned entity's agreement as ordinarily signed. What `status` cannot answer is whether a
- * document exists to fetch, since a `sanctioned` row may be signed or unsigned, and that is the
- * one question `signed` is here for.
+ * document exists to fetch, since `sanctioned` describes the entity and not the agreement, and
+ * that is the one question `signed` is here for.
  */
 function toOrgClaGroup(entry: EasyClaCompanyClaGroup & { signatureID: string }, companyName: string): OrgClaGroup {
   const projects: OrgClaGroupProject[] = (entry.projects ?? [])
@@ -126,15 +126,18 @@ function toOrgClaGroup(entry: EasyClaCompanyClaGroup & { signatureID: string }, 
  * sanctioned entity's agreement as ordinarily signed is the more damaging of the two errors
  * available here.
  *
- * An unsigned agreement is a real case, and it is read from the flag rather than assumed
- * away. The producer sets each row's signed flag from the signature it was built from, and
- * its own tests pin a returned row whose flag is false, so the list is not exclusively
- * signed agreements. Defaulting to `signed` would state that an organization has signed
- * something it has not — the same class of false claim the precedence above avoids, and the
- * reason the flag is checked explicitly rather than treated as always true.
+ * `not-started` cannot come out of this endpoint. Upstream builds every row from a CCLA
+ * signature and copies that signature's own signed flag onto it, and the query it draws those
+ * signatures from appends `signature_signed == true` to its filter unconditionally, with no
+ * parameter to bypass it. So `entry.signed` is true on every row the list returns, and the two
+ * statuses reachable from here are `signed` and `sanctioned`.
  *
- * Sanctions still win over an unsigned agreement, for the same reason they win over a signed
- * one: the sanctions fact is the one a viewer must not miss.
+ * The branch stays, and is read from the flag rather than assumed away, because the status type
+ * is not this endpoint's alone: the pre-signing preview builds an `OrgClaGroup` for an agreement
+ * nobody has signed, and `not-started` is the whole of what that page renders. Defaulting to
+ * `signed` here would additionally mean that the day upstream relaxes that filter, the list
+ * states an organization has signed something it has not — the same class of false claim the
+ * precedence above avoids.
  */
 function toStatus(entry: EasyClaCompanyClaGroup): OrgClaGroupStatus {
   if (entry.sanctioned === true) return 'sanctioned';
@@ -237,10 +240,11 @@ export class OrgClaService {
       return null;
     }
 
-    // Membership is not signedness. A sanctioned row may be unsigned, and upstream presigns the
-    // expected S3 key without checking that anything was ever written there — so calling it for
-    // an unsigned agreement hands back a URL to a document that does not exist. Absent is the
-    // honest answer, and it is the one the caller already handles.
+    // Membership is not signedness, and this checks rather than assumes. Upstream's list filters
+    // to signed signatures, so no row reaching here should fail this — but the document endpoint
+    // presigns the expected S3 key without checking that anything was ever written there, so if
+    // that ever stopped holding the caller would get a URL to a file that does not exist rather
+    // than an error. Absent is the honest answer, and it is the one the caller already handles.
     if (!match.signed) {
       logger.warning(req, 'org_cla_get_pdf_url', 'agreement is not signed, so no document exists', { org_uid: orgUid, signature_id: signatureId });
       return null;
@@ -508,11 +512,13 @@ export class OrgClaService {
     }
 
     // A corporate agreement was just opened — the notable business event on this path, and the only
-    // record tying this request to the signature it created. The signature id is logged for that
-    // correlation and deliberately not returned: nothing on the client reads it, and it identifies
-    // a named person's agreement.
+    // record tying this request to the signature it created.
     logger.info(req, 'org_cla_request_corporate_signature', 'opened a corporate signing session', { org_uid: orgUid, signature_id: signatureId });
 
-    return { signUrl };
+    // The signature id goes back with the address because the address cannot carry it: `return_url`
+    // is an input to the request above and is therefore fixed before a signature exists, so the
+    // client is the only place the two are ever held together — and landing the signatory back on
+    // the agreement they signed needs both.
+    return { signUrl, signatureId };
   }
 }

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -34,6 +34,7 @@ import type {
 import { MicroserviceError } from '../errors';
 import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
+import { isHttpsUrl } from '../helpers/validation.helper';
 import { claReturnUrl, toClaGroupOption, withoutUpstreamBody, withProducerRefusalMessage } from './cla.service';
 import { logger } from './logger.service';
 import { isImpersonating } from '../utils/auth-helper';
@@ -423,6 +424,27 @@ export class OrgClaService {
     // Receiving one means the request was not fulfilled the way it was made, so it fails loudly.
     // Navigating to an empty address would send the signatory to this application's own root and
     // read as a successful hand-off that silently signed nothing.
+    // The scheme is checked, not just the presence of a string. The client assigns this value
+    // straight to `document.location.href`, so a `javascript:` address coming back from a
+    // malformed or compromised response would execute in this application's origin, with this
+    // application's session — and it would arrive at exactly the moment the signatory is
+    // expecting to be sent somewhere. Nothing downstream of here looks at it again.
+    //
+    // Scheme only, not a host allowlist. The signing addresses are EasyCLA's to choose and it has
+    // not published the set, so pinning hosts here would break the hand-off the first time one
+    // changed. The scheme is the part that carries the execution risk.
+    if (signUrl && !isHttpsUrl(signUrl)) {
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream returned a signing address that is not an https URL', {
+        // The address itself is deliberately not logged: it is a capability — anyone holding it can
+        // open a named person's agreement — and if it is hostile it does not belong in a log either.
+        sign_url_scheme: signUrl.split(':', 1)[0]?.slice(0, 20),
+      });
+      throw new MicroserviceError('Upstream returned an unusable corporate signing address', 502, 'CLA_SIGN_URL_INVALID', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
     if (!signUrl || !signatureId) {
       // The fields, not the severity: the throw below reaches the shared error handler, which logs
       // the failure centrally. Duplicating that here as an error would double-count it.

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -33,7 +33,7 @@ import type {
 import { MicroserviceError } from '../errors';
 import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
-import { claReturnUrl, toClaGroupOption, withProducerRefusalMessage } from './cla.service';
+import { claReturnUrl, toClaGroupOption, withoutUpstreamBody, withProducerRefusalMessage } from './cla.service';
 import { logger } from './logger.service';
 import { isImpersonating } from '../utils/auth-helper';
 
@@ -395,12 +395,22 @@ export class OrgClaService {
         errorCode: 'UPSTREAM_ERROR',
         method: 'POST',
         body,
+        // A refusal from this endpoint names the caller's LF username when it is about scope, and
+        // the organization's trade-compliance standing when it is about sanctions. Neither belongs
+        // in an application log. Full redaction would take the refusal sentence with it — the body
+        // is the only place that sentence exists — so the body is kept out of the log here and
+        // dropped from the error below, once the message has been taken out of it.
+        redactResponseBodyFromLogs: true,
       });
     } catch (error) {
       // A 403 here is a sentence written for the signatory — the trade-compliance refusal names
       // the reason and the support route, and the authority refusal names the missing scope.
       // Relabelling is what puts those words on screen instead of "403 Forbidden".
-      throw withProducerRefusalMessage(error, 'org_cla_request_corporate_signature', SERVICE);
+      //
+      // Then the body goes, message already extracted. Without that second step the error reaches
+      // the API error handler still carrying it, and `getLogContext` writes it to the log line
+      // that handler emits — which is the same disclosure the fetch option just prevented.
+      throw withoutUpstreamBody(withProducerRefusalMessage(error, 'org_cla_request_corporate_signature', SERVICE));
     }
 
     const signUrl = result?.sign_url?.trim() ?? '';

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -8,7 +8,7 @@
 // One upstream call per page load, whatever the number of agreements. Searching and paging
 // happen client-side over the fetched set, so nothing on this path fans out per row.
 
-import { ORG_EASYCLA_PATH } from '@lfx-one/shared/constants';
+import { ORG_EASYCLA_PATH, ORG_EASYCLA_RETURN_ORG_PARAM } from '@lfx-one/shared/constants';
 import { isSameClaGroup } from '@lfx-one/shared/utils';
 import type {
   ClaGroupOption,
@@ -377,7 +377,13 @@ export class OrgClaService {
     // controller's. The events below are business events on top of it, not a second request.
     // Derived before the call: an unusable origin dead-ends the hand-off anyway, and failing
     // afterwards would leave a real signing session behind with nowhere to return to.
-    const returnUrl = claReturnUrl(req, ORG_EASYCLA_PATH);
+    // Named on the return address, not left to the cookie. The signatory comes back through a
+    // cross-site navigation, and which organization is selected survives that only in a
+    // `SameSite=Lax` cookie; without it the page falls to the first organization in their list, so
+    // signing for one company lands them looking at another. `orgUid` is the value the grant check
+    // already cleared and the same one sent as `company_sfid`, so the address describes the session
+    // that was actually opened.
+    const returnUrl = claReturnUrl(req, ORG_EASYCLA_PATH, { [ORG_EASYCLA_RETURN_ORG_PARAM]: orgUid });
 
     // snake_case on the wire, unlike the Me-lens prepare-sign next door. Built as a typed object
     // rather than spread from the request so every field crossing the spelling boundary is named.

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -9,6 +9,7 @@
 // happen client-side over the fetched set, so nothing on this path fans out per row.
 
 import { ORG_EASYCLA_PATH } from '@lfx-one/shared/constants';
+import { isSameClaGroup } from '@lfx-one/shared/utils';
 import type {
   ClaGroupOption,
   ClaGroupSearchResponse,
@@ -303,12 +304,13 @@ export class OrgClaService {
    *
    * Runs on the default gateway token with no impersonation branch, same as the Me-lens search:
    * the CLA Group catalogue is not organization-scoped upstream, so there is no ownership check
-   * for a token swap to satisfy. The organization gate on this route is the dark-launch flag and
-   * `requireOrgLensAccess`; nothing about the caller's company reaches the query.
+   * for a token swap to satisfy. The gate on this route is `requireOrgLensAccess` alone; nothing
+   * about the caller's company reaches the query. The dark-launch flag is not part of it — that
+   * flag is an Angular route guard, so it hides the page without closing this endpoint.
    */
   public async getSignOptions(req: Request, searchTerm: string): Promise<ClaGroupSearchResponse> {
-    const startTime = logger.startOperation(req, 'org_cla_sign_options');
-
+    // No `startOperation` here, for the reason `getPdfUrl` above gives: the HTTP lifecycle is the
+    // controller's, and a second one double-counts the completion telemetry for one endpoint.
     const params = new URLSearchParams({ searchTerm });
     const list = await gatewayFetch<EasyClaSearchList>(req, `${claServiceBaseUrl(SERVICE)}/v4/cla-group/search?${params.toString()}`, {
       operation: 'org_cla_sign_options',
@@ -331,7 +333,10 @@ export class OrgClaService {
       results,
     };
 
-    logger.success(req, 'org_cla_sign_options', startTime, {
+    // A business event, not a request completion. How many of the matches are actually signable is
+    // the thing worth watching here: a search that returns rows the picker then greys out is how a
+    // project-to-CLA-Group mapping gap shows up in production.
+    logger.info(req, 'org_cla_sign_options', 'searched signable CLA groups', {
       result_count: envelope.resultCount,
       truncated: envelope.truncated,
       signable_count: results.filter((option) => !!option.projectSfid && option.cclaEnabled === true).length,
@@ -367,11 +372,8 @@ export class OrgClaService {
    * an organization that holds no agreements yet, which is the population this flow serves.
    */
   public async requestCorporateSignature(req: Request, orgUid: string, request: OrgClaSignRequest): Promise<OrgClaSignResponse> {
-    const startTime = logger.startOperation(req, 'org_cla_request_corporate_signature', {
-      project_sfid: request.projectSfid,
-      cla_group_id: request.claGroupId,
-    });
-
+    // No `startOperation` here, for the reason `getPdfUrl` above gives: the HTTP lifecycle is the
+    // controller's. The events below are business events on top of it, not a second request.
     // Derived before the call: an unusable origin dead-ends the hand-off anyway, and failing
     // afterwards would leave a real signing session behind with nowhere to return to.
     const returnUrl = claReturnUrl(req, ORG_EASYCLA_PATH);
@@ -422,7 +424,9 @@ export class OrgClaService {
     // Navigating to an empty address would send the signatory to this application's own root and
     // read as a successful hand-off that silently signed nothing.
     if (!signUrl || !signatureId) {
-      logger.error(req, 'org_cla_request_corporate_signature', startTime, new Error('upstream returned no usable signing session'), {
+      // The fields, not the severity: the throw below reaches the shared error handler, which logs
+      // the failure centrally. Duplicating that here as an error would double-count it.
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream returned no usable signing session', {
         has_sign_url: !!signUrl,
         has_signature_id: !!signatureId,
       });
@@ -443,9 +447,13 @@ export class OrgClaService {
     // the cheaper of the two outcomes by a wide margin: the alternative is a corporate agreement
     // signed against the wrong CLA Group, which is a legal instrument that cannot be withdrawn by
     // this application. Binding the group in the request instead needs an upstream field.
+    // Compared canonically, never as raw strings. The request boundary accepts the hyphenated and
+    // unhyphenated spellings in either case, because the producer does, and the producer answers in
+    // its own canonical one — so a request that spelled the id differently would fail a raw
+    // comparison and have a perfectly valid signing session refused out from under it.
     const returnedClaGroupId = result?.cla_group_id?.trim() ?? '';
-    if (returnedClaGroupId && returnedClaGroupId !== request.claGroupId) {
-      logger.error(req, 'org_cla_request_corporate_signature', startTime, new Error('upstream opened a session for a different CLA Group'), {
+    if (returnedClaGroupId && !isSameClaGroup(returnedClaGroupId, request.claGroupId)) {
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream opened a session for a different CLA Group', {
         requested_cla_group_id: request.claGroupId,
         returned_cla_group_id: returnedClaGroupId,
         project_sfid: request.projectSfid,
@@ -471,9 +479,11 @@ export class OrgClaService {
       );
     }
 
-    // The signature id is logged for correlation and deliberately not returned: nothing on the
-    // client reads it, and it identifies a named person's agreement.
-    logger.success(req, 'org_cla_request_corporate_signature', startTime, { org_uid: orgUid, signature_id: signatureId });
+    // A corporate agreement was just opened — the notable business event on this path, and the only
+    // record tying this request to the signature it created. The signature id is logged for that
+    // correlation and deliberately not returned: nothing on the client reads it, and it identifies
+    // a named person's agreement.
+    logger.info(req, 'org_cla_request_corporate_signature', 'opened a corporate signing session', { org_uid: orgUid, signature_id: signatureId });
 
     return { signUrl };
   }

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -8,13 +8,32 @@
 // One upstream call per page load, whatever the number of agreements. Searching and paging
 // happen client-side over the fetched set, so nothing on this path fans out per row.
 
-import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupProject, OrgClaGroupStatus, PdfUrlResponse } from '@lfx-one/shared/interfaces';
+import { ORG_EASYCLA_PATH } from '@lfx-one/shared/constants';
+import type {
+  ClaGroupOption,
+  ClaGroupSearchResponse,
+  OrgClaGroup,
+  OrgClaGroupList,
+  OrgClaGroupProject,
+  OrgClaGroupStatus,
+  OrgClaSignRequest,
+  OrgClaSignResponse,
+  PdfUrlResponse,
+} from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
-import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList, EasyClaSignedDocument } from '../types/cla.types';
+import type {
+  EasyClaCompanyClaGroup,
+  EasyClaCompanyClaGroupList,
+  EasyClaSearchList,
+  EasyClaSelfServeCorporateSignatureInput,
+  EasyClaSelfServeCorporateSignatureOutput,
+  EasyClaSignedDocument,
+} from '../types/cla.types';
 import { MicroserviceError } from '../errors';
 import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
+import { claReturnUrl, toClaGroupOption, withProducerRefusalMessage } from './cla.service';
 import { logger } from './logger.service';
 import { isImpersonating } from '../utils/auth-helper';
 
@@ -266,5 +285,147 @@ export class OrgClaService {
     // would be invented. The URL is presigned and short-lived, but its lifetime is upstream's to
     // state, and `0` would read to a consumer as already expired.
     return { url };
+  }
+
+  /**
+   * Searches CLA Groups the organization could sign a corporate CLA for (#1983).
+   *
+   * Wraps the Me-lens per-result mapper rather than reimplementing or amending it, and appends
+   * `projectSfid` afterwards. That id is what the corporate signature request is keyed on, and it
+   * has no consumer on the Me-lens path, so carrying it in the shared mapper would put an unread
+   * field into that response and into the state it ships with. Keeping the append here leaves the
+   * Me-lens envelope byte-identical.
+   *
+   * Upstream sets the id from a project-to-CLA-Group mapping row and deliberately leaves it unset
+   * when a CLA Group maps to several projects with none of them foundation-level. It is therefore
+   * carried only when upstream sent one, and its absence is what the picker renders as
+   * "cannot be signed from here" — a property of the CLA Group, not a failure.
+   *
+   * Runs on the default gateway token with no impersonation branch, same as the Me-lens search:
+   * the CLA Group catalogue is not organization-scoped upstream, so there is no ownership check
+   * for a token swap to satisfy. The organization gate on this route is the dark-launch flag and
+   * `requireOrgLensAccess`; nothing about the caller's company reaches the query.
+   */
+  public async getSignOptions(req: Request, searchTerm: string): Promise<ClaGroupSearchResponse> {
+    const startTime = logger.startOperation(req, 'org_cla_sign_options');
+
+    const params = new URLSearchParams({ searchTerm });
+    const list = await gatewayFetch<EasyClaSearchList>(req, `${claServiceBaseUrl(SERVICE)}/v4/cla-group/search?${params.toString()}`, {
+      operation: 'org_cla_sign_options',
+      service: SERVICE,
+      errorMessage: 'Failed to search CLA groups',
+      errorCode: 'UPSTREAM_ERROR',
+    });
+
+    const upstreamResults = list?.results ?? [];
+    const results: ClaGroupOption[] = upstreamResults.map((result) => {
+      const option = toClaGroupOption(result);
+      const projectSfid = result.projectSFID?.trim();
+      return projectSfid ? { ...option, projectSfid } : option;
+    });
+
+    const envelope: ClaGroupSearchResponse = {
+      searchTerm: list?.searchTerm ?? searchTerm,
+      resultCount: list?.resultCount ?? results.length,
+      truncated: list?.truncated === true,
+      results,
+    };
+
+    logger.success(req, 'org_cla_sign_options', startTime, {
+      result_count: envelope.resultCount,
+      truncated: envelope.truncated,
+      signable_count: results.filter((option) => !!option.projectSfid && option.cclaEnabled === true).length,
+    });
+    return envelope;
+  }
+
+  /**
+   * Opens a corporate signing session for the organization and returns where the signatory
+   * completes it (#1983).
+   *
+   * Three values are deliberately not taken from the caller's body:
+   *
+   * - the organization, which is the grant-checked `orgUid` path parameter;
+   * - the return address, derived from the request Host and host-checked, because EasyCLA stores
+   *   it and later redirects to it verbatim — a client-supplied one would be an open redirect;
+   * - the caller's identity, which travels as the default gateway token. That token is the
+   *   signatory's own, exchanged for the gateway audience, and it is what makes the signature
+   *   attributable. There is no impersonation branch precisely because the route is blocked
+   *   during impersonation instead: a corporate agreement signed under an impersonated session
+   *   would bind a company on behalf of somebody who did not act.
+   *
+   * The two attestations are passed through exactly as received. They are not defaulted here and
+   * must not be: the client gates on both, so a request arriving with either false is either a
+   * signatory who withdrew a confirmation or a client that has regressed, and both must reach the
+   * refusal rather than be papered over. Upstream rejects the request ahead of any signing work
+   * for the same reason.
+   *
+   * Authorization is upstream's alone. It checks the caller's signing authority for the project
+   * and organization pair — refusing a platform-administrator token, which an org-lens read grant
+   * has no bearing on — and screens the company for trade compliance on every request. Neither is
+   * pre-empted here: the compliance status carried on an existing agreement row cannot answer for
+   * an organization that holds no agreements yet, which is the population this flow serves.
+   */
+  public async requestCorporateSignature(req: Request, orgUid: string, request: OrgClaSignRequest): Promise<OrgClaSignResponse> {
+    const startTime = logger.startOperation(req, 'org_cla_request_corporate_signature', {
+      project_sfid: request.projectSfid,
+      cla_group_id: request.claGroupId,
+    });
+
+    // Derived before the call: an unusable origin dead-ends the hand-off anyway, and failing
+    // afterwards would leave a real signing session behind with nowhere to return to.
+    const returnUrl = claReturnUrl(req, ORG_EASYCLA_PATH);
+
+    // snake_case on the wire, unlike the Me-lens prepare-sign next door. Built as a typed object
+    // rather than spread from the request so every field crossing the spelling boundary is named.
+    const body: EasyClaSelfServeCorporateSignatureInput = {
+      project_sfid: request.projectSfid,
+      company_sfid: orgUid,
+      return_url: returnUrl,
+      authority_acked: request.authorityAcked,
+      embargo_acked: request.embargoAcked,
+    };
+
+    let result: EasyClaSelfServeCorporateSignatureOutput | null;
+    try {
+      result = await gatewayFetch<EasyClaSelfServeCorporateSignatureOutput>(req, `${claServiceBaseUrl(SERVICE)}/v4/self-serve/request-corporate-signature`, {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+        errorMessage: 'Failed to request the corporate CLA signature',
+        errorCode: 'UPSTREAM_ERROR',
+        method: 'POST',
+        body,
+      });
+    } catch (error) {
+      // A 403 here is a sentence written for the signatory — the trade-compliance refusal names
+      // the reason and the support route, and the authority refusal names the missing scope.
+      // Relabelling is what puts those words on screen instead of "403 Forbidden".
+      throw withProducerRefusalMessage(error, 'org_cla_request_corporate_signature', SERVICE);
+    }
+
+    const signUrl = result?.sign_url?.trim() ?? '';
+    const signatureId = result?.signature_id?.trim() ?? '';
+
+    // An empty signing address is how upstream signals that the agreement was emailed to a named
+    // signatory instead — a shape this route never requests, since it sends no `send_as_email`.
+    // Receiving one means the request was not fulfilled the way it was made, so it fails loudly.
+    // Navigating to an empty address would send the signatory to this application's own root and
+    // read as a successful hand-off that silently signed nothing.
+    if (!signUrl || !signatureId) {
+      logger.error(req, 'org_cla_request_corporate_signature', startTime, new Error('upstream returned no usable signing session'), {
+        has_sign_url: !!signUrl,
+        has_signature_id: !!signatureId,
+      });
+      throw new MicroserviceError('Upstream opened no usable corporate signing session', 502, 'CLA_SIGN_SESSION_INCOMPLETE', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
+    // The signature id is logged for correlation and deliberately not returned: nothing on the
+    // client reads it, and it identifies a named person's agreement.
+    logger.success(req, 'org_cla_request_corporate_signature', startTime, { org_uid: orgUid, signature_id: signatureId });
+
+    return { signUrl };
   }
 }

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -432,6 +432,45 @@ export class OrgClaService {
       });
     }
 
+    // The agreement is requested by project, not by CLA Group: the upstream input takes
+    // `project_sfid` and has no field for a CLA Group, so the group the signatory chose cannot be
+    // bound to the request. It comes back on the response, and that echo is the only place the two
+    // can be compared. Without this check a project whose CLA Group mapping moved between the
+    // search and the confirmation — or a client that posted a mismatched pair — hands the signatory
+    // a session for an agreement they did not choose, and nothing anywhere would say so.
+    //
+    // This necessarily refuses after the envelope exists, leaving one abandoned upstream. That is
+    // the cheaper of the two outcomes by a wide margin: the alternative is a corporate agreement
+    // signed against the wrong CLA Group, which is a legal instrument that cannot be withdrawn by
+    // this application. Binding the group in the request instead needs an upstream field.
+    const returnedClaGroupId = result?.cla_group_id?.trim() ?? '';
+    if (returnedClaGroupId && returnedClaGroupId !== request.claGroupId) {
+      logger.error(req, 'org_cla_request_corporate_signature', startTime, new Error('upstream opened a session for a different CLA Group'), {
+        requested_cla_group_id: request.claGroupId,
+        returned_cla_group_id: returnedClaGroupId,
+        project_sfid: request.projectSfid,
+      });
+      throw new MicroserviceError('Upstream opened a signing session for a different CLA Group', 502, 'CLA_SIGN_GROUP_MISMATCH', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
+    // An absent echo is not treated as a mismatch. The field is declared always-present upstream,
+    // so its absence is an upstream regression rather than evidence of a wrong group, and failing
+    // here would dead-end every hand-off the moment that field were dropped. It is logged so the
+    // loss of the check is visible rather than silent.
+    if (!returnedClaGroupId) {
+      logger.warning(
+        req,
+        'org_cla_request_corporate_signature',
+        'upstream returned no cla_group_id; could not verify the signing session matches the chosen CLA Group',
+        {
+          requested_cla_group_id: request.claGroupId,
+        }
+      );
+    }
+
     // The signature id is logged for correlation and deliberately not returned: nothing on the
     // client reads it, and it identifies a named person's agreement.
     logger.success(req, 'org_cla_request_corporate_signature', startTime, { org_uid: orgUid, signature_id: signatureId });

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -354,3 +354,48 @@ export interface EasyClaSignedDocument {
   signatureID?: string;
   signedClaUrl?: string;
 }
+
+/**
+ * Request body for `POST /v4/self-serve/request-corporate-signature`
+ * (`#/definitions/self-serve-corporate-signature-input`).
+ *
+ * **snake_case in both directions**, unlike the sibling `prepare-sign` endpoint, which is
+ * camelCase in both. Mirrored exactly as it goes on the wire so the spelling boundary sits in
+ * one place — the mapping in `OrgClaService.requestCorporateSignature` — rather than leaking
+ * into the shared contract.
+ *
+ * Four properties the schema defines are deliberately absent: `signing_entity_name`,
+ * `send_as_email`, `authority_name` and `authority_email`. They belong to the send-by-email and
+ * designee paths, which are not implemented here; omitting them from the type is what stops one
+ * being set by accident.
+ */
+export interface EasyClaSelfServeCorporateSignatureInput {
+  project_sfid: string;
+  company_sfid: string;
+  /** Absolute https URL. EasyCLA stores it and later redirects to it verbatim. */
+  return_url: string;
+  /**
+   * Both attestations must be literally `true` or the CLA service refuses ahead of any signing
+   * work. Required as non-optional booleans here so the value has to be supplied by the caller
+   * and cannot default in.
+   */
+  authority_acked: boolean;
+  embargo_acked: boolean;
+}
+
+/**
+ * Response for `POST /v4/self-serve/request-corporate-signature`
+ * (`#/definitions/self-serve-corporate-signature-output`).
+ *
+ * Every field is `x-omitempty: false` upstream, so a present-but-empty string is what a missing
+ * value looks like — hence `sign_url` is checked for content, not for presence.
+ */
+export interface EasyClaSelfServeCorporateSignatureOutput {
+  signature_id?: string;
+  /** Empty when the request was sent as an email to a named signatory — never on this path. */
+  sign_url?: string;
+  cla_group_id?: string;
+  project_sfid?: string;
+  company_id?: string;
+  company_sfid?: string;
+}

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -298,7 +298,13 @@ export const CCLA_SIGN_COPY = {
     body: 'We could not prepare this CLA right now. Please try again, or contact support if the problem continues.',
   },
   picker: {
-    header: 'Sign a Corporate CLA',
+    header: 'Sign a CLA',
+    body: 'Choose the project, CLA group, or repository source (GitHub, GitLab, or Gerrit), for which you want to sign a CLA.',
+    placeholder: 'Search projects, CLA groups, repo sources, or paste a repo link',
+    empty: 'Search for a project, CLA group, repo source, or paste a repo link.',
+    noMatch: 'No matching projects, CLA groups, or foundations.',
+    continueLabel: 'Continue to sign →',
+    cancelLabel: 'Cancel',
     /** Why a row cannot be signed. Shown on the row, because the row stays visible. */
     multiProjectDisabledReason: 'This CLA group covers several projects and cannot be signed from here.',
     cclaDisabledReason: 'This CLA group does not offer a corporate CLA.',

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -221,7 +221,7 @@ export const ORG_CLA_NOT_STARTED_COPY = {
 export const ORG_EASYCLA_PATH = '/org/easycla';
 
 /**
- * Copy for the corporate signing flow (#1983), taken verbatim from the approved design.
+ * Copy for the corporate signing flow (#1983), taken verbatim from the M3 prototype.
  *
  * Held here rather than inlined in the template because this is the first attestation the
  * product renders itself — every earlier CLA surface handed off to another product before any

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -185,6 +185,33 @@ export const CLA_MANAGER_MODAL_COPY = {
 } as const;
 
 /**
+ * The Overview body for an agreement the organization has not signed.
+ *
+ * The list is not exclusively signed agreements — a row's status is read from the producer's
+ * `signed` flag — so this state is reached from the list itself, without going near the signing
+ * flow. Before this copy existed the tab rendered a heading and then nothing.
+ *
+ * Taken verbatim from the M3 prototype, steps and all. The three steps are the only place the
+ * consequence of signing is spelled out before it happens: that whoever signs becomes the initial
+ * CLA Manager, and what that role then controls. Paraphrasing them would quietly change what the
+ * organization is told it is agreeing to arrange.
+ */
+export const ORG_CLA_NOT_STARTED_COPY = {
+  /** `company` and `claGroup` are the organization's and the agreement's names. */
+  lead: (company: string, claGroup: string): string => `${company} has not yet signed a CLA for ${claGroup}.`,
+  stepsHeading: "Here's what the process looks like:",
+  steps: [
+    {
+      label: 'Step 1:',
+      body: 'You will identify who should be the initial CLA Manager. The CLA Manager is the person who manages the list of approved contributors. This might be you, or might be someone else at your company.',
+    },
+    { label: 'Step 2:', body: 'That person will be able to sign the CLA (or send it to someone else for signature).' },
+    { label: 'Step 3:', body: 'Finally, the CLA Manager will be able to start approving contributors and adding other CLA Managers.' },
+  ],
+  startLabel: 'Start the CLA process',
+} as const;
+
+/**
  * Tab order of the Organization Lens CLA Group detail page. `OrgClaDetailTab` is derived from
  * this, so the set exists once: a tab added here is a compile error everywhere that switches on
  * the union until it is handled.

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { OrgClaGroup, OrgClaStatusDisplay } from '../interfaces/cla.interface';
+import type { OrgClaDetailTab, OrgClaGroup, OrgClaStatusDisplay } from '../interfaces/cla.interface';
 
 /** Long enough to not query on every keystroke, short enough that the CLA-group list feels live. */
 export const CLA_GROUP_SEARCH_DEBOUNCE_MS = 250;
@@ -187,9 +187,10 @@ export const CLA_MANAGER_MODAL_COPY = {
 /**
  * The Overview body for an agreement the organization has not signed.
  *
- * The list is not exclusively signed agreements — a row's status is read from the producer's
- * `signed` flag — so this state is reached from the list itself, without going near the signing
- * flow. Before this copy existed the tab rendered a heading and then nothing.
+ * Reached only through the pre-signing preview, which builds its agreement from the picker's
+ * choice. The organization's own list cannot show this state: upstream draws every row from a
+ * signature its query has already filtered to signed. Before this copy existed the tab rendered a
+ * heading and then nothing.
  *
  * Taken verbatim from the M3 prototype, steps and all. The three steps are the only place the
  * consequence of signing is spelled out before it happens: that whoever signs becomes the initial
@@ -219,6 +220,38 @@ export const ORG_CLA_NOT_STARTED_COPY = {
  * address from the request Host, and the two hand-offs must not disagree on where they land.
  */
 export const ORG_EASYCLA_PATH = '/org/easycla';
+
+/**
+ * Child segment of `ORG_EASYCLA_PATH` holding the preview a signatory reads before starting a
+ * corporate CLA (#1983).
+ *
+ * Shared because the route declares it and the CLA picker navigates to it, and the two cannot be
+ * allowed to disagree: `:signatureId` is declared alongside it, so a segment spelled differently
+ * in one place matches as a signature id and renders the not-found state instead.
+ */
+export const ORG_EASYCLA_NEW_SEGMENT = 'new';
+
+/**
+ * Key the picker's chosen CLA Group travels under, in the router state of the navigation to
+ * `ORG_EASYCLA_NEW_SEGMENT` (#1983).
+ *
+ * State rather than the address, because there is nothing in the address to resolve: the CLA
+ * service exposes no fetch-a-CLA-group-by-id endpoint — `/cla-group/{id}` offers only PUT and
+ * DELETE, and the search takes a term — so ids in the URL would be decorative and the display
+ * names would have to ride along with them, leaving the page to render its heading from text
+ * taken out of the URL.
+ */
+export const ORG_CLA_SIGN_SELECTION_STATE = 'orgClaSignSelection';
+
+/**
+ * `sessionStorage` key holding the signature a corporate signing session just created, so the
+ * signatory returns to the agreement they signed rather than to the list (#1983).
+ *
+ * `sessionStorage` precisely because router state is not available: the return from DocuSign is a
+ * cross-site round trip, which no in-memory or history-bound value survives, and this does — in
+ * the one tab that made the request. The value is single-use and cleared on the way back.
+ */
+export const ORG_CLA_SIGNED_SIGNATURE_KEY = 'lfx.orgCla.signedSignatureId';
 
 /**
  * Query parameter naming the organization a corporate signing session was opened for, carried on
@@ -308,6 +341,11 @@ export const CCLA_SIGN_COPY = {
     /** Why a row cannot be signed. Shown on the row, because the row stays visible. */
     multiProjectDisabledReason: 'This CLA group covers several projects and cannot be signed from here.',
     cclaDisabledReason: 'This CLA group does not offer a corporate CLA.',
+    /**
+     * Names the organization rather than the CLA group, because that is the true scope of the
+     * refusal: the group is not spent, this organization's corporate agreement for it exists.
+     */
+    alreadySignedDisabledReason: 'Your organization has already signed a corporate CLA for this CLA group.',
   },
 } as const;
 
@@ -340,4 +378,30 @@ export const ORG_CLA_HEADING_STATUS: Record<OrgClaGroup['status'], string> = {
   signed: 'Signed',
   'not-started': 'Not yet signed',
   sanctioned: 'Unavailable',
+};
+
+/**
+ * Why the CLA Managers and Approval List tabs hold nothing until the agreement is signed, taken
+ * verbatim from the M3 prototype's locked panels.
+ *
+ * Only these two tabs. Both describe a role and a rule set that come into existence *with* the
+ * signature — the signatory becomes the initial CLA Manager, and approval entries are what that
+ * manager then maintains — so on an unsigned agreement there is nothing to list rather than a list
+ * that failed to load. The remaining tabs are unbuilt for every agreement, signed or not, and
+ * saying "once this CLA is signed" on them would promise content signing does not produce.
+ *
+ * Reached only through the pre-signing preview, since upstream's list draws every row from a
+ * signature its query has already filtered to signed. That makes the preview the sole place these
+ * panels render — which is why they are copy rather than an empty section. This is the same gap
+ * the empty Overview had.
+ */
+export const ORG_CLA_LOCKED_TAB_COPY: Partial<Record<OrgClaDetailTab, { title: string; subtitle: string }>> = {
+  managers: {
+    title: 'CLA Managers become available once this CLA is signed',
+    subtitle: 'The person who coordinates signing becomes the initial CLA Manager once this CLA is signed. Additional managers can be added afterward.',
+  },
+  approval: {
+    title: 'The approval list becomes available once this CLA is signed',
+    subtitle: 'Sign this CLA first, then add approval list entries to automatically cover matching contributors.',
+  },
 };

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -221,6 +221,22 @@ export const ORG_CLA_NOT_STARTED_COPY = {
 export const ORG_EASYCLA_PATH = '/org/easycla';
 
 /**
+ * Query parameter naming the organization a corporate signing session was opened for, carried on
+ * `ORG_EASYCLA_PATH` when EasyCLA returns the signatory (#1983).
+ *
+ * The return is a cross-site navigation, and which organization is selected survives only in a
+ * `SameSite=Lax` cookie. When that cookie does not come back the page falls to the first
+ * organization in the viewer's list, so a signatory who signed for one company returns looking at
+ * another — reading as though the signature landed on the wrong organization.
+ *
+ * Shared because the BFF writes it and the Org Lens page reads it. **It names an organization; it
+ * does not grant one.** The page resolves it against the viewer's own authorized organizations and
+ * ignores anything absent from that list, so a crafted link cannot select an organization the
+ * viewer does not hold.
+ */
+export const ORG_EASYCLA_RETURN_ORG_PARAM = 'org';
+
+/**
  * Copy for the corporate signing flow (#1983), taken verbatim from the M3 prototype.
  *
  * Held here rather than inlined in the template because this is the first attestation the

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -212,6 +212,79 @@ export const ORG_CLA_NOT_STARTED_COPY = {
 } as const;
 
 /**
+ * Where EasyCLA returns a signatory after signing a corporate CLA (#1983). Mirrors the `easycla`
+ * child route under /org in the org dashboard routes.
+ *
+ * Sibling of `MY_CLAS_PATH` for the same reason that one is shared: the BFF derives the return
+ * address from the request Host, and the two hand-offs must not disagree on where they land.
+ */
+export const ORG_EASYCLA_PATH = '/org/easycla';
+
+/**
+ * Copy for the corporate signing flow (#1983), taken verbatim from the approved design.
+ *
+ * Held here rather than inlined in the template because this is the first attestation the
+ * product renders itself — every earlier CLA surface handed off to another product before any
+ * attestation appeared. Wording that a signatory affirms under their own authority should not
+ * be reachable by a template edit that reads as a copy tweak, and keeping it in one file gives
+ * the legal review a single subject.
+ *
+ * Not paraphrased, not re-ordered, not shortened.
+ */
+export const CCLA_SIGN_COPY = {
+  attestation: {
+    header: 'Confirm Authorization to Sign the CLA',
+    authorityHeading: 'Authorization Confirmation',
+    authorityLabel: 'I am authorized to sign this Contributor License Agreement (CLA) on behalf of my company.',
+    embargoHeading: 'Compliance Confirmation',
+    embargoLabel: 'I hereby certify that I am not, and/or the organization I am representing is not:',
+    embargoConditions: [
+      'located in Cuba, Iran, North Korea, Syria, the Crimea Region of Ukraine, or the Russian-controlled areas of the Donetsk or Luhansk regions of Ukraine;',
+      'owned or controlled by, acting for or on behalf of, or an individual or entity that has in the past acted for or on behalf of the Government of Cuba, Iran, North Korea, Syria, or Venezuela;',
+    ],
+    /**
+     * The third condition carries a link mid-sentence, so it cannot sit in the array above
+     * without the template either rendering markup from a string or losing the link.
+     */
+    embargoSanctionsCondition: {
+      before: "listed as a blocked person by the U.S. Department of the Treasury's ",
+      linkText: 'Office of Foreign Assets Control (OFAC)',
+      linkUrl: 'https://ofac.treasury.gov/sanctions-programs-and-country-information',
+      after: ' or directly or indirectly owned 50 percent or more by such a listed person',
+    },
+    continueLabel: 'Continue',
+    cancelLabel: 'Cancel',
+  },
+  preparing: {
+    header: 'Configuring CLA Manager Settings…',
+    body: 'Please wait while we configure the initial CLA Manager settings for this CLA.',
+    /** Stated before the signatory commits, so the consequence is not first learned after signing. */
+    consequence: 'When this CLA is signed, you will be the initial CLA Manager.',
+  },
+  ready: {
+    header: 'Review CCLA',
+    body: 'Click below to review and sign CCLA. After the CCLA is signed, you will be the initial CLA Manager and authorized to approve contributors and add additional CLA Managers.',
+    continueLabel: 'Review and Sign CCLA',
+    cancelLabel: 'Cancel',
+  },
+  failure: {
+    header: 'Unable to prepare CLA',
+    /**
+     * Only for a failure the CLA service did not explain. A refusal it *did* explain is shown in
+     * its own words — it names the reason and what to do next, and substituting this would
+     * discard both.
+     */
+    body: 'We could not prepare this CLA right now. Please try again, or contact support if the problem continues.',
+  },
+  picker: {
+    header: 'Sign a Corporate CLA',
+    /** Why a row cannot be signed. Shown on the row, because the row stays visible. */
+    multiProjectDisabledReason: 'This CLA group covers several projects and cannot be signed from here.',
+    cclaDisabledReason: 'This CLA group does not offer a corporate CLA.',
+  },
+} as const;
+
+/**
  * Tab order of the Organization Lens CLA Group detail page. `OrgClaDetailTab` is derived from
  * this, so the set exists once: a tab added here is a compile error everywhere that switches on
  * the union until it is handled.

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -261,11 +261,16 @@ export const CCLA_SIGN_COPY = {
     /** Stated before the signatory commits, so the consequence is not first learned after signing. */
     consequence: 'When this CLA is signed, you will be the initial CLA Manager.',
   },
+  /**
+   * No cancel label, deliberately. By the time this state is on screen the agreement and its
+   * DocuSign envelope already exist upstream, and the address below is the only way anyone reaches
+   * them — so there is no exit here that does not abandon a real agreement. The one way on is
+   * forward, and the copy says the envelope is already waiting rather than implying it is not.
+   */
   ready: {
     header: 'Review CCLA',
-    body: 'Click below to review and sign CCLA. After the CCLA is signed, you will be the initial CLA Manager and authorized to approve contributors and add additional CLA Managers.',
+    body: 'Your CCLA is ready and waiting for signature. Continue to review and sign it. After the CCLA is signed, you will be the initial CLA Manager and authorized to approve contributors and add additional CLA Managers.',
     continueLabel: 'Review and Sign CCLA',
-    cancelLabel: 'Cancel',
   },
   failure: {
     header: 'Unable to prepare CLA',

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -27,11 +27,19 @@ export const ORG_LENS_ROI_ENABLED_FLAG = 'org-lens-roi-enabled';
  * module invisible. The route guard fails closed (unlike `myClasEnabledGuard`).
  *
  * Evaluated through `FeatureFlagService.getBooleanFlag`, which is the Web SDK and never runs
- * server-side, so this hides the route and nav without closing the BFF. That is deliberate and
- * matches M1/M2: the module's routes still require an Org Lens grant, and the data they read is
- * already reachable through the ACS-authorized EasyCLA APIs and the Corporate CLA Console, so a
- * second env-var gate would add a GitOps round-trip to every rollout without withholding
- * anything. Revisit if M3 write paths (sign, managers, approval list) land on these routes.
+ * server-side, so this hides the route and nav without closing the BFF. **Turning this flag off
+ * therefore stops the UI reaching the module; it does not stop a direct call to the BFF.** It is
+ * not a kill switch, and it is not an authorization boundary — the routes are protected by the
+ * Org Lens grant, by `blockDuringImpersonation` on the write, and by the CLA service's own
+ * signing-authority and trade-compliance checks.
+ *
+ * The first M3 write path has now landed on these routes: corporate CLA signing (#1983), which
+ * creates a signature record and a DocuSign envelope. A server-side gate was reconsidered at that
+ * point, as the note here previously said it should be, and still not added — the same corporate
+ * signature is requestable by the same caller through the ACS-authorized EasyCLA v4 API and the
+ * Corporate CLA Console, so a gate withholds no capability while costing a GitOps round-trip and
+ * a pod roll per rollout. What changed is that this is now written down as a decision about a
+ * write, rather than resting on the reads being harmless.
  */
 export const ORG_LENS_CLA_M3_ENABLED_FLAG = 'org-lens-cla-m3-enabled';
 /**

--- a/packages/shared/src/constants/regex.constants.ts
+++ b/packages/shared/src/constants/regex.constants.ts
@@ -10,6 +10,19 @@
  */
 export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * A CLA Group UUID as the EasyCLA producer spells it — 8-4-4-4-12 hex, hyphens optional, either
+ * case, because the producer's own pattern accepts all of those spellings. Deliberately looser
+ * than `UUID_REGEX`, which requires the hyphens.
+ *
+ * Because the accepted spellings differ from each other, **two identifiers that match this pattern
+ * can be the same CLA Group and still not be string-equal.** Never compare two of these directly;
+ * put both through `canonicalClaGroupId` first. Comparing raw is how a valid corporate signing
+ * session came to be refused as a mismatch: the request carried one spelling and the producer
+ * echoed the canonical one back.
+ */
+export const CLA_GROUP_ID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
 /** Salesforce Account ID — "001" prefix + 12 (15-char form) or 15 (18-char form) alphanumeric chars. General Salesforce account-id validator (events, analytics). */
 export const SALESFORCE_ACCOUNT_ID_PATTERN = /^001[A-Za-z0-9]{12,15}$/;
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -219,6 +219,18 @@ export interface ClaGroupOption {
   /** Full repository name the term resolved to — set only when `matchTypes` includes `repository`. */
   matchedRepositoryName?: string;
   matchedRepositoryURL?: string;
+  /**
+   * Salesforce id of the project a corporate signature is requested against (#1983).
+   *
+   * **Set only by the Organization Lens sign-options route.** The Me-lens search omits it: that
+   * hand-off is keyed on `claGroupId` alone, and a field no template reads still ships to the
+   * browser inside the transferred state.
+   *
+   * Absent on the Org Lens path too when the CLA group maps to several projects with no
+   * foundation-level row — upstream declines to pick one arbitrarily. That is a real property of
+   * the CLA group, not a failure, and it makes the group unsignable from here.
+   */
+  projectSfid?: string;
 }
 
 /**
@@ -718,4 +730,89 @@ export interface OrgClaCoverageDialogData {
   claGroupName: string;
   foundationName?: string;
   projects: OrgClaGroupProject[];
+}
+
+/**
+ * One hand-off request for a corporate CLA (#1983).
+ *
+ * The organization is deliberately absent: it comes from the grant-checked `:orgUid` path
+ * segment. So is the return address, which the BFF derives from the request — EasyCLA stores it
+ * and later redirects to it verbatim, so a client-supplied one would be an open redirect.
+ */
+export interface OrgClaSignRequest {
+  /** From the chosen search result. Keys the corporate signature upstream. */
+  projectSfid: string;
+  claGroupId: string;
+  /**
+   * The signatory's own checkbox state at the moment they continued — never a literal, never
+   * inferred from having reached this step. The two attestations are the legally operative part
+   * of this request, and the value that matters is the one the signatory actually set.
+   */
+  authorityAcked: boolean;
+  embargoAcked: boolean;
+}
+
+/**
+ * The signing session EasyCLA opened, as the client consumes it (#1983).
+ *
+ * Deliberately just the address. Upstream also returns the signature, CLA group, project and
+ * company identifiers, and none of them has a consumer here — the hand-off navigates and the
+ * page is replaced. The signature id in particular is a pointer to a named person's agreement,
+ * so shipping it to the browser unread would be handing out a reference for nothing.
+ */
+export interface OrgClaSignResponse {
+  /**
+   * Where the signatory completes the ceremony. Navigated to as returned, never composed.
+   *
+   * Never empty on this path: upstream leaves it empty only for a request sent as an email to a
+   * named signatory, which this route does not make, so an empty value is a failure rather than
+   * a state to render.
+   */
+  signUrl: string;
+}
+
+/**
+ * The two confirmations the signatory gave, as they actually stood when they continued (#1983).
+ *
+ * A distinct type from the request so the attestation step can close with exactly this and
+ * nothing else — the step that collects them is the only place entitled to say what they were.
+ */
+export interface OrgClaSignAttestations {
+  authorityAcked: boolean;
+  embargoAcked: boolean;
+}
+
+/** What the Org Lens CLA group picker is given. */
+export interface OrgClaGroupSelectDialogData {
+  orgUid: string;
+}
+
+/** What the Org Lens CLA group picker closes with. */
+export interface OrgClaGroupPickerResult {
+  claGroupId: string;
+  projectSfid: string;
+  projectName: string;
+}
+
+/**
+ * A picker row, plus why it cannot be chosen. `disabledReason` is null when the row is selectable.
+ *
+ * A row the organization cannot sign keeps its place and states its reason rather than being
+ * filtered out, so the reason is part of the row's shape rather than a lookup beside it.
+ */
+export interface OrgClaGroupOptionView extends ClaGroupOptionView {
+  disabledReason: string | null;
+}
+
+/**
+ * What the hand-off dialog is given: the chosen CLA group, and the confirmations behind it.
+ *
+ * The attestations travel as data rather than being re-collected here, because the step that
+ * collected them is the only one entitled to say what the signatory set.
+ */
+export interface OrgClaSignHandoffDialogData {
+  orgUid: string;
+  projectSfid: string;
+  claGroupId: string;
+  attestations: OrgClaSignAttestations;
 }

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -661,11 +661,16 @@ export interface OrgClaGroup {
   /**
    * Whether a signed CCLA actually exists, taken from upstream's own flag.
    *
-   * Deliberately separate from `status`, which cannot answer this: sanctions win the single
-   * status slot, so a `sanctioned` row may be signed or unsigned. Anything deciding whether
-   * there is a document to fetch must read this rather than infer from the status, and
-   * `signedOn` is not a stand-in either — it is additionally conditional on upstream sending
-   * a date, so a signed agreement can carry no date and still have a document.
+   * Deliberately separate from `status`, which asks a different question: `status` collapses a
+   * fact about the entity (sanctions) and a fact about the agreement (signing) into one slot, so
+   * `status !== 'signed'` cannot be read as "there is no document".
+   *
+   * The list endpoint cannot currently produce a row where the two disagree — it builds every row
+   * from a signature its own query has already filtered to signed — but this shape is not the
+   * list's alone. The pre-signing preview constructs one for an agreement nobody has signed, and
+   * the detail page's download gate serves both sources from this field. `signedOn` is not a
+   * stand-in for it either: that field is additionally conditional on upstream sending a date, so
+   * a signed agreement can carry no date and still have a document.
    */
   signed: boolean;
   status: OrgClaGroupStatus;
@@ -755,10 +760,14 @@ export interface OrgClaSignRequest {
 /**
  * The signing session EasyCLA opened, as the client consumes it (#1983).
  *
- * Deliberately just the address. Upstream also returns the signature, CLA group, project and
- * company identifiers, and none of them has a consumer here — the hand-off navigates and the
- * page is replaced. The signature id in particular is a pointer to a named person's agreement,
- * so shipping it to the browser unread would be handing out a reference for nothing.
+ * The address and the signature it belongs to, and nothing else. Upstream also returns the CLA
+ * group, project and company identifiers, none of which has a consumer here — the hand-off
+ * navigates and the page is replaced.
+ *
+ * The signature id is carried because the return address cannot name it. `return_url` is an
+ * *input* to the upstream request, fixed before a signature exists, so the only place the id and
+ * the address are ever held together is this response — and landing the signatory back on the
+ * agreement they just signed needs both.
  */
 export interface OrgClaSignResponse {
   /**
@@ -769,6 +778,14 @@ export interface OrgClaSignResponse {
    * a state to render.
    */
   signUrl: string;
+  /**
+   * The corporate signature this session will complete — the id that keys its row on the
+   * organization's CLA list, so the return can land on that agreement.
+   *
+   * A pointer to a named organization's agreement, and held accordingly: the client stashes it
+   * for the length of the round trip, spends it once, and never puts it in an address.
+   */
+  signatureId: string;
 }
 
 /**
@@ -785,6 +802,15 @@ export interface OrgClaSignAttestations {
 /** What the Org Lens CLA group picker is given. */
 export interface OrgClaGroupSelectDialogData {
   orgUid: string;
+  /**
+   * The organization's corporate CLAs, so the picker can refuse a CLA Group it already holds one
+   * for. The list is the one already loaded on the CLAs page the picker opens over — it is handed
+   * down rather than fetched again, mirroring `ClaGroupSelectDialogData`.
+   *
+   * Empty is a safe value and is what the page passes when its response belongs to a different
+   * organization: no row is refused, which is the behaviour before this check existed.
+   */
+  claGroups: OrgClaGroup[];
 }
 
 /** What the Org Lens CLA group picker closes with. */
@@ -792,6 +818,23 @@ export interface OrgClaGroupPickerResult {
   claGroupId: string;
   projectSfid: string;
   projectName: string;
+}
+
+/**
+ * The chosen CLA Group as it travels from the picker to the pre-signing preview page (#1983).
+ *
+ * A superset of what the signing request needs, because the preview has to *name* the agreement
+ * as well as key it. Nothing on the receiving page can look these names up: the CLA service has
+ * no fetch-a-CLA-group-by-id endpoint, so a page handed only ids could render a heading for an
+ * agreement it cannot describe.
+ */
+export interface OrgClaSignSelection extends OrgClaGroupPickerResult {
+  /**
+   * The CLA Group's own name, which the preview heads the page with — distinct from
+   * `projectName`, the covered project the corporate signature is keyed on. The two differ
+   * routinely ("Cascade CLA" over "Cascade"), and search names them separately.
+   */
+  claGroupName: string;
 }
 
 /**

--- a/packages/shared/src/utils/cla-identifier.utils.spec.ts
+++ b/packages/shared/src/utils/cla-identifier.utils.spec.ts
@@ -1,0 +1,53 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { canonicalClaGroupId, isSameClaGroup } from './cla-identifier.utils';
+
+const HYPHENATED = '01234567-89ab-cdef-0123-456789abcdef';
+const BARE = '0123456789abcdef0123456789abcdef';
+
+describe('canonicalClaGroupId', () => {
+  it.each([
+    [HYPHENATED, BARE],
+    [HYPHENATED.toUpperCase(), BARE],
+    [BARE, BARE],
+    [`  ${HYPHENATED}  `, BARE],
+  ])('canonicalises %p', (input, expected) => {
+    expect(canonicalClaGroupId(input)).toBe(expected);
+  });
+
+  // An empty canonical form is the "no answer" value the comparison relies on, so anything that is
+  // not CLA-Group-shaped has to reach it rather than pass through as itself.
+  it.each([[''], ['   '], ['not-a-uuid'], ['0123456789abcdef0123456789abcde'], [null], [undefined], [42], [{}]])('rejects %p', (input) => {
+    expect(canonicalClaGroupId(input)).toBe('');
+  });
+});
+
+describe('isSameClaGroup', () => {
+  // The case this exists for: the request carries one accepted spelling and the producer answers in
+  // its own. Comparing raw is what made a valid signing session look like a mismatch.
+  it.each([
+    [HYPHENATED, BARE],
+    [HYPHENATED, HYPHENATED.toUpperCase()],
+    [BARE.toUpperCase(), HYPHENATED],
+  ])('treats %p and %p as the same group', (left, right) => {
+    expect(isSameClaGroup(left, right)).toBe(true);
+  });
+
+  it('distinguishes genuinely different groups', () => {
+    expect(isSameClaGroup(HYPHENATED, 'fedcba98-7654-3210-fedc-ba9876543210')).toBe(false);
+  });
+
+  // Two values that cannot be read are not evidence of a match. Folding them together would make
+  // the mismatch guard pass on exactly the input it is least able to vouch for.
+  it.each([
+    ['', ''],
+    ['nonsense', 'nonsense'],
+    [null, null],
+    [undefined, undefined],
+  ])('does not call %p and %p the same group', (left, right) => {
+    expect(isSameClaGroup(left, right)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/cla-identifier.utils.ts
+++ b/packages/shared/src/utils/cla-identifier.utils.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CLA_GROUP_ID_PATTERN } from '../constants/regex.constants';
+
+/**
+ * The one spelling of a CLA Group id that two values can be compared in.
+ *
+ * `CLA_GROUP_ID_PATTERN` accepts hyphenated and unhyphenated forms in either case, because the
+ * EasyCLA producer does. That means two strings can name the same CLA Group and still fail `===`,
+ * so any comparison has to canonicalise first — lower-cased, hyphens removed. Returns an empty
+ * string for anything that is not CLA-Group-shaped, so a malformed value can never canonicalise
+ * into an accidental match with another malformed one.
+ */
+export function canonicalClaGroupId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+
+  const trimmed = value.trim();
+  if (!CLA_GROUP_ID_PATTERN.test(trimmed)) return '';
+
+  return trimmed.toLowerCase().replaceAll('-', '');
+}
+
+/**
+ * Whether two CLA Group identifiers name the same group, allowing for the spellings the producer
+ * accepts. Two unrecognizable values are never "the same": both canonicalise to empty, and an
+ * empty canonical form is treated as no answer rather than as a match.
+ */
+export function isSameClaGroup(left: unknown, right: unknown): boolean {
+  const a = canonicalClaGroupId(left);
+  return a !== '' && a === canonicalClaGroupId(right);
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -58,6 +58,7 @@ export * from './persona.utils';
 export * from './metric-trend.utils';
 export * from './org-meetings-insights.utils';
 export * from './cla-view.utils';
+export * from './cla-identifier.utils';
 export * from './cla-manager-actions.utils';
 export * from './org-cla-view.utils';
 export * from './committee-engagement-classifier.utils';

--- a/packages/shared/src/utils/org-cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/org-cla-view.utils.spec.ts
@@ -3,7 +3,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { orgClaCoverageChips, orgClaCoverageSummary, orgClaOpenLabel } from './org-cla-view.utils';
+import type { OrgClaSignSelection } from '../interfaces/cla.interface';
+import { orgClaCoverageChips, orgClaCoverageSummary, orgClaOpenLabel, orgClaPreviewGroup } from './org-cla-view.utils';
 
 describe('orgClaOpenLabel', () => {
   it('names the agreement alone when nothing else distinguishes it', () => {
@@ -86,5 +87,43 @@ describe('orgClaCoverageSummary', () => {
 
   it('summarises nothing when the agreement names no projects', () => {
     expect(orgClaCoverageSummary({ projects: [] })).toBe('');
+  });
+});
+
+describe('orgClaPreviewGroup', () => {
+  const selection: OrgClaSignSelection = {
+    claGroupId: 'cla-group-uuid-1',
+    claGroupName: 'Cascade CLA',
+    projectSfid: 'a09410000182dD2AAI',
+    projectName: 'Cascade',
+  };
+
+  it('heads the preview with the CLA Group the picker named, as an agreement nobody has signed', () => {
+    expect(orgClaPreviewGroup(selection)).toMatchObject({ claGroupName: 'Cascade CLA', signed: false, status: 'not-started' });
+  });
+
+  /**
+   * The two fields the signing scope is read from, and the reason this is a function rather than a
+   * spread.
+   *
+   * `projects` holding exactly the entry search named routes the scope through the single-covered-
+   * project branch, which returns the SFID search gave. `foundationSfid` staying unset matters
+   * because that branch is read *first*: setting it would assert a foundation where search may have
+   * named a project, changing the scope the corporate agreement is opened at rather than mislabelling
+   * it. Neither is observable from the preview page's own rendering, which is why they are pinned
+   * here.
+   */
+  it('names exactly the one project search resolved, and asserts no foundation', () => {
+    const group = orgClaPreviewGroup(selection);
+
+    expect(group.projects).toEqual([{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }]);
+    expect(group.foundationSfid).toBeUndefined();
+    expect(group.foundationName).toBeUndefined();
+  });
+
+  // 0, not absent. Absence means the deployment did not report a count; this agreement genuinely has
+  // none, because it has no signature for them to hang off.
+  it('reports no managers and no approval criteria, rather than reporting nothing', () => {
+    expect(orgClaPreviewGroup(selection)).toMatchObject({ claManagersCount: 0, approvalCriteriaCount: 0, needsClaManager: false });
   });
 });

--- a/packages/shared/src/utils/org-cla-view.utils.ts
+++ b/packages/shared/src/utils/org-cla-view.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { OrgClaCoverageChip, OrgClaGroup } from '../interfaces/cla.interface';
+import type { OrgClaCoverageChip, OrgClaGroup, OrgClaSignSelection } from '../interfaces/cla.interface';
 
 export function orgClaCoverageSummary(group: Pick<OrgClaGroup, 'projects'>): string {
   const { projects } = group;
@@ -47,4 +47,40 @@ export function orgClaCoverageChips(group: Pick<OrgClaGroup, 'projects' | 'found
 
   const projectsChip: OrgClaCoverageChip = { label: `Covers ${projects.length} projects`, opensCoverage: true };
   return foundationName ? [{ label: foundationName, opensCoverage: false }, projectsChip] : [projectsChip];
+}
+
+/**
+ * The row the pre-signing preview page renders, built from the picker's choice rather than fetched
+ * (#1983).
+ *
+ * The preview describes an agreement that does not exist yet, so there is no list row to find: the
+ * page is keyed on the CCLA signature id, and nobody has signed. Everything the detail page shows
+ * already works off an `OrgClaGroup`, so this is the one place the selection becomes that shape.
+ *
+ * Two fields carry the whole reason this is a function rather than a spread:
+ *
+ * - **`projects` holds exactly the one entry search named.** That single entry is what routes the
+ *   signing scope through the single-covered-project branch, which returns the SFID search gave.
+ * - **`foundationSfid` is left unset**, even though search resolves `projectSfid` to the foundation
+ *   for a foundation-level group. Setting it would *assert* a foundation where search may have
+ *   named a project, and the signing scope reads `foundationSfid` first — so the assertion would
+ *   change the scope the corporate agreement is opened at rather than merely mislabel it.
+ *
+ * `id` is empty because no signature exists. Nothing keys off it here: the document offer reads
+ * `signed`, and the list lookup is bypassed entirely.
+ */
+export function orgClaPreviewGroup(selection: OrgClaSignSelection): OrgClaGroup {
+  return {
+    id: '',
+    claGroupId: selection.claGroupId,
+    claGroupName: selection.claGroupName,
+    projects: [{ projectName: selection.projectName, projectSfid: selection.projectSfid }],
+    signed: false,
+    status: 'not-started',
+    needsClaManager: false,
+    claManagersCount: 0,
+    // 0, not absent. Absence means the deployment did not report a count; this agreement genuinely
+    // has no approval criteria, because it has no signature for them to hang off.
+    approvalCriteriaCount: 0,
+  };
 }


### PR DESCRIPTION
> **Superseded — do not review this one.** This work is now three stacked PRs, split
> so each is small enough to review with confidence: #2304 (server + shared, no
> user-visible change), #2305 (the outbound signing flow), #2306 (the DocuSign return
> leg). Every review comment raised here has been addressed in whichever of the three
> owns it. Left open for reference until they merge.

> **WIP / Draft.** Work still in progress.

Makes the Sign CLA control on the Organization Lens EasyCLA page operable for the
self-sign path: pick a CLA Group, review the agreement on `/org/easycla/new`, confirm
signing authority and export compliance, then hand off to the EasyCLA signing session
and come back to the signed agreement.

Refs #1983

**External references** — consumes `POST /v4/self-serve/request-corporate-signature`
from linuxfoundation/easycla#5193 (merged 2026-09-04, deployed to DEV). Must be in the
target environment before this is enabled there.

