### PR TITLE
feat(mentorship): split mentor/mentee status; wire mentors-tab actions

### DIFF
--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -7,8 +7,8 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MENTORSHIP_PERSON_STATUS_BADGE_CLASSES, MENTORSHIP_PERSON_STATUS_LABELS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '@lfx-one/shared/constants';
-import { MentorshipPersonStatus, MentorshipProgramPerson } from '@lfx-one/shared/interfaces';
+import { MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES, MENTORSHIP_MENTEE_STATUS_LABELS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
 import { startWith } from 'rxjs';
 
@@ -22,11 +22,11 @@ import { startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ApplicantsTabComponent {
-  public readonly applicants = input.required<MentorshipProgramPerson[]>();
+  public readonly applicants = input.required<MentorshipProgramMentee[]>();
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
-    status: new FormControl<MentorshipPersonStatus | null>(null),
+    status: new FormControl<MentorshipMenteeStatus | null>(null),
   });
 
   private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
@@ -38,7 +38,7 @@ export class ApplicantsTabComponent {
     return [
       { label: 'All statuses', value: null },
       ...statuses.map((status) => ({
-        label: MENTORSHIP_PERSON_STATUS_LABELS[status],
+        label: MENTORSHIP_MENTEE_STATUS_LABELS[status],
         value: status,
       })),
     ];
@@ -52,14 +52,14 @@ export class ApplicantsTabComponent {
       .map((person) => this.toRow(person));
   });
 
-  private toRow(person: MentorshipProgramPerson) {
+  private toRow(person: MentorshipProgramMentee) {
     const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
       avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
-      statusLabel: MENTORSHIP_PERSON_STATUS_LABELS[person.status],
-      statusBadgeClass: MENTORSHIP_PERSON_STATUS_BADGE_CLASSES[person.status],
+      statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
+      statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
       appliedOnLabel: person.appliedOn ? formatIsoDateLabel(person.appliedOn) : '—',
     };
   }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -7,8 +7,8 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MENTORSHIP_PERSON_STATUS_BADGE_CLASSES, MENTORSHIP_PERSON_STATUS_LABELS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '@lfx-one/shared/constants';
-import { MentorshipPersonStatus, MentorshipProgramPerson } from '@lfx-one/shared/interfaces';
+import { MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES, MENTORSHIP_MENTEE_STATUS_LABELS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import { matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
 import { startWith } from 'rxjs';
 
@@ -22,11 +22,11 @@ import { startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CurrentMenteesTabComponent {
-  public readonly mentees = input.required<MentorshipProgramPerson[]>();
+  public readonly mentees = input.required<MentorshipProgramMentee[]>();
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
-    status: new FormControl<MentorshipPersonStatus | null>(null),
+    status: new FormControl<MentorshipMenteeStatus | null>(null),
   });
 
   private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
@@ -38,7 +38,7 @@ export class CurrentMenteesTabComponent {
     return [
       { label: 'All statuses', value: null },
       ...statuses.map((status) => ({
-        label: MENTORSHIP_PERSON_STATUS_LABELS[status],
+        label: MENTORSHIP_MENTEE_STATUS_LABELS[status],
         value: status,
       })),
     ];
@@ -52,14 +52,14 @@ export class CurrentMenteesTabComponent {
       .map((person) => this.toRow(person));
   });
 
-  private toRow(person: MentorshipProgramPerson) {
+  private toRow(person: MentorshipProgramMentee) {
     const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
       avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
-      statusLabel: MENTORSHIP_PERSON_STATUS_LABELS[person.status],
-      statusBadgeClass: MENTORSHIP_PERSON_STATUS_BADGE_CLASSES[person.status],
+      statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
+      statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
@@ -18,7 +18,7 @@
           optionValue="value"
           placeholder="Search and select mentors..."
           [filter]="true"
-          [filterFields]="['label', 'email']"
+          filterBy="label,email"
           filterPlaceholder="Search users"
           [showClear]="true"
           ariaLabel="Select a user to invite as a mentor"

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
@@ -3,42 +3,57 @@
 
 <div class="flex flex-col gap-4" data-testid="mentorship-mentors-tab">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center flex-1">
-      <label class="sm:w-72">
-        <span class="sr-only">Search mentors</span>
-        <lfx-input-text [form]="form" control="search" placeholder="Search" icon="fa-light fa-magnifying-glass" dataTest="mentorship-mentors-search" />
-      </label>
-      <div class="sm:w-52">
+    <label class="w-full">
+      <span class="sr-only">Search mentors</span>
+      <lfx-input-text [form]="form" control="search" placeholder="Search" icon="fa-light fa-magnifying-glass" dataTest="mentorship-mentors-search" />
+    </label>
+
+    <div class="flex items-center gap-2">
+      <div class="w-full sm:w-72">
         <lfx-select
           [form]="form"
-          control="status"
-          [options]="statusOptions()"
+          control="invitee"
+          [options]="inviteOptions()"
           optionLabel="label"
           optionValue="value"
-          placeholder="Status"
-          ariaLabel="Filter mentors by status"
+          placeholder="Search and select mentors..."
+          [filter]="true"
+          [filterFields]="['label', 'email']"
+          filterPlaceholder="Search users"
+          [showClear]="true"
+          ariaLabel="Select a user to invite as a mentor"
           styleClass="w-full"
-          dataTest="mentorship-mentors-status" />
+          dataTest="mentorship-mentors-invitee">
+          <ng-template #item let-option>
+            <div class="flex flex-col gap-0.5">
+              <span class="text-sm font-medium text-gray-900">{{ option.label }}</span>
+              <span class="text-xs text-gray-500">{{ option.email }}</span>
+            </div>
+          </ng-template>
+        </lfx-select>
       </div>
+
+      <lfx-button
+        label="Invite"
+        icon="fa-light fa-plus"
+        iconPos="left"
+        severity="primary"
+        size="small"
+        [disabled]="!canInvite()"
+        (onClick)="onInviteMentor()"
+        data-testid="mentorship-mentors-invite" />
     </div>
-    <lfx-button
-      label="Invite Mentor"
-      icon="fa-light fa-plus"
-      iconPos="left"
-      severity="primary"
-      size="small"
-      (onClick)="onInviteMentor()"
-      data-testid="mentorship-mentors-invite" />
   </div>
 
   <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white">
-    <table class="w-full min-w-[48rem] text-left">
+    <table class="w-full min-w-[48rem] table-fixed text-left">
       <thead>
         <tr class="border-b border-gray-200">
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Mentor</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Status</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Invitation Date</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Profile Created?</th>
+          <th class="w-[35%] px-4 py-3 text-sm font-medium text-gray-600">Mentor</th>
+          <th class="w-[15%] px-4 py-3 text-sm font-medium text-gray-600">Status</th>
+          <th class="w-[24%] px-4 py-3 text-sm font-medium text-gray-600">Invitation / Application</th>
+          <th class="w-[16%] px-4 py-3 text-sm font-medium text-gray-600">Profile Created?</th>
+          <th class="w-[10%] px-4 py-3 text-sm font-medium text-gray-600 text-end">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -55,7 +70,6 @@
                   [ariaLabel]="row.name" />
                 <div class="flex flex-col min-w-0">
                   <span class="text-sm font-medium text-gray-900 truncate">{{ row.name }}</span>
-                  <span class="text-xs text-gray-500 truncate">{{ row.email }}</span>
                 </div>
               </div>
             </td>
@@ -64,12 +78,47 @@
                 {{ row.statusLabel }}
               </span>
             </td>
-            <td class="px-4 py-3 text-sm text-gray-700">{{ row.invitedOnLabel }}</td>
-            <td class="px-4 py-3 text-sm text-gray-700">{{ row.profileCreatedLabel }}</td>
+            <td class="px-4 py-3 text-sm text-gray-700">{{ row.invitationLabel }}</td>
+            <td class="px-4 py-3 text-sm text-green-600" [class.text-red-600]="row.profileCreatedLabel === 'No'">{{ row.profileCreatedLabel }}</td>
+            <td class="px-4 py-3">
+              <div class="flex items-center justify-end gap-3">
+                @if (row.canAccept) {
+                  <button
+                    type="button"
+                    class="text-emerald-600 transition-colors hover:text-emerald-700"
+                    [title]="'Accept ' + row.name"
+                    [attr.aria-label]="'Accept ' + row.name"
+                    (click)="onAcceptMentor(row.name)"
+                    [attr.data-testid]="'mentorship-mentor-accept-' + row.id">
+                    <i class="fa-light fa-circle-check" aria-hidden="true"></i>
+                  </button>
+                }
+                @if (row.canDecline) {
+                  <button
+                    type="button"
+                    class="text-amber-600 transition-colors hover:text-amber-700"
+                    [title]="'Decline ' + row.name"
+                    [attr.aria-label]="'Decline ' + row.name"
+                    (click)="onDeclineMentor(row.name)"
+                    [attr.data-testid]="'mentorship-mentor-decline-' + row.id">
+                    <i class="fa-light fa-circle-xmark" aria-hidden="true"></i>
+                  </button>
+                }
+                <button
+                  type="button"
+                  class="text-red-600 transition-colors hover:text-red-700"
+                  [title]="row.name + ' will be removed from the program'"
+                  [attr.aria-label]="row.name + ' will be removed from the program'"
+                  (click)="onDeleteMentor(row.name)"
+                  [attr.data-testid]="'mentorship-mentor-delete-' + row.id">
+                  <i class="fa-light fa-trash-can" aria-hidden="true"></i>
+                </button>
+              </div>
+            </td>
           </tr>
         } @empty {
           <tr>
-            <td colspan="4" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-mentors-empty">No mentors.</td>
+            <td colspan="5" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-mentors-empty">No mentors.</td>
           </tr>
         }
       </tbody>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
@@ -51,7 +51,7 @@
         <tr class="border-b border-gray-200">
           <th class="w-[35%] px-4 py-3 text-sm font-medium text-gray-600">Mentor</th>
           <th class="w-[15%] px-4 py-3 text-sm font-medium text-gray-600">Status</th>
-          <th class="w-[24%] px-4 py-3 text-sm font-medium text-gray-600">Invitation / Application</th>
+          <th class="w-[24%] px-4 py-3 text-sm font-medium text-gray-600">Invitation Date</th>
           <th class="w-[16%] px-4 py-3 text-sm font-medium text-gray-600">Profile Created?</th>
           <th class="w-[10%] px-4 py-3 text-sm font-medium text-gray-600 text-end">Actions</th>
         </tr>
@@ -69,7 +69,7 @@
                   [styleClass]="row.avatarStyleClass"
                   [ariaLabel]="row.name" />
                 <div class="flex flex-col min-w-0">
-                  <span class="text-sm font-medium text-gray-900 truncate">{{ row.name }}</span>
+                  <span class="text-sm font-medium text-gray-900 truncate" [title]="row.name">{{ row.name }}</span>
                 </div>
               </div>
             </td>
@@ -79,7 +79,7 @@
               </span>
             </td>
             <td class="px-4 py-3 text-sm text-gray-700">{{ row.invitationLabel }}</td>
-            <td class="px-4 py-3 text-sm text-green-600" [class.text-red-600]="row.profileCreatedLabel === 'No'">{{ row.profileCreatedLabel }}</td>
+            <td class="px-4 py-3 text-sm" [class]="row.profileCreatedClass">{{ row.profileCreatedLabel }}</td>
             <td class="px-4 py-3">
               <div class="flex items-center justify-end gap-3">
                 @if (row.canAccept) {
@@ -107,8 +107,8 @@
                 <button
                   type="button"
                   class="text-red-600 transition-colors hover:text-red-700"
-                  [title]="row.name + ' will be removed from the program'"
-                  [attr.aria-label]="row.name + ' will be removed from the program'"
+                  [title]="'Remove ' + row.name + ' from the program'"
+                  [attr.aria-label]="'Remove ' + row.name"
                   (click)="onDeleteMentor(row.name)"
                   [attr.data-testid]="'mentorship-mentor-delete-' + row.id">
                   <i class="fa-light fa-trash-can" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
@@ -9,18 +9,22 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
-  MENTORSHIP_PERSON_STATUS_BADGE_CLASSES,
-  MENTORSHIP_PERSON_STATUS_LABELS,
+  MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES,
+  MENTORSHIP_MENTOR_STATUS_LABELS,
   MENTORSHIP_PROGRAM_AVATAR_PALETTE,
   MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+  MOCK_MENTORSHIP_INVITABLE_USERS,
 } from '@lfx-one/shared/constants';
-import { MentorshipPersonStatus, MentorshipProgramPerson } from '@lfx-one/shared/interfaces';
+import { MentorshipProgramMentor } from '@lfx-one/shared/interfaces';
 import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { startWith } from 'rxjs';
 
 /**
- * Mentors tab — invitation status, dates, and profile-created flag.
+ * Mentors tab — invitation status, dates, and profile-created flag. The toolbar
+ * pairs a row search with a single-select invitee picker + Invite button; rows
+ * expose Accept / Decline / Delete actions gated by the mentor's current status.
+ * All mutating actions stub to a "coming soon" toast until the backend lands.
  */
 @Component({
   selector: 'lfx-mentorship-mentors-tab',
@@ -29,57 +33,84 @@ import { startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MentorsTabComponent {
-  public readonly mentors = input.required<MentorshipProgramPerson[]>();
+  public readonly mentors = input.required<MentorshipProgramMentor[]>();
 
   private readonly messageService = inject(MessageService);
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
-    status: new FormControl<MentorshipPersonStatus | null>(null),
+    invitee: new FormControl<string | null>(null),
   });
 
   private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
     initialValue: this.form.getRawValue(),
   });
 
-  protected readonly statusOptions = computed(() => {
-    const statuses = [...new Set(this.mentors().map((person) => person.status))];
-    return [
-      { label: 'All statuses', value: null },
-      ...statuses.map((status) => ({
-        label: MENTORSHIP_PERSON_STATUS_LABELS[status],
-        value: status,
-      })),
-    ];
+  /**
+   * Invitable users minus anyone already in this program's mentors list (matched
+   * by email — the mock upstream doesn't expose stable ids across sources). Once
+   * the real user-search endpoint lands this becomes a server-driven query and
+   * the exclusion happens on the backend.
+   */
+  protected readonly inviteOptions = computed(() => {
+    const existingEmails = new Set(this.mentors().map((mentor) => mentor.email.toLowerCase()));
+    return MOCK_MENTORSHIP_INVITABLE_USERS.filter((user) => !existingEmails.has(user.email.toLowerCase())).map((user) => ({
+      label: user.name,
+      value: user.id,
+      email: user.email,
+    }));
   });
 
+  protected readonly canInvite = computed(() => !!this.filters().invitee);
+
   protected readonly rows = computed(() => {
-    const { search, status } = this.filters();
+    const { search } = this.filters();
     return this.mentors()
       .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
-      .filter((person) => !status || person.status === status)
       .map((person) => this.toRow(person));
   });
 
   protected onInviteMentor(): void {
+    const inviteeId = this.form.controls.invitee.value;
+    if (!inviteeId) return;
+    const invitee = MOCK_MENTORSHIP_INVITABLE_USERS.find((user) => user.id === inviteeId);
+    this.toastComingSoon(`Invite ${invitee?.name ?? 'mentor'}`);
+    this.form.controls.invitee.reset(null);
+  }
+
+  protected onAcceptMentor(name: string): void {
+    this.toastComingSoon(`Accept ${name}`);
+  }
+
+  protected onDeclineMentor(name: string): void {
+    this.toastComingSoon(`Decline ${name}`);
+  }
+
+  protected onDeleteMentor(name: string): void {
+    this.toastComingSoon(`Remove ${name}`);
+  }
+
+  private toastComingSoon(summary: string): void {
     this.messageService.add({
       severity: 'info',
-      summary: 'Invite mentor',
+      summary,
       detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
       life: 4000,
     });
   }
 
-  private toRow(person: MentorshipProgramPerson) {
+  private toRow(person: MentorshipProgramMentor) {
     const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
       avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
-      statusLabel: MENTORSHIP_PERSON_STATUS_LABELS[person.status],
-      statusBadgeClass: MENTORSHIP_PERSON_STATUS_BADGE_CLASSES[person.status],
-      invitedOnLabel: person.invitedOn ? formatIsoDateLabel(person.invitedOn) : '—',
+      statusLabel: MENTORSHIP_MENTOR_STATUS_LABELS[person.status],
+      statusBadgeClass: MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES[person.status],
+      invitationLabel: person.invitedOn ? formatIsoDateLabel(person.invitedOn) : '—',
       profileCreatedLabel: person.profileCreated ? 'Yes' : 'No',
+      canAccept: person.status === 'pending' || person.status === 'declined',
+      canDecline: person.status === 'pending' || person.status === 'accepted',
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
@@ -13,12 +13,12 @@ import {
   MENTORSHIP_MENTOR_STATUS_LABELS,
   MENTORSHIP_PROGRAM_AVATAR_PALETTE,
   MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-  MOCK_MENTORSHIP_INVITABLE_USERS,
 } from '@lfx-one/shared/constants';
-import { MentorshipProgramMentor } from '@lfx-one/shared/interfaces';
+import { MentorshipInvitableUser, MentorshipProgramMentor } from '@lfx-one/shared/interfaces';
 import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
+import { MentorshipService } from '@services/mentorship.service';
 import { MessageService } from 'primeng/api';
-import { startWith } from 'rxjs';
+import { map, startWith } from 'rxjs';
 
 /**
  * Mentors tab — invitation status, dates, and profile-created flag. The toolbar
@@ -36,6 +36,7 @@ export class MentorsTabComponent {
   public readonly mentors = input.required<MentorshipProgramMentor[]>();
 
   private readonly messageService = inject(MessageService);
+  private readonly mentorshipService = inject(MentorshipService);
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
@@ -46,20 +47,9 @@ export class MentorsTabComponent {
     initialValue: this.form.getRawValue(),
   });
 
-  /**
-   * Invitable users minus anyone already in this program's mentors list (matched
-   * by email — the mock upstream doesn't expose stable ids across sources). Once
-   * the real user-search endpoint lands this becomes a server-driven query and
-   * the exclusion happens on the backend.
-   */
-  protected readonly inviteOptions = computed(() => {
-    const existingEmails = new Set(this.mentors().map((mentor) => mentor.email.toLowerCase()));
-    return MOCK_MENTORSHIP_INVITABLE_USERS.filter((user) => !existingEmails.has(user.email.toLowerCase())).map((user) => ({
-      label: user.name,
-      value: user.id,
-      email: user.email,
-    }));
-  });
+  private readonly invitableUsers = this.initInvitableUsers();
+
+  protected readonly inviteOptions = this.initInviteOptions();
 
   protected readonly canInvite = computed(() => !!this.filters().invitee);
 
@@ -73,7 +63,7 @@ export class MentorsTabComponent {
   protected onInviteMentor(): void {
     const inviteeId = this.form.controls.invitee.value;
     if (!inviteeId) return;
-    const invitee = MOCK_MENTORSHIP_INVITABLE_USERS.find((user) => user.id === inviteeId);
+    const invitee = this.invitableUsers().find((user) => user.id === inviteeId);
     this.toastComingSoon(`Invite ${invitee?.name ?? 'mentor'}`);
     this.form.controls.invitee.reset(null);
   }
@@ -113,5 +103,28 @@ export class MentorsTabComponent {
       canAccept: person.status === 'pending' || person.status === 'declined',
       canDecline: person.status === 'pending' || person.status === 'accepted',
     };
+  }
+
+  /** LFX users that can be invited as mentors, served by the BFF. Not program-scoped. */
+  private initInvitableUsers(): Signal<MentorshipInvitableUser[]> {
+    return toSignal(this.mentorshipService.getInvitableUsers().pipe(map((response) => response.data)), { initialValue: [] });
+  }
+
+  /**
+   * Invitable users minus anyone already in this program's mentors list (matched by
+   * email — the mock sources don't expose stable ids across both). The pool is global,
+   * so the per-program exclusion is a UI concern and stays here.
+   */
+  private initInviteOptions() {
+    return computed(() => {
+      const existingEmails = new Set(this.mentors().map((mentor) => mentor.email.toLowerCase()));
+      return this.invitableUsers()
+        .filter((user) => !existingEmails.has(user.email.toLowerCase()))
+        .map((user) => ({
+          label: user.name,
+          value: user.id,
+          email: user.email,
+        }));
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
@@ -109,6 +109,7 @@ export class MentorsTabComponent {
       statusBadgeClass: MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES[person.status],
       invitationLabel: person.invitedOn ? formatIsoDateLabel(person.invitedOn) : '—',
       profileCreatedLabel: person.profileCreated ? 'Yes' : 'No',
+      profileCreatedClass: person.profileCreated ? 'text-emerald-600' : 'text-red-600',
       canAccept: person.status === 'pending' || person.status === 'declined',
       canDecline: person.status === 'pending' || person.status === 'accepted',
     };

--- a/apps/lfx-one/src/app/shared/services/mentorship.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mentorship.service.ts
@@ -3,11 +3,18 @@
 
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { EMPTY_MENTORSHIP_LF_PROJECTS_RESPONSE, EMPTY_MENTORSHIP_PROGRAMS_RESPONSE, MENTORSHIP_LF_PROJECT_PAGE_SIZE } from '@lfx-one/shared/constants';
+import {
+  EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE,
+  EMPTY_MENTORSHIP_LF_PROJECTS_RESPONSE,
+  EMPTY_MENTORSHIP_PROGRAMS_RESPONSE,
+  MENTORSHIP_INVITABLE_USER_PAGE_SIZE,
+  MENTORSHIP_LF_PROJECT_PAGE_SIZE,
+} from '@lfx-one/shared/constants';
 import {
   MentorshipCiiBadge,
   MentorshipEnrollForm,
   MentorshipEnrollRequest,
+  MentorshipInvitableUsersResponse,
   MentorshipLfProjectsResponse,
   MentorshipNameAvailability,
   MentorshipProgram,
@@ -82,6 +89,18 @@ export class MentorshipService {
     return this.http
       .get<MentorshipLfProjectsResponse>('/api/mentorship/lf-projects', { params: httpParams })
       .pipe(catchError(this.handleError(EMPTY_MENTORSHIP_LF_PROJECTS_RESPONSE, 'getLfProjects')));
+  }
+
+  /** LFX users that can be invited as mentors. Not program-scoped. */
+  public getInvitableUsers(params?: { search?: string; offset?: number; limit?: number }): Observable<MentorshipInvitableUsersResponse> {
+    let httpParams = new HttpParams();
+    if (params?.search) httpParams = httpParams.set('search', params.search);
+    if (params?.offset !== undefined) httpParams = httpParams.set('offset', String(params.offset));
+    httpParams = httpParams.set('limit', String(params?.limit ?? MENTORSHIP_INVITABLE_USER_PAGE_SIZE));
+
+    return this.http
+      .get<MentorshipInvitableUsersResponse>('/api/mentorship/invitable-users', { params: httpParams })
+      .pipe(catchError(this.handleError(EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE, 'getInvitableUsers')));
   }
 
   public getCiiBadge(projectId: string): Observable<MentorshipCiiBadge | null> {

--- a/apps/lfx-one/src/server/controllers/mentorship.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mentorship.controller.ts
@@ -211,6 +211,28 @@ export class MentorshipController {
     }
   }
 
+  // GET /api/mentorship/invitable-users
+  public async getInvitableUsers(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_mentorship_invitable_users');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_mentorship_invitable_users' });
+      }
+
+      const users = await this.mentorshipService.getInvitableUsers(req, {
+        search: parseTrimmedString(req.query['search']),
+        offset: parseIntQuery(req.query['offset']),
+        limit: parseIntQuery(req.query['limit']),
+      });
+
+      logger.success(req, 'get_mentorship_invitable_users', startTime, { result_count: users.data.length });
+      res.json(users);
+    } catch (error) {
+      next(error);
+    }
+  }
+
   // GET /api/mentorship/cii/:projectId
   public async getCiiBadge(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_mentorship_cii_badge');

--- a/apps/lfx-one/src/server/routes/mentorship.route.ts
+++ b/apps/lfx-one/src/server/routes/mentorship.route.ts
@@ -14,6 +14,7 @@ router.get('/programs/:programId', (req, res, next) => mentorshipController.getP
 router.get('/programs', (req, res, next) => mentorshipController.getPrograms(req, res, next));
 router.post('/programs', blockDuringImpersonation, (req, res, next) => mentorshipController.enrollProgram(req, res, next));
 router.get('/lf-projects', (req, res, next) => mentorshipController.getLfProjects(req, res, next));
+router.get('/invitable-users', (req, res, next) => mentorshipController.getInvitableUsers(req, res, next));
 router.get('/cii/:projectId', (req, res, next) => mentorshipController.getCiiBadge(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/mentorship.service.ts
+++ b/apps/lfx-one/src/server/services/mentorship.service.ts
@@ -3,9 +3,11 @@
 
 import {
   EMPTY_MENTORSHIP_PROGRAM_LISTS,
+  MENTORSHIP_INVITABLE_USER_PAGE_SIZE,
   MENTORSHIP_LF_PROJECT_PAGE_SIZE,
   MENTORSHIP_PROGRAM_STATUSES,
   MENTORSHIP_PROJECT_OPTIONS,
+  MOCK_MENTORSHIP_INVITABLE_USERS,
   MOCK_MENTORSHIP_LF_PROJECTS,
   MOCK_MENTORSHIP_PROGRAM_LISTS,
   MOCK_MENTORSHIP_PROGRAMS,
@@ -13,6 +15,7 @@ import {
 import {
   MentorshipCiiBadge,
   MentorshipEnrollRequest,
+  MentorshipInvitableUsersResponse,
   MentorshipLfProjectsResponse,
   MentorshipNameAvailability,
   MentorshipProgram,
@@ -140,6 +143,23 @@ export class MentorshipService {
     const filtered = needle ? MOCK_MENTORSHIP_LF_PROJECTS.filter((project) => project.name.toLowerCase().includes(needle)) : [...MOCK_MENTORSHIP_LF_PROJECTS];
     const page = paginateOffsetLimit(filtered, options.offset ?? 0, options.limit ?? MENTORSHIP_LF_PROJECT_PAGE_SIZE);
     logger.debug(req, 'mentorship_get_lf_projects', 'LF projects page built', { count: page.data.length, total: page.total });
+    return page;
+  }
+
+  /**
+   * LFX users that can be invited as mentors. Not program-scoped — this is the
+   * general user pool; callers exclude anyone already on their own list.
+   */
+  public async getInvitableUsers(req: Request, options: { search?: string; offset?: number; limit?: number } = {}): Promise<MentorshipInvitableUsersResponse> {
+    logger.debug(req, 'mentorship_get_invitable_users', 'Filtering invitable users', options);
+
+    const needle = options.search?.trim().toLowerCase() ?? '';
+    const filtered = needle
+      ? MOCK_MENTORSHIP_INVITABLE_USERS.filter((user) => user.name.toLowerCase().includes(needle) || user.email.toLowerCase().includes(needle))
+      : [...MOCK_MENTORSHIP_INVITABLE_USERS];
+
+    const page = paginateOffsetLimit(filtered, options.offset ?? 0, options.limit ?? MENTORSHIP_INVITABLE_USER_PAGE_SIZE);
+    logger.debug(req, 'mentorship_get_invitable_users', 'Invitable users page built', { count: page.data.length, total: page.total });
     return page;
   }
 

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -16,7 +16,8 @@ import {
   lfxFontSizes,
   MENTION_PLATFORM_CONFIG,
   MENTION_SENTIMENT_CONFIG,
-  MENTORSHIP_PERSON_STATUS_BADGE_CLASSES,
+  MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
+  MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES,
   MENTORSHIP_PROGRAM_AVATAR_PALETTE,
   MENTORSHIP_PROGRAM_STATUS_BADGE_CLASSES,
   MENTORSHIP_TERM_ROW_STATUS_BADGE_CLASSES,
@@ -40,10 +41,12 @@ export default {
     // multi-class strings (e.g. `rounded-xl bg-rose-100 !text-rose-700`) are each generated.
     ...MENTORSHIP_PROGRAM_AVATAR_PALETTE.flatMap((classes) => classes.split(' ')),
     ...Object.values(MENTORSHIP_PROGRAM_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
-    // Mentorship program-detail tabs: person status badges (applicants / mentees / mentors) and
-    // term-row status badges come from the same shared constants file, also outside `content`.
-    // `bg-red-50` (declined) appears nowhere else in scanned source, so it is purged without this.
-    ...Object.values(MENTORSHIP_PERSON_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
+    // Mentorship program-detail tabs: mentor/mentee status badges (Mentors / Applicants / Current
+    // Mentees) and term-row status badges come from shared constants, also outside `content`.
+    // `bg-red-50` (declined) and `bg-slate-100`/`text-slate-600` (withdrawn) don't appear in scanned
+    // source, so they are purged without these entries.
+    ...Object.values(MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
+    ...Object.values(MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     ...Object.values(MENTORSHIP_TERM_ROW_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     // Social Listening platform icon colors (MENTION_PLATFORM_CONFIG in @lfx-one/shared, not scanned here)
     ...Object.values(MENTION_PLATFORM_CONFIG).map((c) => c.colorClass),

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -43,8 +43,8 @@ export default {
     ...Object.values(MENTORSHIP_PROGRAM_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     // Mentorship program-detail tabs: mentor/mentee status badges (Mentors / Applicants / Current
     // Mentees) and term-row status badges come from shared constants, also outside `content`.
-    // `bg-red-50` (declined) and `bg-slate-100`/`text-slate-600` (withdrawn) don't appear in scanned
-    // source, so they are purged without these entries.
+    // The class strings are assembled in @lfx-one/shared, which Tailwind never scans, so these
+    // spreads are what guarantees they survive purging regardless of usage elsewhere.
     ...Object.values(MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     ...Object.values(MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     ...Object.values(MENTORSHIP_TERM_ROW_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -3,6 +3,7 @@
 
 import type {
   MentorshipInvitableUser,
+  MentorshipInvitableUsersResponse,
   MentorshipProgramLists,
   MentorshipProgramMentee,
   MentorshipProgramMentor,
@@ -15,6 +16,11 @@ export const EMPTY_MENTORSHIP_PROGRAM_LISTS: MentorshipProgramLists = {
   mentors: [],
   terms: [],
 };
+
+export const EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE: MentorshipInvitableUsersResponse = { data: [], total: 0 };
+
+/** Default page size for the Mentors-tab invite picker. */
+export const MENTORSHIP_INVITABLE_USER_PAGE_SIZE = 50;
 
 const gridflowMentees: MentorshipProgramMentee[] = [
   {

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -1,7 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { MentorshipProgramLists, MentorshipProgramPerson, MentorshipProgramTermRow } from '../interfaces/mentorship.interface';
+import type {
+  MentorshipInvitableUser,
+  MentorshipProgramLists,
+  MentorshipProgramMentee,
+  MentorshipProgramMentor,
+  MentorshipProgramTermRow,
+} from '../interfaces/mentorship.interface';
 
 export const EMPTY_MENTORSHIP_PROGRAM_LISTS: MentorshipProgramLists = {
   mentees: [],
@@ -10,7 +16,7 @@ export const EMPTY_MENTORSHIP_PROGRAM_LISTS: MentorshipProgramLists = {
   terms: [],
 };
 
-const gridflowMentees: MentorshipProgramPerson[] = [
+const gridflowMentees: MentorshipProgramMentee[] = [
   {
     id: 'mnt_alex_rivera',
     name: 'Alex Rivera',
@@ -18,7 +24,6 @@ const gridflowMentees: MentorshipProgramPerson[] = [
     status: 'accepted',
     termName: 'Fall 2026',
     appliedOn: '2026-07-18',
-    profileCreated: true,
   },
   {
     id: 'mnt_priya_shah',
@@ -27,11 +32,10 @@ const gridflowMentees: MentorshipProgramPerson[] = [
     status: 'accepted',
     termName: 'Fall 2026',
     appliedOn: '2026-07-21',
-    profileCreated: true,
   },
 ];
 
-const gridflowApplicants: MentorshipProgramPerson[] = [
+const gridflowApplicants: MentorshipProgramMentee[] = [
   {
     id: 'app_jordan_hale',
     name: 'Jordan Hale',
@@ -106,13 +110,12 @@ const gridflowApplicants: MentorshipProgramPerson[] = [
   },
 ];
 
-const gridflowMentors: MentorshipProgramPerson[] = [
+const gridflowMentors: MentorshipProgramMentor[] = [
   {
     id: 'mtr_dana_kovacs',
     name: 'Dana Kovacs',
     email: 'dana.kovacs@example.com',
     status: 'accepted',
-    termName: 'Fall 2026',
     invitedOn: '2026-06-12',
     profileCreated: true,
   },
@@ -121,7 +124,6 @@ const gridflowMentors: MentorshipProgramPerson[] = [
     name: 'Marcus Wei',
     email: 'marcus.wei@example.com',
     status: 'accepted',
-    termName: 'Fall 2026',
     invitedOn: '2026-06-14',
     profileCreated: true,
   },
@@ -129,8 +131,7 @@ const gridflowMentors: MentorshipProgramPerson[] = [
     id: 'mtr_sofia_alvarez',
     name: 'Sofia Alvarez',
     email: 'sofia.alvarez@example.com',
-    status: 'invited',
-    termName: 'Fall 2026',
+    status: 'pending',
     invitedOn: '2026-08-01',
     profileCreated: false,
   },
@@ -139,7 +140,6 @@ const gridflowMentors: MentorshipProgramPerson[] = [
     name: 'Ben Hartley',
     email: 'ben.hartley@example.com',
     status: 'accepted',
-    termName: 'Fall 2026',
     invitedOn: '2026-05-20',
     profileCreated: true,
   },
@@ -236,8 +236,7 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         id: 'mtr_apicurio_1',
         name: 'Helen Cho',
         email: 'helen.cho@example.com',
-        status: 'invited',
-        termName: 'Winter 2026',
+        status: 'pending',
         invitedOn: '2026-07-20',
         profileCreated: false,
       },
@@ -245,8 +244,7 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         id: 'mtr_apicurio_2',
         name: 'Omar Farouk',
         email: 'omar.farouk@example.com',
-        status: 'invited',
-        termName: 'Winter 2026',
+        status: 'pending',
         invitedOn: '2026-07-22',
         profileCreated: true,
       },
@@ -276,7 +274,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         status: 'accepted',
         termName: 'Fall 2026',
         appliedOn: '2026-07-10',
-        profileCreated: true,
       },
     ],
     applicants: [
@@ -303,7 +300,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         name: 'Nina Patel',
         email: 'nina.patel@example.com',
         status: 'accepted',
-        termName: 'Fall 2026',
         invitedOn: '2026-05-18',
         profileCreated: true,
       },
@@ -346,7 +342,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         name: 'Grace Lin',
         email: 'grace.lin@example.com',
         status: 'accepted',
-        termName: 'Summer 2026',
         invitedOn: '2026-03-10',
         profileCreated: true,
       },
@@ -355,7 +350,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         name: 'Peter Novak',
         email: 'peter.novak@example.com',
         status: 'accepted',
-        termName: 'Summer 2026',
         invitedOn: '2026-03-12',
         profileCreated: true,
       },
@@ -390,3 +384,23 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
     ],
   },
 };
+
+/**
+ * Deterministic mock pool of LFX users the admin can invite as mentors on the
+ * program-detail Mentors tab. Client-only import path (`@lfx-one/shared/constants`)
+ * until the upstream user-search endpoint is wired.
+ */
+export const MOCK_MENTORSHIP_INVITABLE_USERS: MentorshipInvitableUser[] = [
+  { id: 'usr_ada_lovelace', name: 'Ada Lovelace', email: 'ada.lovelace@example.com' },
+  { id: 'usr_grace_hopper', name: 'Grace Hopper', email: 'grace.hopper@example.com' },
+  { id: 'usr_linus_torvalds', name: 'Linus Torvalds', email: 'linus.torvalds@example.com' },
+  { id: 'usr_margaret_hamilton', name: 'Margaret Hamilton', email: 'margaret.hamilton@example.com' },
+  { id: 'usr_barbara_liskov', name: 'Barbara Liskov', email: 'barbara.liskov@example.com' },
+  { id: 'usr_donald_knuth', name: 'Donald Knuth', email: 'donald.knuth@example.com' },
+  { id: 'usr_katherine_johnson', name: 'Katherine Johnson', email: 'katherine.johnson@example.com' },
+  { id: 'usr_alan_kay', name: 'Alan Kay', email: 'alan.kay@example.com' },
+  { id: 'usr_radia_perlman', name: 'Radia Perlman', email: 'radia.perlman@example.com' },
+  { id: 'usr_tim_berners_lee', name: 'Tim Berners-Lee', email: 'tim.berners-lee@example.com' },
+  { id: 'usr_leslie_lamport', name: 'Leslie Lamport', email: 'leslie.lamport@example.com' },
+  { id: 'usr_shafi_goldwasser', name: 'Shafi Goldwasser', email: 'shafi.goldwasser@example.com' },
+];

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type {
-  MentorshipPersonStatus,
+  MentorshipMenteeStatus,
+  MentorshipMentorStatus,
   MentorshipProgram,
   MentorshipProgramsResponse,
   MentorshipProgramStatus,
@@ -62,22 +63,46 @@ export const MENTORSHIP_PROGRAM_DETAIL_TABS = [
   { value: 'terms', label: 'Terms' },
 ] as const;
 
-export const MENTORSHIP_PERSON_STATUSES = ['accepted', 'pending', 'declined', 'graduated', 'invited'] as const;
+/**
+ * Mentor lifecycle statuses on the admin Mentors tab. Ordered by lifecycle so
+ * `.sort` on this array yields the filter-dropdown order.
+ */
+export const MENTORSHIP_MENTOR_STATUSES = ['pending', 'accepted', 'declined', 'withdrawn'] as const;
 
-export const MENTORSHIP_PERSON_STATUS_LABELS: Record<MentorshipPersonStatus, string> = {
+/**
+ * Mentee lifecycle statuses on the admin Current Mentees / Applicants tabs.
+ * Superset of mentor statuses; mentees additionally reach `graduated`.
+ */
+export const MENTORSHIP_MENTEE_STATUSES = ['pending', 'accepted', 'declined', 'withdrawn', 'graduated'] as const;
+
+export const MENTORSHIP_MENTOR_STATUS_LABELS: Record<MentorshipMentorStatus, string> = {
+  pending: 'Invited',
   accepted: 'Accepted',
-  pending: 'Pending',
   declined: 'Declined',
-  graduated: 'Graduated',
-  invited: 'Invited',
+  withdrawn: 'Withdrawn',
 };
 
-export const MENTORSHIP_PERSON_STATUS_BADGE_CLASSES: Record<MentorshipPersonStatus, string> = {
-  accepted: 'bg-emerald-50 text-emerald-700',
+export const MENTORSHIP_MENTEE_STATUS_LABELS: Record<MentorshipMenteeStatus, string> = {
+  pending: 'Pending',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  withdrawn: 'Withdrawn',
+  graduated: 'Graduated',
+};
+
+export const MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES: Record<MentorshipMentorStatus, string> = {
   pending: 'bg-amber-50 text-amber-700',
+  accepted: 'bg-emerald-50 text-emerald-700',
   declined: 'bg-red-50 text-red-600',
-  graduated: 'bg-gray-100 text-gray-600',
-  invited: 'bg-blue-50 text-blue-700',
+  withdrawn: 'bg-slate-100 text-slate-600',
+};
+
+export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStatus, string> = {
+  pending: 'bg-amber-50 text-amber-700',
+  accepted: 'bg-emerald-50 text-emerald-700',
+  declined: 'bg-red-50 text-red-600',
+  withdrawn: 'bg-slate-100 text-slate-600',
+  graduated: 'bg-teal-50 text-teal-700',
 };
 
 export const MENTORSHIP_TERM_ROW_STATUSES = ['open', 'closed'] as const;

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -64,8 +64,8 @@ export const MENTORSHIP_PROGRAM_DETAIL_TABS = [
 ] as const;
 
 /**
- * Mentor lifecycle statuses on the admin Mentors tab. Ordered by lifecycle so
- * `.sort` on this array yields the filter-dropdown order.
+ * Mentor lifecycle statuses on the admin Mentors tab. Source of the
+ * `MentorshipMentorStatus` union; declaration order is the lifecycle order.
  */
 export const MENTORSHIP_MENTOR_STATUSES = ['pending', 'accepted', 'declined', 'withdrawn'] as const;
 
@@ -94,15 +94,15 @@ export const MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES: Record<MentorshipMentorStat
   pending: 'bg-amber-50 text-amber-700',
   accepted: 'bg-emerald-50 text-emerald-700',
   declined: 'bg-red-50 text-red-600',
-  withdrawn: 'bg-slate-100 text-slate-600',
+  withdrawn: 'bg-gray-100 text-gray-600',
 };
 
 export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStatus, string> = {
   pending: 'bg-amber-50 text-amber-700',
   accepted: 'bg-emerald-50 text-emerald-700',
   declined: 'bg-red-50 text-red-600',
-  withdrawn: 'bg-slate-100 text-slate-600',
-  graduated: 'bg-teal-50 text-teal-700',
+  withdrawn: 'bg-gray-100 text-gray-600',
+  graduated: 'bg-violet-50 text-violet-700',
 };
 
 export const MENTORSHIP_TERM_ROW_STATUSES = ['open', 'closed'] as const;

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type {
-  MENTORSHIP_PERSON_STATUSES,
+  MENTORSHIP_MENTEE_STATUSES,
+  MENTORSHIP_MENTOR_STATUSES,
   MENTORSHIP_PROGRAM_DETAIL_TABS,
   MENTORSHIP_PROGRAM_STATUSES,
   MENTORSHIP_TERM_ROW_STATUSES,
@@ -143,6 +144,14 @@ export type MentorshipLfProjectsResponse = {
   total: number;
 };
 
+/** LFX user option surfaced in the admin Mentors tab "invite mentor" picker. */
+export interface MentorshipInvitableUser {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+}
+
 /** Result of the mock unique-name check. */
 export interface MentorshipNameAvailability {
   available: boolean;
@@ -177,22 +186,34 @@ export interface MentorshipProgramTabCounts {
   terms: number;
 }
 
-/** Person row status on mentees / applicants / mentors tabs. */
-export type MentorshipPersonStatus = (typeof MENTORSHIP_PERSON_STATUSES)[number];
+/** Mentor lifecycle on the Mentors tab. No `graduated` (mentors don't graduate). */
+export type MentorshipMentorStatus = (typeof MENTORSHIP_MENTOR_STATUSES)[number];
 
-/** Mentee, applicant, or mentor row on the admin program-detail tabs. */
-export interface MentorshipProgramPerson {
+/** Mentee lifecycle on the Current Mentees / Applicants tabs. Adds `graduated`. */
+export type MentorshipMenteeStatus = (typeof MENTORSHIP_MENTEE_STATUSES)[number];
+
+/** Shared row fields consumed by the admin program-detail people tables. */
+interface MentorshipProgramPersonBase {
   id: string;
   name: string;
   email: string;
   avatarUrl?: string;
-  status: MentorshipPersonStatus;
-  termName: string;
-  /** ISO `YYYY-MM-DD` invitation date — mentors tab. */
+}
+
+/** Mentor row on the Mentors tab. */
+export interface MentorshipProgramMentor extends MentorshipProgramPersonBase {
+  status: MentorshipMentorStatus;
+  /** ISO `YYYY-MM-DD` invitation date. */
   invitedOn?: string;
-  /** ISO `YYYY-MM-DD` application date — applicants / mentors tab. */
-  appliedOn?: string;
   profileCreated?: boolean;
+}
+
+/** Mentee row on the Current Mentees / Applicants tabs. */
+export interface MentorshipProgramMentee extends MentorshipProgramPersonBase {
+  status: MentorshipMenteeStatus;
+  /** ISO `YYYY-MM-DD` application date. */
+  appliedOn?: string;
+  termName: string;
 }
 
 /** Term lifecycle on the admin program-detail Terms tab. */
@@ -215,9 +236,9 @@ export interface MentorshipProgramTermRow {
 
 /** Tab lists returned with a program-detail payload. */
 export interface MentorshipProgramLists {
-  mentees: MentorshipProgramPerson[];
-  applicants: MentorshipProgramPerson[];
-  mentors: MentorshipProgramPerson[];
+  mentees: MentorshipProgramMentee[];
+  applicants: MentorshipProgramMentee[];
+  mentors: MentorshipProgramMentor[];
   terms: MentorshipProgramTermRow[];
 }
 

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -152,6 +152,11 @@ export interface MentorshipInvitableUser {
   avatarUrl?: string;
 }
 
+export type MentorshipInvitableUsersResponse = {
+  data: MentorshipInvitableUser[];
+  total: number;
+};
+
 /** Result of the mock unique-name check. */
 export interface MentorshipNameAvailability {
   available: boolean;

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -380,13 +380,15 @@ describe('program detail helpers', () => {
     expect(detail.tabCounts).toEqual({ mentees: 1, applicants: 0, mentors: 2, terms: 0 });
   });
 
-  it('matches people by name, email, or term', () => {
+  it('matches people by name or email, but not by term', () => {
     const person = { id: '1', name: 'Alex Rivera', email: 'alex.rivera@example.com', status: 'accepted' as const, termName: 'Fall 2026' };
 
     expect(matchesMentorshipPersonSearch(person, '')).toBe(true);
     expect(matchesMentorshipPersonSearch(person, 'rivera')).toBe(true);
     expect(matchesMentorshipPersonSearch(person, 'ALEX.RIVERA')).toBe(true);
-    expect(matchesMentorshipPersonSearch(person, 'fall')).toBe(true);
+    // Term search was dropped deliberately: mentors carry no `termName`, so the shared
+    // helper only matches the two fields both person shapes always have.
+    expect(matchesMentorshipPersonSearch(person, 'fall')).toBe(false);
     expect(matchesMentorshipPersonSearch(person, 'winter')).toBe(false);
   });
 

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -370,8 +370,8 @@ describe('program detail helpers', () => {
         mentees: [{ id: '1', name: 'A', email: 'a@example.com', status: 'accepted', termName: 'Fall 2026' }],
         applicants: [],
         mentors: [
-          { id: '2', name: 'B', email: 'b@example.com', status: 'invited', termName: 'Fall 2026' },
-          { id: '3', name: 'C', email: 'c@example.com', status: 'accepted', termName: 'Fall 2026' },
+          { id: '2', name: 'B', email: 'b@example.com', status: 'pending' },
+          { id: '3', name: 'C', email: 'c@example.com', status: 'accepted' },
         ],
         terms: [],
       }

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -23,7 +23,8 @@ import type {
   MentorshipProgram,
   MentorshipProgramDetail,
   MentorshipProgramLists,
-  MentorshipProgramPerson,
+  MentorshipProgramMentee,
+  MentorshipProgramMentor,
   MentorshipProgramTabCounts,
   MentorshipProgramTerm,
   MentorshipProgramTermRow,
@@ -309,11 +310,11 @@ export function buildMentorshipProgramDetail(program: MentorshipProgram, lists: 
   };
 }
 
-/** Case-insensitive match on name, email, or term. Empty search matches everyone. */
-export function matchesMentorshipPersonSearch(person: MentorshipProgramPerson, search: string): boolean {
+/** Case-insensitive match on name or email. Empty search matches everyone. */
+export function matchesMentorshipPersonSearch(person: MentorshipProgramMentee | MentorshipProgramMentor, search: string): boolean {
   const needle = search.trim().toLowerCase();
   if (!needle) return true;
-  return person.name.toLowerCase().includes(needle) || person.email.toLowerCase().includes(needle) || person.termName.toLowerCase().includes(needle);
+  return person.name.toLowerCase().includes(needle) || person.email.toLowerCase().includes(needle);
 }
 
 /** Inclusive UTC date range for term / invitation columns, e.g. `Jul 1, 2026 – Aug 31, 2026`. */


### PR DESCRIPTION
## Overview
### feat(mentorship): split mentor/mentee status; wire mentors-tab actions
- Split MentorshipPersonStatus into MentorshipMentorStatus and
  MentorshipMenteeStatus. Drop `invited`, add `withdrawn`; mentees also
  reach `graduated`. Split MentorshipProgramPerson into
  MentorshipProgramMentor and MentorshipProgramMentee.
- Split label + badge-class maps (MENTORSHIP_MENTOR_* / MENTOR_MENTEE_*)
  and update the Tailwind safelist to reference both. Withdrawn uses the
  `gray` neutral scale; graduated uses the `violet` accent. Both are
  `lfxColors` brand scales, so they track brand updates.
- Add MentorshipInvitableUser + MOCK_MENTORSHIP_INVITABLE_USERS backing
  the new Mentors-tab invitee picker. Mock mentors previously in the
  `invited` status flip to `pending`.
- Mentors tab: drop the status filter, add a single-select mentor
  picker with a `+ Invite` pill, and render Accept / Decline / Delete
  icon-buttons per row gated by mentor status. The date column stays
  "Invitation Date". Lock column widths with `table-fixed`
  and per-<th> `w-[…]` utilities so `truncate` actually clips.
- Applicants and Current Mentees tabs updated to consume the mentee
  status types + label/badge maps.

Refs LFXV2-3171

## Follow-up commits

`8cdc9a2` — fixes from the local pre-PR review trio:

- Repaired a failing spec: `matchesMentorshipPersonSearch` was narrowed to
  name + email, but the spec still asserted a term name matched, turning
  `yarn test` red. Term search is intentionally gone — mentors carry no
  `termName`, so the helper matches only the fields both person shapes
  always have. The spec now pins that contract explicitly.
- Moved status badges onto brand scales. `slate` and `teal` are not in
  `lfxColors`, so they silently stopped tracking brand updates; `withdrawn`
  moved to `gray` and `graduated` to `violet`. The Profile Created cell
  moved from `text-green-600` to the `emerald` scale already used by the
  Accept button beside it.
- Precomputed `profileCreatedClass` from the underlying boolean instead of
  string-comparing the display label (`=== 'No'`), which would have broken
  silently on a copy change.
- Made the Delete button's accessible name an action ("Remove &lt;name&gt;")
  rather than a consequence sentence, matching its Accept/Decline siblings.
- Added a title tooltip on the mentor name, which truncates under the fixed
  `w-[35%]` column and lost its email sub-line.
- Kept the date column as "Invitation Date": `MentorshipProgramMentor` only
  carries `invitedOn`, so "Invitation / Application" promised an
  application date the type cannot hold.
- Corrected two comments that described behaviour the code does not have.

`89e6c06` — fixes the Bugbot finding on this PR:

- The invite picker passed `filterFields="['label', 'email']"`, but PrimeNG
  resolves filter fields as
  `this.filterBy?.split(',') || this.filterFields || [this.optionLabel]`.
  `filterBy` short-circuits `filterFields`, and the `lfx-select` wrapper
  defaults `filterBy` to the truthy string `'label'`, so `filterFields` was
  never reached and email search silently matched nothing. Now uses
  `filterBy="label,email"`.

## Summary
This pull request refactors the mentorship admin program-detail tabs to use more specific types and constants for mentors and mentees, and introduces significant improvements to the mentors tab UI and logic. The changes improve type safety, maintainability, and user experience, especially around inviting mentors and managing mentor actions.

**Type and constant refactoring:**

- Replaced generic "person" types and constants with distinct "mentor" and "mentee" types and constants throughout the applicants, current mentees, and mentors tabs. This ensures clearer separation of logic and improves type safety.

**Mentors tab UI and logic enhancements:**

- Redesigned the mentors tab toolbar to combine search and a single-select invitee picker, allowing admins to search and invite new mentors from a filtered list of users not already in the program. The picker filters on both name and email. The Invite button is now only enabled when a user is selected.
- Updated the mentors table layout for better readability, with fixed column widths and a new "Actions" column for row-level actions. Mentor emails are now shown in the invite dropdown instead of the table.
- Added row-level action buttons for accepting, declining, and removing mentors, with visibility based on mentor status. All actions currently trigger a "coming soon" toast as backend support is pending.

**Tailwind CSS safelist updates:**

- Updated the Tailwind CSS safelist to include new mentor and mentee status badge classes, ensuring correct styles are preserved after purging.

**Constants and mock data:**

- Added `MOCK_MENTORSHIP_INVITABLE_USERS` for use in the invitee picker, and updated relevant imports and usages.

**Behaviour change worth calling out:** search on the Applicants and Current Mentees tabs no longer matches on term name — it matches name and email only. Both tabs still render their Term column.

These changes collectively make the mentorship admin UI more robust, clearer, and ready for further backend integration.
