### PR TITLE
test(settings): add E2E coverage for email management

### DIFF
--- a/apps/lfx-one/e2e/account-settings-email-robust.spec.ts
+++ b/apps/lfx-one/e2e/account-settings-email-robust.spec.ts
@@ -1,0 +1,145 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Account Settings — email management, structural spec (#1852).
+ *
+ * Asserts the data-testid contract the Email Settings section promises to maintain:
+ * section/heading/card ids, per-address row and kebab ids, badge scoping, the loading
+ * placeholder, and where the validation banner sits in the tree. Kept free of user-facing
+ * copy so a wording change breaks only the content spec — the one exception is the kebab
+ * popup, whose PrimeNG MenuItem model carries no testid and must be queried by role.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  ALTERNATE_EMAIL,
+  DATA_LOAD_TIMEOUT,
+  ELEMENT_TIMEOUT,
+  emailRow,
+  installEmailMocks,
+  INVITE_VALIDATION_MESSAGE,
+  MENU_USE_FOR_INVITES,
+  menuItem,
+  openEmailSettings,
+  openRowMenu,
+  PRIMARY_EMAIL,
+  SECOND_ALTERNATE_EMAIL,
+  skipWhenAuthMissing,
+  suppressCookieBanner,
+} from './helpers/account-settings-email.helper';
+
+test.setTimeout(60_000);
+
+const ALL_EMAILS = [PRIMARY_EMAIL, ALTERNATE_EMAIL, SECOND_ALTERNATE_EMAIL];
+const INVITE_ON_ALTERNATE = { email_id: 'email-id-alt', email: ALTERNATE_EMAIL };
+
+test.describe('Account Settings — Email Management — Robust Tests', () => {
+  test.describe('Data-testid presence', () => {
+    test.beforeEach(async ({ page }) => {
+      await openEmailSettings(page);
+    });
+
+    test('exposes the section, heading and list card', async ({ page }) => {
+      await expect(page.getByTestId('section-email-settings')).toBeAttached();
+      await expect(page.getByTestId('email-settings-heading')).toBeAttached();
+      await expect(page.getByTestId('email-list-card')).toBeAttached();
+      await expect(page.getByTestId('email-settings-loading')).toHaveCount(0);
+      await expect(page.getByTestId('no-emails-message')).toHaveCount(0);
+    });
+
+    test('renders one row per address, keyed by address', async ({ page }) => {
+      await expect(page.locator('[data-testid^="email-row-"]')).toHaveCount(ALL_EMAILS.length);
+      for (const email of ALL_EMAILS) {
+        await expect(emailRow(page, email)).toBeAttached();
+      }
+    });
+
+    test('scopes the primary and verified badges to the primary row', async ({ page }) => {
+      await expect(page.getByTestId('primary-badge')).toHaveCount(1);
+      await expect(emailRow(page, PRIMARY_EMAIL).getByTestId('primary-badge')).toBeAttached();
+      await expect(page.getByTestId('verified-badge')).toHaveCount(ALL_EMAILS.length);
+    });
+  });
+
+  test.describe('Loading state', () => {
+    test('shows email-settings-loading before the list card', async ({ page }) => {
+      skipWhenAuthMissing();
+      await suppressCookieBanner(page);
+      await installEmailMocks(page, { emailsDelayMs: 3_000 });
+      await page.goto('/profile/settings', { waitUntil: 'domcontentloaded' });
+
+      const loading = page.getByTestId('email-settings-loading');
+      const card = page.getByTestId('email-list-card');
+      await expect(loading).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(card).toHaveCount(0);
+
+      await expect(card).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+      await expect(loading).toHaveCount(0);
+    });
+  });
+
+  test.describe('Meeting-invite badge contract', () => {
+    test('attaches no invite badge while the primary address is in effect', async ({ page }) => {
+      await openEmailSettings(page);
+      await expect(page.getByTestId('meeting-invites-badge')).toHaveCount(0);
+    });
+
+    test('attaches exactly one invite badge, inside the overriding row', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: INVITE_ON_ALTERNATE });
+      await expect(page.getByTestId('meeting-invites-badge')).toHaveCount(1);
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId('meeting-invites-badge')).toBeAttached();
+    });
+  });
+
+  test.describe('Menu trigger contract', () => {
+    test('labels each kebab trigger with its address', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: INVITE_ON_ALTERNATE });
+      for (const email of ALL_EMAILS) {
+        await expect(page.getByTestId(`email-menu-${email}`).locator('button')).toHaveAttribute('aria-label', `Email actions for ${email}`);
+      }
+    });
+
+    test('renders the popup outside its row (appendTo="body")', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: INVITE_ON_ALTERNATE });
+      await openRowMenu(page, SECOND_ALTERNATE_EMAIL);
+
+      await expect(menuItem(page, MENU_USE_FOR_INVITES)).toBeAttached();
+
+      // Row-scoped queries would silently miss the popup — assert it really is detached from the row.
+      const row = await emailRow(page, SECOND_ALTERNATE_EMAIL).elementHandle();
+      const menu = await page.getByRole('menu').elementHandle();
+      const nestedInRow = await page.evaluate(([rowEl, menuEl]) => rowEl!.contains(menuEl), [row, menu]);
+      expect(nestedInRow).toBe(false);
+    });
+  });
+
+  test.describe('Banner contract', () => {
+    test('places the banner inside the section but outside the list card', async ({ page }) => {
+      await openEmailSettings(page, { putBehavior: { kind: 'error', status: 400, message: INVITE_VALIDATION_MESSAGE } });
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+
+      const banner = page.getByTestId('meeting-invite-error-banner');
+      await expect(banner).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(page.getByTestId('section-email-settings').getByTestId('meeting-invite-error-banner')).toBeAttached();
+      await expect(page.getByTestId('email-list-card').getByTestId('meeting-invite-error-banner')).toHaveCount(0);
+    });
+
+    test('attaches no banner on the success path', async ({ page }) => {
+      await openEmailSettings(page);
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId('meeting-invites-badge')).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+      await expect(page.getByTestId('meeting-invite-error-banner')).toHaveCount(0);
+    });
+  });
+});

