### PR TITLE
feat(formation): carry is_foundation and parent_uid

### DIFF
--- a/packages/shared/src/enums/formation.enum.spec.ts
+++ b/packages/shared/src/enums/formation.enum.spec.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest';
 
 import { FORMATION_SUB_STAGE_LABELS } from '../constants/formation.constants';
 import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } from './formation.enum';
-import type { FormationTemplate } from '../interfaces/formation.interface';
+import type { Formation, FormationItem, FormationTemplate } from '../interfaces/formation.interface';
 
 describe('FormationTemplateSectionKey', () => {
   it('is exhaustive against the two-section seeded template taxonomy', () => {
@@ -118,5 +118,105 @@ describe('FormationTemplate shape', () => {
     expect(manualItem.action_link).toContain('{{project.uid}}');
     expect(linkItem.action_link).toBe('https://example.com/docusign/envelope');
     expect(noLinkItem).not.toHaveProperty('action_link');
+  });
+});
+
+describe('Formation shape', () => {
+  // These two derivation-input fields (#1957, GH-2163 §1) replace the removed `entity_type`
+  // field. `satisfies` alone can't gate their presence or nullability — this package's `test`
+  // script (vitest, esbuild transpile) doesn't type-check, and `check-types` (tsc --noEmit)
+  // excludes `*.spec.ts` — so the round-trip below is the only thing that actually gates
+  // `parent_uid: null` surviving JSON transport as `null` rather than being dropped the way
+  // `undefined` would be. It does NOT and cannot gate that `entity_type` stays removed from the
+  // type — these are plain object literals, not re-checked against `Formation` at runtime, so a
+  // literal that never wrote `entity_type` proves nothing about whether the interface still has
+  // it. That removal is enforced only by `yarn check-types`/`yarn build` over the non-spec sources.
+  it('round-trips is_foundation and a null parent_uid (top-level project) through JSON', () => {
+    const formation = {
+      uid: 'formation-test',
+      parent_project_uid: 'project-test',
+      parent_project_slug: 'project-test-slug',
+      parent_project_name: 'Project Test',
+      is_foundation: true,
+      parent_uid: null,
+      template_uid: 'formation-template-test',
+      template_version: 1,
+      sub_stage: 'exploratory',
+      announcement_date: null,
+      is_activating: false,
+      gating_items_open: 1,
+      gating_items_total: 1,
+      blocking_item_title: null,
+      subtitle: null,
+      created_at: '2026-09-08T00:00:00.000Z',
+      updated_at: '2026-09-08T00:00:00.000Z',
+    } satisfies Formation;
+
+    const roundTripped = JSON.parse(JSON.stringify(formation)) as Formation;
+
+    expect(roundTripped.is_foundation).toBe(true);
+    expect(roundTripped).toHaveProperty('parent_uid');
+    expect(roundTripped.parent_uid).toBeNull();
+  });
+
+  it('round-trips a non-null parent_uid (nested project) through JSON', () => {
+    const formation = {
+      uid: 'formation-test-2',
+      parent_project_uid: 'project-test-2',
+      parent_project_slug: 'project-test-2-slug',
+      parent_project_name: 'Project Test 2',
+      is_foundation: false,
+      parent_uid: 'foundation-project-uid',
+      template_uid: 'formation-template-test',
+      template_version: 1,
+      sub_stage: 'engaged',
+      announcement_date: null,
+      is_activating: false,
+      gating_items_open: 1,
+      gating_items_total: 1,
+      blocking_item_title: null,
+      subtitle: null,
+      created_at: '2026-09-08T00:00:00.000Z',
+      updated_at: '2026-09-08T00:00:00.000Z',
+    } satisfies Formation;
+
+    const roundTripped = JSON.parse(JSON.stringify(formation)) as Formation;
+
+    expect(roundTripped.is_foundation).toBe(false);
+    expect(roundTripped.parent_uid).toBe('foundation-project-uid');
+  });
+});
+
+describe('FormationItem shape', () => {
+  it('round-trips project_uid through JSON', () => {
+    const item = {
+      uid: 'formation-item-test',
+      formation_uid: 'formation-test',
+      project_uid: 'project-test',
+      template_item_key: 'launch-chat-workspace',
+      section_key: 'community_and_launch',
+      section_title: 'Community and launch',
+      title: 'Chat workspace',
+      status: 'not_started',
+      is_gating: false,
+      owner_team: null,
+      owner: null,
+      due_date: null,
+      action: 'manual',
+      action_href: null,
+      detail: null,
+      notes: null,
+      links: [],
+      sub_items: [],
+      skip_reason: null,
+      can_complete: true,
+      created_at: '2026-09-08T00:00:00.000Z',
+      updated_at: '2026-09-08T00:00:00.000Z',
+    } satisfies FormationItem;
+
+    const roundTripped = JSON.parse(JSON.stringify(item)) as FormationItem;
+
+    expect(roundTripped).toHaveProperty('project_uid');
+    expect(roundTripped.project_uid).toBe('project-test');
   });
 });

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -270,15 +270,17 @@ export interface FormationChecklistResponse {
 }
 
 /**
- * Per-`sub_stage` counts for the queue's filter pills. `foundations` and `child_projects` name
- * the {@link FormationEntityType} derived taxonomy — `child_projects` counts both `child_project`
- * and `project` rows (i.e. every non-foundation), so a plain top-level project isn't dropped from
- * the breakdown while still counting toward `total`.
+ * Per-`sub_stage` counts for the queue's filter pills. `foundations` and `projects` name the
+ * {@link FormationEntityType} derived taxonomy — `projects` counts both `child_project` and
+ * `project` rows (i.e. every non-foundation), so a plain top-level project isn't dropped from the
+ * breakdown while still counting toward `total`. Named `projects`, not `child_projects`, because
+ * the taxonomy now deliberately distinguishes a plain top-level `project` from a `child_project`
+ * and this aggregate deliberately includes both.
  */
 export type FormationQueueTiles = Record<FormationSubStage, number> & {
   total: number;
   foundations: number;
-  child_projects: number;
+  projects: number;
 };
 
 /** Response body for `GET /api/formations`. */

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -30,10 +30,15 @@ import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } 
 export type FormationSubStage = 'exploratory' | 'engaged' | 'on_hold';
 
 /**
- * What kind of record is in formation — drives the queue's Type column and indentation.
- * TODO(#1958): this is a display taxonomy that should be derived (`is_foundation` on the project,
- * plus "parent is not the root" for a child project) rather than stored; `child_project` is kept
- * as a stored value for now because the canonical `Formation` has neither signal yet.
+ * What kind of record is in formation — drives the queue's Type column and indentation. Derived,
+ * never stored: compute with {@link deriveFormationEntityType} (`formation.utils.ts`) from
+ * {@link Formation.is_foundation} and {@link Formation.parent_uid}, don't add a stored field for
+ * it (GH-2163 §1, confirmed on #1957 8 Sep — "nothing stored, and we can derive").
+ *
+ * Outstanding: the derivation is only correct if a top-level project's `parent_uid` reaches the
+ * client as `null` rather than the real (hidden, per-environment) root project's UID — see that
+ * field's doc comment. Nothing in this repo performs that normalization yet; it lands with the
+ * BFF's queue-wiring work, not here.
  */
 export type FormationEntityType = 'foundation' | 'child_project' | 'project';
 
@@ -45,12 +50,36 @@ export interface FormationUser {
 
 export interface Formation {
   uid: string;
+  /** The project this formation is FOR — not that project's parent; see {@link Formation.parent_uid} for that. */
   parent_project_uid: string;
   parent_project_slug: string;
   parent_project_name: string;
-  /** Present only for a `child_project` — the foundation/project this formation nests under, for the queue's indented display. */
+  /** Present only when {@link deriveFormationEntityType} resolves `child_project` — the foundation/project this formation nests under, for the queue's indented display. */
   parent_formation_name?: string;
-  entity_type: FormationEntityType;
+  /** Derivation input (#1957, GH-2163 §1) — whether {@link Formation.parent_project_uid}'s project is a foundation. Mirrors the upstream project's `is_foundation`. */
+  is_foundation: boolean;
+  /**
+   * Derivation input (#1957, GH-2163 §1) — the UID of {@link Formation.parent_project_uid}'s
+   * project's OWN parent (one level further up than `parent_project_uid` itself). Upstream, a
+   * project's `parent_uid` is required and non-empty — even a top-level project is parented to
+   * the hidden `ROOT` project (`lfx-v2-project-service` `scripts/root-project-setup`), whose UID
+   * is a fresh, per-environment UUID that is resolved only server-side (this repo's
+   * `persona-detection.service.ts` NATS `PROJECT_SLUG_TO_UID` lookup) and never reaches the
+   * client. This field must therefore be `null` here rather than that UID — the producer (the
+   * BFF, when it wires the real service) collapses a `ROOT`-parented project's `parent_uid` to
+   * `null` before this payload is built. This repo already has the ROOT-collapse precedent, just
+   * shaped slightly differently: `resolveParentProject` in `public-meeting.controller.ts`
+   * (LFXV2-3266) nulls out a project's *resolved parent object* — `parent?.slug ===
+   * ROOT_PROJECT_SLUG ? null : parent` — surfaced as `PublicMeetingProject.parent`, rather than
+   * collapsing a raw `parent_uid` string the way this field does; `deriveFormationEntityType`
+   * (`formation.utils.ts`) also treats an un-collapsed empty string the same as `null`, since an
+   * omitted/blank value is a more likely producer slip than a real ROOT UUID. Nothing in this
+   * repo performs the `parent_uid`-collapse normalization yet — nothing here derives
+   * `FormationEntityType` from a raw upstream value either. If a caller ever observes a real UID
+   * (not `null`/empty) on a top-level project, that normalization is missing or broken, and every
+   * foundation-tier formation would silently misderive as `child_project`.
+   */
+  parent_uid: string | null;
   template_uid: string;
   template_version: number;
   sub_stage: FormationSubStage;
@@ -100,6 +129,15 @@ export interface FormationSubItem {
 export interface FormationItem {
   uid: string;
   formation_uid: string;
+  /**
+   * The project this item's formation belongs to. Present because the real service (#1957)
+   * addresses an item's write route by `(project_uid, item_key)`, not by `uid` alone — the API
+   * gateway's authorization rule reads `project:<uid>` straight off the request path, and an
+   * opaque item `uid` would force that check inside the service instead. `uid` remains the
+   * durable reference for deep links and activity; `template_item_key` (the service's `item_key`)
+   * is stable by contract — a template upgrade only adds items, never renames or resets one.
+   */
+  project_uid: string;
   template_item_key: string;
   section_key: string;
   section_title: string;
@@ -231,7 +269,12 @@ export interface FormationChecklistResponse {
   data_source: 'fixture' | 'live';
 }
 
-/** Per-`sub_stage` counts for the queue's filter pills. */
+/**
+ * Per-`sub_stage` counts for the queue's filter pills. `foundations` and `child_projects` name
+ * the {@link FormationEntityType} derived taxonomy — `child_projects` counts both `child_project`
+ * and `project` rows (i.e. every non-foundation), so a plain top-level project isn't dropped from
+ * the breakdown while still counting toward `total`.
+ */
 export type FormationQueueTiles = Record<FormationSubStage, number> & {
   total: number;
   foundations: number;

--- a/packages/shared/src/utils/formation.utils.spec.ts
+++ b/packages/shared/src/utils/formation.utils.spec.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { deriveFormationEntityType } from './formation.utils';
+
+describe('deriveFormationEntityType', () => {
+  it('derives foundation when is_foundation is true, regardless of parent_uid', () => {
+    expect(deriveFormationEntityType({ is_foundation: true, parent_uid: null })).toBe('foundation');
+    expect(deriveFormationEntityType({ is_foundation: true, parent_uid: 'some-parent-uid' })).toBe('foundation');
+  });
+
+  it('derives project when not a foundation and parent_uid is null (top-level)', () => {
+    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: null })).toBe('project');
+  });
+
+  it('derives project for every other falsy parent_uid form, not just null', () => {
+    // Deliberately falsy, not `=== null`: a producer that omits the key (`undefined`) or sends
+    // an un-collapsed empty string is the more likely deviation from the `null` contract than a
+    // real ROOT UUID, and must not silently mislabel a top-level project as `child_project`.
+    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: undefined as unknown as null })).toBe('project');
+    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: '' as unknown as null })).toBe('project');
+  });
+
+  it('derives child_project when not a foundation and parent_uid names a real parent', () => {
+    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: 'cncf-uid' })).toBe('child_project');
+  });
+});

