### PR TITLE
feat(org-lens): search the projects a CLA agreement covers

### DIFF
--- a/apps/lfx-one/e2e/org-easycla-list.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-list.spec.ts
@@ -184,6 +184,41 @@ test.describe('Org Lens EasyCLA list — content', () => {
     await expect(page.getByTestId('org-easycla-card')).toHaveCount(1);
   });
 
+  test('finds one project among the many an agreement covers', async ({ page }) => {
+    await gotoEasyclaList(
+      page,
+      stubList([
+        claGroup({
+          id: 'sig-1',
+          claGroupName: 'Nimbus Foundation CLA',
+          projects: [
+            { projectSfid: 'a09410000182dD3AAI', projectName: 'Cascade' },
+            { projectSfid: 'a09410000182dD4AAI', projectName: 'Driftwood' },
+            { projectSfid: 'a09410000182dD5AAI', projectName: 'Cascadia Tools' },
+          ],
+        }),
+      ])
+    );
+
+    await page.getByTestId('org-easycla-card-coverage-link').first().click();
+
+    const projects = page.getByTestId('org-easycla-coverage-project');
+    await expect(projects).toHaveCount(3, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Typed into the real field rather than set on the form, because this filter has no debounce —
+    // if the reactive binding were ever swapped for a change-event one, the list would stop tracking
+    // the keystrokes and only a real browser would notice.
+    await page.locator('[data-test="org-easycla-coverage-search"]').fill('casc');
+    await expect(projects).toHaveText(['Cascade', 'Cascadia Tools']);
+
+    await page.locator('[data-test="org-easycla-coverage-search"]').fill('nimbus');
+    await expect(projects).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-coverage-no-match')).toBeVisible();
+
+    await page.locator('[data-test="org-easycla-coverage-search"]').fill('');
+    await expect(projects).toHaveCount(3);
+  });
+
   test('hides the pager when every agreement fits on one page', async ({ page }) => {
     await gotoEasyclaList(page, stubList([claGroup({ id: 'sig-1', claGroupName: 'Nimbus Foundation CLA' })]));
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
@@ -49,7 +49,7 @@
       }
     </ul>
   } @else {
-    <p class="mt-3 text-sm text-gray-700" data-testid="org-easycla-coverage-no-match">No covered projects match your search.</p>
+    <p class="mt-3 text-sm text-gray-700" data-testid="org-easycla-coverage-no-match">{{ noMatchMessage }}</p>
   }
 } @else {
   <p class="text-sm text-gray-600" data-testid="org-easycla-coverage-empty">No individual projects are listed. This agreement covers the foundation.</p>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
@@ -4,16 +4,42 @@
 <h3 class="sr-only" data-testid="org-easycla-coverage-title">Projects covered by {{ claGroupName }}</h3>
 @if (projects.length) {
   <p class="mb-3 text-xs text-gray-500" data-testid="org-easycla-coverage-hint">{{ coverageHint }}</p>
+
   <!--
-    The list scrolls inside the dialog rather than growing it, as the design has it. A foundation-wide
-    agreement can name a dozen projects or more, and without this the Close control below is pushed
-    off the bottom on the rows most likely to be opened.
+    The dialog header is the visible title, so this field has no label of its own to point at; the
+    placeholder is not one, being unreadable to assistive tech the moment a term is typed.
   -->
-  <ul class="flex max-h-80 flex-col gap-2 overflow-y-auto" data-testid="org-easycla-coverage-list">
-    @for (project of projects; track project.projectName) {
-      <li class="text-sm text-gray-800" data-testid="org-easycla-coverage-project">{{ project.projectName }}</li>
-    }
-  </ul>
+  <label for="org-easycla-coverage-search-input" class="sr-only">Search covered projects</label>
+  <lfx-input-text
+    [form]="searchForm"
+    control="search"
+    inputId="org-easycla-coverage-search-input"
+    placeholder="Search covered projects…"
+    icon="fa-light fa-magnifying-glass"
+    styleClass="w-full"
+    size="small"
+    autocomplete="off"
+    dataTest="org-easycla-coverage-search" />
+
+  @if (filteredProjects().length) {
+    <!--
+      The list scrolls inside the dialog rather than growing it, as the design has it. A foundation-wide
+      agreement can name a dozen projects or more, and without this the Close control below is pushed
+      off the bottom on the rows most likely to be opened.
+
+      `tabindex` because a scroll container holding no focusable content is unreachable by keyboard —
+      the clipped names could not be scrolled into view at all. Unconditional rather than gated on
+      overflowing: whether it overflows is a rendered height, so any project-count threshold standing
+      in for it is a guess that breaks the moment a row's height changes.
+    -->
+    <ul class="mt-3 flex max-h-80 flex-col gap-2 overflow-y-auto" tabindex="0" aria-label="Covered projects" data-testid="org-easycla-coverage-list">
+      @for (project of filteredProjects(); track project.projectName) {
+        <li class="text-sm text-gray-800" data-testid="org-easycla-coverage-project">{{ project.projectName }}</li>
+      }
+    </ul>
+  } @else {
+    <p class="mt-3 text-sm text-gray-700" data-testid="org-easycla-coverage-no-match">No covered projects match your search.</p>
+  }
 } @else {
   <p class="text-sm text-gray-600" data-testid="org-easycla-coverage-empty">No individual projects are listed. This agreement covers the foundation.</p>
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
@@ -23,18 +23,22 @@
 
   @if (filteredProjects().length) {
     <!--
-      The list scrolls inside the dialog rather than growing it, as the design has it. A foundation-wide
-      agreement can name a dozen projects or more, and without this the Close control below is pushed
-      off the bottom on the rows most likely to be opened.
+      Bounded and rule-separated, as `person-detail-drawer` renders its own lists — which is also what
+      the design's table rule draws. No hover tint though: that rule is a blanket one over every table
+      in the prototype, including the ones whose rows are links, and these rows open nothing.
 
-      `tabindex` because a scroll container holding no focusable content is unreachable by keyboard —
-      the clipped names could not be scrolled into view at all. Unconditional rather than gated on
-      overflowing: whether it overflows is a rendered height, so any project-count threshold standing
-      in for it is a guess that breaks the moment a row's height changes.
+      Scrolling rather than growing keeps the Close control on screen for a foundation-wide agreement.
+      `tabindex` because the container holds nothing focusable, so the clipped names were unreachable
+      by keyboard — unconditional, since overflow is a rendered height and a count threshold standing
+      in for it is a guess.
     -->
-    <ul class="mt-3 flex max-h-80 flex-col gap-2 overflow-y-auto" tabindex="0" aria-label="Covered projects" data-testid="org-easycla-coverage-list">
+    <ul
+      class="mt-3 flex max-h-80 flex-col divide-y divide-gray-100 overflow-y-auto rounded-lg border border-gray-200"
+      tabindex="0"
+      aria-label="Covered projects"
+      data-testid="org-easycla-coverage-list">
       @for (project of filteredProjects(); track project.projectName) {
-        <li class="text-sm text-gray-800" data-testid="org-easycla-coverage-project">{{ project.projectName }}</li>
+        <li class="px-4 py-3 text-sm text-gray-800" data-testid="org-easycla-coverage-project">{{ project.projectName }}</li>
       }
     </ul>
   } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.html
@@ -21,6 +21,13 @@
     autocomplete="off"
     dataTest="org-easycla-coverage-search" />
 
+  <!--
+    Always rendered, with only its text changing. Wrapped in an `@if` it would be created together
+    with its content, and a region that does not pre-exist its content is frequently not announced —
+    which is also why the no-match line below cannot serve as one.
+  -->
+  <div class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-testid="org-easycla-coverage-announcement">{{ filterAnnouncement() }}</div>
+
   @if (filteredProjects().length) {
     <!--
       Bounded and rule-separated, as `person-detail-drawer` renders its own lists — which is also what

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
@@ -267,11 +267,12 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
       expect(region()?.textContent?.trim()).toBe('No covered projects match your search.');
 
       search(fixture, '');
-      expect(region()?.textContent?.trim()).toBe('');
+      expect(region()?.textContent?.trim()).toBe('Search cleared. Showing all covered projects.');
 
       // The announcement trims separately from the filter, so without this a blank term would
       // narrate "3 projects match your search." over a list correctly showing everything — the
-      // full-count noise the region exists to suppress.
+      // full-count noise the region exists to suppress. Whitespace-only is not a search, so it
+      // stays silent even after a real term was typed and cleared.
       search(fixture, '   ');
       expect(region()?.textContent?.trim()).toBe('');
     });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
@@ -58,6 +58,20 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
     return fixture;
   }
 
