### PR TITLE
fix(events): dedupe deep-link resolution and fix event-id matching

### DIFF
--- a/apps/lfx-one/e2e/event-selection-robust.spec.ts
+++ b/apps/lfx-one/e2e/event-selection-robust.spec.ts
@@ -3,51 +3,10 @@
 
 import { expect, Page, test } from '@playwright/test';
 import { skipWhenAuthMissing } from './helpers/auth.helper';
+import { mockEventRoutes } from './helpers/events-mock.helper';
 import { DEFAULT_LENS, LENS_COOKIE_KEY } from '@lfx-one/shared/constants';
 
 test.beforeEach(() => skipWhenAuthMissing());
-
-const EMPTY_EVENTS_RESPONSE = { data: [], total: 0, pageSize: 10, offset: 0 };
-const EMPTY_COUNTRIES_RESPONSE = { data: [] };
-
-/**
- * Register a route handler that mocks all /api/events* calls deterministically.
- *
- * @param probeTotal  Total returned by the pageSize=1 registered-events probe (default 0 = no
- *                    registered events). Set >0 to simulate a user who is registered.
- * @param mainStatus  HTTP status for the primary events query (default 200 = success with empty
- *                    list). Set to 500 to trigger the error empty-state branch.
- */
-async function mockEventRoutes(page: Page, { probeTotal = 0, mainStatus = 200 }: { probeTotal?: number; mainStatus?: number } = {}) {
-  await page.route('**/api/events**', (route) => {
-    const url = route.request().url();
-
-    if (url.includes('/countries')) {
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
-    }
-    if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('/organizations') || url.includes('/all')) {
-      return route.fulfill({ status: mainStatus !== 200 ? mainStatus : 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
-    }
-
-    // Distinguish the pageSize=1 probe from the main paginated query via URL params.
-    const parsedUrl = new URL(url);
-    const isProbe = parsedUrl.searchParams.get('pageSize') === '1';
-
-    if (isProbe) {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ data: [], total: probeTotal, pageSize: 1, offset: 0 }),
-      });
-    }
-
-    if (mainStatus !== 200) {
-      return route.fulfill({ status: mainStatus, contentType: 'application/json', body: JSON.stringify({ error: 'Server error' }) });
-    }
-
-    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
-  });
-}
 
 /**
  * Navigate to /me/events, switch to the given tab, open the application dialog, and wait

--- a/apps/lfx-one/e2e/helpers/events-mock.helper.ts
+++ b/apps/lfx-one/e2e/helpers/events-mock.helper.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Page } from '@playwright/test';
+
+const EMPTY_EVENTS_RESPONSE = { data: [], total: 0, pageSize: 10, offset: 0 };
+const EMPTY_COUNTRIES_RESPONSE = { data: [] };
+
+export interface MockEventRoutesOptions<T extends { id: string }> {
+  /** Total returned by the pageSize=1 registered-events probe (default 0 = no registered events). */
+  probeTotal?: number;
+  /** HTTP status for the primary events query (default 200 = success with empty list). */
+  mainStatus?: number;
+  /** Event returned by the `eventId`-filtered deep-link resolver when its id matches. */
+  matchedEvent?: T;
+}
+
+/**
+ * Mocks all `/api/events*` calls shared by the events-list, event-selection, and deep-link
+ * flows. Single source for this route shape so drift between specs (e.g. the `/organizations`
+ * vs `search-organizations` endpoints) can't silently reappear.
+ */
+export async function mockEventRoutes<T extends { id: string }>(
+  page: Page,
+  { probeTotal = 0, mainStatus = 200, matchedEvent }: MockEventRoutesOptions<T> = {}
+): Promise<void> {
+  await page.route('**/api/events**', (route) => {
+    const url = route.request().url();
+
+    if (url.includes('/countries')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
+    }
+    if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('organizations') || url.includes('/all')) {
+      return route.fulfill({ status: mainStatus !== 200 ? mainStatus : 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+    }
+
+    const parsedUrl = new URL(url);
+    const eventId = parsedUrl.searchParams.get('eventId');
+    if (eventId) {
+      const data = matchedEvent && eventId === matchedEvent.id ? [matchedEvent] : [];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data, total: data.length, pageSize: 1, offset: 0 }) });
+    }
+
+    // Distinguish the pageSize=1 probe from the main paginated query via URL params.
+    if (parsedUrl.searchParams.get('pageSize') === '1') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], total: probeTotal, pageSize: 1, offset: 0 }),
+      });
+    }
+
+    if (mainStatus !== 200) {
+      return route.fulfill({ status: mainStatus, contentType: 'application/json', body: JSON.stringify({ error: 'Server error' }) });
+    }
+
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
+  });
+}