--- a/packages/shared/src/utils/formation.utils.spec.ts
+++ b/packages/shared/src/utils/formation.utils.spec.ts
@@ -19,8 +19,8 @@ describe('deriveFormationEntityType', () => {
     // Deliberately falsy, not `=== null`: a producer that omits the key (`undefined`) or sends
     // an un-collapsed empty string is the more likely deviation from the `null` contract than a
     // real ROOT UUID, and must not silently mislabel a top-level project as `child_project`.
-    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: undefined as unknown as null })).toBe('project');
-    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: '' as unknown as null })).toBe('project');
+    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: undefined })).toBe('project');
+    expect(deriveFormationEntityType({ is_foundation: false, parent_uid: '' })).toBe('project');
   });
 
   it('derives child_project when not a foundation and parent_uid names a real parent', () => {

--- a/packages/shared/src/utils/formation.utils.ts
+++ b/packages/shared/src/utils/formation.utils.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Formation, FormationEntityType } from '../interfaces/formation.interface';
+
+/**
+ * Derives the Formations queue's Type-column taxonomy from the two inputs the formation service
+ * serves (#1957, GH-2163 §1) — confirmed 8 Sep as "nothing stored, and we can derive." Never
+ * store the result; call this wherever {@link FormationEntityType} is needed.
+ *
+ * `parent_uid` must already be `null` for a top-level project, not the hidden `ROOT` project's
+ * UID — see {@link Formation.parent_uid}'s doc comment for why. The check below is deliberately
+ * falsy (`!formation.parent_uid`), not a strict `=== null`, matching this repo's existing
+ * ROOT-collapse precedent (`public-meeting.controller.ts`'s `!project.parent_uid` check) — a
+ * producer that omits the key (`undefined`) or sends an un-collapsed empty string must not
+ * silently fall through to `child_project` just because it wrote the wrong falsy value. A caller
+ * getting `child_project` for a project it knows is top-level means the producer sent a real,
+ * non-empty UID (the un-normalized ROOT case), not that this function is wrong.
+ */
+export function deriveFormationEntityType(formation: Pick<Formation, 'is_foundation' | 'parent_uid'>): FormationEntityType {
+  if (formation.is_foundation) {
+    return 'foundation';
+  }
+  if (!formation.parent_uid) {
+    return 'project';
+  }
+  return 'child_project';
+}

--- a/packages/shared/src/utils/formation.utils.ts
+++ b/packages/shared/src/utils/formation.utils.ts
@@ -16,8 +16,12 @@ import type { Formation, FormationEntityType } from '../interfaces/formation.int
  * silently fall through to `child_project` just because it wrote the wrong falsy value. A caller
  * getting `child_project` for a project it knows is top-level means the producer sent a real,
  * non-empty UID (the un-normalized ROOT case), not that this function is wrong.
+ *
+ * `parent_uid` is `?: string | null` here, not `Formation`'s plain `string | null`, so the
+ * falsy-not-strict-null contract above is modeled honestly: `Formation.parent_uid` itself can
+ * never be `undefined`, but this helper deliberately also accepts a caller that omits the key.
  */
-export function deriveFormationEntityType(formation: Pick<Formation, 'is_foundation' | 'parent_uid'>): FormationEntityType {
+export function deriveFormationEntityType(formation: Pick<Formation, 'is_foundation'> & { parent_uid?: string | null }): FormationEntityType {
   if (formation.is_foundation) {
     return 'foundation';
   }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -67,3 +67,4 @@ export * from './newsletter.utils';
 export * from './event.utils';
 export * from './social-listening.utils';
 export * from './social-listening-filter.utils';
+export * from './formation.utils';


### PR DESCRIPTION
## Summary

Carries the two derivation inputs `lfx-v2-formation-service` (#1957) confirmed it will serve for the Formations queue's Type column, and one addressing field for the item write route. Types + doc contract + spec only — no BFF, UI, or service code, matching the shape of #2213.

- **`Formation.is_foundation: boolean`** and **`Formation.parent_uid: string | null`** — the two derivation inputs. `parent_uid` is `null` for a top-level project.
- **Removed `Formation.entity_type: FormationEntityType`.** `FormationEntityType` stays as a type, but is now derived — never stored — via the new pure `deriveFormationEntityType()` helper (`packages/shared/src/utils/formation.utils.ts`).
- **`FormationItem.project_uid: string`** — added because the service's write route is addressed `(project_uid, item_key)`, not by item `uid` alone: the API gateway's authorization rule reads `project:<uid>` off the request path.

Refs #1957, #2163.

### `entity_type` removal — verdict and why

**Remove it.** On #1957 (8 Sep), the service owner confirmed: *"The project reference this service reads already carries `is_foundation`, `parent_uid` and the sub-stage. The queue will serve those and let the UI derive the label. Needs #2175 to carry both fields."* Keeping a stored `entity_type` alongside those two inputs would leave two sources of truth for one fact, with nothing reconciling them.

**Root-detection finding that drove the `parent_uid: string | null` contract:** checked whether the client can identify "parent is the hidden ROOT project" from data it already holds — it cannot. Upstream, `parent_uid` is required and non-empty (even a top-level project is parented to the hidden `ROOT` project per `lfx-v2-project-service`'s `scripts/root-project-setup`). That project's UID is a fresh, per-environment UUID resolved only server-side over NATS (this repo's `persona-detection.service.ts`) and never reaches the browser. So the producer (the BFF, once it wires the real service) must collapse a `ROOT`-parented project's `parent_uid` to `null` before this payload is built — this repo already has a shaped precedent for that kind of ROOT-collapse in `public-meeting.controller.ts` (LFXV2-3266), documented in the new field's doc comment. Nothing in this repo performs that normalization yet since no formation data source exists — that's called out explicitly as outstanding.

`deriveFormationEntityType()` treats any falsy `parent_uid` (`null`, `undefined`, or an un-collapsed empty string) as top-level, not just a strict `null`, so a producer slip that omits the key doesn't silently misderive every top-level project as `child_project`.

### Follow-ups for the unmerged `#2033` branch (`feat/GH-1958-formation-checklist-queue`)

Verified via `git merge-tree` that #2033 still merges cleanly (one pre-existing, unrelated conflict in `sidebar-nav.service.spec.ts`; nothing in the formation files conflicts). Its own copy of `formation.interface.ts` is stale relative to `main` regardless and needs to take main's version on rebase. Beyond that, this removal forces:

- `formations-table.component.ts:85` — swap `FORMATION_ENTITY_TYPE_LABELS[row.entity_type]` for `FORMATION_ENTITY_TYPE_LABELS[deriveFormationEntityType(row)]`
- `formation-fixture.helper.ts` (lines ~320-404) — drop the stored `entity_type` writes, emit `is_foundation` + `parent_uid` instead
- `e2e/fixtures/mock-data/formation.mock.ts` and `e2e/helpers/formation-api-mock.helper.ts:79,82` — same swap for fixture values and tile counts

### Out of scope, flagged not skipped

- `evidence_link` — still open on #1957 (single `http`/`https` field vs. the canonical `links[]`); not this PR's to settle.
- The BFF's ROOT→`null` normalization — belongs with the queue wiring, not a types PR.

## Test plan

- [x] `./check-headers.sh`
- [x] `yarn lint && yarn format && yarn test && yarn build`
- [x] `yarn workspace @lfx-one/shared test` — 1402 tests passing, including new `deriveFormationEntityType` truth-table coverage and JSON round-trip specs for `is_foundation`/`parent_uid`/`project_uid`
- [x] `git merge-tree --write-tree origin/feat/GH-1958-formation-checklist-queue HEAD` — confirmed clean (see follow-ups above)
- [x] Three-reviewer pre-PR audit (general, self-serve code-review, self-serve learnings-review) — two Important findings addressed (strict `=== null` check widened to falsy; a vacuous round-trip assertion removed and doc-comment precedent citation corrected)
- No dev server or browser validation — nothing on `main` renders these types yet.