+  /** Types into the real field rather than the protected form, so the reactive-forms wiring is under test too. */
+  function search(fixture: ComponentFixture<OrgEasyclaCoverageDialogComponent>, term: string): void {
+    const input = fixture.nativeElement.querySelector('[data-test="org-easycla-coverage-search"]') as HTMLInputElement;
+    input.value = term;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  }
+
+  function projectNames(fixture: ComponentFixture<OrgEasyclaCoverageDialogComponent>): (string | undefined)[] {
+    return Array.from(fixture.nativeElement.querySelectorAll('[data-testid="org-easycla-coverage-project"]')).map((el) =>
+      (el as HTMLElement).textContent?.trim()
+    );
+  }
+
   it('lists every covered project', async () => {
     const fixture = await render({
       claGroupName: 'Acme CLA',
@@ -128,5 +142,94 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
     const fixture = await render({ claGroupName: 'Acme CLA', projects: [] });
 
     expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-close"]')).not.toBeNull();
+  });
+
+  it('keeps the scrolling list reachable by keyboard', async () => {
+    const fixture = await render({
+      claGroupName: 'Acme CLA',
+      projects: Array.from({ length: 14 }, (_, i) => ({ projectName: `Project ${i + 1}` })),
+    });
+    const list = fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-list"]') as HTMLElement | null;
+
+    // The list holds no links or buttons, so without a tab stop of its own the clipped names cannot
+    // be scrolled into view without a pointer.
+    expect(list?.getAttribute('tabindex')).toBe('0');
+    expect(list?.getAttribute('aria-label')).toBe('Covered projects');
+  });
+
+  describe('search', () => {
+    const projects = [{ projectName: 'Cascade' }, { projectName: 'Driftwood' }, { projectName: 'Cascadia Tools' }];
+
+    it('narrows the list to the projects matching the term', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+
+      search(fixture, 'casc');
+
+      expect(projectNames(fixture)).toEqual(['Cascade', 'Cascadia Tools']);
+    });
+
+    it('matches regardless of case', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+
+      search(fixture, 'DRIFTWOOD');
+
+      expect(projectNames(fixture)).toEqual(['Driftwood']);
+    });
+
+    it('matches on any part of a name, not only its start', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+
+      search(fixture, 'wood');
+
+      expect(projectNames(fixture)).toEqual(['Driftwood']);
+    });
+
+    it('says nothing matched rather than showing an empty list', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+
+      search(fixture, 'nimbus');
+
+      // An empty list with no explanation reads as a load failure, and the caveat above it still
+      // claims the agreement covers projects — so the dialog would contradict itself in silence.
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-list"]')).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-no-match"]')?.textContent?.trim()).toBe(
+        'No covered projects match your search.'
+      );
+    });
+
+    it('restores the full list when the term is cleared', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+
+      search(fixture, 'nimbus');
+      search(fixture, '');
+
+      expect(projectNames(fixture)).toEqual(['Cascade', 'Driftwood', 'Cascadia Tools']);
+      expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-no-match"]')).toBeNull();
+    });
+
+    it('treats a whitespace-only term as no term at all', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+
+      search(fixture, '   ');
+
+      // Without trimming, a stray space matches nothing and the dialog claims the agreement covers
+      // no projects — the worst reading available, produced by the least deliberate input.
+      expect(projectNames(fixture)).toEqual(['Cascade', 'Driftwood', 'Cascadia Tools']);
+    });
+
+    it('gives the field an accessible name, since the dialog header is not its label', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+      const input = fixture.nativeElement.querySelector('[data-test="org-easycla-coverage-search"]') as HTMLInputElement | null;
+      const label = fixture.nativeElement.querySelector('label[for="org-easycla-coverage-search-input"]') as HTMLElement | null;
+
+      expect(input?.id).toBe('org-easycla-coverage-search-input');
+      expect(label?.textContent?.trim()).toBe('Search covered projects');
+    });
+
+    it('offers no search where there is no list to search', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', foundationName: 'Acme Foundation', projects: [] });
+
+      expect(fixture.nativeElement.querySelector('[data-test="org-easycla-coverage-search"]')).toBeNull();
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
@@ -144,6 +144,26 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-close"]')).not.toBeNull();
   });
 