--- a/apps/lfx-one/e2e/my-events-request-deeplink-robust.spec.ts
+++ b/apps/lfx-one/e2e/my-events-request-deeplink-robust.spec.ts
@@ -1,0 +1,81 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, test } from '@playwright/test';
+import { skipWhenAuthMissing } from './helpers/auth.helper';
+import { mockEventRoutes } from './helpers/events-mock.helper';
+import { DEFAULT_LENS, LENS_COOKIE_KEY } from '@lfx-one/shared/constants';
+
+test.beforeEach(() => skipWhenAuthMissing());
+
+const MATCHED_EVENT = {
+  id: 'evt-deep-link-robust-1',
+  name: 'Open Source Summit',
+  url: 'https://events.linuxfoundation.org/open-source-summit',
+  registrationUrl: null,
+  foundation: 'Linux Foundation',
+  startDate: '2026-06-30T00:00:00.000Z',
+  date: 'Jun 30–Jul 2, 2026',
+  location: 'Seattle, WA',
+  role: 'Attendee',
+  status: 'Registered',
+};
+
+const DIALOG_TIMEOUT = { timeout: 10000 };
+
+test.describe('My Events — Visa/Travel-Fund Request Deep Link — Robust Structural Tests', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    // Ensure "me" lens is active so lensRedirectGuard doesn't redirect to /foundation/events.
+    const domain = baseURL ? new URL(baseURL).hostname : 'localhost';
+    await context.addCookies([{ name: LENS_COOKIE_KEY, value: DEFAULT_LENS, domain, path: '/' }]);
+  });
+
+  test.describe('Visa dialog — deep-linked structure', () => {
+    test('dialog, step indicator, and terms container are all attached', async ({ page }) => {
+      await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+      await page.goto(`/events?tab=visa-letters&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+
+      await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+      await expect(page.getByTestId('visa-request-step-indicator')).toBeAttached();
+      await expect(page.getByTestId('visa-request-terms')).toBeAttached();
+    });
+
+    test('step indicator renders exactly 3 step circles', async ({ page }) => {
+      await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+      await page.goto(`/events?tab=visa-letters&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+
+      await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+      await expect(page.locator('[data-testid^="visa-request-step-circle-"]')).toHaveCount(3);
+    });
+  });
+
+  test.describe('Travel-funding dialog — deep-linked structure', () => {
+    test('dialog, step indicator, and terms container are all attached', async ({ page }) => {
+      await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+      await page.goto(`/events?tab=travel-funding&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+
+      await expect(page.getByTestId('travel-fund-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+      await expect(page.getByTestId('travel-fund-step-indicator')).toBeAttached();
+      await expect(page.getByTestId('travel-fund-terms')).toBeAttached();
+    });
+
+    test('step indicator renders exactly 4 step circles', async ({ page }) => {
+      await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+      await page.goto(`/events?tab=travel-funding&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+
+      await expect(page.getByTestId('travel-fund-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+      await expect(page.locator('[data-testid^="travel-fund-step-circle-"]')).toHaveCount(4);
+    });
+  });
+
+  test.describe('No-match fallback — structure', () => {
+    test('falls back to the event-selection grid instead of the terms container', async ({ page }) => {
+      await mockEventRoutes(page); // no matchedEvent — the eventId lookup always returns empty
+      await page.goto('/events?tab=visa-letters&event=unknown-event-id', { waitUntil: 'domcontentloaded' });
+
+      await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+      await expect(page.getByTestId('event-selection-grid')).toBeVisible(DIALOG_TIMEOUT);
+      await expect(page.getByTestId('visa-request-terms')).not.toBeAttached();
+    });
+  });
+});

--- a/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
+++ b/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
@@ -69,9 +69,29 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link — non-"me" sta
   // Regression coverage for PR #2247 review (Copilot): MyEventsDashboardComponent only mounts
   // under the me/project lens, so a deep link opened while the persisted lens is foundation/org
   // must force the lens to `me` (myEventsRequestLensGuard) rather than silently never auto-opening.
+  //
+  // The lens cookie alone isn't enough to prove this: activeLens() clamps `foundation` back down to
+  // `me` for an account with no foundation-granting role, which would make this pass even with the
+  // guard removed. Stubbing `isLFStaff: true` (mirrors marketing-access.spec.ts's `stubPersona`)
+  // grants `foundation` for real, so the guard is the only thing standing between this cookie and a
+  // dialog that never opens.
   test('foundation lens: the guard forces me and the dialog still auto-opens', async ({ page, context, baseURL }) => {
     const domain = baseURL ? new URL(baseURL).hostname : 'localhost';
     await context.addCookies([{ name: LENS_COOKIE_KEY, value: 'foundation', domain, path: '/' }]);
+    await page.route('**/api/user/personas*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          personas: ['contributor'],
+          personaProjects: {},
+          projects: [],
+          organizations: [],
+          isRootWriter: false,
+          isLFStaff: true,
+        }),
+      })
+    );
 
     await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
     await page.goto(`/events?tab=visa-letters&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });

--- a/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
+++ b/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
@@ -1,14 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { skipWhenAuthMissing } from './helpers/auth.helper';
+import { mockEventRoutes } from './helpers/events-mock.helper';
 import { DEFAULT_LENS, LENS_COOKIE_KEY } from '@lfx-one/shared/constants';
 
 test.beforeEach(() => skipWhenAuthMissing());
-
-const EMPTY_EVENTS_RESPONSE = { data: [], total: 0, pageSize: 10, offset: 0 };
-const EMPTY_COUNTRIES_RESPONSE = { data: [] };
 
 const DEEP_LINK_EVENT_ID = 'evt-deep-link-123';
 const MATCHED_EVENT = {
@@ -26,34 +24,6 @@ const MATCHED_EVENT = {
 
 const DIALOG_TIMEOUT = { timeout: 10000 };
 
-/**
- * Mocks all /api/events* calls. The `eventId`-filtered call (the deep-link resolver, made
- * client-side once the dialog opens) returns `matchedEvent` when its id matches, otherwise empty.
- * Every other call this test actually exercises client-side (the event-selection grid's fetch,
- * countries, organizations) resolves empty so the dialog renders deterministically.
- */
-async function mockEventRoutes(page: Page, { matchedEvent }: { matchedEvent?: typeof MATCHED_EVENT } = {}) {
-  await page.route('**/api/events**', (route) => {
-    const url = route.request().url();
-
-    if (url.includes('/countries')) {
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
-    }
-    if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('search-organizations') || url.includes('/all')) {
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
-    }
-
-    const parsedUrl = new URL(url);
-    const eventId = parsedUrl.searchParams.get('eventId');
-    if (eventId) {
-      const data = matchedEvent && eventId === matchedEvent.id ? [matchedEvent] : [];
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data, total: data.length, pageSize: 1, offset: 0 }) });
-    }
-
-    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
-  });
-}
-
 test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
   test.beforeEach(async ({ context, baseURL }) => {
     // Ensure "me" lens is active so lensRedirectGuard doesn't redirect to /foundation/events.
@@ -67,7 +37,7 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
     await expect(page).not.toHaveURL(/auth0\.com/);
 
     await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
-    await expect(page.getByTestId('visa-request-step-circle-2')).toHaveClass(/bg-blue-600/);
+    await expect(page.getByTestId('visa-request-terms')).toBeVisible();
 
     // The `event` param is stripped once consumed, so a refresh doesn't reopen the dialog.
     await expect(page).toHaveURL(/tab=visa-letters/);
@@ -80,7 +50,7 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
     await expect(page).not.toHaveURL(/auth0\.com/);
 
     await expect(page.getByTestId('travel-fund-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
-    await expect(page.getByTestId('travel-fund-step-circle-2')).toHaveClass(/bg-blue-600/);
+    await expect(page.getByTestId('travel-fund-terms')).toBeVisible();
     await expect(page).not.toHaveURL(/event=/);
   });
 

--- a/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
+++ b/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
@@ -1,0 +1,97 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, test } from '@playwright/test';
+import { skipWhenAuthMissing } from './helpers/auth.helper';
+import { DEFAULT_LENS, LENS_COOKIE_KEY } from '@lfx-one/shared/constants';
+
+test.beforeEach(() => skipWhenAuthMissing());
+
+const EMPTY_EVENTS_RESPONSE = { data: [], total: 0, pageSize: 10, offset: 0 };
+const EMPTY_COUNTRIES_RESPONSE = { data: [] };
+
+const DEEP_LINK_EVENT_ID = 'evt-deep-link-123';
+const MATCHED_EVENT = {
+  id: DEEP_LINK_EVENT_ID,
+  name: 'Open Source Summit',
+  url: 'https://events.linuxfoundation.org/open-source-summit',
+  registrationUrl: null,
+  foundation: 'Linux Foundation',
+  startDate: '2026-06-30T00:00:00.000Z',
+  date: 'Jun 30–Jul 2, 2026',
+  location: 'Seattle, WA',
+  role: 'Attendee',
+  status: 'Registered',
+};
+
+/**
+ * Mocks all /api/events* calls. The `eventId`-filtered call (the deep-link resolver) returns
+ * `matchedEvent` when its id matches, otherwise empty — every other call (stats probes, request
+ * lists, countries) resolves empty so the dashboard renders deterministically.
+ */
+async function mockEventRoutes(page: Page, { matchedEvent }: { matchedEvent?: typeof MATCHED_EVENT } = {}) {
+  await page.route('**/api/events**', (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname.includes('/countries')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
+    }
+    if (
+      url.pathname.includes('/visa-requests') ||
+      url.pathname.includes('/travel-fund-requests') ||
+      url.pathname.includes('/organizations') ||
+      url.pathname.includes('/all')
+    ) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
+    }
+
+    const eventId = url.searchParams.get('eventId');
+    if (eventId) {
+      const data = matchedEvent && eventId === matchedEvent.id ? [matchedEvent] : [];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data, total: data.length, pageSize: 1, offset: 0 }) });
+    }
+
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
+  });
+}
+
+test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
+  test.beforeEach(async ({ context, baseURL }) => {
+    // Ensure "me" lens is active so lensRedirectGuard doesn't redirect to /foundation/events.
+    const domain = baseURL ? new URL(baseURL).hostname : 'localhost';
+    await context.addCookies([{ name: LENS_COOKIE_KEY, value: DEFAULT_LENS, domain, path: '/' }]);
+  });
+
+  test('opens the visa dialog on the Terms step and strips ?event= once matched', async ({ page }) => {
+    await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+    await page.goto(`/events?tab=visa-letters&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('visa-request-step-circle-2')).toHaveClass(/bg-blue-600/);
+
+    // The `event` param is stripped once consumed, so a refresh doesn't reopen the dialog.
+    await expect(page).toHaveURL(/tab=visa-letters/);
+    await expect(page).not.toHaveURL(/event=/);
+  });
+
+  test('opens the travel-funding dialog on the Terms step when the event matches', async ({ page }) => {
+    await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+    await page.goto(`/events?tab=travel-funding&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('travel-fund-application-dialog')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('travel-fund-step-circle-2')).toHaveClass(/bg-blue-600/);
+    await expect(page).not.toHaveURL(/event=/);
+  });
+
+  test('falls back to Choose an Event with a toast when the event id has no match', async ({ page }) => {
+    await mockEventRoutes(page); // no matchedEvent — the eventId lookup always returns empty
+    await page.goto('/events?tab=visa-letters&event=unknown-event-id', { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('event-selection-grid')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("couldn't find that event")).toBeVisible();
+  });
+});

--- a/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
+++ b/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
@@ -24,28 +24,27 @@ const MATCHED_EVENT = {
   status: 'Registered',
 };
 
+const DIALOG_TIMEOUT = { timeout: 10000 };
+
 /**
- * Mocks all /api/events* calls. The `eventId`-filtered call (the deep-link resolver) returns
- * `matchedEvent` when its id matches, otherwise empty — every other call (stats probes, request
- * lists, countries) resolves empty so the dashboard renders deterministically.
+ * Mocks all /api/events* calls. The `eventId`-filtered call (the deep-link resolver, made
+ * client-side once the dialog opens) returns `matchedEvent` when its id matches, otherwise empty.
+ * Every other call this test actually exercises client-side (the event-selection grid's fetch,
+ * countries, organizations) resolves empty so the dialog renders deterministically.
  */
 async function mockEventRoutes(page: Page, { matchedEvent }: { matchedEvent?: typeof MATCHED_EVENT } = {}) {
   await page.route('**/api/events**', (route) => {
-    const url = new URL(route.request().url());
+    const url = route.request().url();
 
-    if (url.pathname.includes('/countries')) {
+    if (url.includes('/countries')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
     }
-    if (
-      url.pathname.includes('/visa-requests') ||
-      url.pathname.includes('/travel-fund-requests') ||
-      url.pathname.includes('/organizations') ||
-      url.pathname.includes('/all')
-    ) {
+    if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('search-organizations') || url.includes('/all')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
     }
 
-    const eventId = url.searchParams.get('eventId');
+    const parsedUrl = new URL(url);
+    const eventId = parsedUrl.searchParams.get('eventId');
     if (eventId) {
       const data = matchedEvent && eventId === matchedEvent.id ? [matchedEvent] : [];
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data, total: data.length, pageSize: 1, offset: 0 }) });
@@ -67,7 +66,7 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
     await page.goto(`/events?tab=visa-letters&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
     await expect(page.getByTestId('visa-request-step-circle-2')).toHaveClass(/bg-blue-600/);
 
     // The `event` param is stripped once consumed, so a refresh doesn't reopen the dialog.
@@ -80,7 +79,7 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
     await page.goto(`/events?tab=travel-funding&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('travel-fund-application-dialog')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('travel-fund-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
     await expect(page.getByTestId('travel-fund-step-circle-2')).toHaveClass(/bg-blue-600/);
     await expect(page).not.toHaveURL(/event=/);
   });
@@ -90,8 +89,8 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
     await page.goto('/events?tab=visa-letters&event=unknown-event-id', { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('event-selection-grid')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+    await expect(page.getByTestId('event-selection-grid')).toBeVisible(DIALOG_TIMEOUT);
     await expect(page.getByText("couldn't find that event")).toBeVisible();
   });
 });

--- a/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
+++ b/apps/lfx-one/e2e/my-events-request-deeplink.spec.ts
@@ -64,3 +64,21 @@ test.describe('My Events — Visa/Travel-Fund Request Deep Link', () => {
     await expect(page.getByText("couldn't find that event")).toBeVisible();
   });
 });
+
+test.describe('My Events — Visa/Travel-Fund Request Deep Link — non-"me" starting lens', () => {
+  // Regression coverage for PR #2247 review (Copilot): MyEventsDashboardComponent only mounts
+  // under the me/project lens, so a deep link opened while the persisted lens is foundation/org
+  // must force the lens to `me` (myEventsRequestLensGuard) rather than silently never auto-opening.
+  test('foundation lens: the guard forces me and the dialog still auto-opens', async ({ page, context, baseURL }) => {
+    const domain = baseURL ? new URL(baseURL).hostname : 'localhost';
+    await context.addCookies([{ name: LENS_COOKIE_KEY, value: 'foundation', domain, path: '/' }]);
+
+    await mockEventRoutes(page, { matchedEvent: MATCHED_EVENT });
+    await page.goto(`/events?tab=visa-letters&event=${MATCHED_EVENT.id}`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page).not.toHaveURL(/\/foundation\/events/);
+
+    await expect(page.getByTestId('visa-request-application-dialog')).toBeVisible(DIALOG_TIMEOUT);
+    await expect(page.getByTestId('visa-request-terms')).toBeVisible();
+  });
+});

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -17,6 +17,7 @@ import { orgLensRoiEnabledGuard } from './shared/guards/org-lens-roi-enabled.gua
 import { akritesEnabledGuard } from './shared/guards/akrites-enabled.guard';
 import { mentorshipEnabledGuard } from './shared/guards/mentorship-enabled.guard';
 import { mktgOsAgentsEnabledGuard } from './shared/guards/mktg-os-agents-enabled.guard';
+import { myEventsRequestLensGuard } from './shared/guards/my-events-request-lens.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
 import { settingsLensRedirectGuard } from './shared/guards/settings-lens-redirect.guard';
 
@@ -449,7 +450,7 @@ export const routes: Routes = [
       },
       {
         path: 'events',
-        canActivate: [lensRedirectGuard, projectQueryParamGuard],
+        canActivate: [myEventsRequestLensGuard, lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
       },
       {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
@@ -31,6 +31,8 @@ export class EventRequestListComponent {
   public readonly requestType = input.required<RequestType>();
   public readonly searchQuery = input<string>('');
   public readonly status = input<string | null>(null);
+  /** Deep-linked event id (`?event=<id>`) to preselect when the application dialog opens. */
+  public readonly initialEventId = input<string | null>(null);
 
   protected readonly loading = signal(false);
   protected readonly sortField = signal<string>('APPLICATION_DATE');
@@ -85,6 +87,7 @@ export class EventRequestListComponent {
       modal: true,
       closable: true,
       closeOnEscape: true,
+      data: { initialEventId: this.initialEventId() },
     });
   }
 

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
@@ -80,7 +80,7 @@ export class EventRequestListComponent {
       });
   }
 
-  public openApplicationDialog(): void {
+  public openApplicationDialog(): boolean {
     this.dialogService.open(this.config().dialogComponent, {
       header: this.config().dialogHeader,
       width: '800px',
@@ -89,6 +89,7 @@ export class EventRequestListComponent {
       closeOnEscape: true,
       data: { initialEventId: this.initialEventId() },
     });
+    return true;
   }
 
   protected onPageChange(event: { first: number; rows: number }): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
@@ -80,7 +80,7 @@ export class EventRequestListComponent {
       });
   }
 
-  public openApplicationDialog(): boolean {
+  public openApplicationDialog(): void {
     this.dialogService.open(this.config().dialogComponent, {
       header: this.config().dialogHeader,
       width: '800px',
@@ -89,7 +89,6 @@ export class EventRequestListComponent {
       closeOnEscape: true,
       data: { initialEventId: this.initialEventId() },
     });
-    return true;
   }
 
   protected onPageChange(event: { first: number; rows: number }): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.html
@@ -65,8 +65,18 @@
         data-testid="events-past-table" />
     }
   } @else if (activeTab() === 'visa-letters') {
-    <lfx-event-request-list requestType="visa" [searchQuery]="searchQuery()" [status]="status()" data-testid="visa-requests-table" />
+    <lfx-event-request-list
+      requestType="visa"
+      [searchQuery]="searchQuery()"
+      [status]="status()"
+      [initialEventId]="initialEventId()"
+      data-testid="visa-requests-table" />
   } @else if (activeTab() === 'travel-funding') {
-    <lfx-event-request-list requestType="travel-fund" [searchQuery]="searchQuery()" [status]="status()" data-testid="travel-funding-table" />
+    <lfx-event-request-list
+      requestType="travel-fund"
+      [searchQuery]="searchQuery()"
+      [status]="status()"
+      [initialEventId]="initialEventId()"
+      data-testid="travel-funding-table" />
   }
 </div>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -93,9 +93,9 @@ export class EventsListComponent {
       });
   }
 
-  /** Delegates to the currently rendered EventRequestListComponent (visa-letters / travel-funding tabs). */
-  public openCurrentRequestDialog(): void {
-    this.requestListRef()?.openApplicationDialog();
+  /** Delegates to the currently rendered EventRequestListComponent (visa-letters / travel-funding tabs). False if it isn't rendered yet. */
+  public openCurrentRequestDialog(): boolean {
+    return this.requestListRef()?.openApplicationDialog() ?? false;
   }
 
   protected onUpcomingPageChange(event: PageChangeEvent): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -29,6 +29,8 @@ export class EventsListComponent {
   public readonly searchQuery = input<string>('');
   public readonly role = input<string | null>(null);
   public readonly status = input<string | null>(null);
+  /** Deep-linked event id (`?event=<id>`) to forward to the request list's application dialog. */
+  public readonly initialEventId = input<string | null>(null);
 
   protected readonly upcomingEventsLoading = signal(true);
   protected readonly pastEventsLoading = signal(true);

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -95,7 +95,11 @@ export class EventsListComponent {
 
   /** Delegates to the currently rendered EventRequestListComponent (visa-letters / travel-funding tabs). False if it isn't rendered yet. */
   public openCurrentRequestDialog(): boolean {
-    return this.requestListRef()?.openApplicationDialog() ?? false;
+    const ref = this.requestListRef();
+    if (!ref) return false;
+
+    ref.openApplicationDialog();
+    return true;
   }
 
   protected onUpcomingPageChange(event: PageChangeEvent): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
@@ -18,8 +18,9 @@
     <div class="scroll-area overflow-y-auto pr-1">
       @if (step() === 'select-event') {
         @if (resolvingDeepLink()) {
-          <div class="flex items-center justify-center py-16">
-            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+          <div class="flex items-center justify-center py-16" role="status" aria-live="polite">
+            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
+            <span class="sr-only">Loading event...</span>
           </div>
         } @else {
           <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="travel-fund" />

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
@@ -17,7 +17,13 @@
     <!-- Step content -->
     <div class="scroll-area overflow-y-auto pr-1">
       @if (step() === 'select-event') {
-        <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="travel-fund" />
+        @if (resolvingDeepLink()) {
+          <div class="flex items-center justify-center py-16">
+            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+          </div>
+        } @else {
+          <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="travel-fund" />
+        }
       } @else if (step() === 'terms') {
         <lfx-travel-fund-terms />
       } @else if (step() === 'about-me') {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
@@ -8,7 +8,8 @@ import { UserService } from '@app/shared/services/user.service';
 import { ButtonComponent } from '@components/button/button.component';
 import { MyEvent, TravelFundAboutMe, TravelFundApplication, TravelFundExpenses, TravelFundStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { catchError, of } from 'rxjs';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
 import { EventSelectionComponent } from '../event-selection/event-selection.component';
 import { StepIndicatorComponent } from '../step-indicator/step-indicator.component';
@@ -34,6 +35,7 @@ import { TRAVEL_FUND_STEP_ORDER } from '@lfx-one/shared/constants/events.constan
 })
 export class TravelFundApplicationDialogComponent {
   private readonly ref = inject(DynamicDialogRef);
+  private readonly config = inject(DynamicDialogConfig);
   private readonly eventsService = inject(EventsService);
   private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
@@ -70,6 +72,10 @@ export class TravelFundApplicationDialogComponent {
       isCompleted: TRAVEL_FUND_STEP_ORDER.indexOf(s.id) < TRAVEL_FUND_STEP_ORDER.indexOf(this.step()),
     }))
   );
+
+  public constructor() {
+    this.resolveDeepLinkedEvent();
+  }
 
   public onNextStep(): void {
     if (this.step() === 'terms') {
@@ -137,5 +143,32 @@ export class TravelFundApplicationDialogComponent {
 
   public onCancel(): void {
     this.ref.close(null);
+  }
+
+  /** Preselects the event from a deep link (`?tab=travel-funding&event=<id>`), skipping to the Terms step on a match. */
+  private resolveDeepLinkedEvent(): void {
+    const eventId = (this.config.data?.initialEventId as string | null | undefined) || undefined;
+    if (!eventId) return;
+
+    this.eventsService
+      .getMyEvents({ eventId, isPast: false, registeredOnly: true, isTravelFundRequestAccepted: true, excludePastTravelFundDeadline: true })
+      .pipe(
+        catchError(() => of(null)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((response) => {
+        const event = response?.data[0];
+        if (event) {
+          this.selectedEvent.set(event);
+          this.step.set('terms');
+          return;
+        }
+
+        this.messageService.add({
+          severity: 'info',
+          summary: 'Event not found',
+          detail: "We couldn't find that event among your eligible registered events — please choose it below.",
+        });
+      });
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
@@ -9,7 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { MyEvent, TravelFundAboutMe, TravelFundApplication, TravelFundExpenses, TravelFundStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { catchError, finalize, of } from 'rxjs';
+import { finalize } from 'rxjs';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
 import { EventSelectionComponent } from '../event-selection/event-selection.component';
 import { StepIndicatorComponent } from '../step-indicator/step-indicator.component';
@@ -17,6 +17,7 @@ import { TravelFundTermsComponent } from '../travel-fund-terms/travel-fund-terms
 import { AboutMeFormComponent } from '../about-me-form/about-me-form.component';
 import { TravelExpensesFormComponent } from '../travel-expenses-form/travel-expenses-form.component';
 import { TRAVEL_FUND_STEP_ORDER } from '@lfx-one/shared/constants/events.constants';
+import { resolveDeepLinkedEvent$ } from '../../utils/resolve-deep-linked-event.util';
 
 @Component({
   selector: 'lfx-travel-fund-application-dialog',
@@ -153,21 +154,20 @@ export class TravelFundApplicationDialogComponent {
     if (!eventId) return;
 
     this.resolvingDeepLink.set(true);
-    this.eventsService
-      .getMyEvents({ eventId, isPast: false, registeredOnly: true, isTravelFundRequestAccepted: true, excludePastTravelFundDeadline: true })
+    resolveDeepLinkedEvent$(
+      this.eventsService.getMyEvents({ eventId, isPast: false, registeredOnly: true, isTravelFundRequestAccepted: true, excludePastTravelFundDeadline: true }),
+      eventId,
+      'travel fund request'
+    )
       .pipe(
-        catchError((error) => {
-          console.error('Failed to resolve deep-linked travel fund request event:', error);
-          return of('error' as const);
-        }),
         finalize(() => this.resolvingDeepLink.set(false)),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((response) => {
+      .subscribe((event) => {
         // The user may already have picked an event manually while this was in flight — don't clobber it.
         if (this.step() !== 'select-event' || this.selectedEvent()) return;
 
-        if (response === 'error') {
+        if (event === 'error') {
           this.messageService.add({
             severity: 'error',
             summary: 'Error',
@@ -176,7 +176,6 @@ export class TravelFundApplicationDialogComponent {
           return;
         }
 
-        const event = response.data[0];
         if (event) {
           this.selectedEvent.set(event);
           this.step.set('terms');

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
@@ -9,7 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { MyEvent, TravelFundAboutMe, TravelFundApplication, TravelFundExpenses, TravelFundStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { catchError, of } from 'rxjs';
+import { catchError, finalize, of } from 'rxjs';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
 import { EventSelectionComponent } from '../event-selection/event-selection.component';
 import { StepIndicatorComponent } from '../step-indicator/step-indicator.component';
@@ -51,6 +51,8 @@ export class TravelFundApplicationDialogComponent {
   protected submitting = signal(false);
   protected submitted = signal(false);
   protected submittedEventName = signal('');
+  /** True while resolving a deep-linked `?event=<id>` — gates the select-event step so it doesn't flash before snapping to Terms. */
+  protected readonly resolvingDeepLink = signal(false);
 
   protected readonly isNextDisabled = computed(() => {
     if (this.step() === 'select-event') return !this.selectedEvent();
@@ -150,14 +152,31 @@ export class TravelFundApplicationDialogComponent {
     const eventId = (this.config.data?.initialEventId as string | null | undefined) || undefined;
     if (!eventId) return;
 
+    this.resolvingDeepLink.set(true);
     this.eventsService
       .getMyEvents({ eventId, isPast: false, registeredOnly: true, isTravelFundRequestAccepted: true, excludePastTravelFundDeadline: true })
       .pipe(
-        catchError(() => of(null)),
+        catchError((error) => {
+          console.error('Failed to resolve deep-linked travel fund request event:', error);
+          return of('error' as const);
+        }),
+        finalize(() => this.resolvingDeepLink.set(false)),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((response) => {
-        const event = response?.data[0];
+        // The user may already have picked an event manually while this was in flight — don't clobber it.
+        if (this.step() !== 'select-event' || this.selectedEvent()) return;
+
+        if (response === 'error') {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'Something went wrong while loading your events. Please try again.',
+          });
+          return;
+        }
+
+        const event = response.data[0];
         if (event) {
           this.selectedEvent.set(event);
           this.step.set('terms');

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
@@ -18,8 +18,9 @@
     @if (step() === 'select-event') {
       <div class="scroll-area overflow-y-auto pr-1">
         @if (resolvingDeepLink()) {
-          <div class="flex items-center justify-center py-16">
-            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+          <div class="flex items-center justify-center py-16" role="status" aria-live="polite">
+            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
+            <span class="sr-only">Loading event...</span>
           </div>
         } @else {
           <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="visa" />

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
@@ -17,7 +17,13 @@
     <!-- Step content -->
     @if (step() === 'select-event') {
       <div class="scroll-area overflow-y-auto pr-1">
-        <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="visa" />
+        @if (resolvingDeepLink()) {
+          <div class="flex items-center justify-center py-16">
+            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+          </div>
+        } @else {
+          <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="visa" />
+        }
       </div>
     } @else if (step() === 'terms') {
       <lfx-visa-request-terms />

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
@@ -9,13 +9,14 @@ import { ButtonComponent } from '@components/button/button.component';
 import { MyEvent, VisaRequestApplicantInfo, VisaRequestApplication, VisaRequestStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { catchError, finalize, of } from 'rxjs';
+import { finalize } from 'rxjs';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
 import { EventSelectionComponent } from '../event-selection/event-selection.component';
 import { StepIndicatorComponent } from '../step-indicator/step-indicator.component';
 import { VisaRequestApplyFormComponent } from '../visa-request-apply-form/visa-request-apply-form.component';
 import { VisaRequestTermsComponent } from '../visa-request-terms/visa-request-terms.component';
 import { VIS_REQUEST_STEP_ORDER } from '@lfx-one/shared/constants/events.constants';
+import { resolveDeepLinkedEvent$ } from '../../utils/resolve-deep-linked-event.util';
 
 @Component({
   selector: 'lfx-visa-request-application-dialog',
@@ -146,21 +147,20 @@ export class VisaRequestApplicationDialogComponent {
     if (!eventId) return;
 
     this.resolvingDeepLink.set(true);
-    this.eventsService
-      .getMyEvents({ eventId, isPast: false, registeredOnly: true, isVisaRequestAccepted: true })
+    resolveDeepLinkedEvent$(
+      this.eventsService.getMyEvents({ eventId, isPast: false, registeredOnly: true, isVisaRequestAccepted: true }),
+      eventId,
+      'visa request'
+    )
       .pipe(
-        catchError((error) => {
-          console.error('Failed to resolve deep-linked visa request event:', error);
-          return of('error' as const);
-        }),
         finalize(() => this.resolvingDeepLink.set(false)),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((response) => {
+      .subscribe((event) => {
         // The user may already have picked an event manually while this was in flight — don't clobber it.
         if (this.step() !== 'select-event' || this.selectedEvent()) return;
 
-        if (response === 'error') {
+        if (event === 'error') {
           this.messageService.add({
             severity: 'error',
             summary: 'Error',
@@ -169,7 +169,6 @@ export class VisaRequestApplicationDialogComponent {
           return;
         }
 
-        const event = response.data[0];
         if (event) {
           this.selectedEvent.set(event);
           this.step.set('terms');

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
@@ -9,7 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { MyEvent, VisaRequestApplicantInfo, VisaRequestApplication, VisaRequestStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { catchError, of } from 'rxjs';
+import { catchError, finalize, of } from 'rxjs';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
 import { EventSelectionComponent } from '../event-selection/event-selection.component';
 import { StepIndicatorComponent } from '../step-indicator/step-indicator.component';
@@ -47,6 +47,8 @@ export class VisaRequestApplicationDialogComponent {
   protected submitting = signal(false);
   protected submitted = signal(false);
   protected submittedEventName = signal('');
+  /** True while resolving a deep-linked `?event=<id>` — gates the select-event step so it doesn't flash before snapping to Terms. */
+  protected readonly resolvingDeepLink = signal(false);
 
   protected readonly isNextDisabled = computed(() => {
     if (this.step() === 'select-event') return !this.selectedEvent();
@@ -143,14 +145,31 @@ export class VisaRequestApplicationDialogComponent {
     const eventId = (this.config.data?.initialEventId as string | null | undefined) || undefined;
     if (!eventId) return;
 
+    this.resolvingDeepLink.set(true);
     this.eventsService
       .getMyEvents({ eventId, isPast: false, registeredOnly: true, isVisaRequestAccepted: true })
       .pipe(
-        catchError(() => of(null)),
+        catchError((error) => {
+          console.error('Failed to resolve deep-linked visa request event:', error);
+          return of('error' as const);
+        }),
+        finalize(() => this.resolvingDeepLink.set(false)),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((response) => {
-        const event = response?.data[0];
+        // The user may already have picked an event manually while this was in flight — don't clobber it.
+        if (this.step() !== 'select-event' || this.selectedEvent()) return;
+
+        if (response === 'error') {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'Something went wrong while loading your events. Please try again.',
+          });
+          return;
+        }
+
+        const event = response.data[0];
         if (event) {
           this.selectedEvent.set(event);
           this.step.set('terms');

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
@@ -8,7 +8,8 @@ import { UserService } from '@app/shared/services/user.service';
 import { ButtonComponent } from '@components/button/button.component';
 import { MyEvent, VisaRequestApplicantInfo, VisaRequestApplication, VisaRequestStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { catchError, of } from 'rxjs';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
 import { EventSelectionComponent } from '../event-selection/event-selection.component';
 import { StepIndicatorComponent } from '../step-indicator/step-indicator.component';
@@ -32,6 +33,7 @@ import { VIS_REQUEST_STEP_ORDER } from '@lfx-one/shared/constants/events.constan
 })
 export class VisaRequestApplicationDialogComponent {
   private readonly ref = inject(DynamicDialogRef);
+  private readonly config = inject(DynamicDialogConfig);
   private readonly eventsService = inject(EventsService);
   private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
@@ -65,6 +67,10 @@ export class VisaRequestApplicationDialogComponent {
       isCompleted: VIS_REQUEST_STEP_ORDER.indexOf(s.id) < VIS_REQUEST_STEP_ORDER.indexOf(this.step()),
     }))
   );
+
+  public constructor() {
+    this.resolveDeepLinkedEvent();
+  }
 
   public onNextStep(): void {
     if (this.step() === 'terms') {
@@ -130,5 +136,32 @@ export class VisaRequestApplicationDialogComponent {
 
   public onCancel(): void {
     this.ref.close(null);
+  }
+
+  /** Preselects the event from a deep link (`?tab=visa-letters&event=<id>`), skipping to the Terms step on a match. */
+  private resolveDeepLinkedEvent(): void {
+    const eventId = (this.config.data?.initialEventId as string | null | undefined) || undefined;
+    if (!eventId) return;
+
+    this.eventsService
+      .getMyEvents({ eventId, isPast: false, registeredOnly: true, isVisaRequestAccepted: true })
+      .pipe(
+        catchError(() => of(null)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((response) => {
+        const event = response?.data[0];
+        if (event) {
+          this.selectedEvent.set(event);
+          this.step.set('terms');
+          return;
+        }
+
+        this.messageService.add({
+          severity: 'info',
+          summary: 'Event not found',
+          detail: "We couldn't find that event among your eligible registered events — please choose it below.",
+        });
+      });
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -97,7 +97,7 @@
             severity="primary"
             size="small"
             [disabled]="!isCreateEnabled()"
-            (onClick)="openCurrentRequestDialog()"
+            (onClick)="onNewRequestClick()"
             data-testid="events-new-request-button" />
         }
       </lfx-card-tabs-bar>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -127,6 +127,7 @@
           [searchQuery]="selectedSearchQuery()"
           [role]="selectedRole()"
           [status]="selectedStatus()"
+          [initialEventId]="activeEventId()"
           (resetFilters)="resetFilters()" />
       </div>
     </lfx-card>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -25,6 +25,7 @@ import { catchError, combineLatest, defer, filter, finalize, map, of } from 'rxj
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
 import { EventsListComponent } from './components/events-list/events-list.component';
+import { buildDeepLinkKey } from './utils/deep-link-consumption.util';
 import { UserService } from '@app/shared/services/user.service';
 
 /** Dedicated toast key so the custom support-CTA template renders only for this component's Salesforce-ID error toast. */
@@ -57,8 +58,13 @@ export class MyEventsDashboardComponent {
   /** Single subscription to the route's query params — activeTab and activeEventId both derive from it. */
   private readonly queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
 
-  /** Guards the deep-linked `?event=` auto-open so each event id fires at most once per page load. */
-  private readonly consumedDeepLinkEventIds = new Set<string>();
+  /**
+   * Guards the deep-linked `?event=` auto-open so each (tab, event) pair fires at most once per
+   * page load. Keyed by `buildDeepLinkKey(tab, eventId)`, not the bare eventId (PR #2247 review,
+   * Copilot) — an eventId alone isn't unique across tabs, so consuming a visa-letters deep link
+   * must not also suppress a later travel-funding deep link for the same event.
+   */
+  private readonly consumedDeepLinkKeys = new Set<string>();
 
   protected readonly activeTab: Signal<EventTabId> = this.initActiveTab();
   /** Event id from a deep link (`?tab=visa-letters&event=<id>`); null once the URL is stripped post-auto-open, or absent. */
@@ -102,17 +108,21 @@ export class MyEventsDashboardComponent {
     // effect(), per the frontend checklist (effect() is reserved for logging/debugging —
     // docs/reviews/frontend-checklist.md §5); afterNextRender's explicit injector keeps the
     // deferred-render timing this needs without an active injection context at fire time.
-    combineLatest([toObservable(this.isRequestTab), toObservable(this.activeEventId), toObservable(this.isCreateEnabled)])
+    combineLatest([toObservable(this.activeTab), toObservable(this.isRequestTab), toObservable(this.activeEventId), toObservable(this.isCreateEnabled)])
       .pipe(
-        map(([isRequestTab, eventId, isCreateEnabled]) => (isRequestTab && isCreateEnabled ? eventId : null)),
-        filter((eventId): eventId is string => !!eventId && !this.consumedDeepLinkEventIds.has(eventId)),
+        map(([tab, isRequestTab, eventId, isCreateEnabled]) => (isRequestTab && isCreateEnabled && eventId ? { tab, eventId } : null)),
+        filter(
+          (deepLink): deepLink is { tab: EventTabId; eventId: string } =>
+            !!deepLink && !this.consumedDeepLinkKeys.has(buildDeepLinkKey(deepLink.tab, deepLink.eventId))
+        ),
         takeUntilDestroyed()
       )
-      .subscribe((eventId) => {
+      .subscribe(({ tab, eventId }) => {
+        const key = buildDeepLinkKey(tab, eventId);
         afterNextRender(
           () => {
-            if (this.consumedDeepLinkEventIds.has(eventId) || !this.openCurrentRequestDialog()) return;
-            this.consumedDeepLinkEventIds.add(eventId);
+            if (this.consumedDeepLinkKeys.has(key) || !this.openCurrentRequestDialog()) return;
+            this.consumedDeepLinkKeys.add(key);
             void this.router.navigate([], { relativeTo: this.route, queryParams: { event: null }, queryParamsHandling: 'merge', replaceUrl: true });
           },
           { injector: this.injector }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -1,13 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
+import { Component, computed, effect, inject, Signal, signal, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
-import { MY_EVENT_STATUS_OPTIONS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
+import { DEFAULT_MY_EVENTS_TAB_ID, MY_EVENT_STATUS_OPTIONS, VALID_MY_EVENTS_TAB_IDS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { MessageService } from 'primeng/api';
@@ -41,9 +42,16 @@ const SALESFORCE_ERROR_TOAST_KEY = 'my-events-salesforce-error';
 export class MyEventsDashboardComponent {
   private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly eventsListRef = viewChild(EventsListComponent);
 
-  protected readonly activeTab = signal<EventTabId>('upcoming');
+  /** Guards the deep-linked `?event=` auto-open so it fires at most once per page load. */
+  private readonly deepLinkEventConsumed = signal(false);
+
+  protected readonly activeTab: Signal<EventTabId> = this.initActiveTab();
+  /** Event id from a deep link (`?tab=visa-letters&event=<id>`); null once the URL is stripped post-auto-open, or absent. */
+  protected readonly activeEventId: Signal<string | null> = this.initActiveEventId();
 
   protected readonly tabOptions: FilterPillOption[] = [
     { id: 'upcoming', label: 'Upcoming' },
@@ -83,6 +91,19 @@ export class MyEventsDashboardComponent {
   protected readonly salesforceErrorToastKey = SALESFORCE_ERROR_TOAST_KEY;
   protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
 
+  public constructor() {
+    // Auto-open the request dialog for a deep link (`?tab=visa-letters&event=<id>`), once
+    // isCreateEnabled resolves. Guarded so switching tabs away and back never reopens it.
+    effect(() => {
+      if (this.deepLinkEventConsumed()) return;
+      if (!this.isRequestTab() || !this.activeEventId() || !this.isCreateEnabled()) return;
+
+      this.deepLinkEventConsumed.set(true);
+      void this.router.navigate([], { relativeTo: this.route, queryParams: { event: null }, queryParamsHandling: 'merge', replaceUrl: true });
+      this.openCurrentRequestDialog();
+    });
+  }
+
   protected onFoundationChange(value: string | null): void {
     this.selectedFoundation.set(value);
   }
@@ -100,7 +121,15 @@ export class MyEventsDashboardComponent {
   }
 
   protected onActiveTabChange(tab: string): void {
-    this.activeTab.set(tab as EventTabId);
+    if (!VALID_MY_EVENTS_TAB_IDS.has(tab as EventTabId)) return;
+
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab: tab === DEFAULT_MY_EVENTS_TAB_ID ? null : tab, event: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+
     // Reset all filters when switching tabs — each tab has different filter sets
     this.selectedFoundation.set(null);
     this.selectedRole.set(null);
@@ -118,6 +147,19 @@ export class MyEventsDashboardComponent {
     this.selectedRole.set(null);
     this.selectedStatus.set(null);
     this.selectedSearchQuery.set('');
+  }
+
+  private initActiveTab(): Signal<EventTabId> {
+    const queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
+    return computed(() => {
+      const raw = queryParamMap().get('tab');
+      return raw && VALID_MY_EVENTS_TAB_IDS.has(raw as EventTabId) ? (raw as EventTabId) : DEFAULT_MY_EVENTS_TAB_ID;
+    });
+  }
+
+  private initActiveEventId(): Signal<string | null> {
+    const queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
+    return computed(() => queryParamMap().get('event'));
   }
 
   private initIsCreateEnabled(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -97,14 +97,13 @@ export class MyEventsDashboardComponent {
   protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
 
   public constructor() {
-    // Auto-open the request dialog for a deep link (`?tab=visa-letters&event=<id>`), once
-    // isCreateEnabled resolves. Effects run before child components render on the same pass, so
-    // the request-list child for this tab may not exist yet when these guards first pass — the
-    // actual open is deferred to afterNextRender (after children commit) and only marked consumed
-    // once it actually opens, so a still-unready child causes a silent retry, not a silent no-op.
+    // Auto-open the request dialog for a deep link (`?tab=visa-letters&event=<id>`). Reads
+    // eventsListRef() so a late-mounting child re-triggers this effect and retries the open,
+    // rather than silently dropping the deep link if it wasn't rendered yet on the first pass.
     effect(() => {
       if (this.deepLinkEventConsumed()) return;
       if (!this.isRequestTab() || !this.activeEventId() || !this.isCreateEnabled()) return;
+      this.eventsListRef();
 
       afterNextRender(
         () => {
@@ -115,6 +114,8 @@ export class MyEventsDashboardComponent {
         { injector: this.injector }
       );
     });
+    // effect() (not toObservable+RxJS) is deliberate: the body's only job is scheduling an
+    // afterNextRender callback, which needs an injection context at the point it fires.
   }
 
   protected onFoundationChange(value: string | null): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, Component, computed, effect, inject, Injector, Signal, signal, viewChild } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { afterNextRender, Component, computed, inject, Injector, Signal, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -20,7 +20,7 @@ import { OpenIntercomDirective } from '@shared/directives/open-intercom.directiv
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
 import { Tooltip } from 'primeng/tooltip';
-import { catchError, defer, finalize, map, of } from 'rxjs';
+import { catchError, combineLatest, defer, filter, finalize, map, of } from 'rxjs';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
 import { EventsListComponent } from './components/events-list/events-list.component';
@@ -56,8 +56,8 @@ export class MyEventsDashboardComponent {
   /** Single subscription to the route's query params — activeTab and activeEventId both derive from it. */
   private readonly queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
 
-  /** Guards the deep-linked `?event=` auto-open so it fires at most once per page load. */
-  private readonly deepLinkEventConsumed = signal(false);
+  /** Guards the deep-linked `?event=` auto-open so each event id fires at most once per page load. */
+  private readonly consumedDeepLinkEventIds = new Set<string>();
 
   protected readonly activeTab: Signal<EventTabId> = this.initActiveTab();
   /** Event id from a deep link (`?tab=visa-letters&event=<id>`); null once the URL is stripped post-auto-open, or absent. */
@@ -97,25 +97,26 @@ export class MyEventsDashboardComponent {
   protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
 
   public constructor() {
-    // Auto-open the request dialog for a deep link (`?tab=visa-letters&event=<id>`). Reads
-    // eventsListRef() so a late-mounting child re-triggers this effect and retries the open,
-    // rather than silently dropping the deep link if it wasn't rendered yet on the first pass.
-    effect(() => {
-      if (this.deepLinkEventConsumed()) return;
-      if (!this.isRequestTab() || !this.activeEventId() || !this.isCreateEnabled()) return;
-      this.eventsListRef();
-
-      afterNextRender(
-        () => {
-          if (this.deepLinkEventConsumed() || !this.openCurrentRequestDialog()) return;
-          this.deepLinkEventConsumed.set(true);
-          void this.router.navigate([], { relativeTo: this.route, queryParams: { event: null }, queryParamsHandling: 'merge', replaceUrl: true });
-        },
-        { injector: this.injector }
-      );
-    });
-    // effect() (not toObservable+RxJS) is deliberate: the body's only job is scheduling an
-    // afterNextRender callback, which needs an injection context at the point it fires.
+    // Auto-open the request dialog for a deep link (`?tab=visa-letters&event=<id>`). RxJS, not
+    // effect(), per the frontend checklist (effect() is reserved for logging/debugging —
+    // docs/reviews/frontend-checklist.md §5); afterNextRender's explicit injector keeps the
+    // deferred-render timing this needs without an active injection context at fire time.
+    combineLatest([toObservable(this.isRequestTab), toObservable(this.activeEventId), toObservable(this.isCreateEnabled)])
+      .pipe(
+        map(([isRequestTab, eventId, isCreateEnabled]) => (isRequestTab && isCreateEnabled ? eventId : null)),
+        filter((eventId): eventId is string => !!eventId && !this.consumedDeepLinkEventIds.has(eventId)),
+        takeUntilDestroyed()
+      )
+      .subscribe((eventId) => {
+        afterNextRender(
+          () => {
+            if (this.consumedDeepLinkEventIds.has(eventId) || !this.openCurrentRequestDialog()) return;
+            this.consumedDeepLinkEventIds.add(eventId);
+            void this.router.navigate([], { relativeTo: this.route, queryParams: { event: null }, queryParamsHandling: 'merge', replaceUrl: true });
+          },
+          { injector: this.injector }
+        );
+      });
   }
 
   protected onFoundationChange(value: string | null): void {
@@ -157,6 +158,11 @@ export class MyEventsDashboardComponent {
   protected openCurrentRequestDialog(): boolean {
     if (!this.isCreateEnabled()) return false;
     return this.eventsListRef()?.openCurrentRequestDialog() ?? false;
+  }
+
+  /** Template wrapper — (onClick) expects void; openCurrentRequestDialog()'s boolean return would otherwise trigger preventDefault(). */
+  protected onNewRequestClick(): void {
+    this.openCurrentRequestDialog();
   }
 
   protected resetFilters(): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -1,14 +1,20 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, effect, inject, Signal, signal, viewChild } from '@angular/core';
+import { afterNextRender, Component, computed, effect, inject, Injector, Signal, signal, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
-import { DEFAULT_MY_EVENTS_TAB_ID, MY_EVENT_STATUS_OPTIONS, VALID_MY_EVENTS_TAB_IDS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
+import {
+  DEFAULT_MY_EVENTS_TAB_ID,
+  MY_EVENT_STATUS_OPTIONS,
+  MY_EVENTS_TABS,
+  VALID_MY_EVENTS_TAB_IDS,
+  VISA_REQUEST_STATUS_OPTIONS,
+} from '@lfx-one/shared/constants';
 import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { MessageService } from 'primeng/api';
@@ -44,7 +50,11 @@ export class MyEventsDashboardComponent {
   private readonly messageService = inject(MessageService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly injector = inject(Injector);
   private readonly eventsListRef = viewChild(EventsListComponent);
+
+  /** Single subscription to the route's query params — activeTab and activeEventId both derive from it. */
+  private readonly queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
 
   /** Guards the deep-linked `?event=` auto-open so it fires at most once per page load. */
   private readonly deepLinkEventConsumed = signal(false);
@@ -53,12 +63,7 @@ export class MyEventsDashboardComponent {
   /** Event id from a deep link (`?tab=visa-letters&event=<id>`); null once the URL is stripped post-auto-open, or absent. */
   protected readonly activeEventId: Signal<string | null> = this.initActiveEventId();
 
-  protected readonly tabOptions: FilterPillOption[] = [
-    { id: 'upcoming', label: 'Upcoming' },
-    { id: 'past', label: 'Past' },
-    { id: 'visa-letters', label: 'Visa Letters' },
-    { id: 'travel-funding', label: 'Travel Funding' },
-  ];
+  protected readonly tabOptions: FilterPillOption[] = MY_EVENTS_TABS;
   protected readonly selectedFoundation = signal<string | null>(null);
   protected readonly selectedRole = signal<string | null>(null);
   protected readonly selectedStatus = signal<string | null>(null);
@@ -93,14 +98,22 @@ export class MyEventsDashboardComponent {
 
   public constructor() {
     // Auto-open the request dialog for a deep link (`?tab=visa-letters&event=<id>`), once
-    // isCreateEnabled resolves. Guarded so switching tabs away and back never reopens it.
+    // isCreateEnabled resolves. Effects run before child components render on the same pass, so
+    // the request-list child for this tab may not exist yet when these guards first pass — the
+    // actual open is deferred to afterNextRender (after children commit) and only marked consumed
+    // once it actually opens, so a still-unready child causes a silent retry, not a silent no-op.
     effect(() => {
       if (this.deepLinkEventConsumed()) return;
       if (!this.isRequestTab() || !this.activeEventId() || !this.isCreateEnabled()) return;
 
-      this.deepLinkEventConsumed.set(true);
-      void this.router.navigate([], { relativeTo: this.route, queryParams: { event: null }, queryParamsHandling: 'merge', replaceUrl: true });
-      this.openCurrentRequestDialog();
+      afterNextRender(
+        () => {
+          if (this.deepLinkEventConsumed() || !this.openCurrentRequestDialog()) return;
+          this.deepLinkEventConsumed.set(true);
+          void this.router.navigate([], { relativeTo: this.route, queryParams: { event: null }, queryParamsHandling: 'merge', replaceUrl: true });
+        },
+        { injector: this.injector }
+      );
     });
   }
 
@@ -123,6 +136,8 @@ export class MyEventsDashboardComponent {
   protected onActiveTabChange(tab: string): void {
     if (!VALID_MY_EVENTS_TAB_IDS.has(tab as EventTabId)) return;
 
+    // Deliberate replaceUrl, matching the deep-link strip above and OrgEventsDashboardComponent's
+    // tab pattern — manual tab switches don't push a history entry.
     void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { tab: tab === DEFAULT_MY_EVENTS_TAB_ID ? null : tab, event: null },
@@ -137,9 +152,10 @@ export class MyEventsDashboardComponent {
     this.selectedSearchQuery.set('');
   }
 
-  protected openCurrentRequestDialog(): void {
-    if (!this.isCreateEnabled()) return;
-    this.eventsListRef()?.openCurrentRequestDialog();
+  /** False when isCreateEnabled is false or the active tab's request-list child isn't rendered yet. */
+  protected openCurrentRequestDialog(): boolean {
+    if (!this.isCreateEnabled()) return false;
+    return this.eventsListRef()?.openCurrentRequestDialog() ?? false;
   }
 
   protected resetFilters(): void {
@@ -150,16 +166,14 @@ export class MyEventsDashboardComponent {
   }
 
   private initActiveTab(): Signal<EventTabId> {
-    const queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
     return computed(() => {
-      const raw = queryParamMap().get('tab');
+      const raw = this.queryParamMap().get('tab');
       return raw && VALID_MY_EVENTS_TAB_IDS.has(raw as EventTabId) ? (raw as EventTabId) : DEFAULT_MY_EVENTS_TAB_ID;
     });
   }
 
   private initActiveEventId(): Signal<string | null> {
-    const queryParamMap = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
-    return computed(() => queryParamMap().get('event'));
+    return computed(() => this.queryParamMap().get('event'));
   }
 
   private initIsCreateEnabled(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -11,6 +11,7 @@ import { ToastMessageComponent } from '@components/toast-message/toast-message.c
 import {
   DEFAULT_MY_EVENTS_TAB_ID,
   MY_EVENT_STATUS_OPTIONS,
+  MY_EVENTS_REQUEST_TAB_IDS,
   MY_EVENTS_TABS,
   VALID_MY_EVENTS_TAB_IDS,
   VISA_REQUEST_STATUS_OPTIONS,
@@ -72,7 +73,7 @@ export class MyEventsDashboardComponent {
   protected readonly isPast = computed(() => this.activeTab() === 'past');
 
   /** True when the active tab uses request-style filters (no role, no foundation, different statuses). */
-  protected readonly isRequestTab = computed(() => this.activeTab() === 'visa-letters' || this.activeTab() === 'travel-funding');
+  protected readonly isRequestTab = computed(() => MY_EVENTS_REQUEST_TAB_IDS.has(this.activeTab()));
 
   protected readonly currentStatusOptions = computed<FilterOption[]>(() => (this.isRequestTab() ? VISA_REQUEST_STATUS_OPTIONS : MY_EVENT_STATUS_OPTIONS));
 

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/deep-link-consumption.util.spec.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/deep-link-consumption.util.spec.ts
@@ -1,0 +1,23 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { buildDeepLinkKey } from './deep-link-consumption.util';
+
+// Regression coverage for PR #2247 review (Copilot): the consumption key must be scoped by tab,
+// not just eventId, so a visa-letters deep link consumed first doesn't suppress a later
+// travel-funding deep link for the same event.
+describe('buildDeepLinkKey', () => {
+  it('produces different keys for the same event id under different tabs', () => {
+    expect(buildDeepLinkKey('visa-letters', 'evt-1')).not.toBe(buildDeepLinkKey('travel-funding', 'evt-1'));
+  });
+
+  it('produces different keys for different event ids under the same tab', () => {
+    expect(buildDeepLinkKey('visa-letters', 'evt-1')).not.toBe(buildDeepLinkKey('visa-letters', 'evt-2'));
+  });
+
+  it('produces the same key for the same tab and event id', () => {
+    expect(buildDeepLinkKey('visa-letters', 'evt-1')).toBe(buildDeepLinkKey('visa-letters', 'evt-1'));
+  });
+});

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/deep-link-consumption.util.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/deep-link-consumption.util.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { EventTabId } from '@lfx-one/shared/interfaces';
+
+/**
+ * Key for `consumedDeepLinkEventIds` (PR #2247 review, Copilot) — an eventId alone isn't unique
+ * across tabs, so a `visa-letters&event=X` deep link consumed first must not also suppress a
+ * later `travel-funding&event=X` deep link for the same event.
+ */
+export function buildDeepLinkKey(tab: EventTabId, eventId: string): string {
+  return `${tab}:${eventId}`;
+}

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/resolve-deep-linked-event.util.spec.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/resolve-deep-linked-event.util.spec.ts
@@ -1,0 +1,60 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MyEvent, MyEventsResponse } from '@lfx-one/shared/interfaces';
+import { firstValueFrom, of, throwError } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveDeepLinkedEvent$ } from './resolve-deep-linked-event.util';
+
+// Regression coverage for PR #2247 review (Copilot): matching must be by id, not by response
+// ordering — a regression to `response.data[0]` would pass silently against the e2e mock, which
+// only ever returns a single matching row.
+describe('resolveDeepLinkedEvent$', () => {
+  const buildEvent = (id: string): MyEvent =>
+    ({
+      id,
+      name: `Event ${id}`,
+      url: '',
+      registrationUrl: null,
+      foundation: 'Linux Foundation',
+      startDate: '2026-06-30T00:00:00.000Z',
+      date: 'Jun 30–Jul 2, 2026',
+      location: 'Seattle, WA',
+      role: 'Attendee',
+      status: 'Registered',
+    }) as MyEvent;
+
+  const buildResponse = (data: MyEvent[]): MyEventsResponse => ({ data, total: data.length, pageSize: 10, offset: 0 });
+
+  it('returns the row matching the requested id, even when an earlier row does not match', async () => {
+    const target = buildEvent('evt-2');
+    const response = buildResponse([buildEvent('evt-1'), target, buildEvent('evt-3')]);
+
+    const result = await firstValueFrom(resolveDeepLinkedEvent$(of(response), 'evt-2', 'visa request'));
+
+    expect(result).toEqual(target);
+  });
+
+  it('returns null when no row matches the requested id', async () => {
+    const response = buildResponse([buildEvent('evt-1'), buildEvent('evt-3')]);
+
+    const result = await firstValueFrom(resolveDeepLinkedEvent$(of(response), 'evt-2', 'visa request'));
+
+    expect(result).toBeNull();
+  });
+
+  it('normalizes a failed fetch into the error sentinel', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await firstValueFrom(
+      resolveDeepLinkedEvent$(
+        throwError(() => new Error('network error')),
+        'evt-2',
+        'visa request'
+      )
+    );
+
+    expect(result).toBe('error');
+  });
+});

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/resolve-deep-linked-event.util.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/utils/resolve-deep-linked-event.util.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MyEvent, MyEventsResponse } from '@lfx-one/shared/interfaces';
+import { catchError, map, Observable, of } from 'rxjs';
+
+/**
+ * Resolves a deep-linked `?event=<id>` against a request-type-scoped `getMyEvents` fetch.
+ * Matches by id rather than trusting the response's ordering, and normalizes a failed fetch
+ * into an `'error'` sentinel so callers don't need their own `catchError`.
+ */
+export function resolveDeepLinkedEvent$(fetch$: Observable<MyEventsResponse>, eventId: string, label: string): Observable<MyEvent | null | 'error'> {
+  return fetch$.pipe(
+    map((response) => response.data.find((event) => event.id === eventId) ?? null),
+    catchError((error) => {
+      console.error(`Failed to resolve deep-linked ${label} event:`, error);
+      return of('error' as const);
+    })
+  );
+}

--- a/apps/lfx-one/src/app/shared/guards/my-events-request-lens.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-events-request-lens.guard.spec.ts
@@ -1,0 +1,60 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { Lens } from '@lfx-one/shared/interfaces';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LensService } from '../services/lens.service';
+import { myEventsRequestLensGuard } from './my-events-request-lens.guard';
+
+// Regression coverage for PR #2247 review (Cursor Bugbot): setLens('me') must run unconditionally
+// for a qualifying deep link, not gated on activeLens() — activeLens() clamps to 'me' transiently
+// before writer grants load, even while the persisted lens is still 'foundation'/'project', so
+// gating on it would skip the very correction this guard exists to make.
+describe('myEventsRequestLensGuard', () => {
+  const route = (queryParams: Record<string, string>): ActivatedRouteSnapshot => ({ queryParams }) as unknown as ActivatedRouteSnapshot;
+
+  const runGuard = (queryParams: Record<string, string>, activeLens: Lens) => {
+    const setLens = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [{ provide: LensService, useValue: { activeLens: () => activeLens, setLens } }],
+    });
+
+    const result = TestBed.runInInjectionContext(() => myEventsRequestLensGuard(route(queryParams), {} as RouterStateSnapshot));
+    return { result, setLens };
+  };
+
+  it.each(['me', 'foundation', 'project', 'org'] as Lens[])('forces the me lens for a visa-letters deep link regardless of activeLens() (%s)', (activeLens) => {
+    const { result, setLens } = runGuard({ tab: 'visa-letters', event: 'evt-1' }, activeLens);
+
+    expect(result).toBe(true);
+    expect(setLens).toHaveBeenCalledWith('me');
+  });
+
+  it('forces the me lens for a travel-funding deep link', () => {
+    const { setLens } = runGuard({ tab: 'travel-funding', event: 'evt-1' }, 'foundation');
+
+    expect(setLens).toHaveBeenCalledWith('me');
+  });
+
+  it('does not touch the lens when the tab is not a request tab', () => {
+    const { result, setLens } = runGuard({ tab: 'upcoming', event: 'evt-1' }, 'foundation');
+
+    expect(result).toBe(true);
+    expect(setLens).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the lens when there is no event id', () => {
+    const { setLens } = runGuard({ tab: 'visa-letters' }, 'foundation');
+
+    expect(setLens).not.toHaveBeenCalled();
+  });
+
+  it('does not touch the lens when there is no tab', () => {
+    const { setLens } = runGuard({ event: 'evt-1' }, 'foundation');
+
+    expect(setLens).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/app/shared/guards/my-events-request-lens.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-events-request-lens.guard.ts
@@ -17,13 +17,20 @@ import { LensService } from '../services/lens.service';
  * otherwise), so a link opened while the persisted lens is `org` or `foundation` would silently
  * never auto-open the dialog. `setLens('me')` applies and persists the switch without navigating
  * (unlike `switchLens`), so the deep link's own URL still resolves the route on this pass.
+ *
+ * Calls `setLens('me')` unconditionally (no `activeLens() !== 'me'` guard) — `activeLens()` is a
+ * read-time clamp over the persisted `selectedLens`, and can already read `'me'` transiently
+ * (writer grants load post-hydration, see `getAllowedLensIds()`) while `selectedLens` itself is
+ * still `'foundation'`/`'project'`. Gating on `activeLens()` would then skip the very correction
+ * this guard exists to make. `setLens` is safe to call redundantly (`applyLensSelection` no-ops
+ * when unchanged) and `'me'` is always in the allowed set, so calling it unconditionally can't regress.
  */
 export const myEventsRequestLensGuard: CanActivateFn = (route) => {
   const lensService = inject(LensService);
 
   const tab = route.queryParams['tab'] as EventTabId | undefined;
   const eventId = route.queryParams['event'];
-  if (tab && MY_EVENTS_REQUEST_TAB_IDS.has(tab) && eventId && lensService.activeLens() !== 'me') {
+  if (tab && MY_EVENTS_REQUEST_TAB_IDS.has(tab) && eventId) {
     lensService.setLens('me');
   }
 

--- a/apps/lfx-one/src/app/shared/guards/my-events-request-lens.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-events-request-lens.guard.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { MY_EVENTS_REQUEST_TAB_IDS } from '@lfx-one/shared/constants';
+import { EventTabId } from '@lfx-one/shared/interfaces';
+
+import { LensService } from '../services/lens.service';
+
+/**
+ * Forces the `me` lens for a deep-linked visa-letter/travel-funding request
+ * (`/events?tab=visa-letters&event=<id>`) before `lensRedirectGuard` runs.
+ *
+ * `MyEventsDashboardComponent` — and the deep-link auto-open it hosts — only ever mounts under
+ * the `me`/`project` lens (`EventsDashboardComponent` swaps to the org/foundation dashboards
+ * otherwise), so a link opened while the persisted lens is `org` or `foundation` would silently
+ * never auto-open the dialog. `setLens('me')` applies and persists the switch without navigating
+ * (unlike `switchLens`), so the deep link's own URL still resolves the route on this pass.
+ */
+export const myEventsRequestLensGuard: CanActivateFn = (route) => {
+  const lensService = inject(LensService);
+
+  const tab = route.queryParams['tab'] as EventTabId | undefined;
+  const eventId = route.queryParams['event'];
+  if (tab && MY_EVENTS_REQUEST_TAB_IDS.has(tab) && eventId && lensService.activeLens() !== 'me') {
+    lensService.setLens('me');
+  }
+
+  return true;
+};

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -89,7 +89,7 @@ export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active',
 export const VALID_MY_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'attended', 'not-registered']);
 
 /** My Events dashboard tabs in visible order (`upcoming` is the default) — single source for the tab-pills bar and `?tab=` validation. */
-export const MY_EVENTS_TABS: FilterPillOption[] = [
+export const MY_EVENTS_TABS: (FilterPillOption & { id: EventTabId })[] = [
   { id: 'upcoming', label: 'Upcoming' },
   { id: 'past', label: 'Past' },
   { id: 'visa-letters', label: 'Visa Letters' },
@@ -99,7 +99,7 @@ export const MY_EVENTS_TABS: FilterPillOption[] = [
 /** Default tab for the My Events dashboard when `?tab=` is absent or invalid. */
 export const DEFAULT_MY_EVENTS_TAB_ID: EventTabId = 'upcoming';
 /** Derived from MY_EVENTS_TABS; used to validate `?tab=` query-param input. */
-export const VALID_MY_EVENTS_TAB_IDS: ReadonlySet<EventTabId> = new Set(MY_EVENTS_TABS.map((t) => t.id as EventTabId));
+export const VALID_MY_EVENTS_TAB_IDS: ReadonlySet<EventTabId> = new Set(MY_EVENTS_TABS.map((t) => t.id));
 /** Severity map for foundation event display statuses, used by the events table tag component. */
 export const FOUNDATION_EVENT_STATUS_SEVERITY_MAP: Partial<Record<string, TagSeverity>> = {
   [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -100,6 +100,8 @@ export const MY_EVENTS_TABS: (FilterPillOption & { id: EventTabId })[] = [
 export const DEFAULT_MY_EVENTS_TAB_ID: EventTabId = 'upcoming';
 /** Derived from MY_EVENTS_TABS; used to validate `?tab=` query-param input. */
 export const VALID_MY_EVENTS_TAB_IDS: ReadonlySet<EventTabId> = new Set(MY_EVENTS_TABS.map((t) => t.id));
+/** The two request-style tabs (different filters, and deep-linkable via `?tab=<id>&event=<id>`). */
+export const MY_EVENTS_REQUEST_TAB_IDS: ReadonlySet<EventTabId> = new Set(['visa-letters', 'travel-funding']);
 /** Severity map for foundation event display statuses, used by the events table tag component. */
 export const FOUNDATION_EVENT_STATUS_SEVERITY_MAP: Partial<Record<string, TagSeverity>> = {
   [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -5,6 +5,7 @@ import { FoundationEventStatus } from '../enums';
 import type {
   AttendeeAccommodationPaidBy,
   AttendeeType,
+  EventTabId,
   FilterOption,
   MyEventsResponse,
   EventsResponse,
@@ -85,6 +86,11 @@ export const COMING_SOON_SENTINEL = 'coming-soon';
 
 export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active', 'Planned', 'Pending', 'Completed', COMING_SOON_SENTINEL]);
 export const VALID_MY_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'attended', 'not-registered']);
+
+/** Default tab for the My Events dashboard when `?tab=` is absent or invalid. */
+export const DEFAULT_MY_EVENTS_TAB_ID: EventTabId = 'upcoming';
+/** The tabs the My Events dashboard actually renders; used to validate `?tab=` query-param input. */
+export const VALID_MY_EVENTS_TAB_IDS: ReadonlySet<EventTabId> = new Set<EventTabId>(['upcoming', 'past', 'visa-letters', 'travel-funding']);
 /** Severity map for foundation event display statuses, used by the events table tag component. */
 export const FOUNDATION_EVENT_STATUS_SEVERITY_MAP: Partial<Record<string, TagSeverity>> = {
   [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -7,6 +7,7 @@ import type {
   AttendeeType,
   EventTabId,
   FilterOption,
+  FilterPillOption,
   MyEventsResponse,
   EventsResponse,
   MyEventOrganizationsResponse,
@@ -87,10 +88,18 @@ export const COMING_SOON_SENTINEL = 'coming-soon';
 export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active', 'Planned', 'Pending', 'Completed', COMING_SOON_SENTINEL]);
 export const VALID_MY_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'attended', 'not-registered']);
 
+/** My Events dashboard tabs in visible order (`upcoming` is the default) — single source for the tab-pills bar and `?tab=` validation. */
+export const MY_EVENTS_TABS: FilterPillOption[] = [
+  { id: 'upcoming', label: 'Upcoming' },
+  { id: 'past', label: 'Past' },
+  { id: 'visa-letters', label: 'Visa Letters' },
+  { id: 'travel-funding', label: 'Travel Funding' },
+];
+
 /** Default tab for the My Events dashboard when `?tab=` is absent or invalid. */
 export const DEFAULT_MY_EVENTS_TAB_ID: EventTabId = 'upcoming';
-/** The tabs the My Events dashboard actually renders; used to validate `?tab=` query-param input. */
-export const VALID_MY_EVENTS_TAB_IDS: ReadonlySet<EventTabId> = new Set<EventTabId>(['upcoming', 'past', 'visa-letters', 'travel-funding']);
+/** Derived from MY_EVENTS_TABS; used to validate `?tab=` query-param input. */
+export const VALID_MY_EVENTS_TAB_IDS: ReadonlySet<EventTabId> = new Set(MY_EVENTS_TABS.map((t) => t.id as EventTabId));
 /** Severity map for foundation event display statuses, used by the events table tag component. */
 export const FOUNDATION_EVENT_STATUS_SEVERITY_MAP: Partial<Record<string, TagSeverity>> = {
   [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',


### PR DESCRIPTION
## Summary

- Adds deep-link support so event pages can link directly into the My Events dashboard: `?tab=visa-letters&event=<id>` and `?tab=travel-funding&event=<id>` auto-open the matching request dialog with the event preselected, skipping to the Terms step
- Falls back to manual "Choose an Event" selection with a toast when the linked event id doesn't match one of the user's eligible registered events
- Extracts a shared `resolveDeepLinkedEvent$` util used by both the visa and travel-fund request dialogs, replacing ~45 lines of duplicated logic and fixing a missing id-match check (previously trusted the first response entry rather than matching by id)
- Replaces an `effect()`-based auto-open with an RxJS (`combineLatest`/`toObservable`/`takeUntilDestroyed`) pipeline per the frontend checklist's effect()-is-for-logging-only convention
- Tracks consumed deep-link event ids in a `Set` instead of a single boolean flag, so a second deep link with a different event id can still auto-open
- Adds e2e coverage (content + structural specs) for both request types and the no-match fallback, and unifies the duplicated `mockEventRoutes` test helper

Fixes #2242