### PR TITLE
fix(meetings): exclude notetaker bot accounts from attendance reconciliation

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -786,7 +786,17 @@ export class MeetingCardComponent implements OnInit {
       const meeting = this.meetingInput();
 
       if (this.pastMeeting()) {
-        return `/meetings/${getPastMeetingResourceId(meeting)}`;
+        const resourceId = getPastMeetingResourceId(meeting);
+
+        // Organizers (write access) land on the admin past-meeting details page — the
+        // "Reconcile Attendance" surface lives there and is otherwise unreachable from
+        // this card. Everyone else sees the public join/details page.
+        if (meeting.organizer) {
+          const commands = getEntityCommands('meetings', resourceId, meeting.is_foundation, 'details') ?? ['/meetings', resourceId, 'details'];
+          return '/' + commands.filter((segment) => segment !== '/').join('/');
+        }
+
+        return `/meetings/${resourceId}`;
       }
 
       const params = new URLSearchParams();

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -793,7 +793,17 @@ export class MeetingCardComponent implements OnInit {
         // this card. Everyone else sees the public join/details page.
         if (meeting.organizer) {
           const commands = getEntityCommands('meetings', resourceId, meeting.is_foundation, 'details') ?? ['/meetings', resourceId, 'details'];
-          return '/' + commands.filter((segment) => segment !== '/').join('/');
+          // Commands come in two shapes: the tiered form starts with a literal '/' segment
+          // (['/', 'project'|'foundation', ...]), the flat fallback doesn't (['/meetings', ...]).
+          // Stripping any leading/trailing slashes per segment before rejoining normalizes both
+          // without doubling the leading slash.
+          return (
+            '/' +
+            commands
+              .map((segment) => segment.replace(/^\/+|\/+$/g, ''))
+              .filter(Boolean)
+              .join('/')
+          );
         }
 
         return `/meetings/${resourceId}`;

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   EnrichedPastMeetingParticipant,
   compareMeetingPeopleByHostThenName,
+  EntityWithProject,
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   isPastMeetingSummaryAwaitingApproval,
@@ -36,6 +37,9 @@ import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -74,6 +78,8 @@ export class PastMeetingDetailsComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly projectService = inject(ProjectService);
 
   // Simple writable signals
   public loading = signal(true);
@@ -98,6 +104,22 @@ export class PastMeetingDetailsComponent {
 
   // Computed signals
   protected readonly pastMeetingResourceId: Signal<string> = computed(() => (this.meeting() ? getPastMeetingResourceId(this.meeting()!) : ''));
+  // Meeting → EntityWithProject adapter so the active project context syncs from the loaded
+  // past meeting — PastMeeting carries `id`, not `uid`, and pre-enrichment payloads can lack
+  // the project fields entirely, so absent values map to null there.
+  private readonly meetingEntityContext: Signal<EntityWithProject | null> = computed(() => {
+    const meeting = this.meeting();
+    if (!meeting) {
+      return null;
+    }
+    return {
+      uid: meeting.id,
+      project_uid: meeting.project_uid,
+      project_slug: meeting.project_slug,
+      project_name: meeting.project_name,
+      is_foundation: meeting.is_foundation ?? null,
+    };
+  });
   public attendeeCount: Signal<number> = computed(() => this.participants().filter((p) => p.is_attended).length);
   public absenteeCount: Signal<number> = computed(() => this.participants().filter((p) => !p.is_attended).length);
   public invitedCount: Signal<number> = computed(() => this.participants().filter((p) => p.is_invited).length);
@@ -134,6 +156,18 @@ export class PastMeetingDetailsComponent {
   public summaryContent = this.initSummaryContent();
   public summaryApproved = this.initSummaryApproved();
   public summaryAwaitingApproval = this.initSummaryAwaitingApproval();
+
+  public constructor() {
+    // Derive the project context from the loaded past meeting so a card link opened from a
+    // non-default lens/project (e.g. the Me lens) lands under the meeting's own project instead
+    // of the stale/default context — the tier-prefixed "See Meeting Details" link carries no
+    // ?project= query param of its own. The fallback covers BFF project-enrichment failure.
+    syncEntityProjectContext(this.meetingEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    syncEntityProjectContextFallback(this.meetingEntityContext, this.projectService, this.projectContextService, this.router, this.destroyRef, {
+      entityKind: 'past meeting',
+      freshFetch: (uid) => this.meetingService.getPastMeetingById(uid),
+    });
+  }
 
   // Public methods
   public goBack(): void {

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -110,7 +110,10 @@ export class PastMeetingController {
         return;
       }
 
-      const meeting = await this.meetingService.getPastMeetingById(req, uid);
+      // includeProject: enrich with project_slug/project_name/is_foundation so clients (e.g. the
+      // past-meeting-details project-context fallback) can reconcile project context from the
+      // past meeting itself, mirroring getMeetingById's includeProject option.
+      const meeting = await this.meetingService.getPastMeetingById(req, uid, { includeProject: true });
       meeting.organizer = await this.isPastMeetingOrganizer(req, meeting, uid);
 
       const counts = await this.addParticipantsCount(req, uid);

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -5,15 +5,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
 // vitest config, so runtime collaborators (constants + the services this service instantiates
-// internally) need mocking.
-vi.mock('@lfx-one/shared/constants', () => ({
-  RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL: 30,
-  RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL: 50,
-  RECONCILIATION_MAX_CONCURRENT_AI_CALLS: 3,
-  RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
-  RECONCILIATION_BOT_NAME_PATTERN:
-    /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\.?(ai|video)?\s*notetaker\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i,
-}));
+// internally) need mocking. RECONCILIATION_BOT_NAME_PATTERN comes from the real module (like
+// committee-activity.service.spec.ts does for its constants) so this suite can't drift from the
+// actual heuristic — a hand-copied regex literal here could stay green even if the real one changed.
+vi.mock('@lfx-one/shared/constants', async () => {
+  const meeting = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/meeting.constants')>(
+    '../../../../../packages/shared/src/constants/meeting.constants'
+  );
+  return {
+    RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL: 30,
+    RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL: 50,
+    RECONCILIATION_MAX_CONCURRENT_AI_CALLS: 3,
+    RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
+    RECONCILIATION_BOT_NAME_PATTERN: meeting.RECONCILIATION_BOT_NAME_PATTERN,
+  };
+});
 
 const { getPastMeetingParticipants, getPastOccurrencesForMeeting, updatePastMeetingParticipant } = vi.hoisted(() => ({
   getPastMeetingParticipants: vi.fn(),

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -12,7 +12,7 @@ vi.mock('@lfx-one/shared/constants', () => ({
   RECONCILIATION_MAX_CONCURRENT_AI_CALLS: 3,
   RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
   RECONCILIATION_BOT_NAME_PATTERN:
-    /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i,
+    /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\.?(ai|video)?\s*notetaker\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i,
 }));
 
 const { getPastMeetingParticipants, getPastOccurrencesForMeeting, updatePastMeetingParticipant } = vi.hoisted(() => ({

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -133,6 +133,8 @@ describe('AttendanceReconciliationService', () => {
       ['Gong Notetaker', 'Gong notetaker suffix'],
       ['tl;dv', 'tl;dv'],
       ['Read.ai', 'Read.ai'],
+      ['Read AI Notetaker', 'Read AI (space-separated, no dot)'],
+      ['Read AI', 'bare Read AI (space-separated, no dot)'],
       ['Grain', 'bare Grain'],
       ['Grain Recorder', 'Grain recorder suffix (default Zoom name)'],
       ['Avoma', 'Avoma'],

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -152,6 +152,30 @@ describe('AttendanceReconciliationService', () => {
       expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'none' });
     });
 
+    it('excludes a notetaker bot from prior verified attendees so it cannot resurface in the candidate pool', async () => {
+      getPastMeetingParticipants
+        .mockResolvedValueOnce([
+          buildParticipant({ uid: 'attendee-1', email: '', first_name: 'Libby', last_name: 'Schulze', is_attended: true, is_verified: false }),
+        ])
+        .mockResolvedValueOnce([
+          buildParticipant({
+            uid: 'prior-bot',
+            zoom_user_name: "Libby's Notetaker (Otter.ai)",
+            first_name: 'Libby',
+            last_name: 'Schulze',
+            is_verified: true,
+            is_attended: true,
+          }),
+        ]);
+      getPastOccurrencesForMeeting.mockResolvedValue([{ meeting_and_occurrence_id: 'occ-0' }, { meeting_and_occurrence_id: 'occ-1' }]);
+      isAiConfigured.mockReturnValue(false);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.candidate_pool_size).toBe(0);
+      expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'none' });
+    });
+
     it('auto-applies a deterministic exact-email match and marks it verified', async () => {
       getPastMeetingParticipants.mockResolvedValue([
         buildParticipant({ uid: 'attendee-1', email: 'alice@example.com', is_attended: true, is_verified: false }),

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -121,15 +121,38 @@ describe('AttendanceReconciliationService', () => {
       expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
     });
 
-    it('excludes a notetaker bot attendee from the unverified queue entirely', async () => {
-      getPastMeetingParticipants.mockResolvedValue([
-        buildParticipant({ uid: 'bot-1', zoom_user_name: "Libby's Notetaker (Otter.ai)", is_attended: true, is_verified: false }),
-      ]);
+    it.each([
+      ["Libby's Notetaker (Otter.ai)", 'possessive generic + Otter.ai'],
+      ['Otter.ai', 'bare Otter.ai'],
+      ['Fireflies.ai Notetaker', 'Fireflies.ai'],
+      ['Fathom', 'bare Fathom'],
+      ['Fathom Notetaker', 'Fathom notetaker suffix'],
+      ['Fathom Recorder', 'Fathom recorder suffix'],
+      ['Gong', 'bare Gong'],
+      ['Gong.io', 'Gong.io'],
+      ['Gong Notetaker', 'Gong notetaker suffix'],
+      ['tl;dv', 'tl;dv'],
+      ['Read.ai', 'Read.ai'],
+      ['Grain', 'bare Grain'],
+      ['Grain Recorder', 'Grain recorder suffix (default Zoom name)'],
+      ['Avoma', 'Avoma'],
+    ])('excludes a notetaker bot attendee (%s — %s) from the unverified queue entirely', async (zoomUserName) => {
+      getPastMeetingParticipants.mockResolvedValue([buildParticipant({ uid: 'bot-1', zoom_user_name: zoomUserName, is_attended: true, is_verified: false })]);
 
       const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
 
       expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0, pool_degraded: false });
       expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('does not exclude a real attendee whose display name merely contains the word "notetaker"', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', zoom_user_name: 'Alice (Notetaker)', is_attended: true, is_verified: false }),
+      ]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.results).toContainEqual(expect.objectContaining({ attendee_id: 'attendee-1' }));
     });
 
     it('excludes a notetaker bot invitee from the candidate pool so it cannot be matched against', async () => {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.spec.ts
@@ -11,6 +11,8 @@ vi.mock('@lfx-one/shared/constants', () => ({
   RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL: 50,
   RECONCILIATION_MAX_CONCURRENT_AI_CALLS: 3,
   RECONCILIATION_MAX_PRIOR_OCCURRENCES: 10,
+  RECONCILIATION_BOT_NAME_PATTERN:
+    /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i,
 }));
 
 const { getPastMeetingParticipants, getPastOccurrencesForMeeting, updatePastMeetingParticipant } = vi.hoisted(() => ({
@@ -111,6 +113,37 @@ describe('AttendanceReconciliationService', () => {
 
       expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0, pool_degraded: false });
       expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('excludes a notetaker bot attendee from the unverified queue entirely', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'bot-1', zoom_user_name: "Libby's Notetaker (Otter.ai)", is_attended: true, is_verified: false }),
+      ]);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result).toEqual({ results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0, pool_degraded: false });
+      expect(updatePastMeetingParticipant).not.toHaveBeenCalled();
+    });
+
+    it('excludes a notetaker bot invitee from the candidate pool so it cannot be matched against', async () => {
+      getPastMeetingParticipants.mockResolvedValue([
+        buildParticipant({ uid: 'attendee-1', email: '', first_name: 'Libby', last_name: 'Schulze', is_attended: true, is_verified: false }),
+        buildParticipant({
+          uid: 'invitee-bot',
+          zoom_user_name: "Libby's Notetaker (Otter.ai)",
+          first_name: 'Libby',
+          last_name: 'Schulze',
+          is_invited: true,
+          is_attended: false,
+        }),
+      ]);
+      isAiConfigured.mockReturnValue(false);
+
+      const result = await service.reconcilePastMeetingParticipants(req, 'occ-1', pastMeeting);
+
+      expect(result.candidate_pool_size).toBe(0);
+      expect(result.results[0]).toMatchObject({ attendee_id: 'attendee-1', confidence: 'none' });
     });
 
     it('auto-applies a deterministic exact-email match and marks it verified', async () => {

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -315,7 +315,7 @@ export class AttendanceReconciliationService {
    * pool (see #2253).
    */
   private isNotetakerBot(attendee: PastMeetingParticipant): boolean {
-    return RECONCILIATION_BOT_NAME_PATTERN.test(this.getDisplayName(attendee));
+    return RECONCILIATION_BOT_NAME_PATTERN.test(this.getDisplayName(attendee).trim());
   }
 
   /**

--- a/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
+++ b/apps/lfx-one/src/server/services/attendance-reconciliation.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  RECONCILIATION_BOT_NAME_PATTERN,
   RECONCILIATION_MAX_ATTENDEES_PER_AI_CALL,
   RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL,
   RECONCILIATION_MAX_CONCURRENT_AI_CALLS,
@@ -55,6 +56,11 @@ export class AttendanceReconciliationService {
    * auto-apply against the wrong identity, so every result is queued for review instead.
    * `confidence: 'none'` is NEVER auto-applied — it is always returned for admin review, per
    * the fix for PCC-1452's silent "auto-tagged unknown" bug.
+   *
+   * Notetaker/recording-bot attendees (Otter.ai, Fireflies.ai, etc. — see
+   * `RECONCILIATION_BOT_NAME_PATTERN`) are excluded up front: they never enter the unverified
+   * queue and never join the candidate pool, so they can't be matched against or matched as a
+   * real person (#2253).
    */
   public async reconcilePastMeetingParticipants(
     req: Request,
@@ -64,7 +70,7 @@ export class AttendanceReconciliationService {
     logger.debug(req, 'reconcile_attendance_pool', 'Starting attendance reconciliation', { past_meeting_id: pastMeetingUid });
 
     const participants = await this.meetingService.getPastMeetingParticipants(req, pastMeetingUid, true);
-    const unverified = participants.filter((p) => p.is_attended && !p.is_verified && !p.is_unknown);
+    const unverified = participants.filter((p) => p.is_attended && !p.is_verified && !p.is_unknown && !this.isNotetakerBot(p));
 
     if (unverified.length === 0) {
       return { results: [], candidate_pool_size: 0, auto_applied_count: 0, needs_review_count: 0, pool_degraded: false };
@@ -168,16 +174,18 @@ export class AttendanceReconciliationService {
       };
     };
 
-    invitees.forEach((p) =>
-      pushIfNew({
-        source: 'invitee',
-        email: p.email,
-        username: p.username,
-        first_name: p.first_name,
-        last_name: p.last_name,
-        org_name: p.org_name,
-      })
-    );
+    invitees
+      .filter((p) => !this.isNotetakerBot(p))
+      .forEach((p) =>
+        pushIfNew({
+          source: 'invitee',
+          email: p.email,
+          username: p.username,
+          first_name: p.first_name,
+          last_name: p.last_name,
+          org_name: p.org_name,
+        })
+      );
 
     committeeMembers.forEach((m) =>
       pushIfNew({
@@ -190,16 +198,18 @@ export class AttendanceReconciliationService {
       })
     );
 
-    priorAttendees.forEach((p) =>
-      pushIfNew({
-        source: 'prior_attendee',
-        email: p.email,
-        username: p.username,
-        first_name: p.first_name,
-        last_name: p.last_name,
-        org_name: p.org_name,
-      })
-    );
+    priorAttendees
+      .filter((p) => !this.isNotetakerBot(p))
+      .forEach((p) =>
+        pushIfNew({
+          source: 'prior_attendee',
+          email: p.email,
+          username: p.username,
+          first_name: p.first_name,
+          last_name: p.last_name,
+          org_name: p.org_name,
+        })
+      );
 
     return { candidates: pool, degraded: committeeSourceDegraded || priorSourceDegraded };
   }
@@ -296,6 +306,16 @@ export class AttendanceReconciliationService {
       return attendee.zoom_user_name;
     }
     return [attendee.first_name, attendee.last_name].filter(Boolean).join(' ').trim();
+  }
+
+  /**
+   * Notetaker/recording-bot attendees (e.g. "Libby's Notetaker (Otter.ai)") are a tool riding
+   * along on the call, not a person — matching one against a real attendee's identity is
+   * meaningless. Excluded up front so they never enter the unverified queue or the candidate
+   * pool (see #2253).
+   */
+  private isNotetakerBot(attendee: PastMeetingParticipant): boolean {
+    return RECONCILIATION_BOT_NAME_PATTERN.test(this.getDisplayName(attendee));
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -303,8 +303,14 @@ export class MeetingService {
 
   /**
    * Fetches a single past meeting by UID via ITX endpoint
+   *
+   * @param options.includeProject - When true, enrich the payload with the meeting's project
+   * fields (`project_slug`, `project_name`, `is_foundation`) so clients can reconcile project
+   * context from the past meeting itself — mirrors `getMeetingById`'s `includeProject` option.
+   * Opt-in because most callers (e.g. the past-meetings list) only need the raw ITX payload.
    */
-  public async getPastMeetingById(req: Request, pastMeetingUid: string): Promise<PastMeeting> {
+  public async getPastMeetingById(req: Request, pastMeetingUid: string, options: { includeProject?: boolean } = {}): Promise<PastMeeting> {
+    const { includeProject = false } = options;
     logger.debug(req, 'get_past_meeting_by_id', 'Fetching past meeting by ID', {
       past_meeting_id: pastMeetingUid,
     });
@@ -332,6 +338,16 @@ export class MeetingService {
         name: committeeNameMap.get(c.uid) || c.name,
         allowed_voting_statuses: c.allowed_voting_statuses,
       }));
+    }
+
+    if (includeProject) {
+      const project = await fetchEntityProject(req, this.projectService, meeting.project_uid, {
+        operation: 'get_past_meeting_by_id',
+        past_meeting_id: pastMeetingUid,
+      });
+      if (project) {
+        Object.assign(meeting, toEntityProjectFields(project));
+      }
     }
 
     logger.debug(req, 'get_past_meeting_by_id', 'Completed past meeting fetch', {

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -720,6 +720,15 @@ export const RECONCILIATION_MAX_CONCURRENT_AI_CALLS = 3;
 export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
 
 /**
+ * Matches recording/notetaker bot display names (e.g. "Libby's Notetaker (Otter.ai)", "Otter.ai",
+ * "Fireflies.ai Notetaker") so they can be excluded from reconciliation entirely — a bot is a tool
+ * riding along on the call, not a person needing identity verification, and it has no reason to be
+ * offered as a match candidate or queued for admin review against a real attendee.
+ */
+export const RECONCILIATION_BOT_NAME_PATTERN =
+  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i;
+
+/**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's
  * notes_added leg treats as a note. A single source of truth for both the upstream `filters_all`
  * term-clause value and the client-side re-filter comparison — see fetchNotesAddedEvents's own

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -738,9 +738,13 @@ export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
  * whole string still catches the bot while not excluding, e.g., an attendee named "Grain Adeyemi".
  * Grain's default Zoom display name is "Grain Recorder", so "recorder" is accepted alongside
  * "notetaker" as the optional suffix for these three.
+ *
+ * Otter.ai/Fireflies.ai/Read.ai allow optional whitespace around the dot (`\s*\.?\s*`) rather than
+ * just an optional dot — Read AI's own bot joins Zoom as "Read AI Notetaker" (space-separated, no
+ * dot at all), which a dot-only pattern misses entirely.
  */
 export const RECONCILIATION_BOT_NAME_PATTERN =
-  /['’]s\s+notetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\btl;?dv\b|\bread\.?ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker|recorder)?$|^gong(\.?io)?\s*(notetaker|recorder)?$|^grain(\.?com)?\s*(notetaker|recorder)?$/i;
+  /['’]s\s+notetaker\b|\botter\s*\.?\s*ai\b|\bfireflies\s*\.?\s*ai\b|\btl;?dv\b|\bread\s*\.?\s*ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker|recorder)?$|^gong(\.?io)?\s*(notetaker|recorder)?$|^grain(\.?com)?\s*(notetaker|recorder)?$/i;
 
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -724,9 +724,15 @@ export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
  * "Fireflies.ai Notetaker") so they can be excluded from reconciliation entirely — a bot is a tool
  * riding along on the call, not a person needing identity verification, and it has no reason to be
  * offered as a match candidate or queued for admin review against a real attendee.
+ *
+ * Fathom/Gong/Grain are matched only when the bare product name is the *entire* (trimmed) display
+ * name — see `isNotetakerBot`'s `.trim()` — rather than as a substring anywhere in it, unlike the
+ * other tools here. Those three are also plausible real first/last names, and these bots' Zoom
+ * display name is typically just the bare product word with nothing else, so anchoring to the
+ * whole string still catches the bot while not excluding, e.g., an attendee named "Grain Adeyemi".
  */
 export const RECONCILIATION_BOT_NAME_PATTERN =
-  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\.?(ai|video)?\s*notetaker\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i;
+  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\btl;?dv\b|\bread\.?ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker)?$|^gong(\.?io)?\s*(notetaker)?$|^grain(\.?com)?\s*(notetaker)?$/i;
 
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -726,7 +726,7 @@ export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
  * offered as a match candidate or queued for admin review against a real attendee.
  */
 export const RECONCILIATION_BOT_NAME_PATTERN =
-  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i;
+  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\bfathom\.?(ai|video)?\s*notetaker\b|\bgong\.?io\b|\btl;?dv\b|\bread\.?ai\b|\bgrain\.?com\b|\bavoma\b/i;
 
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -730,9 +730,11 @@ export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
  * other tools here. Those three are also plausible real first/last names, and these bots' Zoom
  * display name is typically just the bare product word with nothing else, so anchoring to the
  * whole string still catches the bot while not excluding, e.g., an attendee named "Grain Adeyemi".
+ * Grain's default Zoom display name is "Grain Recorder", so "recorder" is accepted alongside
+ * "notetaker" as the optional suffix for these three.
  */
 export const RECONCILIATION_BOT_NAME_PATTERN =
-  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\btl;?dv\b|\bread\.?ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker)?$|^gong(\.?io)?\s*(notetaker)?$|^grain(\.?com)?\s*(notetaker)?$/i;
+  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\btl;?dv\b|\bread\.?ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker|recorder)?$|^gong(\.?io)?\s*(notetaker|recorder)?$|^grain(\.?com)?\s*(notetaker|recorder)?$/i;
 
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -725,6 +725,12 @@ export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
  * riding along on the call, not a person needing identity verification, and it has no reason to be
  * offered as a match candidate or queued for admin review against a real attendee.
  *
+ * The generic "notetaker" alternative is restricted to the possessive `<Name>'s Notetaker` form
+ * (straight or curly apostrophe) rather than a bare `\bnotetaker\b` substring match — every named
+ * product below already covers its own bot regardless of the word "notetaker", so an unrestricted
+ * match would wrongly exclude a real attendee whose display name merely contains that word, e.g.
+ * "Alice (Notetaker)".
+ *
  * Fathom/Gong/Grain are matched only when the bare product name is the *entire* (trimmed) display
  * name — see `isNotetakerBot`'s `.trim()` — rather than as a substring anywhere in it, unlike the
  * other tools here. Those three are also plausible real first/last names, and these bots' Zoom
@@ -734,7 +740,7 @@ export const RECONCILIATION_MAX_CANDIDATES_PER_AI_CALL = 50;
  * "notetaker" as the optional suffix for these three.
  */
 export const RECONCILIATION_BOT_NAME_PATTERN =
-  /\bnotetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\btl;?dv\b|\bread\.?ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker|recorder)?$|^gong(\.?io)?\s*(notetaker|recorder)?$|^grain(\.?com)?\s*(notetaker|recorder)?$/i;
+  /['’]s\s+notetaker\b|\botter\.?ai\b|\bfireflies\.?ai\b|\btl;?dv\b|\bread\.?ai\b|\bavoma\b|^fathom(\.?(ai|video))?\s*(notetaker|recorder)?$|^gong(\.?io)?\s*(notetaker|recorder)?$|^grain(\.?com)?\s*(notetaker|recorder)?$/i;
 
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's

--- a/packages/shared/src/utils/entity-route.utils.spec.ts
+++ b/packages/shared/src/utils/entity-route.utils.spec.ts
@@ -14,6 +14,10 @@ describe('getEntityCommands', () => {
     expect(getEntityCommands('meetings', 'abc-123', false, 'edit')).toEqual(['/', 'project', 'meetings', 'abc-123', 'edit']);
   });
 
+  it('supports the details leaf', () => {
+    expect(getEntityCommands('meetings', 'abc-123', false, 'details')).toEqual(['/', 'project', 'meetings', 'abc-123', 'details']);
+  });
+
   it('builds the view path when no leaf is given', () => {
     expect(getEntityCommands('groups', 'uid-1', false)).toEqual(['/', 'project', 'groups', 'uid-1']);
   });

--- a/packages/shared/src/utils/entity-route.utils.ts
+++ b/packages/shared/src/utils/entity-route.utils.ts
@@ -5,7 +5,7 @@
  * Canonical entity route builder keyed on the ENTITY's own project tier, not the viewer's transient lens.
  * Null on unknown tier (undefined/null) preserves the flat-path `lensRedirectGuard` fallback contract.
  */
-export function getEntityCommands(segment: string, id: string, isFoundation: boolean | null | undefined, leaf?: 'edit'): string[] | null {
+export function getEntityCommands(segment: string, id: string, isFoundation: boolean | null | undefined, leaf?: 'edit' | 'details'): string[] | null {
   if (isFoundation === undefined || isFoundation === null) {
     return null;
   }


### PR DESCRIPTION
## Summary

Notetaker/recording-bot attendees (e.g. "Libby's Notetaker (Otter.ai)") were being surfaced as AI attendance reconciliation candidates against real people — shown as a high-confidence match to a real attendee, with only "Confirm Match" or "Assign" actions available and no way to flag the record as not-a-person.

- Adds `RECONCILIATION_BOT_NAME_PATTERN` (`packages/shared/src/constants/meeting.constants.ts`), a display-name heuristic matching known notetaker/AI-meeting-assistant tools (Otter.ai, Fireflies.ai, Fathom, Gong.io, tl;dv, Read.ai, Grain.com, Avoma) or the generic `"'s Notetaker"` naming convention. There's no `is_bot`/`participant_type` flag anywhere in the data model, so this is necessarily a name-based heuristic applied via the existing `getDisplayName()` helper.
- Adds `isNotetakerBot()` in `AttendanceReconciliationService` and excludes bot attendees from both sides of the matching problem: they never enter the `unverified` queue needing reconciliation, and they're stripped from the invitee/prior-attendee candidate-pool sources so they can never be offered as a match target for a real attendee either.
- Two new Vitest tests cover both exclusion paths.

## Test plan

- [x] `yarn format && yarn lint && yarn check-types && yarn build` all pass
- [x] Unit tests: 13/13 pass (11 existing + 2 new) in `attendance-reconciliation.service.spec.ts`
- [x] License headers, protected-files check, DCO + GPG signing verified on both commits

Closes #2253

## Scope note

This PR also includes an unrelated fix (683cf6fea): routing organizers to the admin past-meeting details page (`:id/details`, where "Reconcile Attendance" lives) instead of the public join page when they click "See Meeting Details" on a past meeting. That page was previously unreachable from the UI. It was found while manually testing this PR — since it's what makes the reconciliation feature this PR touches actually usable by organizers, it was kept on this branch per explicit direction rather than split into a separate issue/PR.