+  it('separates the projects into rules rather than listing them bare', async () => {
+    const fixture = await render({
+      claGroupName: 'Acme CLA',
+      projects: [{ projectName: 'Cascade' }, { projectName: 'Driftwood' }],
+    });
+    const list = fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-list"]') as HTMLElement | null;
+    const row = fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-project"]') as HTMLElement | null;
+
+    // The design draws this as a bordered table, and the application renders its own lists the same
+    // way. Pinned because a bare list reads as unfinished and looks like a tidy-up rather than a loss.
+    expect(list?.className).toContain('divide-y');
+    expect(list?.className).toContain('border');
+    expect(row?.className).toContain('py-3');
+
+    // No hover tint: these rows open nothing, so a highlight following the cursor advertises an
+    // action that does not exist.
+    expect(list?.className).not.toMatch(/hover:/);
+    expect(row?.className).not.toMatch(/hover:/);
+  });
+
   it('keeps the scrolling list reachable by keyboard', async () => {
     const fixture = await render({
       claGroupName: 'Acme CLA',

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
@@ -246,6 +246,29 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
       expect(label?.textContent?.trim()).toBe('Search covered projects');
     });
 
+    it('announces what the filter did, since focus stays in the field', async () => {
+      const fixture = await render({ claGroupName: 'Acme CLA', projects });
+      const region = () => fixture.nativeElement.querySelector('[data-testid="org-easycla-coverage-announcement"]') as HTMLElement | null;
+
+      // Mounted and silent before a term is typed. Both halves matter: a region created alongside
+      // its text is frequently not announced, and a count nobody asked for is noise on open.
+      expect(region()).not.toBeNull();
+      expect(region()?.getAttribute('aria-live')).toBe('polite');
+      expect(region()?.textContent?.trim()).toBe('');
+
+      search(fixture, 'casc');
+      expect(region()?.textContent?.trim()).toBe('2 projects match your search.');
+
+      search(fixture, 'wood');
+      expect(region()?.textContent?.trim()).toBe('1 project matches your search.');
+
+      search(fixture, 'nimbus');
+      expect(region()?.textContent?.trim()).toBe('No covered projects match your search.');
+
+      search(fixture, '');
+      expect(region()?.textContent?.trim()).toBe('');
+    });
+
     it('offers no search where there is no list to search', async () => {
       const fixture = await render({ claGroupName: 'Acme CLA', foundationName: 'Acme Foundation', projects: [] });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
@@ -78,10 +78,7 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
       projects: [{ projectName: 'Cascade' }, { projectName: 'Driftwood' }],
     });
 
-    const names = Array.from(fixture.nativeElement.querySelectorAll('[data-testid="org-easycla-coverage-project"]')).map((el) =>
-      (el as HTMLElement).textContent?.trim()
-    );
-    expect(names).toEqual(['Cascade', 'Driftwood']);
+    expect(projectNames(fixture)).toEqual(['Cascade', 'Driftwood']);
   });
 
   it('explains when no individual projects are listed', async () => {
@@ -254,6 +251,10 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
       // its text is frequently not announced, and a count nobody asked for is noise on open.
       expect(region()).not.toBeNull();
       expect(region()?.getAttribute('aria-live')).toBe('polite');
+      // `role` is the hook assistive tech maps to a status region, and `aria-atomic` is what makes
+      // the whole sentence re-announce when only the count within it changes.
+      expect(region()?.getAttribute('role')).toBe('status');
+      expect(region()?.getAttribute('aria-atomic')).toBe('true');
       expect(region()?.textContent?.trim()).toBe('');
 
       search(fixture, 'casc');
@@ -266,6 +267,12 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
       expect(region()?.textContent?.trim()).toBe('No covered projects match your search.');
 
       search(fixture, '');
+      expect(region()?.textContent?.trim()).toBe('');
+
+      // The announcement trims separately from the filter, so without this a blank term would
+      // narrate "3 projects match your search." over a list correctly showing everything — the
+      // full-count noise the region exists to suppress.
+      search(fixture, '   ');
       expect(region()?.textContent?.trim()).toBe('');
     });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.spec.ts