--- a/apps/lfx-one/e2e/account-settings-email.spec.ts
+++ b/apps/lfx-one/e2e/account-settings-email.spec.ts
@@ -1,0 +1,183 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Account Settings — email management, content spec (#1852).
+ *
+ * Drives the Email Settings section of /profile/settings through the meeting-invitation
+ * preference workflow: choosing an alternate address, resetting to the primary via the
+ * sentinel, the delete guard, the cross-row in-flight lock, and the 400-only validation
+ * banner. The email API surface is mocked (see helpers/account-settings-email.helper.ts)
+ * so the spec doesn't depend on a seeded backend test user.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  ALTERNATE_EMAIL,
+  closeRowMenu,
+  DELETE_BLOCKED_BY_INVITE_TITLE,
+  DELETE_BLOCKED_BY_SAVE_TITLE,
+  ELEMENT_TIMEOUT,
+  emailRow,
+  INVITE_VALIDATION_MESSAGE,
+  MEETING_INVITE_PRIMARY_SENTINEL,
+  MENU_DELETE,
+  MENU_MAKE_PRIMARY,
+  MENU_RESET_TO_PRIMARY,
+  MENU_USE_FOR_INVITES,
+  menuItem,
+  openEmailSettings,
+  openRowMenu,
+  PRIMARY_EMAIL,
+  SECOND_ALTERNATE_EMAIL,
+} from './helpers/account-settings-email.helper';
+
+test.setTimeout(60_000);
+
+const INVITE_BADGE = 'meeting-invites-badge';
+const ERROR_BANNER = 'meeting-invite-error-banner';
+const SUPPORT_BUTTON = { name: 'contact support' } as const;
+
+test.describe('Account Settings — Email Management', () => {
+  test.describe('Meeting-invitation selection', () => {
+    test('sets an alternate address as the meeting-invitation email', async ({ page }) => {
+      const mocks = await openEmailSettings(page);
+
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId(INVITE_BADGE)).toHaveCount(0);
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId(INVITE_BADGE)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(emailRow(page, PRIMARY_EMAIL).getByTestId(INVITE_BADGE)).toHaveCount(0);
+      expect(mocks.putBodies()).toEqual([{ email: ALTERNATE_EMAIL }]);
+    });
+
+    test('refreshes the badge from a refetch, not from optimistic rendering', async ({ page }) => {
+      const mocks = await openEmailSettings(page);
+      const initialInviteGets = mocks.inviteGetCount();
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId(INVITE_BADGE)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+      // The badge is only reachable through the post-write emailRefresh refetch — a purely
+      // optimistic render would leave the GET count untouched.
+      expect(mocks.inviteGetCount()).toBeGreaterThan(initialInviteGets);
+    });
+
+    test('resets to the primary address via the sentinel', async ({ page }) => {
+      const mocks = await openEmailSettings(page, { initialInvite: { email_id: 'email-id-alt', email: ALTERNATE_EMAIL } });
+
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId(INVITE_BADGE)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+      await openRowMenu(page, PRIMARY_EMAIL);
+      await menuItem(page, MENU_RESET_TO_PRIMARY).click();
+
+      await expect(page.locator(`[data-testid="${INVITE_BADGE}"]`)).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+      expect(mocks.putBodies()).toEqual([{ email: MEETING_INVITE_PRIMARY_SENTINEL }]);
+    });
+
+    test('offers no no-op invite action on the row that already holds the override', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: { email_id: 'email-id-alt', email: ALTERNATE_EMAIL } });
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await expect(menuItem(page, MENU_USE_FOR_INVITES)).toHaveCount(0);
+      await expect(menuItem(page, MENU_RESET_TO_PRIMARY)).toHaveCount(0);
+      // The row still offers its unrelated actions, so the absence above isn't an empty menu.
+      await expect(menuItem(page, MENU_MAKE_PRIMARY)).toBeVisible();
+    });
+
+    test('offers no reset action while the primary address is already in effect', async ({ page }) => {
+      await openEmailSettings(page);
+
+      // With no override the primary row has no actions at all, so no kebab renders for it.
+      await expect(page.getByTestId(`email-menu-${PRIMARY_EMAIL}`)).toHaveCount(0);
+    });
+  });
+
+  test.describe('Delete guard', () => {
+    test('disables Delete on the meeting-invitation address and explains why', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: { email_id: 'email-id-alt', email: ALTERNATE_EMAIL } });
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      const blocked = menuItem(page, MENU_DELETE);
+      await expect(blocked).toHaveAttribute('aria-disabled', 'true');
+      await expect(blocked.locator('a')).toHaveAttribute('title', DELETE_BLOCKED_BY_INVITE_TITLE);
+    });
+
+    test('leaves Delete enabled on the other alternate address', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: { email_id: 'email-id-alt', email: ALTERNATE_EMAIL } });
+
+      await openRowMenu(page, SECOND_ALTERNATE_EMAIL);
+      await expect(menuItem(page, MENU_DELETE)).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    test('offers no Delete on the primary address', async ({ page }) => {
+      await openEmailSettings(page, { initialInvite: { email_id: 'email-id-alt', email: ALTERNATE_EMAIL } });
+
+      await openRowMenu(page, PRIMARY_EMAIL);
+      await expect(menuItem(page, MENU_DELETE)).toHaveCount(0);
+    });
+  });
+
+  test.describe('Write in flight', () => {
+    test('locks every row while the preference write is pending', async ({ page }) => {
+      const mocks = await openEmailSettings(page);
+      const releasePut = mocks.holdPut();
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+
+      // The lock is deliberately global, not per-row: a *different* row is checked here.
+      await openRowMenu(page, SECOND_ALTERNATE_EMAIL);
+      await expect(menuItem(page, MENU_USE_FOR_INVITES)).toHaveAttribute('aria-disabled', 'true');
+      const blocked = menuItem(page, MENU_DELETE);
+      await expect(blocked).toHaveAttribute('aria-disabled', 'true');
+      await expect(blocked.locator('a')).toHaveAttribute('title', DELETE_BLOCKED_BY_SAVE_TITLE);
+
+      await closeRowMenu(page);
+      releasePut();
+      await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId(INVITE_BADGE)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+      await openRowMenu(page, SECOND_ALTERNATE_EMAIL);
+      await expect(menuItem(page, MENU_USE_FOR_INVITES)).toHaveAttribute('aria-disabled', 'false');
+      await expect(menuItem(page, MENU_DELETE)).toHaveAttribute('aria-disabled', 'false');
+    });
+  });
+
+  test.describe('Validation banner', () => {
+    test('surfaces a 400 from the preference endpoint inline and dismisses it', async ({ page }) => {
+      await openEmailSettings(page, { putBehavior: { kind: 'error', status: 400, message: INVITE_VALIDATION_MESSAGE } });
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+
+      const banner = page.getByTestId(ERROR_BANNER);
+      await expect(banner).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(banner).toContainText(INVITE_VALIDATION_MESSAGE);
+      await expect(banner.getByRole('button', SUPPORT_BUTTON)).toBeVisible();
+      // A rejected write must not move the badge.
+      await expect(page.locator(`[data-testid="${INVITE_BADGE}"]`)).toHaveCount(0);
+
+      await banner.getByRole('button', { name: 'Close' }).click();
+      await expect(banner).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+    });
+
+    test('routes a non-validation failure to a toast rather than the inline banner', async ({ page }) => {
+      const unavailable = 'Meeting service is temporarily unavailable. Try again shortly.';
+      await openEmailSettings(page, { putBehavior: { kind: 'error', status: 503, message: unavailable } });
+
+      await openRowMenu(page, ALTERNATE_EMAIL);
+      await menuItem(page, MENU_USE_FOR_INVITES).click();
+
+      await expect(page.getByText(unavailable)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(page.getByTestId(ERROR_BANNER)).toHaveCount(0);
+    });
+  });
+});

--- a/apps/lfx-one/e2e/account-settings-email.spec.ts
+++ b/apps/lfx-one/e2e/account-settings-email.spec.ts
@@ -170,7 +170,8 @@ test.describe('Account Settings — Email Management', () => {
     });
 
     test('routes a non-validation failure to a toast rather than the inline banner', async ({ page }) => {
-      const unavailable = 'Meeting service is temporarily unavailable. Try again shortly.';
+      // Verbatim from profile.controller.ts's `unavailable` arm.
+      const unavailable = 'The meeting service is temporarily unavailable. Please try again in a few minutes.';
       await openEmailSettings(page, { putBehavior: { kind: 'error', status: 503, message: unavailable } });
 
       await openRowMenu(page, ALTERNATE_EMAIL);

--- a/apps/lfx-one/e2e/account-settings-email.spec.ts
+++ b/apps/lfx-one/e2e/account-settings-email.spec.ts
@@ -75,11 +75,17 @@ test.describe('Account Settings — Email Management', () => {
       const mocks = await openEmailSettings(page, { initialInvite: { email_id: 'email-id-alt', email: ALTERNATE_EMAIL } });
 
       await expect(emailRow(page, ALTERNATE_EMAIL).getByTestId(INVITE_BADGE)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      const initialInviteGets = mocks.inviteGetCount();
 
       await openRowMenu(page, PRIMARY_EMAIL);
       await menuItem(page, MENU_RESET_TO_PRIMARY).click();
 
-      await expect(page.locator(`[data-testid="${INVITE_BADGE}"]`)).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+      // The post-write refetch unmounts the whole card, badges included, so a bare count-0 would
+      // also pass mid-load. Settle on rendered rows after a completed refetch before asserting.
+      await expect.poll(() => mocks.inviteGetCount(), { timeout: ELEMENT_TIMEOUT }).toBeGreaterThan(initialInviteGets);
+      await expect(page.getByTestId('email-settings-loading')).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+      await expect(emailRow(page, ALTERNATE_EMAIL)).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(page.locator(`[data-testid="${INVITE_BADGE}"]`)).toHaveCount(0);
       expect(mocks.putBodies()).toEqual([{ email: MEETING_INVITE_PRIMARY_SENTINEL }]);
     });
 

--- a/apps/lfx-one/e2e/helpers/account-settings-email.helper.ts
+++ b/apps/lfx-one/e2e/helpers/account-settings-email.helper.ts
@@ -1,0 +1,228 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared mock surface for the Account Settings email-management specs (#1852).
+ *
+ * The page's email section loads its address list and its meeting-invitation preference
+ * as one pair (forkJoin in AccountSettingsComponent), and re-fetches that pair after every
+ * successful write. These mocks model that with mutable state so a post-write refetch
+ * returns the *new* value — which is what makes the badge-refresh assertions meaningful
+ * rather than a check on optimistic rendering.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+// Synthetic fixtures only — check-fixture-emails.sh blocks real customer/vendor domains.
+export const PRIMARY_EMAIL = 'primary.user@example.com';
+export const ALTERNATE_EMAIL = 'alt.user@example.com';
+// A third row exists so the in-flight guard can be proven on a row other than the one clicked.
+export const SECOND_ALTERNATE_EMAIL = 'second.alt@example.com';
+
+// Mirrors MEETING_INVITE_PRIMARY_SENTINEL in @lfx-one/shared/constants. Inlined rather than
+// imported because the shared constants barrel transitively pulls Angular runtime code that
+// the Playwright Node loader can't compile (same reason as profile-identities-support-link).
+export const MEETING_INVITE_PRIMARY_SENTINEL = 'primary';
+
+// Upstream copy for a rejected address, as profile.controller.ts returns it on a 400.
+export const INVITE_VALIDATION_MESSAGE =
+  'This email is not an active, verified address on your account yet. Choose a different email, or verify it and try again.';
+
+export const DELETE_BLOCKED_BY_INVITE_TITLE = 'This email is set for meeting invitations. Choose a different meeting-invitation email before deleting it.';
+export const DELETE_BLOCKED_BY_SAVE_TITLE = 'Updating the meeting-invitation email. Wait for it to finish before deleting an address.';
+
+export const MENU_USE_FOR_INVITES = 'Use for Meeting Invitations';
+export const MENU_RESET_TO_PRIMARY = 'Reset to Default (Primary Email)';
+export const MENU_MAKE_PRIMARY = 'Make Primary';
+export const MENU_DELETE = 'Delete';
+
+export const DATA_LOAD_TIMEOUT = 30_000;
+export const ELEMENT_TIMEOUT = 10_000;
+
+const EMAIL_ROUTE_GLOB = '**/api/profile/emails**';
+
+/** Shape of GET/PUT /api/profile/emails/meeting-invite (MeetingInviteEmail). */
+export interface InviteState {
+  email_id: string | null;
+  email: string | null;
+}
+
+export const NO_INVITE_OVERRIDE: InviteState = { email_id: null, email: null };
+
+export type PutBehavior = { kind: 'success' } | { kind: 'error'; status: number; message: string };
+
+export interface EmailMockOptions {
+  /** Meeting-invitation override the first GET reports. Defaults to none (falls back to primary). */
+  initialInvite?: InviteState;
+  /** How PUT /emails/meeting-invite responds. Defaults to success. */
+  putBehavior?: PutBehavior;
+  /** Artificial delay on GET /emails, used to observe the loading state. */
+  emailsDelayMs?: number;
+}
+
+export interface EmailMocks {
+  /** Request bodies recorded from PUT /emails/meeting-invite, in order. */
+  putBodies: () => { email: string }[];
+  /** How many times GET /emails/meeting-invite has been served. */
+  inviteGetCount: () => number;
+  /** Suspend the next PUT so the write stays in flight; call the returned fn to complete it. */
+  holdPut: () => () => void;
+}
+
+function emailListPayload(): Record<string, unknown> {
+  return {
+    primary_email: PRIMARY_EMAIL,
+    alternate_emails: [
+      // user_id is what makes canDelete true — without it the Delete item never renders.
+      { email: ALTERNATE_EMAIL, verified: true, user_id: 'auth0|alt-user' },
+      { email: SECOND_ALTERNATE_EMAIL, verified: true, user_id: 'auth0|second-alt-user' },
+    ],
+  };
+}
+
+function inviteStateFor(email: string | null): InviteState {
+  return email === null ? NO_INVITE_OVERRIDE : { email_id: `email-id-${email}`, email };
+}
+
+/**
+ * Registers a single handler for the whole /api/profile/emails surface and branches on
+ * pathname + method. One handler is deliberate: a second route on `**\/api/profile/emails*`
+ * would also swallow `/emails/meeting-invite`, making behavior depend on registration order.
+ */
+export async function installEmailMocks(page: Page, options: EmailMockOptions = {}): Promise<EmailMocks> {
+  let invite: InviteState = options.initialInvite ?? NO_INVITE_OVERRIDE;
+  const putBehavior: PutBehavior = options.putBehavior ?? { kind: 'success' };
+  const emailsDelayMs = options.emailsDelayMs ?? 0;
+
+  const recordedPutBodies: { email: string }[] = [];
+  let inviteGets = 0;
+  let putGate: Promise<void> | null = null;
+
+  await page.route(EMAIL_ROUTE_GLOB, async (route) => {
+    const request = route.request();
+    const { pathname } = new URL(request.url());
+    const method = request.method();
+
+    if (pathname.endsWith('/api/profile/emails') && method === 'GET') {
+      if (emailsDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, emailsDelayMs));
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(emailListPayload()) });
+    }
+
+    if (pathname.endsWith('/api/profile/emails/meeting-invite')) {
+      if (method === 'GET') {
+        inviteGets += 1;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(invite) });
+      }
+
+      if (method === 'PUT') {
+        const body = request.postDataJSON() as { email: string };
+        recordedPutBodies.push(body);
+
+        if (putGate) {
+          await putGate;
+        }
+
+        if (putBehavior.kind === 'error') {
+          return route.fulfill({
+            status: putBehavior.status,
+            contentType: 'application/json',
+            body: JSON.stringify({ error: 'meeting_invite_rejected', message: putBehavior.message }),
+          });
+        }
+
+        const isReset = body.email.trim().toLowerCase() === MEETING_INVITE_PRIMARY_SENTINEL;
+        invite = inviteStateFor(isReset ? null : body.email);
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(invite) });
+      }
+    }
+
+    return route.fallback();
+  });
+
+  return {
+    putBodies: () => recordedPutBodies,
+    inviteGetCount: () => inviteGets,
+    holdPut: () => {
+      let release: () => void = () => undefined;
+      putGate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return () => {
+        putGate = null;
+        release();
+      };
+    },
+  };
+}
+
+/**
+ * Neutralize the Osano consent overlay, which otherwise intercepts pointer events on the
+ * kebab triggers. Registered via addInitScript so it applies before page scripts on every
+ * navigation (mirrors profile-identities-support-link / profile-edit-drawer).
+ */
+export async function suppressCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const hide = (): void => {
+      if (document.getElementById('e2e-hide-osano')) {
+        return;
+      }
+      const style = document.createElement('style');
+      style.id = 'e2e-hide-osano';
+      style.textContent = '.osano-cm-window { display: none !important; pointer-events: none !important; }';
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', hide);
+    } else {
+      hide();
+    }
+  });
+}
+
+// Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
+// storageState, broken Auth0 login helper) still fail loudly when creds ARE configured —
+// URL-based detection silently turned those into green skips instead. Matches the pattern in
+// helpers/org-groups.helper.ts.
+const AUTH_CREDS_PRESENT = !!process.env['TEST_USERNAME'] && !!process.env['TEST_PASSWORD'];
+
+export function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+/** Install mocks, land on /profile/settings, and wait for the email list to render. */
+export async function openEmailSettings(page: Page, options: EmailMockOptions = {}): Promise<EmailMocks> {
+  skipWhenAuthMissing();
+  await suppressCookieBanner(page);
+  const mocks = await installEmailMocks(page, options);
+  await page.goto('/profile/settings', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('email-list-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  return mocks;
+}
+
+export function emailRow(page: Page, email: string) {
+  return page.getByTestId(`email-row-${email}`);
+}
+
+/**
+ * Open a row's kebab menu. The popup is appended to <body>, so menu items are always queried
+ * at page level — never scoped to the row element.
+ */
+export async function openRowMenu(page: Page, email: string): Promise<void> {
+  await page.getByTestId(`email-menu-${email}`).locator('button').click();
+  await expect(page.getByRole('menu')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+}
+
+/** Close an open kebab popup so the next row's menu can be opened cleanly. */
+export async function closeRowMenu(page: Page): Promise<void> {
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('menu')).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+}
+
+export function menuItem(page: Page, label: string) {
+  return page.getByRole('menuitem', { name: label, exact: true });
+}

--- a/apps/lfx-one/e2e/helpers/account-settings-email.helper.ts
+++ b/apps/lfx-one/e2e/helpers/account-settings-email.helper.ts
@@ -80,6 +80,18 @@ function emailListPayload(): Record<string, unknown> {
   };
 }
 
+/**
+ * The exact body BaseApiError.toResponse() emits, so the specs run the branch of
+ * extractErrorMessage production runs: errors[].message for the 400 (the endpoint's only 400 is a
+ * ServiceValidationError) and the top-level error for anything else. There is no top-level message.
+ */
+function errorBody(behavior: { status: number; message: string }): Record<string, unknown> {
+  const base = { error: behavior.message, service: 'profile_controller', path: '/api/profile/emails/meeting-invite' };
+  return behavior.status === 400
+    ? { ...base, code: 'VALIDATION_ERROR', errors: [{ field: 'email', message: behavior.message, code: 'FIELD_VALIDATION_ERROR' }] }
+    : { ...base, code: 'SERVICE_UNAVAILABLE' };
+}
+
 function inviteStateFor(email: string | null): InviteState {
   return email === null ? NO_INVITE_OVERRIDE : { email_id: `email-id-${email}`, email };
 }
@@ -128,7 +140,7 @@ export async function installEmailMocks(page: Page, options: EmailMockOptions = 
           return route.fulfill({
             status: putBehavior.status,
             contentType: 'application/json',
-            body: JSON.stringify({ error: 'meeting_invite_rejected', message: putBehavior.message }),
+            body: JSON.stringify(errorBody(putBehavior)),
           });
         }
 


### PR DESCRIPTION
## Summary

- Adds the content + structural spec pair for the Email Settings section of `/profile/settings`, which had no E2E coverage. The `data-testid` surface landed with #1073; only the specs were missing.
- `account-settings-email.spec.ts` drives the meeting-invitation workflow: selecting an alternate address (asserting the wire payload, not just the badge), resetting to the primary via the `primary` sentinel, the delete guard on the invite address, the cross-row lock while a write is in flight, and the 400-only validation banner (with a 503 arm proving non-validation failures route to a toast instead).
- `account-settings-email-robust.spec.ts` asserts the testid contract: section/heading/card ids, one row per address keyed by address, badge scoping, the loading→card transition, kebab `aria-label`s, the popup's `appendTo="body"` placement, and where the banner sits in the tree.
- `helpers/account-settings-email.helper.ts` mocks the `/api/profile/emails` surface with mutable state so a post-write refetch returns the new value — the badge assertions therefore prove the refetch, not optimistic rendering. One route handler branching on pathname + method, so behavior can't depend on registration order.
- Test-only; no component or server changes.

## Notes for reviewers

- PrimeNG's `MenuItem` model carries no `data-testid`, so kebab menu items are selected with `getByRole('menuitem', …)` — the one content-based selector in the structural spec. Rows, badges, banner, and menu *triggers* are still asserted structurally.
- The `e2e-tests` job in `quality-check.yml` is commented out on `main`, so these specs won't show as a check on this PR — they're local/opt-in coverage today. They self-skip when `TEST_USERNAME`/`TEST_PASSWORD` are unset, so they're safe if that job is ever re-enabled.

Closes #1852