@@ -258,13 +258,17 @@ describe('OrgEasyclaCoverageDialogComponent', () => {
       expect(region()?.textContent?.trim()).toBe('');
 
       search(fixture, 'casc');
-      expect(region()?.textContent?.trim()).toBe('2 projects match your search.');
+      expect(region()?.textContent?.trim()).toBe('2 projects match "casc".');
+
+      // Two terms can match the same count; quoting the term is what makes the text node change.
+      search(fixture, 'ca');
+      expect(region()?.textContent?.trim()).toBe('2 projects match "ca".');
 
       search(fixture, 'wood');
-      expect(region()?.textContent?.trim()).toBe('1 project matches your search.');
+      expect(region()?.textContent?.trim()).toBe('1 project matches "wood".');
 
       search(fixture, 'nimbus');
-      expect(region()?.textContent?.trim()).toBe('No covered projects match your search.');
+      expect(region()?.textContent?.trim()).toBe('No covered projects match "nimbus".');
 
       search(fixture, '');
       expect(region()?.textContent?.trim()).toBe('Search cleared. Showing all covered projects.');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
@@ -109,8 +109,8 @@ export class OrgEasyclaCoverageDialogComponent {
       if (!trimmed) return justCleared ? this.restoredMessage : '';
 
       const count = this.filteredProjects().length;
-      if (count === 0) return this.noMatchMessage;
-      return count === 1 ? '1 project matches your search.' : `${count} projects match your search.`;
+      if (count === 0) return `No covered projects match "${trimmed}".`;
+      return count === 1 ? `1 project matches "${trimmed}".` : `${count} projects match "${trimmed}".`;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
@@ -1,11 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, Signal } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
 import type { OrgClaCoverageDialogData, OrgClaGroup, OrgClaGroupProject } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 
 /**
  * How this dialog is opened, owned here rather than by each caller.
@@ -31,12 +34,14 @@ export function orgClaCoverageDialogConfig(group: OrgClaGroup): DynamicDialogCon
 
 @Component({
   selector: 'lfx-org-easycla-coverage-dialog',
-  imports: [ButtonComponent],
+  imports: [ButtonComponent, InputTextComponent],
   templateUrl: './org-easycla-coverage-dialog.component.html',
 })
 export class OrgEasyclaCoverageDialogComponent {
   private readonly dialogConfig = inject<DynamicDialogConfig<OrgClaCoverageDialogData>>(DynamicDialogConfig);
   private readonly dialogRef = inject(DynamicDialogRef);
+
+  protected readonly searchForm = new FormGroup({ search: new FormControl('', { nonNullable: true }) });
 
   protected readonly claGroupName = this.dialogConfig.data?.claGroupName ?? '';
   protected readonly projects: OrgClaGroupProject[] = this.dialogConfig.data?.projects ?? [];
@@ -47,7 +52,20 @@ export class OrgEasyclaCoverageDialogComponent {
     ? `Part of ${this.dialogConfig.data.foundationName} — this CLA covers the projects below, not necessarily every project in the foundation.`
     : 'This CLA covers the projects below.';
 
+  // Undebounced, unlike the org pages' search fields. Those debounce a filter over a roster or a
+  // server query; this one filters an array the dialog was handed at construction, so the work per
+  // keystroke is a substring test over a handful of names and a delay would only be felt as lag.
+  private readonly searchTerm = toSignal(this.searchForm.controls.search.valueChanges, { initialValue: '' });
+  protected readonly filteredProjects = this.initFilteredProjects();
+
   protected close(): void {
     this.dialogRef.close();
+  }
+
+  private initFilteredProjects(): Signal<OrgClaGroupProject[]> {
+    return computed(() => {
+      const term = this.searchTerm().trim().toLowerCase();
+      return term ? this.projects.filter((project) => project.projectName.toLowerCase().includes(term)) : this.projects;
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
@@ -50,6 +50,10 @@ export class OrgEasyclaCoverageDialogComponent {
     ? `Part of ${this.dialogConfig.data.foundationName} — this CLA covers the projects below, not necessarily every project in the foundation.`
     : 'This CLA covers the projects below.';
 
+  // One source for both ends of the no-match state: the visible line and the announcement below
+  // have to say the same thing, and holding the sentence twice is how they stop.
+  protected readonly noMatchMessage = 'No covered projects match your search.';
+
   protected readonly searchForm = new FormGroup({ search: new FormControl('', { nonNullable: true }) });
 
   // Undebounced, unlike the org pages' search fields. Those debounce a filter over a roster or a
@@ -86,7 +90,7 @@ export class OrgEasyclaCoverageDialogComponent {
       if (!this.searchTerm().trim()) return '';
 
       const count = this.filteredProjects().length;
-      if (count === 0) return 'No covered projects match your search.';
+      if (count === 0) return this.noMatchMessage;
       return count === 1 ? '1 project matches your search.' : `${count} projects match your search.`;
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
@@ -6,6 +6,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
 import type { OrgClaCoverageDialogData, OrgClaGroup, OrgClaGroupProject } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { scan } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -53,13 +54,30 @@ export class OrgEasyclaCoverageDialogComponent {
   // One source for both ends of the no-match state: the visible line and the announcement below
   // have to say the same thing, and holding the sentence twice is how they stop.
   protected readonly noMatchMessage = 'No covered projects match your search.';
+  protected readonly restoredMessage = 'Search cleared. Showing all covered projects.';
 
   protected readonly searchForm = new FormGroup({ search: new FormControl('', { nonNullable: true }) });
 
   // Undebounced, unlike the org pages' search fields. Those debounce a filter over a roster or a
   // server query; this one filters an array the dialog was handed at construction, so the work per
   // keystroke is a substring test over a handful of names and a delay would only be felt as lag.
-  private readonly searchTerm = toSignal(this.searchForm.controls.search.valueChanges, { initialValue: '' });
+  private readonly searchState = toSignal(
+    this.searchForm.controls.search.valueChanges.pipe(
+      scan(
+        (prev: { trimmed: string; justCleared: boolean }, value: string) => {
+          const trimmed = value.trim();
+          return {
+            trimmed,
+            // Empty on open and empty after a clear are the same value; `justCleared` is the one
+            // event that means the full list came back, not the initial render.
+            justCleared: prev.trimmed.length > 0 && trimmed.length === 0,
+          };
+        },
+        { trimmed: '', justCleared: false }
+      )
+    ),
+    { initialValue: { trimmed: '', justCleared: false } }
+  );
   protected readonly filteredProjects = this.initFilteredProjects();
   protected readonly filterAnnouncement = this.initFilterAnnouncement();
 
@@ -69,7 +87,7 @@ export class OrgEasyclaCoverageDialogComponent {
 
   private initFilteredProjects(): Signal<OrgClaGroupProject[]> {
     return computed(() => {
-      const term = this.searchTerm().trim().toLowerCase();
+      const term = this.searchState().trimmed.toLowerCase();
       return term ? this.projects.filter((project) => project.projectName.toLowerCase().includes(term)) : this.projects;
     });
   }
@@ -82,12 +100,13 @@ export class OrgEasyclaCoverageDialogComponent {
    * already populated, which is exactly the case a live region is frequently not announced for.
    *
    * Computed from the filtered set rather than assigned per keystroke, so the narration cannot
-   * disagree with the rows on screen. Silent until a term is typed: announcing the full count when
-   * the view opens states something the viewer never asked.
+   * disagree with the rows on screen. Silent on open and on a whitespace-only field; announces
+   * when a clear puts the full list back.
    */
   private initFilterAnnouncement(): Signal<string> {
     return computed(() => {
-      if (!this.searchTerm().trim()) return '';
+      const { trimmed, justCleared } = this.searchState();
+      if (!trimmed) return justCleared ? this.restoredMessage : '';
 
       const count = this.filteredProjects().length;
       if (count === 0) return this.noMatchMessage;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-coverage-dialog/org-easycla-coverage-dialog.component.ts
@@ -41,8 +41,6 @@ export class OrgEasyclaCoverageDialogComponent {
   private readonly dialogConfig = inject<DynamicDialogConfig<OrgClaCoverageDialogData>>(DynamicDialogConfig);
   private readonly dialogRef = inject(DynamicDialogRef);
 
-  protected readonly searchForm = new FormGroup({ search: new FormControl('', { nonNullable: true }) });
-
   protected readonly claGroupName = this.dialogConfig.data?.claGroupName ?? '';
   protected readonly projects: OrgClaGroupProject[] = this.dialogConfig.data?.projects ?? [];
 
@@ -52,11 +50,14 @@ export class OrgEasyclaCoverageDialogComponent {
     ? `Part of ${this.dialogConfig.data.foundationName} — this CLA covers the projects below, not necessarily every project in the foundation.`
     : 'This CLA covers the projects below.';
 
+  protected readonly searchForm = new FormGroup({ search: new FormControl('', { nonNullable: true }) });
+
   // Undebounced, unlike the org pages' search fields. Those debounce a filter over a roster or a
   // server query; this one filters an array the dialog was handed at construction, so the work per
   // keystroke is a substring test over a handful of names and a delay would only be felt as lag.
   private readonly searchTerm = toSignal(this.searchForm.controls.search.valueChanges, { initialValue: '' });
   protected readonly filteredProjects = this.initFilteredProjects();
+  protected readonly filterAnnouncement = this.initFilterAnnouncement();
 
   protected close(): void {
     this.dialogRef.close();
@@ -66,6 +67,27 @@ export class OrgEasyclaCoverageDialogComponent {
     return computed(() => {
       const term = this.searchTerm().trim().toLowerCase();
       return term ? this.projects.filter((project) => project.projectName.toLowerCase().includes(term)) : this.projects;
+    });
+  }
+
+  /**
+   * What the filter did, for assistive tech.
+   *
+   * Focus stays in the search field while the list behind it changes, so nothing about the result
+   * reaches a screen reader otherwise — the rows are not focusable and the no-match line is inserted
+   * already populated, which is exactly the case a live region is frequently not announced for.
+   *
+   * Computed from the filtered set rather than assigned per keystroke, so the narration cannot
+   * disagree with the rows on screen. Silent until a term is typed: announcing the full count when
+   * the view opens states something the viewer never asked.
+   */
+  private initFilterAnnouncement(): Signal<string> {
+    return computed(() => {
+      if (!this.searchTerm().trim()) return '';
+
+      const count = this.filteredProjects().length;
+      if (count === 0) return 'No covered projects match your search.';
+      return count === 1 ? '1 project matches your search.' : `${count} projects match your search.`;
     });
   }
 }


### PR DESCRIPTION
Filters the covered-projects view as you type, which the approved design puts a
search box over and this had deferred. Raised in manual QA of #2255.

The deferral argued from where the data lives — the whole list arrives with the
row, so there is nothing to page. But the design's search box was never a paging
device. A viewer scanning a dozen project names for the one they already know is
the case it serves, and holding the list in memory is what makes answering that
cheap rather than what makes it unnecessary. Whether a list of these sizes needs a
filter at all is a fair question and still open; the design asks for one, so it
ships.

Case-insensitive, and matches any part of a name rather than only its start,
because someone hunting one project among many knows a word from its name and not
necessarily its first. A term matching nothing says so: an empty list sitting
under the "not necessarily every project in the foundation" caveat reads as a load
failure rather than an answer. A whitespace-only term is treated as no term, and
the foundation-wide case — which lists nothing — gets no search box.

Built from what the app already has: `lfx-input-text` over a reactive form, and a
`computed()` across the projects the dialog was handed at construction. No new
component and no new theme token. Undebounced, unlike the org pages' search fields
— those debounce a roster filter or a server query, where this one runs a substring
test over a handful of names and a delay would only be felt as lag.

Also gives that scrolling list a tab stop and an accessible name. It holds no links
or buttons, so the names clipped by the height cap could not be brought into view
without a pointer. Raised in review of #2255 and deferred to here. Unconditional
rather than gated on the list overflowing: whether it overflows is a rendered
height, so any project-count threshold standing in for it is a guess that breaks
when a row's height changes.

Eleven new unit specs, mutation-checked — making the filter a no-op fails five of
them, and dropping either `.trim()` fails a spec of its own. One new content
e2e covers type, narrow, no-match, clear; like the rest of the suite it has not
been executed, since the Playwright workflow is `workflow_call`-only with its
invocation commented out.

Refs #1978

