### PR TITLE
feat(mentorship): add admin program detail page with four management tabs

### DIFF
--- a/apps/lfx-one/src/app/modules/mentorship/admin/admin.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/admin.component.html
@@ -15,6 +15,7 @@
           iconPos="left"
           severity="primary"
           size="small"
+          styleClass="sm:w-56 whitespace-nowrap !py-2.5"
           (onClick)="onEnrollProgram()"
           data-testid="mentorship-admin-enroll-button" />
       </div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-details-step/enroll-details-step.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-details-step/enroll-details-step.component.html
@@ -124,6 +124,7 @@
           size="small"
           [disabled]="!draftTechnology()"
           (onClick)="addTechnology()"
+          styleClass="whitespace-nowrap !py-2.5"
           data-testid="mentorship-enroll-add-technology" />
       </div>
       @if (technologies().length) {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-setup-step/enroll-setup-step.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-setup-step/enroll-setup-step.component.html
@@ -31,6 +31,7 @@
           size="small"
           [disabled]="!draftSkillValue()"
           (onClick)="addSkill()"
+          styleClass="whitespace-nowrap !py-2.5"
           data-testid="mentorship-enroll-add-skill" />
       </div>
       @if (skills().length) {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
@@ -63,7 +63,7 @@
     <span class="font-semibold text-gray-900">Note:</span> {{ statusNote }}
   </p>
 
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white">
     <lfx-table
       [value]="rows()"
       dataKey="id"
@@ -73,7 +73,7 @@
       [rowsPerPageOptions]="rowsPerPageOptions"
       [showCurrentPageReport]="true"
       currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-      tableStyleClass="table-fixed"
+      tableStyleClass="table-fixed min-w-[56rem]"
       paginatorDropdownAppendTo="body"
       ariaLabel="Applicants">
       <ng-template #header>
@@ -90,27 +90,15 @@
       <ng-template #body let-row>
         <tr [attr.data-testid]="'mentorship-applicant-row-' + row.id">
           <td class="px-4 py-3 max-w-[26%]">
-            <div class="flex items-center gap-3 min-w-0 w-full">
-              <lfx-avatar
-                [image]="row.avatarUrl ?? ''"
-                [label]="row.initials"
-                shape="circle"
-                size="normal"
-                [styleClass]="row.avatarStyleClass"
-                [ariaLabel]="row.name" />
-              <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
-                <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="row.name">{{ row.name }}</span>
-                <button
-                  type="button"
-                  class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
-                  [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
-                  [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
-                  (click)="onOpenNote(row.id, row.name)"
-                  [attr.data-testid]="'mentorship-applicant-note-' + row.id">
-                  {{ row.noteLabel }}
-                </button>
-              </div>
-            </div>
+            <lfx-mentorship-person-cell
+              [name]="row.name"
+              [initials]="row.initials"
+              [avatarStyleClass]="row.avatarStyleClass"
+              [avatarUrl]="row.avatarUrl"
+              [noteLabel]="row.noteLabel"
+              [hasNote]="row.hasNote"
+              [noteTestId]="'mentorship-applicant-note-' + row.id"
+              (noteClick)="onOpenNote(row.id, row.name)" />
           </td>
           <td class="px-4 py-3 max-w-[11%]">
             <span class="max-w-full block truncate text-sm text-gray-700" [title]="row.termName">{{ row.termName }}</span>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
@@ -3,66 +3,170 @@
 
 <div class="flex flex-col gap-4" data-testid="mentorship-applicants-tab">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-    <label class="sm:w-72">
+    <!-- min-w-0 + flex-1: the search takes the leftover width without squeezing the
+         filter and export controls, which otherwise wrap their labels. -->
+    <label class="w-full min-w-0 sm:flex-1">
       <span class="sr-only">Search applicants</span>
       <lfx-input-text [form]="form" control="search" placeholder="Search" icon="fa-light fa-magnifying-glass" dataTest="mentorship-applicants-search" />
     </label>
-    <div class="sm:w-52">
-      <lfx-select
-        [form]="form"
-        control="status"
-        [options]="statusOptions()"
-        optionLabel="label"
-        optionValue="value"
-        placeholder="Status"
-        ariaLabel="Filter applicants by status"
-        styleClass="w-full"
-        dataTest="mentorship-applicants-status" />
+
+    <div class="flex shrink-0 items-center gap-2">
+      <lfx-button
+        label="Decline by Term"
+        severity="warn"
+        size="small"
+        [outlined]="true"
+        styleClass="whitespace-nowrap !py-2.5"
+        (onClick)="onDeclineByTerm()"
+        data-testid="mentorship-applicants-decline-by-term" />
+
+      <div class="w-full sm:w-44">
+        <lfx-select
+          [form]="form"
+          control="status"
+          [options]="statusOptions"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Filter By Status"
+          ariaLabel="Filter applicants by status"
+          styleClass="w-full"
+          dataTest="mentorship-applicants-status" />
+      </div>
+
+      <div class="w-full sm:w-40">
+        <lfx-select
+          [form]="form"
+          control="term"
+          [options]="termOptions()"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Filter by Term"
+          ariaLabel="Filter applicants by term"
+          styleClass="w-full"
+          dataTest="mentorship-applicants-term" />
+      </div>
+
+      <lfx-button
+        label="Download By Status"
+        icon="fa-light fa-download"
+        iconPos="left"
+        severity="secondary"
+        size="small"
+        [outlined]="true"
+        styleClass="whitespace-nowrap !py-2.5"
+        (onClick)="onDownloadByStatus()"
+        data-testid="mentorship-applicants-download" />
     </div>
   </div>
 
-  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white">
-    <table class="w-full min-w-[40rem] text-left">
-      <thead>
-        <tr class="border-b border-gray-200">
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Applicant</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Term</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Applied</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Status</th>
+  <p class="max-w-3xl rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600" data-testid="mentorship-applicants-note">
+    <span class="font-semibold text-gray-900">Note:</span> {{ statusNote }}
+  </p>
+
+  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+    <lfx-table
+      [value]="rows()"
+      dataKey="id"
+      size="small"
+      [paginator]="true"
+      [rows]="pageSize"
+      [rowsPerPageOptions]="rowsPerPageOptions"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+      tableStyleClass="table-fixed"
+      paginatorDropdownAppendTo="body"
+      ariaLabel="Applicants">
+      <ng-template #header>
+        <tr>
+          <th class="w-[26%] px-4 py-3 !text-sm !font-medium !text-gray-600">Mentee</th>
+          <th class="w-[11%] px-4 py-3 !text-sm !font-medium !text-gray-600">Term</th>
+          <th class="w-[15%] px-4 py-3 !text-sm !font-medium !text-gray-600">Status</th>
+          <th class="w-[18%] px-4 py-3 !text-sm !font-medium !text-gray-600">Application Dates</th>
+          <th class="w-[22%] px-4 py-3 !text-sm !font-medium !text-gray-600">Other Active Applications</th>
+          <th class="w-[8%] px-4 py-3 !text-sm !font-medium !text-gray-600 text-end">Actions</th>
         </tr>
-      </thead>
-      <tbody>
-        @for (row of rows(); track row.id) {
-          <tr class="border-b border-gray-100 last:border-b-0" [attr.data-testid]="'mentorship-applicant-row-' + row.id">
-            <td class="px-4 py-3">
-              <div class="flex items-center gap-3 min-w-0">
-                <lfx-avatar
-                  [image]="row.avatarUrl ?? ''"
-                  [label]="row.initials"
-                  shape="circle"
-                  size="normal"
-                  [styleClass]="row.avatarStyleClass"
-                  [ariaLabel]="row.name" />
-                <div class="flex flex-col min-w-0">
-                  <span class="text-sm font-medium text-gray-900 truncate">{{ row.name }}</span>
-                  <span class="text-xs text-gray-500 truncate">{{ row.email }}</span>
-                </div>
+      </ng-template>
+
+      <ng-template #body let-row>
+        <tr [attr.data-testid]="'mentorship-applicant-row-' + row.id">
+          <td class="px-4 py-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <lfx-avatar
+                [image]="row.avatarUrl ?? ''"
+                [label]="row.initials"
+                shape="circle"
+                size="normal"
+                [styleClass]="row.avatarStyleClass"
+                [ariaLabel]="row.name" />
+              <div class="flex flex-col min-w-0">
+                <span class="text-sm font-medium text-blue-600 truncate" [title]="row.name">{{ row.name }}</span>
+                <button
+                  type="button"
+                  class="text-xs text-gray-500 truncate text-left transition-colors hover:text-blue-600"
+                  [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
+                  [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
+                  (click)="onOpenNote(row.id)"
+                  [attr.data-testid]="'mentorship-applicant-note-' + row.id">
+                  {{ row.noteLabel }}
+                </button>
               </div>
-            </td>
-            <td class="px-4 py-3 text-sm text-gray-700">{{ row.termName }}</td>
-            <td class="px-4 py-3 text-sm text-gray-700">{{ row.appliedOnLabel }}</td>
-            <td class="px-4 py-3">
-              <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
-                {{ row.statusLabel }}
-              </span>
-            </td>
-          </tr>
-        } @empty {
-          <tr>
-            <td colspan="4" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-applicants-empty">No applicants.</td>
-          </tr>
-        }
-      </tbody>
-    </table>
+            </div>
+          </td>
+          <td class="px-4 py-3 text-sm text-gray-700">{{ row.termName }}</td>
+          <td class="px-4 py-3">
+            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+              {{ row.statusLabel }}
+            </span>
+          </td>
+          <td class="px-4 py-3 text-sm text-gray-500">
+            <div class="flex flex-col gap-0.5">
+              <span>Created: {{ row.createdLabel }}</span>
+              <span>Updated: {{ row.updatedLabel }}</span>
+            </div>
+          </td>
+          <td class="px-4 py-3">
+            @if (row.otherApplications.length > 0) {
+              <div class="flex flex-col gap-0.5">
+                @for (application of row.otherApplications; track application.programId) {
+                  <span class="text-sm truncate">
+                    <a class="text-blue-600 transition-colors hover:text-blue-700 hover:underline" [routerLink]="['/mentorship/admin', application.programId]">
+                      {{ application.programName }}
+                    </a>
+                    <span class="text-gray-500"> — {{ application.statusLabel }}</span>
+                  </span>
+                }
+              </div>
+            } @else {
+              <span class="text-sm text-gray-500">—</span>
+            }
+          </td>
+          <td class="px-4 py-3">
+            <div class="flex items-center justify-end">
+              @if (row.menuItems.length > 0) {
+                <div class="relative inline-block">
+                  <lfx-button
+                    icon="fa-light fa-ellipsis"
+                    severity="secondary"
+                    size="small"
+                    [outlined]="true"
+                    [ariaLabel]="'Actions for ' + row.name"
+                    (onClick)="actionMenu.toggle($event)"
+                    [attr.data-testid]="'mentorship-applicant-actions-' + row.id" />
+                  <lfx-menu #actionMenu [model]="row.menuItems" [popup]="true" appendTo="body" styleClass="!min-w-[10rem]" />
+                </div>
+              } @else {
+                <span class="text-sm text-gray-500">-</span>
+              }
+            </div>
+          </td>
+        </tr>
+      </ng-template>
+
+      <ng-template #emptymessage>
+        <tr>
+          <td colspan="6" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-applicants-empty">No applicants.</td>
+        </tr>
+      </ng-template>
+    </lfx-table>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
@@ -2,15 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-4" data-testid="mentorship-applicants-tab">
-  <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+  <div class="flex flex-col gap-3 md:flex-row md:items-center">
     <!-- min-w-0 + flex-1: the search takes the leftover width without squeezing the
          filter and export controls, which otherwise wrap their labels. -->
-    <label class="w-full min-w-0 sm:flex-1">
+    <label class="w-full min-w-0 md:flex-1">
       <span class="sr-only">Search applicants</span>
       <lfx-input-text [form]="form" control="search" placeholder="Search" icon="fa-light fa-magnifying-glass" dataTest="mentorship-applicants-search" />
     </label>
 
-    <div class="flex shrink-0 items-center gap-2">
+    <div class="flex shrink-0 items-center gap-2 flex-wrap">
       <lfx-button
         label="Decline by Term"
         severity="warn"
@@ -20,7 +20,7 @@
         (onClick)="onDeclineByTerm()"
         data-testid="mentorship-applicants-decline-by-term" />
 
-      <div class="w-full sm:w-44">
+      <div class="w-full md:w-44">
         <lfx-select
           [form]="form"
           control="status"
@@ -33,7 +33,7 @@
           dataTest="mentorship-applicants-status" />
       </div>
 
-      <div class="w-full sm:w-40">
+      <div class="w-full md:w-40">
         <lfx-select
           [form]="form"
           control="term"
@@ -89,8 +89,8 @@
 
       <ng-template #body let-row>
         <tr [attr.data-testid]="'mentorship-applicant-row-' + row.id">
-          <td class="px-4 py-3">
-            <div class="flex items-center gap-3 min-w-0">
+          <td class="px-4 py-3 max-w-[26%]">
+            <div class="flex items-center gap-3 min-w-0 w-full">
               <lfx-avatar
                 [image]="row.avatarUrl ?? ''"
                 [label]="row.initials"
@@ -98,11 +98,11 @@
                 size="normal"
                 [styleClass]="row.avatarStyleClass"
                 [ariaLabel]="row.name" />
-              <div class="flex flex-col min-w-0">
-                <span class="text-sm font-medium text-blue-600 truncate" [title]="row.name">{{ row.name }}</span>
+              <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
+                <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="row.name">{{ row.name }}</span>
                 <button
                   type="button"
-                  class="text-xs text-gray-500 truncate text-left transition-colors hover:text-blue-600"
+                  class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
                   [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
                   [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
                   (click)="onOpenNote(row.id)"
@@ -112,28 +112,32 @@
               </div>
             </div>
           </td>
-          <td class="px-4 py-3 text-sm text-gray-700">{{ row.termName }}</td>
+          <td class="px-4 py-3 max-w-[11%]">
+            <span class="max-w-full block truncate text-sm text-gray-700" [title]="row.termName">{{ row.termName }}</span>
+          </td>
           <td class="px-4 py-3">
-            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">
               {{ row.statusLabel }}
             </span>
           </td>
-          <td class="px-4 py-3 text-sm text-gray-500">
-            <div class="flex flex-col gap-0.5">
+          <td class="px-4 py-3">
+            <div class="flex flex-col gap-0.5 text-sm text-gray-500">
               <span>Created: {{ row.createdLabel }}</span>
               <span>Updated: {{ row.updatedLabel }}</span>
             </div>
           </td>
-          <td class="px-4 py-3">
+          <td class="px-4 py-3 max-w-[18%]">
             @if (row.otherApplications.length > 0) {
-              <div class="flex flex-col gap-0.5">
+              <div class="flex flex-col gap-0.5 w-full">
                 @for (application of row.otherApplications; track application.programId) {
-                  <span class="text-sm truncate">
-                    <a class="text-blue-600 transition-colors hover:text-blue-700 hover:underline" [routerLink]="['/mentorship/admin', application.programId]">
+                  <div class="text-sm w-full flex items-center flex-wrap">
+                    <a
+                      class="max-w-full block truncate text-blue-600 transition-colors hover:text-blue-700 hover:underline"
+                      [routerLink]="['/mentorship/admin', application.programId]">
                       {{ application.programName }}
                     </a>
                     <span class="text-gray-500"> — {{ application.statusLabel }}</span>
-                  </span>
+                  </div>
                 }
               </div>
             } @else {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
@@ -17,7 +17,7 @@
         size="small"
         [outlined]="true"
         styleClass="whitespace-nowrap !py-2.5"
-        (onClick)="onDeclineByTerm()"
+        (onClick)="onAction('Decline by term')"
         data-testid="mentorship-applicants-decline-by-term" />
 
       <div class="w-full md:w-44">
@@ -54,7 +54,7 @@
         size="small"
         [outlined]="true"
         styleClass="whitespace-nowrap !py-2.5"
-        (onClick)="onDownloadByStatus()"
+        (onClick)="onAction('Download by status')"
         data-testid="mentorship-applicants-download" />
     </div>
   </div>
@@ -105,7 +105,7 @@
                   class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
                   [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
                   [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
-                  (click)="onOpenNote(row.id)"
+                  (click)="onOpenNote(row.id, row.name)"
                   [attr.data-testid]="'mentorship-applicant-note-' + row.id">
                   {{ row.noteLabel }}
                 </button>
@@ -126,14 +126,16 @@
               <span>Updated: {{ row.updatedLabel }}</span>
             </div>
           </td>
-          <td class="px-4 py-3 max-w-[18%]">
+          <td class="px-4 py-3 max-w-[22%]">
             @if (row.otherApplications.length > 0) {
               <div class="flex flex-col gap-0.5 w-full">
                 @for (application of row.otherApplications; track application.programId) {
                   <div class="text-sm w-full flex items-center flex-wrap">
                     <a
                       class="max-w-full block truncate text-blue-600 transition-colors hover:text-blue-700 hover:underline"
-                      [routerLink]="['/mentorship/admin', application.programId]">
+                      [routerLink]="['/mentorship/admin', application.programId]"
+                      [title]="application.programName + ' — ' + application.statusLabel"
+                      [attr.data-testid]="'mentorship-applicant-other-application-' + application.programId">
                       {{ application.programName }}
                     </a>
                     <span class="text-gray-500"> — {{ application.statusLabel }}</span>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.html
@@ -69,6 +69,8 @@
       dataKey="id"
       size="small"
       [paginator]="true"
+      [first]="first()"
+      (onPage)="first.set($event.first)"
       [rows]="pageSize"
       [rowsPerPageOptions]="rowsPerPageOptions"
       [showCurrentPageReport]="true"
@@ -135,23 +137,7 @@
             }
           </td>
           <td class="px-4 py-3">
-            <div class="flex items-center justify-end">
-              @if (row.menuItems.length > 0) {
-                <div class="relative inline-block">
-                  <lfx-button
-                    icon="fa-light fa-ellipsis"
-                    severity="secondary"
-                    size="small"
-                    [outlined]="true"
-                    [ariaLabel]="'Actions for ' + row.name"
-                    (onClick)="actionMenu.toggle($event)"
-                    [attr.data-testid]="'mentorship-applicant-actions-' + row.id" />
-                  <lfx-menu #actionMenu [model]="row.menuItems" [popup]="true" appendTo="body" styleClass="!min-w-[10rem]" />
-                </div>
-              } @else {
-                <span class="text-sm text-gray-500">-</span>
-              }
-            </div>
+            <lfx-mentorship-row-actions [personName]="row.name" [actions]="row.actions" [testId]="'mentorship-applicant-actions-' + row.id" />
           </td>
         </tr>
       </ng-template>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
@@ -4,11 +4,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
+import { MentorshipNoteRequest, MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { DialogService } from 'primeng/dynamicdialog';
-import { of } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ApplicantsTabComponent } from './applicants-tab.component';
 
@@ -27,21 +25,18 @@ describe('ApplicantsTabComponent', () => {
   });
 
   let fixture: ComponentFixture<ApplicantsTabComponent>;
-  let dialogOpen: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    dialogOpen = vi.fn(() => ({ onClose: of('a saved note') }));
-
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       imports: [ApplicantsTabComponent],
-      providers: [provideNoopAnimations(), provideRouter([]), MessageService, { provide: DialogService, useValue: { open: dialogOpen } }],
+      providers: [provideNoopAnimations(), provideRouter([]), MessageService],
     });
 
     fixture = TestBed.createComponent(ApplicantsTabComponent);
     fixture.componentRef.setInput('applicants', [
       applicant({
-        otherApplications: [{ programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'applied' }],
+        otherApplications: [{ programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'pending', tasksSubmitted: 1, tasksTotal: 3 }],
       }),
       // Same `pending` status, but every prerequisite is in.
       applicant({ id: 'app_2', name: 'Diego Souza', tasksSubmitted: 5, tasksTotal: 5 }),
@@ -69,7 +64,7 @@ describe('ApplicantsTabComponent', () => {
     expect(rowText('app_1')).toContain('Created: Jun 28, 2026');
     expect(rowText('app_1')).toContain('Updated: Jul 2, 2026');
 
-    const link = element().querySelector<HTMLAnchorElement>('[data-testid="mentorship-applicant-row-app_1"] a');
+    const link = element().querySelector<HTMLAnchorElement>('[data-testid="mentorship-applicant-other-application-mp_apicurio_winter26"]');
     expect(link?.textContent?.trim()).toBe('Apicurio Registry');
     expect(link?.getAttribute('href')).toBe('/mentorship/admin/mp_apicurio_winter26');
     expect(rowText('app_1')).toContain('— Applied');
@@ -118,15 +113,19 @@ describe('ApplicantsTabComponent', () => {
     expect(labelsFor('app_3')).toEqual(['Decline', 'Withdraw']);
   });
 
-  it('stores the note returned by the dialog against the row it was opened for', () => {
-    const noteButton = element().querySelector<HTMLButtonElement>('[data-testid="mentorship-applicant-note-app_2"]');
+  it('asks the parent to open the note rather than owning the dialog itself', () => {
+    const requests: MentorshipNoteRequest[] = [];
+    fixture.componentInstance.noteRequested.subscribe((request) => requests.push(request));
 
-    expect(noteButton?.textContent?.trim()).toBe('Add note');
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-applicant-note-app_2"]')?.click();
 
-    noteButton?.click();
+    expect(requests).toEqual([{ personId: 'app_2', personName: 'Diego Souza' }]);
+  });
+
+  it('renders the parent note draft in place of the note the row arrived with', () => {
+    fixture.componentRef.setInput('noteDrafts', { app_2: 'a saved note' });
     fixture.detectChanges();
 
-    expect(dialogOpen).toHaveBeenCalledTimes(1);
     expect(element().querySelector('[data-testid="mentorship-applicant-note-app_2"]')?.textContent?.trim()).toBe('a saved note');
     expect(element().querySelector('[data-testid="mentorship-applicant-note-app_1"]')?.textContent?.trim()).toBe('Add note');
   });

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
@@ -1,0 +1,133 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApplicantsTabComponent } from './applicants-tab.component';
+
+describe('ApplicantsTabComponent', () => {
+  const applicant = (overrides: Partial<MentorshipProgramApplicant> = {}): MentorshipProgramApplicant => ({
+    id: 'app_1',
+    name: 'Ifeoma Adeyemi',
+    email: 'ifeoma.adeyemi@example.com',
+    status: 'pending',
+    termName: 'Fall 2026',
+    createdOn: '2026-06-28',
+    updatedOn: '2026-07-02',
+    tasksSubmitted: 2,
+    tasksTotal: 5,
+    ...overrides,
+  });
+
+  let fixture: ComponentFixture<ApplicantsTabComponent>;
+  let dialogOpen: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    dialogOpen = vi.fn(() => ({ onClose: of('a saved note') }));
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ApplicantsTabComponent],
+      providers: [provideNoopAnimations(), provideRouter([]), MessageService, { provide: DialogService, useValue: { open: dialogOpen } }],
+    });
+
+    fixture = TestBed.createComponent(ApplicantsTabComponent);
+    fixture.componentRef.setInput('applicants', [
+      applicant({
+        otherApplications: [{ programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'applied' }],
+      }),
+      // Same `pending` status, but every prerequisite is in.
+      applicant({ id: 'app_2', name: 'Diego Souza', tasksSubmitted: 5, tasksTotal: 5 }),
+      applicant({ id: 'app_3', name: 'Aiko Tanaka', status: 'graduated', termName: 'Spring 2026', tasksSubmitted: undefined, tasksTotal: undefined }),
+    ]);
+    fixture.detectChanges();
+  });
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const rowText = (id: string): string => (element().querySelector(`[data-testid="mentorship-applicant-row-${id}"]`)?.textContent ?? '').replace(/\s+/g, ' ');
+
+  it('renders the columns from the design', () => {
+    const headers = Array.from(element().querySelectorAll('thead th')).map((th) => (th.textContent ?? '').trim());
+
+    expect(headers).toEqual(['Mentee', 'Term', 'Status', 'Application Dates', 'Other Active Applications', 'Actions']);
+  });
+
+  it('splits the pending status into Applied and Tasks Completed by prerequisite progress', () => {
+    expect(rowText('app_1')).toContain('Applied');
+    expect(rowText('app_1')).not.toContain('Tasks Completed');
+    expect(rowText('app_2')).toContain('Tasks Completed');
+  });
+
+  it('shows the created and updated dates, and links out to other active applications', () => {
+    expect(rowText('app_1')).toContain('Created: Jun 28, 2026');
+    expect(rowText('app_1')).toContain('Updated: Jul 2, 2026');
+
+    const link = element().querySelector<HTMLAnchorElement>('[data-testid="mentorship-applicant-row-app_1"] a');
+    expect(link?.textContent?.trim()).toBe('Apicurio Registry');
+    expect(link?.getAttribute('href')).toBe('/mentorship/admin/mp_apicurio_winter26');
+    expect(rowText('app_1')).toContain('— Applied');
+  });
+
+  it('explains the Applied / Tasks Completed split above the table', () => {
+    const note = element().querySelector('[data-testid="mentorship-applicants-note"]')?.textContent ?? '';
+
+    expect(note).toContain('Note:');
+    expect(note).toContain('Tasks Completed');
+  });
+
+  it('filters by display status and by term', () => {
+    const component = fixture.componentInstance;
+
+    expect(component['statusOptions'].map((option) => option.label)).toEqual([
+      'All statuses',
+      'Applied',
+      'Tasks Completed',
+      'Accepted',
+      'Declined',
+      'Withdrawn',
+      'Graduated',
+    ]);
+    expect(component['termOptions']().map((option) => option.label)).toEqual(['All terms', 'Fall 2026', 'Spring 2026']);
+
+    // `tasks-completed` is a display status only — it must still match the pending row.
+    component['form'].controls.status.setValue('tasks-completed');
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['app_2']);
+
+    component['form'].controls.status.reset(null);
+    component['form'].controls.term.setValue('Spring 2026');
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['app_3']);
+  });
+
+  it('offers accept / decline / withdraw, and never re-accepts a graduate', () => {
+    const component = fixture.componentInstance;
+    const labelsFor = (id: string): string[] =>
+      component['rows']()
+        .find((row) => row.id === id)
+        ?.menuItems.map((item) => item.label ?? '') ?? [];
+
+    expect(labelsFor('app_1')).toEqual(['Accept', 'Decline', 'Withdraw']);
+    expect(labelsFor('app_3')).toEqual(['Decline', 'Withdraw']);
+  });
+
+  it('stores the note returned by the dialog against the row it was opened for', () => {
+    const noteButton = element().querySelector<HTMLButtonElement>('[data-testid="mentorship-applicant-note-app_2"]');
+
+    expect(noteButton?.textContent?.trim()).toBe('Add note');
+
+    noteButton?.click();
+    fixture.detectChanges();
+
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    expect(element().querySelector('[data-testid="mentorship-applicant-note-app_2"]')?.textContent?.trim()).toBe('a saved note');
+    expect(element().querySelector('[data-testid="mentorship-applicant-note-app_1"]')?.textContent?.trim()).toBe('Add note');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
@@ -70,6 +70,25 @@ describe('ApplicantsTabComponent', () => {
     expect(rowText('app_1')).toContain('— Applied');
   });
 
+  it('lists only still-active other applications, dropping the rejections', () => {
+    fixture.componentRef.setInput('applicants', [
+      applicant({
+        otherApplications: [
+          { programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'pending', tasksSubmitted: 1, tasksTotal: 3 },
+          { programId: 'mp_thanos_summer26', programName: 'Thanos', status: 'graduated' },
+          { programId: 'mp_declined', programName: 'Declined Program', status: 'declined' },
+          { programId: 'mp_withdrawn', programName: 'Withdrawn Program', status: 'withdrawn' },
+        ],
+      }),
+    ]);
+    fixture.detectChanges();
+
+    const shown = Array.from(element().querySelectorAll('[data-testid^="mentorship-applicant-other-application-"]')).map((link) =>
+      (link.textContent ?? '').trim()
+    );
+    expect(shown).toEqual(['Apicurio Registry', 'Thanos']);
+  });
+
   it('explains the Applied / Tasks Completed split above the table', () => {
     const note = element().querySelector('[data-testid="mentorship-applicants-note"]')?.textContent ?? '';
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.spec.ts
@@ -126,7 +126,7 @@ describe('ApplicantsTabComponent', () => {
     const labelsFor = (id: string): string[] =>
       component['rows']()
         .find((row) => row.id === id)
-        ?.menuItems.map((item) => item.label ?? '') ?? [];
+        ?.actions.map((action) => action.label) ?? [];
 
     expect(labelsFor('app_1')).toEqual(['Accept', 'Decline', 'Withdraw']);
     expect(labelsFor('app_3')).toEqual(['Decline', 'Withdraw']);

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -24,7 +24,7 @@ import {
   MENTORSHIP_PERSON_PAGE_SIZE,
   MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
 } from '@lfx-one/shared/constants';
-import { MentorshipApplicantDisplayStatus, MentorshipNoteRequest, MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
+import { FilterOption, MentorshipApplicantDisplayStatus, MentorshipNoteRequest, MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
 import {
   formatIsoDateLabel,
   matchesMentorshipPersonSearch,
@@ -65,7 +65,7 @@ export class ApplicantsTabComponent {
   protected readonly statusNote = MENTORSHIP_APPLICANT_STATUS_NOTE;
 
   /** Fixed rather than derived from the rows: every status an application can display as. */
-  protected readonly statusOptions = [
+  protected readonly statusOptions: FilterOption<MentorshipApplicantDisplayStatus | null>[] = [
     { label: MENTORSHIP_ALL_STATUSES_OPTION_LABEL, value: null },
     ...MENTORSHIP_APPLICANT_DISPLAY_STATUSES.map((status) => ({ label: MENTORSHIP_APPLICANT_STATUS_LABELS[status], value: status })),
   ];

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -5,13 +5,13 @@ import { ChangeDetectionStrategy, Component, computed, inject, input, output } f
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
+  MENTORSHIP_ACTIVE_APPLICATION_STATUSES,
   MENTORSHIP_ADD_NOTE_LABEL,
   MENTORSHIP_ALL_STATUSES_OPTION_LABEL,
   MENTORSHIP_ALL_TERMS_OPTION_LABEL,
@@ -38,6 +38,7 @@ import { MenuItem } from 'primeng/api';
 import { startWith } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { PersonCellComponent } from '../person-cell/person-cell.component';
 
 /**
  * Applicants tab — one row per application, filtered by search, display status, and term.
@@ -47,7 +48,7 @@ import { MentorshipComingSoonService } from '../../services/mentorship-coming-so
  */
 @Component({
   selector: 'lfx-mentorship-applicants-tab',
-  imports: [ReactiveFormsModule, RouterLink, AvatarComponent, ButtonComponent, InputTextComponent, MenuComponent, SelectComponent, TableComponent],
+  imports: [ReactiveFormsModule, RouterLink, ButtonComponent, InputTextComponent, MenuComponent, PersonCellComponent, SelectComponent, TableComponent],
   templateUrl: './applicants-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -125,10 +126,13 @@ export class ApplicantsTabComponent {
       statusBadgeClass: MENTORSHIP_APPLICANT_STATUS_BADGE_CLASSES[displayStatus],
       createdLabel: formatIsoDateLabel(person.createdOn),
       updatedLabel: formatIsoDateLabel(person.updatedOn),
-      otherApplications: (person.otherApplications ?? []).map((application) => ({
-        ...application,
-        statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[mentorshipApplicantDisplayStatus(application)],
-      })),
+      // The column is headed "Other Active Applications", so declined and withdrawn ones drop out.
+      otherApplications: (person.otherApplications ?? [])
+        .filter((application) => MENTORSHIP_ACTIVE_APPLICATION_STATUSES.includes(application.status))
+        .map((application) => ({
+          ...application,
+          statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[mentorshipApplicantDisplayStatus(application)],
+        })),
       hasNote: note.length > 0,
       noteLabel: note.length > 0 ? note : MENTORSHIP_ADD_NOTE_LABEL,
       menuItems: this.menuItemsFor(person),

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input, linkedSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
@@ -12,6 +12,9 @@ import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
+  MENTORSHIP_ADD_NOTE_LABEL,
+  MENTORSHIP_ALL_STATUSES_OPTION_LABEL,
+  MENTORSHIP_ALL_TERMS_OPTION_LABEL,
   MENTORSHIP_APPLICANT_ACTION_ICONS,
   MENTORSHIP_APPLICANT_ACTION_LABELS,
   MENTORSHIP_APPLICANT_DISPLAY_STATUSES,
@@ -20,9 +23,8 @@ import {
   MENTORSHIP_APPLICANT_STATUS_NOTE,
   MENTORSHIP_PERSON_PAGE_SIZE,
   MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
-  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
 } from '@lfx-one/shared/constants';
-import { MentorshipApplicantDisplayStatus, MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
+import { MentorshipApplicantDisplayStatus, MentorshipNoteRequest, MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
 import {
   formatIsoDateLabel,
   matchesMentorshipPersonSearch,
@@ -30,18 +32,18 @@ import {
   mentorshipApplicantDisplayStatus,
   mentorshipPersonAvatarClass,
   mentorshipPersonInitials,
+  mentorshipTermFilterOptions,
 } from '@lfx-one/shared/utils';
-import { MenuItem, MessageService } from 'primeng/api';
-import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { startWith, take } from 'rxjs';
+import { MenuItem } from 'primeng/api';
+import { startWith } from 'rxjs';
 
-import { MenteeNoteDialogComponent } from '../mentee-note-dialog/mentee-note-dialog.component';
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 
 /**
  * Applicants tab — one row per application, filtered by search, display status, and term.
  * Row actions (accept / decline / withdraw), Decline by Term, and the status export all
- * stub to a "coming soon" toast until the backend lands; the reviewer note is the one
- * action that takes effect, held locally.
+ * stub to a "coming soon" toast until the backend lands. The reviewer note is the one
+ * action that takes effect; the parent owns its state, so it outlives a tab switch.
  */
 @Component({
   selector: 'lfx-mentorship-applicants-tab',
@@ -50,10 +52,12 @@ import { MenteeNoteDialogComponent } from '../mentee-note-dialog/mentee-note-dia
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ApplicantsTabComponent {
-  public readonly applicants = input.required<MentorshipProgramApplicant[]>();
+  private readonly comingSoon = inject(MentorshipComingSoonService);
 
-  private readonly dialogService = inject(DialogService);
-  private readonly messageService = inject(MessageService);
+  public readonly applicants = input.required<MentorshipProgramApplicant[]>();
+  /** Notes edited this session, keyed by person id; overrides the note a row arrived with. */
+  public readonly noteDrafts = input<Record<string, string>>({});
+  public readonly noteRequested = output<MentorshipNoteRequest>();
 
   protected readonly pageSize = MENTORSHIP_PERSON_PAGE_SIZE;
   protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
@@ -61,7 +65,7 @@ export class ApplicantsTabComponent {
 
   /** Fixed rather than derived from the rows: every status an application can display as. */
   protected readonly statusOptions = [
-    { label: 'All statuses', value: null },
+    { label: MENTORSHIP_ALL_STATUSES_OPTION_LABEL, value: null },
     ...MENTORSHIP_APPLICANT_DISPLAY_STATUSES.map((status) => ({ label: MENTORSHIP_APPLICANT_STATUS_LABELS[status], value: status })),
   ];
 
@@ -75,80 +79,26 @@ export class ApplicantsTabComponent {
     initialValue: this.form.getRawValue(),
   });
 
-  /**
-   * Reviewer notes are local until a write endpoint exists, so a re-emission of the
-   * same upstream applicants must keep them. Only a genuinely different set resets.
-   */
-  protected readonly draftApplicants = linkedSignal<MentorshipProgramApplicant[], MentorshipProgramApplicant[]>({
-    source: this.applicants,
-    computation: (applicants, previous) => (previous && this.sameApplicantIds(previous.source, applicants) ? previous.value : applicants),
-  });
-
   protected readonly termOptions = this.initTermOptions();
 
   protected readonly rows = this.initRows();
 
-  protected onOpenNote(id: string): void {
-    const applicant = this.draftApplicants().find((person) => person.id === id);
-    if (!applicant) return;
-
-    const dialogRef = this.dialogService.open(MenteeNoteDialogComponent, {
-      header: 'Reviewer note',
-      width: '34rem',
-      modal: true,
-      closable: true,
-      dismissableMask: true,
-      data: { menteeId: applicant.id, menteeName: applicant.name, note: applicant.note ?? '' },
-    }) as DynamicDialogRef;
-
-    dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
-      // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
-      // an empty string is an explicit clear.
-      if (note === undefined) return;
-      this.draftApplicants.set(this.draftApplicants().map((person) => (person.id === id ? { ...person, note: note || undefined } : person)));
-    });
+  protected onOpenNote(id: string, name: string): void {
+    this.noteRequested.emit({ personId: id, personName: name });
   }
 
-  protected onDeclineByTerm(): void {
-    this.toastComingSoon('Decline by term');
-  }
-
-  protected onDownloadByStatus(): void {
-    this.toastComingSoon('Download by status');
-  }
-
-  private toastComingSoon(summary: string): void {
-    this.messageService.add({
-      severity: 'info',
-      summary,
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-      life: 4000,
-    });
-  }
-
-  private sameApplicantIds(a: MentorshipProgramApplicant[], b: MentorshipProgramApplicant[]): boolean {
-    return a.length === b.length && a.every((applicant, index) => applicant.id === b[index].id);
-  }
-
-  private menuItemsFor(person: MentorshipProgramApplicant): MenuItem[] {
-    return mentorshipApplicantActionsFor(person.status).map((action) => ({
-      label: MENTORSHIP_APPLICANT_ACTION_LABELS[action],
-      icon: MENTORSHIP_APPLICANT_ACTION_ICONS[action],
-      command: () => this.toastComingSoon(`${MENTORSHIP_APPLICANT_ACTION_LABELS[action]} ${person.name}`),
-    }));
+  protected onAction(summary: string): void {
+    this.comingSoon.notify(summary);
   }
 
   private initTermOptions() {
-    return computed(() => {
-      const terms = [...new Set(this.draftApplicants().map((person) => person.termName))];
-      return [{ label: 'All terms', value: null }, ...terms.map((term) => ({ label: term, value: term }))];
-    });
+    return computed(() => mentorshipTermFilterOptions(this.applicants(), MENTORSHIP_ALL_TERMS_OPTION_LABEL));
   }
 
   private initRows() {
     return computed(() => {
       const { search, status, term } = this.filters();
-      return this.draftApplicants()
+      return this.applicants()
         .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
         .filter((person) => !status || mentorshipApplicantDisplayStatus(person) === status)
         .filter((person) => !term || person.termName === term)
@@ -156,9 +106,17 @@ export class ApplicantsTabComponent {
     });
   }
 
+  private menuItemsFor(person: MentorshipProgramApplicant): MenuItem[] {
+    return mentorshipApplicantActionsFor(person.status).map((action) => ({
+      label: MENTORSHIP_APPLICANT_ACTION_LABELS[action],
+      icon: MENTORSHIP_APPLICANT_ACTION_ICONS[action],
+      command: () => this.comingSoon.notify(`${MENTORSHIP_APPLICANT_ACTION_LABELS[action]} ${person.name}`),
+    }));
+  }
+
   private toRow(person: MentorshipProgramApplicant) {
     const displayStatus = mentorshipApplicantDisplayStatus(person);
-    const note = person.note?.trim() ?? '';
+    const note = (this.noteDrafts()[person.id] ?? person.note ?? '').trim();
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
@@ -169,10 +127,10 @@ export class ApplicantsTabComponent {
       updatedLabel: formatIsoDateLabel(person.updatedOn),
       otherApplications: (person.otherApplications ?? []).map((application) => ({
         ...application,
-        statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[application.status],
+        statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[mentorshipApplicantDisplayStatus(application)],
       })),
       hasNote: note.length > 0,
-      noteLabel: note.length > 0 ? note : 'Add note',
+      noteLabel: note.length > 0 ? note : MENTORSHIP_ADD_NOTE_LABEL,
       menuItems: this.menuItemsFor(person),
     };
   }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -1,13 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
-import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
@@ -30,15 +29,17 @@ import {
   matchesMentorshipPersonSearch,
   mentorshipApplicantActionsFor,
   mentorshipApplicantDisplayStatus,
+  mentorshipNoteDisplay,
   mentorshipPersonAvatarClass,
   mentorshipPersonInitials,
+  mentorshipRowActions,
   mentorshipTermFilterOptions,
 } from '@lfx-one/shared/utils';
-import { MenuItem } from 'primeng/api';
-import { startWith } from 'rxjs';
+import { startWith, tap } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 import { PersonCellComponent } from '../person-cell/person-cell.component';
+import { RowActionsComponent } from '../row-actions/row-actions.component';
 
 /**
  * Applicants tab — one row per application, filtered by search, display status, and term.
@@ -48,7 +49,7 @@ import { PersonCellComponent } from '../person-cell/person-cell.component';
  */
 @Component({
   selector: 'lfx-mentorship-applicants-tab',
-  imports: [ReactiveFormsModule, RouterLink, ButtonComponent, InputTextComponent, MenuComponent, PersonCellComponent, SelectComponent, TableComponent],
+  imports: [ReactiveFormsModule, RouterLink, ButtonComponent, InputTextComponent, PersonCellComponent, RowActionsComponent, SelectComponent, TableComponent],
   templateUrl: './applicants-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -76,9 +77,20 @@ export class ApplicantsTabComponent {
     term: new FormControl<string | null>(null),
   });
 
-  private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
-    initialValue: this.form.getRawValue(),
-  });
+  /**
+   * Paginator offset. Tracked so that narrowing the list can send the table back to the
+   * first page — PrimeNG keeps its own offset when the value array shrinks underneath it,
+   * which would otherwise leave the admin on a page that no longer exists.
+   */
+  protected readonly first = signal(0);
+
+  private readonly filters = toSignal(
+    this.form.valueChanges.pipe(
+      tap(() => this.first.set(0)),
+      startWith(this.form.getRawValue())
+    ),
+    { initialValue: this.form.getRawValue() }
+  );
 
   protected readonly termOptions = this.initTermOptions();
 
@@ -107,17 +119,8 @@ export class ApplicantsTabComponent {
     });
   }
 
-  private menuItemsFor(person: MentorshipProgramApplicant): MenuItem[] {
-    return mentorshipApplicantActionsFor(person.status).map((action) => ({
-      label: MENTORSHIP_APPLICANT_ACTION_LABELS[action],
-      icon: MENTORSHIP_APPLICANT_ACTION_ICONS[action],
-      command: () => this.comingSoon.notify(`${MENTORSHIP_APPLICANT_ACTION_LABELS[action]} ${person.name}`),
-    }));
-  }
-
   private toRow(person: MentorshipProgramApplicant) {
     const displayStatus = mentorshipApplicantDisplayStatus(person);
-    const note = (this.noteDrafts()[person.id] ?? person.note ?? '').trim();
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
@@ -133,9 +136,8 @@ export class ApplicantsTabComponent {
           ...application,
           statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[mentorshipApplicantDisplayStatus(application)],
         })),
-      hasNote: note.length > 0,
-      noteLabel: note.length > 0 ? note : MENTORSHIP_ADD_NOTE_LABEL,
-      menuItems: this.menuItemsFor(person),
+      ...mentorshipNoteDisplay(this.noteDrafts(), person, MENTORSHIP_ADD_NOTE_LABEL),
+      actions: mentorshipRowActions(mentorshipApplicantActionsFor(person.status), MENTORSHIP_APPLICANT_ACTION_LABELS, MENTORSHIP_APPLICANT_ACTION_ICONS),
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -1,65 +1,179 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES, MENTORSHIP_MENTEE_STATUS_LABELS } from '@lfx-one/shared/constants';
-import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
-import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials } from '@lfx-one/shared/utils';
-import { startWith } from 'rxjs';
+import { TableComponent } from '@components/table/table.component';
+import {
+  MENTORSHIP_APPLICANT_ACTION_ICONS,
+  MENTORSHIP_APPLICANT_ACTION_LABELS,
+  MENTORSHIP_APPLICANT_DISPLAY_STATUSES,
+  MENTORSHIP_APPLICANT_STATUS_BADGE_CLASSES,
+  MENTORSHIP_APPLICANT_STATUS_LABELS,
+  MENTORSHIP_APPLICANT_STATUS_NOTE,
+  MENTORSHIP_PERSON_PAGE_SIZE,
+  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
+  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+} from '@lfx-one/shared/constants';
+import { MentorshipApplicantDisplayStatus, MentorshipProgramApplicant } from '@lfx-one/shared/interfaces';
+import {
+  formatIsoDateLabel,
+  matchesMentorshipPersonSearch,
+  mentorshipApplicantActionsFor,
+  mentorshipApplicantDisplayStatus,
+  mentorshipPersonAvatarClass,
+  mentorshipPersonInitials,
+} from '@lfx-one/shared/utils';
+import { MenuItem, MessageService } from 'primeng/api';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { startWith, take } from 'rxjs';
+
+import { MenteeNoteDialogComponent } from '../mentee-note-dialog/mentee-note-dialog.component';
 
 /**
- * Applicants tab — pending / declined applications with search + status filter.
+ * Applicants tab — one row per application, filtered by search, display status, and term.
+ * Row actions (accept / decline / withdraw), Decline by Term, and the status export all
+ * stub to a "coming soon" toast until the backend lands; the reviewer note is the one
+ * action that takes effect, held locally.
  */
 @Component({
   selector: 'lfx-mentorship-applicants-tab',
-  imports: [ReactiveFormsModule, AvatarComponent, InputTextComponent, SelectComponent],
+  imports: [ReactiveFormsModule, RouterLink, AvatarComponent, ButtonComponent, InputTextComponent, MenuComponent, SelectComponent, TableComponent],
   templateUrl: './applicants-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ApplicantsTabComponent {
-  public readonly applicants = input.required<MentorshipProgramMentee[]>();
+  public readonly applicants = input.required<MentorshipProgramApplicant[]>();
+
+  private readonly dialogService = inject(DialogService);
+  private readonly messageService = inject(MessageService);
+
+  protected readonly pageSize = MENTORSHIP_PERSON_PAGE_SIZE;
+  protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
+  protected readonly statusNote = MENTORSHIP_APPLICANT_STATUS_NOTE;
+
+  /** Fixed rather than derived from the rows: every status an application can display as. */
+  protected readonly statusOptions = [
+    { label: 'All statuses', value: null },
+    ...MENTORSHIP_APPLICANT_DISPLAY_STATUSES.map((status) => ({ label: MENTORSHIP_APPLICANT_STATUS_LABELS[status], value: status })),
+  ];
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
-    status: new FormControl<MentorshipMenteeStatus | null>(null),
+    status: new FormControl<MentorshipApplicantDisplayStatus | null>(null),
+    term: new FormControl<string | null>(null),
   });
 
   private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
     initialValue: this.form.getRawValue(),
   });
 
-  protected readonly statusOptions = computed(() => {
-    const statuses = [...new Set(this.applicants().map((person) => person.status))];
-    return [
-      { label: 'All statuses', value: null },
-      ...statuses.map((status) => ({
-        label: MENTORSHIP_MENTEE_STATUS_LABELS[status],
-        value: status,
-      })),
-    ];
+  /**
+   * Reviewer notes are local until a write endpoint exists, so a re-emission of the
+   * same upstream applicants must keep them. Only a genuinely different set resets.
+   */
+  protected readonly draftApplicants = linkedSignal<MentorshipProgramApplicant[], MentorshipProgramApplicant[]>({
+    source: this.applicants,
+    computation: (applicants, previous) => (previous && this.sameApplicantIds(previous.source, applicants) ? previous.value : applicants),
   });
 
-  protected readonly rows = computed(() => {
-    const { search, status } = this.filters();
-    return this.applicants()
-      .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
-      .filter((person) => !status || person.status === status)
-      .map((person) => this.toRow(person));
-  });
+  protected readonly termOptions = this.initTermOptions();
 
-  private toRow(person: MentorshipProgramMentee) {
+  protected readonly rows = this.initRows();
+
+  protected onOpenNote(id: string): void {
+    const applicant = this.draftApplicants().find((person) => person.id === id);
+    if (!applicant) return;
+
+    const dialogRef = this.dialogService.open(MenteeNoteDialogComponent, {
+      header: 'Reviewer note',
+      width: '34rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { menteeId: applicant.id, menteeName: applicant.name, note: applicant.note ?? '' },
+    }) as DynamicDialogRef;
+
+    dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
+      // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
+      // an empty string is an explicit clear.
+      if (note === undefined) return;
+      this.draftApplicants.set(this.draftApplicants().map((person) => (person.id === id ? { ...person, note: note || undefined } : person)));
+    });
+  }
+
+  protected onDeclineByTerm(): void {
+    this.toastComingSoon('Decline by term');
+  }
+
+  protected onDownloadByStatus(): void {
+    this.toastComingSoon('Download by status');
+  }
+
+  private toastComingSoon(summary: string): void {
+    this.messageService.add({
+      severity: 'info',
+      summary,
+      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      life: 4000,
+    });
+  }
+
+  private sameApplicantIds(a: MentorshipProgramApplicant[], b: MentorshipProgramApplicant[]): boolean {
+    return a.length === b.length && a.every((applicant, index) => applicant.id === b[index].id);
+  }
+
+  private menuItemsFor(person: MentorshipProgramApplicant): MenuItem[] {
+    return mentorshipApplicantActionsFor(person.status).map((action) => ({
+      label: MENTORSHIP_APPLICANT_ACTION_LABELS[action],
+      icon: MENTORSHIP_APPLICANT_ACTION_ICONS[action],
+      command: () => this.toastComingSoon(`${MENTORSHIP_APPLICANT_ACTION_LABELS[action]} ${person.name}`),
+    }));
+  }
+
+  private initTermOptions() {
+    return computed(() => {
+      const terms = [...new Set(this.draftApplicants().map((person) => person.termName))];
+      return [{ label: 'All terms', value: null }, ...terms.map((term) => ({ label: term, value: term }))];
+    });
+  }
+
+  private initRows() {
+    return computed(() => {
+      const { search, status, term } = this.filters();
+      return this.draftApplicants()
+        .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
+        .filter((person) => !status || mentorshipApplicantDisplayStatus(person) === status)
+        .filter((person) => !term || person.termName === term)
+        .map((person) => this.toRow(person));
+    });
+  }
+
+  private toRow(person: MentorshipProgramApplicant) {
+    const displayStatus = mentorshipApplicantDisplayStatus(person);
+    const note = person.note?.trim() ?? '';
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
       avatarStyleClass: mentorshipPersonAvatarClass(person.name),
-      statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
-      statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
-      appliedOnLabel: person.appliedOn ? formatIsoDateLabel(person.appliedOn) : '—',
+      statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[displayStatus],
+      statusBadgeClass: MENTORSHIP_APPLICANT_STATUS_BADGE_CLASSES[displayStatus],
+      createdLabel: formatIsoDateLabel(person.createdOn),
+      updatedLabel: formatIsoDateLabel(person.updatedOn),
+      otherApplications: (person.otherApplications ?? []).map((application) => ({
+        ...application,
+        statusLabel: MENTORSHIP_APPLICANT_STATUS_LABELS[application.status],
+      })),
+      hasNote: note.length > 0,
+      noteLabel: note.length > 0 ? note : 'Add note',
+      menuItems: this.menuItemsFor(person),
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -7,9 +7,9 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES, MENTORSHIP_MENTEE_STATUS_LABELS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES, MENTORSHIP_MENTEE_STATUS_LABELS } from '@lfx-one/shared/constants';
 import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
-import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
+import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials } from '@lfx-one/shared/utils';
 import { startWith } from 'rxjs';
 
 /**
@@ -53,11 +53,10 @@ export class ApplicantsTabComponent {
   });
 
   private toRow(person: MentorshipProgramMentee) {
-    const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
-      avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
+      avatarStyleClass: mentorshipPersonAvatarClass(person.name),
       statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
       statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
       appliedOnLabel: person.appliedOn ? formatIsoDateLabel(person.appliedOn) : '—',

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
@@ -3,64 +3,146 @@
 
 <div class="flex flex-col gap-4" data-testid="mentorship-current-mentees-tab">
   <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-    <label class="sm:w-72">
+    <!-- min-w-0 + flex-1: the search takes the leftover width without squeezing the
+         filter and export controls, which otherwise wrap their labels. -->
+    <label class="w-full min-w-0 sm:flex-1">
       <span class="sr-only">Search mentees</span>
       <lfx-input-text [form]="form" control="search" placeholder="Search" icon="fa-light fa-magnifying-glass" dataTest="mentorship-mentees-search" />
     </label>
-    <div class="sm:w-52">
-      <lfx-select
-        [form]="form"
-        control="status"
-        [options]="statusOptions()"
-        optionLabel="label"
-        optionValue="value"
-        placeholder="Status"
-        ariaLabel="Filter mentees by status"
-        styleClass="w-full"
-        dataTest="mentorship-mentees-status" />
+
+    <div class="flex shrink-0 items-center gap-2">
+      <div class="w-full sm:w-48">
+        <lfx-select
+          [form]="form"
+          control="status"
+          [options]="statusOptions"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Filter By Status"
+          ariaLabel="Filter mentees by status"
+          styleClass="w-full"
+          dataTest="mentorship-mentees-status" />
+      </div>
+
+      <lfx-button
+        label="Download By Status"
+        icon="fa-light fa-download"
+        iconPos="left"
+        severity="secondary"
+        size="small"
+        [outlined]="true"
+        styleClass="whitespace-nowrap !py-2.5"
+        (onClick)="onDownloadByStatus()"
+        data-testid="mentorship-mentees-download" />
     </div>
   </div>
 
-  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white">
-    <table class="w-full min-w-[36rem] text-left">
-      <thead>
-        <tr class="border-b border-gray-200">
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Mentee</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Term</th>
-          <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Status</th>
+  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+    <lfx-table
+      [value]="rows()"
+      dataKey="id"
+      size="small"
+      [paginator]="true"
+      [rows]="pageSize"
+      [rowsPerPageOptions]="rowsPerPageOptions"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+      tableStyleClass="table-fixed"
+      paginatorDropdownAppendTo="body"
+      ariaLabel="Current mentees">
+      <ng-template #header>
+        <tr>
+          <th class="w-[32%] px-4 py-3 !text-sm !font-medium !text-gray-600">Mentee</th>
+          <th class="w-[14%] px-4 py-3 !text-sm !font-medium !text-gray-600">Status</th>
+          <th class="w-[20%] px-4 py-3 !text-sm !font-medium !text-gray-600">Tasks</th>
+          <th class="w-[20%] px-4 py-3 !text-sm !font-medium !text-gray-600">Create Task</th>
+          <th class="w-[14%] px-4 py-3 !text-sm !font-medium !text-gray-600 text-end">Actions</th>
         </tr>
-      </thead>
-      <tbody>
-        @for (row of rows(); track row.id) {
-          <tr class="border-b border-gray-100 last:border-b-0" [attr.data-testid]="'mentorship-mentee-row-' + row.id">
-            <td class="px-4 py-3">
-              <div class="flex items-center gap-3 min-w-0">
-                <lfx-avatar
-                  [image]="row.avatarUrl ?? ''"
-                  [label]="row.initials"
-                  shape="circle"
-                  size="normal"
-                  [styleClass]="row.avatarStyleClass"
-                  [ariaLabel]="row.name" />
-                <div class="flex flex-col min-w-0">
-                  <span class="text-sm font-medium text-gray-900 truncate">{{ row.name }}</span>
-                  <span class="text-xs text-gray-500 truncate">{{ row.email }}</span>
-                </div>
+      </ng-template>
+
+      <ng-template #body let-row>
+        <tr [attr.data-testid]="'mentorship-mentee-row-' + row.id">
+          <td class="px-4 py-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <lfx-avatar
+                [image]="row.avatarUrl ?? ''"
+                [label]="row.initials"
+                shape="circle"
+                size="normal"
+                [styleClass]="row.avatarStyleClass"
+                [ariaLabel]="row.name" />
+              <div class="flex flex-col min-w-0">
+                <span class="text-sm font-medium text-blue-600 truncate" [title]="row.name">{{ row.name }}</span>
+                <button
+                  type="button"
+                  class="text-xs text-gray-500 truncate text-left transition-colors hover:text-blue-600"
+                  [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
+                  [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
+                  (click)="onOpenNote(row.id)"
+                  [attr.data-testid]="'mentorship-mentee-note-' + row.id">
+                  {{ row.noteLabel }}
+                </button>
               </div>
-            </td>
-            <td class="px-4 py-3 text-sm text-gray-700">{{ row.termName }}</td>
-            <td class="px-4 py-3">
-              <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
-                {{ row.statusLabel }}
-              </span>
-            </td>
-          </tr>
-        } @empty {
-          <tr>
-            <td colspan="3" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-mentees-empty">No current mentees.</td>
-          </tr>
-        }
-      </tbody>
-    </table>
+            </div>
+          </td>
+          <td class="px-4 py-3">
+            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+              {{ row.statusLabel }}
+            </span>
+          </td>
+          <td class="px-4 py-3">
+            @if (row.taskLabel) {
+              <button
+                type="button"
+                class="text-sm text-blue-600 transition-colors hover:text-blue-700 hover:underline"
+                [attr.aria-label]="'View tasks for ' + row.name"
+                (click)="onViewTasks(row.name)"
+                [attr.data-testid]="'mentorship-mentee-tasks-' + row.id">
+                {{ row.taskLabel }}
+              </button>
+            } @else {
+              <span class="text-sm text-gray-500">No tasks assigned</span>
+            }
+          </td>
+          <td class="px-4 py-3">
+            <lfx-button
+              label="Create Task"
+              icon="fa-light fa-plus"
+              iconPos="left"
+              severity="secondary"
+              size="small"
+              [outlined]="true"
+              [ariaLabel]="'Create a task for ' + row.name"
+              (onClick)="onCreateTask(row.name)"
+              [attr.data-testid]="'mentorship-mentee-create-task-' + row.id" />
+          </td>
+          <td class="px-4 py-3">
+            <div class="flex items-center justify-end">
+              @if (row.menuItems.length > 0) {
+                <div class="relative inline-block">
+                  <lfx-button
+                    icon="fa-light fa-ellipsis"
+                    severity="secondary"
+                    size="small"
+                    [outlined]="true"
+                    [ariaLabel]="'Actions for ' + row.name"
+                    (onClick)="actionMenu.toggle($event)"
+                    [attr.data-testid]="'mentorship-mentee-actions-' + row.id" />
+                  <lfx-menu #actionMenu [model]="row.menuItems" [popup]="true" appendTo="body" styleClass="!min-w-[10rem]" />
+                </div>
+              } @else {
+                <span class="text-sm text-gray-500">-</span>
+              }
+            </div>
+          </td>
+        </tr>
+      </ng-template>
+
+      <ng-template #emptymessage>
+        <tr>
+          <td colspan="5" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-mentees-empty">No current mentees.</td>
+        </tr>
+      </ng-template>
+    </lfx-table>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
@@ -32,7 +32,7 @@
         size="small"
         [outlined]="true"
         styleClass="whitespace-nowrap !py-2.5"
-        (onClick)="onDownloadByStatus()"
+        (onClick)="onAction('Download by status')"
         data-testid="mentorship-mentees-download" />
     </div>
   </div>
@@ -78,7 +78,7 @@
                   class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
                   [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
                   [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
-                  (click)="onOpenNote(row.id)"
+                  (click)="onOpenNote(row.id, row.name)"
                   [attr.data-testid]="'mentorship-mentee-note-' + row.id">
                   {{ row.noteLabel }}
                 </button>
@@ -86,7 +86,7 @@
             </div>
           </td>
           <td class="px-4 py-3">
-            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">
               {{ row.statusLabel }}
             </span>
           </td>
@@ -96,7 +96,7 @@
                 type="button"
                 class="max-w-full block truncate text-sm text-blue-600 transition-colors hover:text-blue-700 hover:underline"
                 [attr.aria-label]="'View tasks for ' + row.name"
-                (click)="onViewTasks(row.name)"
+                (click)="onAction('View tasks for ' + row.name)"
                 [attr.data-testid]="'mentorship-mentee-tasks-' + row.id">
                 {{ row.taskLabel }}
               </button>
@@ -113,7 +113,7 @@
               size="small"
               [outlined]="true"
               [ariaLabel]="'Create a task for ' + row.name"
-              (onClick)="onCreateTask(row.name)"
+              (onClick)="onAction('Create a task for ' + row.name)"
               [attr.data-testid]="'mentorship-mentee-create-task-' + row.id" />
           </td>
           <td class="px-4 py-3">

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
@@ -43,6 +43,8 @@
       dataKey="id"
       size="small"
       [paginator]="true"
+      [first]="first()"
+      (onPage)="first.set($event.first)"
       [rows]="pageSize"
       [rowsPerPageOptions]="rowsPerPageOptions"
       [showCurrentPageReport]="true"
@@ -106,23 +108,7 @@
               [attr.data-testid]="'mentorship-mentee-create-task-' + row.id" />
           </td>
           <td class="px-4 py-3">
-            <div class="flex items-center justify-end">
-              @if (row.menuItems.length > 0) {
-                <div class="relative inline-block">
-                  <lfx-button
-                    icon="fa-light fa-ellipsis"
-                    severity="secondary"
-                    size="small"
-                    [outlined]="true"
-                    [ariaLabel]="'Actions for ' + row.name"
-                    (onClick)="actionMenu.toggle($event)"
-                    [attr.data-testid]="'mentorship-mentee-actions-' + row.id" />
-                  <lfx-menu #actionMenu [model]="row.menuItems" [popup]="true" appendTo="body" styleClass="!min-w-[10rem]" />
-                </div>
-              } @else {
-                <span class="text-sm text-gray-500">-</span>
-              }
-            </div>
+            <lfx-mentorship-row-actions [personName]="row.name" [actions]="row.actions" [testId]="'mentorship-mentee-actions-' + row.id" />
           </td>
         </tr>
       </ng-template>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white">
     <lfx-table
       [value]="rows()"
       dataKey="id"
@@ -47,7 +47,7 @@
       [rowsPerPageOptions]="rowsPerPageOptions"
       [showCurrentPageReport]="true"
       currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-      tableStyleClass="table-fixed"
+      tableStyleClass="table-fixed min-w-[48rem]"
       paginatorDropdownAppendTo="body"
       ariaLabel="Current mentees">
       <ng-template #header>
@@ -63,27 +63,15 @@
       <ng-template #body let-row>
         <tr [attr.data-testid]="'mentorship-mentee-row-' + row.id">
           <td class="px-4 py-3 max-w-[32%]">
-            <div class="flex items-center gap-3 min-w-0 w-full">
-              <lfx-avatar
-                [image]="row.avatarUrl ?? ''"
-                [label]="row.initials"
-                shape="circle"
-                size="normal"
-                [styleClass]="row.avatarStyleClass"
-                [ariaLabel]="row.name" />
-              <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
-                <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="row.name">{{ row.name }}</span>
-                <button
-                  type="button"
-                  class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
-                  [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
-                  [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
-                  (click)="onOpenNote(row.id, row.name)"
-                  [attr.data-testid]="'mentorship-mentee-note-' + row.id">
-                  {{ row.noteLabel }}
-                </button>
-              </div>
-            </div>
+            <lfx-mentorship-person-cell
+              [name]="row.name"
+              [initials]="row.initials"
+              [avatarStyleClass]="row.avatarStyleClass"
+              [avatarUrl]="row.avatarUrl"
+              [noteLabel]="row.noteLabel"
+              [hasNote]="row.hasNote"
+              [noteTestId]="'mentorship-mentee-note-' + row.id"
+              (noteClick)="onOpenNote(row.id, row.name)" />
           </td>
           <td class="px-4 py-3">
             <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">
@@ -95,6 +83,7 @@
               <button
                 type="button"
                 class="max-w-full block truncate text-sm text-blue-600 transition-colors hover:text-blue-700 hover:underline"
+                [title]="row.taskLabel"
                 [attr.aria-label]="'View tasks for ' + row.name"
                 (click)="onAction('View tasks for ' + row.name)"
                 [attr.data-testid]="'mentorship-mentee-tasks-' + row.id">

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.html
@@ -62,8 +62,8 @@
 
       <ng-template #body let-row>
         <tr [attr.data-testid]="'mentorship-mentee-row-' + row.id">
-          <td class="px-4 py-3">
-            <div class="flex items-center gap-3 min-w-0">
+          <td class="px-4 py-3 max-w-[32%]">
+            <div class="flex items-center gap-3 min-w-0 w-full">
               <lfx-avatar
                 [image]="row.avatarUrl ?? ''"
                 [label]="row.initials"
@@ -71,11 +71,11 @@
                 size="normal"
                 [styleClass]="row.avatarStyleClass"
                 [ariaLabel]="row.name" />
-              <div class="flex flex-col min-w-0">
-                <span class="text-sm font-medium text-blue-600 truncate" [title]="row.name">{{ row.name }}</span>
+              <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
+                <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="row.name">{{ row.name }}</span>
                 <button
                   type="button"
-                  class="text-xs text-gray-500 truncate text-left transition-colors hover:text-blue-600"
+                  class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
                   [title]="row.hasNote ? row.noteLabel : 'Add a reviewer note for ' + row.name"
                   [attr.aria-label]="(row.hasNote ? 'Edit' : 'Add') + ' reviewer note for ' + row.name"
                   (click)="onOpenNote(row.id)"
@@ -90,18 +90,18 @@
               {{ row.statusLabel }}
             </span>
           </td>
-          <td class="px-4 py-3">
+          <td class="px-4 py-3 max-w-[20%]">
             @if (row.taskLabel) {
               <button
                 type="button"
-                class="text-sm text-blue-600 transition-colors hover:text-blue-700 hover:underline"
+                class="max-w-full block truncate text-sm text-blue-600 transition-colors hover:text-blue-700 hover:underline"
                 [attr.aria-label]="'View tasks for ' + row.name"
                 (click)="onViewTasks(row.name)"
                 [attr.data-testid]="'mentorship-mentee-tasks-' + row.id">
                 {{ row.taskLabel }}
               </button>
             } @else {
-              <span class="text-sm text-gray-500">No tasks assigned</span>
+              <span class="max-w-full block truncate text-sm text-gray-500">No tasks assigned</span>
             }
           </td>
           <td class="px-4 py-3">

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CurrentMenteesTabComponent } from './current-mentees-tab.component';
+
+describe('CurrentMenteesTabComponent', () => {
+  const mentee = (overrides: Partial<MentorshipProgramMentee> = {}): MentorshipProgramMentee => ({
+    id: 'mnt_1',
+    name: 'Alex Rivera',
+    email: 'alex.rivera@example.com',
+    status: 'accepted',
+    termName: 'Fall 2026',
+    tasksSubmitted: 7,
+    tasksTotal: 12,
+    ...overrides,
+  });
+
+  let fixture: ComponentFixture<CurrentMenteesTabComponent>;
+  let dialogOpen: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    dialogOpen = vi.fn(() => ({ onClose: of('a saved note') }));
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [CurrentMenteesTabComponent],
+      providers: [provideNoopAnimations(), MessageService, { provide: DialogService, useValue: { open: dialogOpen } }],
+    });
+
+    fixture = TestBed.createComponent(CurrentMenteesTabComponent);
+    fixture.componentRef.setInput('mentees', [mentee(), mentee({ id: 'mnt_2', name: 'Priya Shah', status: 'graduated' })]);
+    fixture.detectChanges();
+  });
+
+  const headerLabels = (): string[] =>
+    Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('thead th')).map((th) => (th.textContent ?? '').trim());
+
+  it('renders the columns with Actions last', () => {
+    expect(headerLabels()).toEqual(['Mentee', 'Status', 'Tasks', 'Create Task', 'Actions']);
+  });
+
+  it('renders a row per mentee with its task progress', () => {
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('[data-testid="mentorship-mentee-row-mnt_1"]')).toBeTruthy();
+    expect(element.querySelector('[data-testid="mentorship-mentee-tasks-mnt_1"]')?.textContent?.trim()).toBe('7 of 12 submitted');
+  });
+
+  it('offers only the two statuses this tab lists, and no term filter', () => {
+    const element = fixture.nativeElement as HTMLElement;
+
+    // The LFX form wrappers project `dataTest` as `data-test`, not `data-testid`.
+    expect(element.querySelector('[data-test="mentorship-mentees-status"]')).toBeTruthy();
+    expect(element.querySelector('[data-test="mentorship-mentees-term"]')).toBeNull();
+    expect(fixture.componentInstance['statusOptions'].map((option) => option.label)).toEqual(['All statuses', 'Accepted', 'Graduated']);
+  });
+
+  it('stores the note returned by the dialog against the row it was opened for', () => {
+    const element = fixture.nativeElement as HTMLElement;
+    const noteButton = element.querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_2"]');
+
+    expect(noteButton?.textContent?.trim()).toBe('Add note');
+
+    noteButton?.click();
+    fixture.detectChanges();
+
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    expect(element.querySelector('[data-testid="mentorship-mentee-note-mnt_2"]')?.textContent?.trim()).toBe('a saved note');
+    // The note must land on the row it was opened for, not leak across rows.
+    expect(element.querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('Add note');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
@@ -58,15 +58,6 @@ describe('CurrentMenteesTabComponent', () => {
     expect(fixture.componentInstance['statusOptions'].map((option) => option.label)).toEqual(['All statuses', 'Accepted', 'Graduated']);
   });
 
-  it('lists only enrolled mentees, leaving the rest to the Applicants tab', () => {
-    fixture.componentRef.setInput('mentees', [mentee(), mentee({ id: 'mnt_3', name: 'Sam Okoro', status: 'pending' })]);
-    fixture.detectChanges();
-
-    const element = fixture.nativeElement as HTMLElement;
-    expect(element.querySelector('[data-testid="mentorship-mentee-row-mnt_1"]')).toBeTruthy();
-    expect(element.querySelector('[data-testid="mentorship-mentee-row-mnt_3"]')).toBeNull();
-  });
-
   it('asks the parent to open the note rather than owning the dialog itself', () => {
     const requests: MentorshipNoteRequest[] = [];
     fixture.componentInstance.noteRequested.subscribe((request) => requests.push(request));

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
@@ -3,11 +3,9 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { MentorshipNoteRequest, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { DialogService } from 'primeng/dynamicdialog';
-import { of } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { CurrentMenteesTabComponent } from './current-mentees-tab.component';
 
@@ -24,15 +22,12 @@ describe('CurrentMenteesTabComponent', () => {
   });
 
   let fixture: ComponentFixture<CurrentMenteesTabComponent>;
-  let dialogOpen: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    dialogOpen = vi.fn(() => ({ onClose: of('a saved note') }));
-
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       imports: [CurrentMenteesTabComponent],
-      providers: [provideNoopAnimations(), MessageService, { provide: DialogService, useValue: { open: dialogOpen } }],
+      providers: [provideNoopAnimations(), MessageService],
     });
 
     fixture = TestBed.createComponent(CurrentMenteesTabComponent);
@@ -63,18 +58,33 @@ describe('CurrentMenteesTabComponent', () => {
     expect(fixture.componentInstance['statusOptions'].map((option) => option.label)).toEqual(['All statuses', 'Accepted', 'Graduated']);
   });
 
-  it('stores the note returned by the dialog against the row it was opened for', () => {
-    const element = fixture.nativeElement as HTMLElement;
-    const noteButton = element.querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_2"]');
-
-    expect(noteButton?.textContent?.trim()).toBe('Add note');
-
-    noteButton?.click();
+  it('lists only enrolled mentees, leaving the rest to the Applicants tab', () => {
+    fixture.componentRef.setInput('mentees', [mentee(), mentee({ id: 'mnt_3', name: 'Sam Okoro', status: 'pending' })]);
     fixture.detectChanges();
 
-    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('[data-testid="mentorship-mentee-row-mnt_1"]')).toBeTruthy();
+    expect(element.querySelector('[data-testid="mentorship-mentee-row-mnt_3"]')).toBeNull();
+  });
+
+  it('asks the parent to open the note rather than owning the dialog itself', () => {
+    const requests: MentorshipNoteRequest[] = [];
+    fixture.componentInstance.noteRequested.subscribe((request) => requests.push(request));
+
+    const element = fixture.nativeElement as HTMLElement;
+    element.querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_2"]')?.click();
+
+    expect(requests).toEqual([{ personId: 'mnt_2', personName: 'Priya Shah' }]);
+  });
+
+  it('renders the parent note draft in place of the note the row arrived with', () => {
+    fixture.componentRef.setInput('mentees', [mentee({ note: 'from the server' }), mentee({ id: 'mnt_2', name: 'Priya Shah', status: 'graduated' })]);
+    fixture.componentRef.setInput('noteDrafts', { mnt_2: 'a saved note' });
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
     expect(element.querySelector('[data-testid="mentorship-mentee-note-mnt_2"]')?.textContent?.trim()).toBe('a saved note');
-    // The note must land on the row it was opened for, not leak across rows.
-    expect(element.querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('Add note');
+    // A row without a draft keeps whatever it arrived with, rather than picking up a neighbour's.
+    expect(element.querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('from the server');
   });
 });

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.spec.ts
@@ -58,6 +58,33 @@ describe('CurrentMenteesTabComponent', () => {
     expect(fixture.componentInstance['statusOptions'].map((option) => option.label)).toEqual(['All statuses', 'Accepted', 'Graduated']);
   });
 
+  it('narrows the rows to the chosen status, and back again when cleared', () => {
+    const component = fixture.componentInstance;
+
+    component['form'].controls.status.setValue('graduated');
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['mnt_2']);
+
+    component['form'].controls.status.setValue('accepted');
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['mnt_1']);
+
+    component['form'].controls.status.reset(null);
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['mnt_1', 'mnt_2']);
+  });
+
+  it('returns to the first page when a filter narrows the list', () => {
+    const component = fixture.componentInstance;
+    component['first'].set(10);
+
+    component['form'].controls.search.setValue('Priya');
+    fixture.detectChanges();
+
+    // Otherwise the table stays on an offset the filtered list no longer reaches.
+    expect(component['first']()).toBe(0);
+  });
+
   it('asks the parent to open the note rather than owning the dialog itself', () => {
     const requests: MentorshipNoteRequest[] = [];
     fixture.componentInstance.noteRequested.subscribe((request) => requests.push(request));

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -1,12 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
-import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
@@ -25,14 +24,16 @@ import {
   formatMentorshipTaskProgress,
   matchesMentorshipPersonSearch,
   mentorshipMenteeActionsFor,
+  mentorshipNoteDisplay,
   mentorshipPersonAvatarClass,
   mentorshipPersonInitials,
+  mentorshipRowActions,
 } from '@lfx-one/shared/utils';
-import { MenuItem } from 'primeng/api';
-import { startWith } from 'rxjs';
+import { startWith, tap } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 import { PersonCellComponent } from '../person-cell/person-cell.component';
+import { RowActionsComponent } from '../row-actions/row-actions.component';
 
 /**
  * Current mentees tab — task progress plus the reviewer note. Lists only the enrolled
@@ -44,7 +45,7 @@ import { PersonCellComponent } from '../person-cell/person-cell.component';
  */
 @Component({
   selector: 'lfx-mentorship-current-mentees-tab',
-  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent, MenuComponent, PersonCellComponent, SelectComponent, TableComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent, PersonCellComponent, RowActionsComponent, SelectComponent, TableComponent],
   templateUrl: './current-mentees-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -70,9 +71,20 @@ export class CurrentMenteesTabComponent {
     status: new FormControl<MentorshipMenteeStatus | null>(null),
   });
 
-  private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
-    initialValue: this.form.getRawValue(),
-  });
+  /**
+   * Paginator offset. Tracked so that narrowing the list can send the table back to the
+   * first page — PrimeNG keeps its own offset when the value array shrinks underneath it,
+   * which would otherwise leave the admin on a page that no longer exists.
+   */
+  protected readonly first = signal(0);
+
+  private readonly filters = toSignal(
+    this.form.valueChanges.pipe(
+      tap(() => this.first.set(0)),
+      startWith(this.form.getRawValue())
+    ),
+    { initialValue: this.form.getRawValue() }
+  );
 
   protected readonly rows = this.initRows();
 
@@ -94,16 +106,7 @@ export class CurrentMenteesTabComponent {
     });
   }
 
-  private menuItemsFor(person: MentorshipProgramMentee): MenuItem[] {
-    return mentorshipMenteeActionsFor(person.status).map((action) => ({
-      label: MENTORSHIP_MENTEE_ACTION_LABELS[action],
-      icon: MENTORSHIP_MENTEE_ACTION_ICONS[action],
-      command: () => this.comingSoon.notify(`${MENTORSHIP_MENTEE_ACTION_LABELS[action]} ${person.name}`),
-    }));
-  }
-
   private toRow(person: MentorshipProgramMentee) {
-    const note = (this.noteDrafts()[person.id] ?? person.note ?? '').trim();
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
@@ -111,9 +114,8 @@ export class CurrentMenteesTabComponent {
       statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
       statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
       taskLabel: formatMentorshipTaskProgress(person.tasksSubmitted, person.tasksTotal),
-      hasNote: note.length > 0,
-      noteLabel: note.length > 0 ? note : MENTORSHIP_ADD_NOTE_LABEL,
-      menuItems: this.menuItemsFor(person),
+      ...mentorshipNoteDisplay(this.noteDrafts(), person, MENTORSHIP_ADD_NOTE_LABEL),
+      actions: mentorshipRowActions(mentorshipMenteeActionsFor(person.status), MENTORSHIP_MENTEE_ACTION_LABELS, MENTORSHIP_MENTEE_ACTION_ICONS),
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -18,11 +18,16 @@ import {
   MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS,
   MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTEE_STATUS_LABELS,
-  MENTORSHIP_PROGRAM_AVATAR_PALETTE,
   MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
 } from '@lfx-one/shared/constants';
 import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
-import { formatMentorshipTaskProgress, matchesMentorshipPersonSearch, mentorshipMenteeActionsFor, mentorshipPersonInitials } from '@lfx-one/shared/utils';
+import {
+  formatMentorshipTaskProgress,
+  matchesMentorshipPersonSearch,
+  mentorshipMenteeActionsFor,
+  mentorshipPersonAvatarClass,
+  mentorshipPersonInitials,
+} from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { startWith, take } from 'rxjs';
@@ -142,12 +147,11 @@ export class CurrentMenteesTabComponent {
   }
 
   private toRow(person: MentorshipProgramMentee) {
-    const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
     const note = person.note?.trim() ?? '';
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
-      avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
+      avatarStyleClass: mentorshipPersonAvatarClass(person.name),
       statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
       statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
       taskLabel: formatMentorshipTaskProgress(person.tasksSubmitted, person.tasksTotal),

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -20,7 +20,7 @@ import {
   MENTORSHIP_PERSON_PAGE_SIZE,
   MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
 } from '@lfx-one/shared/constants';
-import { MentorshipMenteeStatus, MentorshipNoteRequest, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { FilterOption, MentorshipMenteeStatus, MentorshipNoteRequest, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import {
   formatMentorshipTaskProgress,
   matchesMentorshipPersonSearch,
@@ -60,7 +60,7 @@ export class CurrentMenteesTabComponent {
   protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
 
   /** Fixed rather than derived from the rows: the two statuses this tab can list. */
-  protected readonly statusOptions = [
+  protected readonly statusOptions: FilterOption<MentorshipMenteeStatus | null>[] = [
     { label: MENTORSHIP_ALL_STATUSES_OPTION_LABEL, value: null },
     ...MENTORSHIP_CURRENT_MENTEE_STATUSES.map((status) => ({ label: MENTORSHIP_MENTEE_STATUS_LABELS[status], value: status })),
   ];

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input, linkedSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
@@ -11,16 +11,17 @@ import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
+  MENTORSHIP_ADD_NOTE_LABEL,
+  MENTORSHIP_ALL_STATUSES_OPTION_LABEL,
   MENTORSHIP_CURRENT_MENTEE_STATUSES,
   MENTORSHIP_MENTEE_ACTION_ICONS,
   MENTORSHIP_MENTEE_ACTION_LABELS,
-  MENTORSHIP_PERSON_PAGE_SIZE,
-  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
   MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTEE_STATUS_LABELS,
-  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+  MENTORSHIP_PERSON_PAGE_SIZE,
+  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
 } from '@lfx-one/shared/constants';
-import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { MentorshipMenteeStatus, MentorshipNoteRequest, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import {
   formatMentorshipTaskProgress,
   matchesMentorshipPersonSearch,
@@ -28,18 +29,18 @@ import {
   mentorshipPersonAvatarClass,
   mentorshipPersonInitials,
 } from '@lfx-one/shared/utils';
-import { MenuItem, MessageService } from 'primeng/api';
-import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { startWith, take } from 'rxjs';
+import { MenuItem } from 'primeng/api';
+import { startWith } from 'rxjs';
 
-import { MenteeNoteDialogComponent } from '../mentee-note-dialog/mentee-note-dialog.component';
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 
 /**
- * Current mentees tab — task progress plus the reviewer note, filtered by search and
- * status (accepted / graduated, the only statuses this tab lists). Row actions
- * (withdraw / decline / graduate), Create Task, View Tasks, and the status export all
- * stub to a "coming soon" toast until the backend lands; the reviewer note is the one
- * action that takes effect, held locally.
+ * Current mentees tab — task progress plus the reviewer note. Lists only the enrolled
+ * statuses (accepted / graduated); everyone else belongs to the Applicants tab, and the
+ * status filter offers exactly the two it lists. Row actions (withdraw / decline /
+ * graduate), Create Task, View Tasks, and the status export all stub to a "coming soon"
+ * toast until the backend lands. The reviewer note is the one action that takes effect;
+ * the parent owns its state, so it outlives a tab switch.
  */
 @Component({
   selector: 'lfx-mentorship-current-mentees-tab',
@@ -48,17 +49,19 @@ import { MenteeNoteDialogComponent } from '../mentee-note-dialog/mentee-note-dia
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CurrentMenteesTabComponent {
-  public readonly mentees = input.required<MentorshipProgramMentee[]>();
+  private readonly comingSoon = inject(MentorshipComingSoonService);
 
-  private readonly dialogService = inject(DialogService);
-  private readonly messageService = inject(MessageService);
+  public readonly mentees = input.required<MentorshipProgramMentee[]>();
+  /** Notes edited this session, keyed by person id; overrides the note a row arrived with. */
+  public readonly noteDrafts = input<Record<string, string>>({});
+  public readonly noteRequested = output<MentorshipNoteRequest>();
 
   protected readonly pageSize = MENTORSHIP_PERSON_PAGE_SIZE;
   protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
 
   /** Fixed rather than derived from the rows: the two statuses this tab can list. */
   protected readonly statusOptions = [
-    { label: 'All statuses', value: null },
+    { label: MENTORSHIP_ALL_STATUSES_OPTION_LABEL, value: null },
     ...MENTORSHIP_CURRENT_MENTEE_STATUSES.map((status) => ({ label: MENTORSHIP_MENTEE_STATUS_LABELS[status], value: status })),
   ];
 
@@ -71,83 +74,37 @@ export class CurrentMenteesTabComponent {
     initialValue: this.form.getRawValue(),
   });
 
-  /**
-   * Reviewer notes are local until a write endpoint exists, so a re-emission of the
-   * same upstream mentees must keep them. Only a genuinely different set resets.
-   */
-  protected readonly draftMentees = linkedSignal<MentorshipProgramMentee[], MentorshipProgramMentee[]>({
-    source: this.mentees,
-    computation: (mentees, previous) => (previous && this.sameMenteeIds(previous.source, mentees) ? previous.value : mentees),
-  });
-
   protected readonly rows = this.initRows();
 
-  protected onOpenNote(id: string): void {
-    const mentee = this.draftMentees().find((person) => person.id === id);
-    if (!mentee) return;
-
-    const dialogRef = this.dialogService.open(MenteeNoteDialogComponent, {
-      header: 'Reviewer note',
-      width: '34rem',
-      modal: true,
-      closable: true,
-      dismissableMask: true,
-      data: { menteeId: mentee.id, menteeName: mentee.name, note: mentee.note ?? '' },
-    }) as DynamicDialogRef;
-
-    dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
-      // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
-      // an empty string is an explicit clear.
-      if (note === undefined) return;
-      this.draftMentees.set(this.draftMentees().map((person) => (person.id === id ? { ...person, note: note || undefined } : person)));
-    });
+  protected onOpenNote(id: string, name: string): void {
+    this.noteRequested.emit({ personId: id, personName: name });
   }
 
-  protected onCreateTask(name: string): void {
-    this.toastComingSoon(`Create a task for ${name}`);
-  }
-
-  protected onViewTasks(name: string): void {
-    this.toastComingSoon(`View tasks for ${name}`);
-  }
-
-  protected onDownloadByStatus(): void {
-    this.toastComingSoon('Download by status');
-  }
-
-  private toastComingSoon(summary: string): void {
-    this.messageService.add({
-      severity: 'info',
-      summary,
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-      life: 4000,
-    });
-  }
-
-  private sameMenteeIds(a: MentorshipProgramMentee[], b: MentorshipProgramMentee[]): boolean {
-    return a.length === b.length && a.every((mentee, index) => mentee.id === b[index].id);
-  }
-
-  private menuItemsFor(person: MentorshipProgramMentee): MenuItem[] {
-    return mentorshipMenteeActionsFor(person.status).map((action) => ({
-      label: MENTORSHIP_MENTEE_ACTION_LABELS[action],
-      icon: MENTORSHIP_MENTEE_ACTION_ICONS[action],
-      command: () => this.toastComingSoon(`${MENTORSHIP_MENTEE_ACTION_LABELS[action]} ${person.name}`),
-    }));
+  protected onAction(summary: string): void {
+    this.comingSoon.notify(summary);
   }
 
   private initRows() {
     return computed(() => {
       const { search, status } = this.filters();
-      return this.draftMentees()
+      return this.mentees()
+        .filter((person) => MENTORSHIP_CURRENT_MENTEE_STATUSES.includes(person.status))
         .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
         .filter((person) => !status || person.status === status)
         .map((person) => this.toRow(person));
     });
   }
 
+  private menuItemsFor(person: MentorshipProgramMentee): MenuItem[] {
+    return mentorshipMenteeActionsFor(person.status).map((action) => ({
+      label: MENTORSHIP_MENTEE_ACTION_LABELS[action],
+      icon: MENTORSHIP_MENTEE_ACTION_ICONS[action],
+      command: () => this.comingSoon.notify(`${MENTORSHIP_MENTEE_ACTION_LABELS[action]} ${person.name}`),
+    }));
+  }
+
   private toRow(person: MentorshipProgramMentee) {
-    const note = person.note?.trim() ?? '';
+    const note = (this.noteDrafts()[person.id] ?? person.note ?? '').trim();
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
@@ -156,7 +113,7 @@ export class CurrentMenteesTabComponent {
       statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
       taskLabel: formatMentorshipTaskProgress(person.tasksSubmitted, person.tasksTotal),
       hasNote: note.length > 0,
-      noteLabel: note.length > 0 ? note : 'Add note',
+      noteLabel: note.length > 0 ? note : MENTORSHIP_ADD_NOTE_LABEL,
       menuItems: this.menuItemsFor(person),
     };
   }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -4,7 +4,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MenuComponent } from '@components/menu/menu.component';
@@ -33,6 +32,7 @@ import { MenuItem } from 'primeng/api';
 import { startWith } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { PersonCellComponent } from '../person-cell/person-cell.component';
 
 /**
  * Current mentees tab — task progress plus the reviewer note. Lists only the enrolled
@@ -44,7 +44,7 @@ import { MentorshipComingSoonService } from '../../services/mentorship-coming-so
  */
 @Component({
   selector: 'lfx-mentorship-current-mentees-tab',
-  imports: [ReactiveFormsModule, AvatarComponent, ButtonComponent, InputTextComponent, MenuComponent, SelectComponent, TableComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent, MenuComponent, PersonCellComponent, SelectComponent, TableComponent],
   templateUrl: './current-mentees-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -88,7 +88,6 @@ export class CurrentMenteesTabComponent {
     return computed(() => {
       const { search, status } = this.filters();
       return this.mentees()
-        .filter((person) => MENTORSHIP_CURRENT_MENTEE_STATUSES.includes(person.status))
         .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
         .filter((person) => !status || person.status === status)
         .map((person) => this.toRow(person));

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -14,8 +14,8 @@ import {
   MENTORSHIP_CURRENT_MENTEE_STATUSES,
   MENTORSHIP_MENTEE_ACTION_ICONS,
   MENTORSHIP_MENTEE_ACTION_LABELS,
-  MENTORSHIP_MENTEE_PAGE_SIZE,
-  MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS,
+  MENTORSHIP_PERSON_PAGE_SIZE,
+  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
   MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTEE_STATUS_LABELS,
   MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
@@ -53,8 +53,8 @@ export class CurrentMenteesTabComponent {
   private readonly dialogService = inject(DialogService);
   private readonly messageService = inject(MessageService);
 
-  protected readonly pageSize = MENTORSHIP_MENTEE_PAGE_SIZE;
-  protected readonly rowsPerPageOptions = MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS;
+  protected readonly pageSize = MENTORSHIP_PERSON_PAGE_SIZE;
+  protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
 
   /** Fixed rather than derived from the rows: the two statuses this tab can list. */
   protected readonly statusOptions = [

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -1,28 +1,61 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+import { MenuComponent } from '@components/menu/menu.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES, MENTORSHIP_MENTEE_STATUS_LABELS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '@lfx-one/shared/constants';
+import { TableComponent } from '@components/table/table.component';
+import {
+  MENTORSHIP_CURRENT_MENTEE_STATUSES,
+  MENTORSHIP_MENTEE_ACTION_ICONS,
+  MENTORSHIP_MENTEE_ACTION_LABELS,
+  MENTORSHIP_MENTEE_PAGE_SIZE,
+  MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS,
+  MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
+  MENTORSHIP_MENTEE_STATUS_LABELS,
+  MENTORSHIP_PROGRAM_AVATAR_PALETTE,
+  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+} from '@lfx-one/shared/constants';
 import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
-import { matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
-import { startWith } from 'rxjs';
+import { formatMentorshipTaskProgress, matchesMentorshipPersonSearch, mentorshipMenteeActionsFor, mentorshipPersonInitials } from '@lfx-one/shared/utils';
+import { MenuItem, MessageService } from 'primeng/api';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { startWith, take } from 'rxjs';
+
+import { MenteeNoteDialogComponent } from '../mentee-note-dialog/mentee-note-dialog.component';
 
 /**
- * Current mentees tab — accepted / graduated people with search + status filter.
+ * Current mentees tab — task progress plus the reviewer note, filtered by search and
+ * status (accepted / graduated, the only statuses this tab lists). Row actions
+ * (withdraw / decline / graduate), Create Task, View Tasks, and the status export all
+ * stub to a "coming soon" toast until the backend lands; the reviewer note is the one
+ * action that takes effect, held locally.
  */
 @Component({
   selector: 'lfx-mentorship-current-mentees-tab',
-  imports: [ReactiveFormsModule, AvatarComponent, InputTextComponent, SelectComponent],
+  imports: [ReactiveFormsModule, AvatarComponent, ButtonComponent, InputTextComponent, MenuComponent, SelectComponent, TableComponent],
   templateUrl: './current-mentees-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CurrentMenteesTabComponent {
   public readonly mentees = input.required<MentorshipProgramMentee[]>();
+
+  private readonly dialogService = inject(DialogService);
+  private readonly messageService = inject(MessageService);
+
+  protected readonly pageSize = MENTORSHIP_MENTEE_PAGE_SIZE;
+  protected readonly rowsPerPageOptions = MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS;
+
+  /** Fixed rather than derived from the rows: the two statuses this tab can list. */
+  protected readonly statusOptions = [
+    { label: 'All statuses', value: null },
+    ...MENTORSHIP_CURRENT_MENTEE_STATUSES.map((status) => ({ label: MENTORSHIP_MENTEE_STATUS_LABELS[status], value: status })),
+  ];
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
@@ -33,33 +66,94 @@ export class CurrentMenteesTabComponent {
     initialValue: this.form.getRawValue(),
   });
 
-  protected readonly statusOptions = computed(() => {
-    const statuses = [...new Set(this.mentees().map((person) => person.status))];
-    return [
-      { label: 'All statuses', value: null },
-      ...statuses.map((status) => ({
-        label: MENTORSHIP_MENTEE_STATUS_LABELS[status],
-        value: status,
-      })),
-    ];
+  /**
+   * Reviewer notes are local until a write endpoint exists, so a re-emission of the
+   * same upstream mentees must keep them. Only a genuinely different set resets.
+   */
+  protected readonly draftMentees = linkedSignal<MentorshipProgramMentee[], MentorshipProgramMentee[]>({
+    source: this.mentees,
+    computation: (mentees, previous) => (previous && this.sameMenteeIds(previous.source, mentees) ? previous.value : mentees),
   });
 
-  protected readonly rows = computed(() => {
-    const { search, status } = this.filters();
-    return this.mentees()
-      .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
-      .filter((person) => !status || person.status === status)
-      .map((person) => this.toRow(person));
-  });
+  protected readonly rows = this.initRows();
+
+  protected onOpenNote(id: string): void {
+    const mentee = this.draftMentees().find((person) => person.id === id);
+    if (!mentee) return;
+
+    const dialogRef = this.dialogService.open(MenteeNoteDialogComponent, {
+      header: 'Reviewer note',
+      width: '34rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { menteeId: mentee.id, menteeName: mentee.name, note: mentee.note ?? '' },
+    }) as DynamicDialogRef;
+
+    dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
+      // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
+      // an empty string is an explicit clear.
+      if (note === undefined) return;
+      this.draftMentees.set(this.draftMentees().map((person) => (person.id === id ? { ...person, note: note || undefined } : person)));
+    });
+  }
+
+  protected onCreateTask(name: string): void {
+    this.toastComingSoon(`Create a task for ${name}`);
+  }
+
+  protected onViewTasks(name: string): void {
+    this.toastComingSoon(`View tasks for ${name}`);
+  }
+
+  protected onDownloadByStatus(): void {
+    this.toastComingSoon('Download by status');
+  }
+
+  private toastComingSoon(summary: string): void {
+    this.messageService.add({
+      severity: 'info',
+      summary,
+      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      life: 4000,
+    });
+  }
+
+  private sameMenteeIds(a: MentorshipProgramMentee[], b: MentorshipProgramMentee[]): boolean {
+    return a.length === b.length && a.every((mentee, index) => mentee.id === b[index].id);
+  }
+
+  private menuItemsFor(person: MentorshipProgramMentee): MenuItem[] {
+    return mentorshipMenteeActionsFor(person.status).map((action) => ({
+      label: MENTORSHIP_MENTEE_ACTION_LABELS[action],
+      icon: MENTORSHIP_MENTEE_ACTION_ICONS[action],
+      command: () => this.toastComingSoon(`${MENTORSHIP_MENTEE_ACTION_LABELS[action]} ${person.name}`),
+    }));
+  }
+
+  private initRows() {
+    return computed(() => {
+      const { search, status } = this.filters();
+      return this.draftMentees()
+        .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
+        .filter((person) => !status || person.status === status)
+        .map((person) => this.toRow(person));
+    });
+  }
 
   private toRow(person: MentorshipProgramMentee) {
     const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
+    const note = person.note?.trim() ?? '';
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
       avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
       statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
       statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
+      taskLabel: formatMentorshipTaskProgress(person.tasksSubmitted, person.tasksTotal),
+      hasNote: note.length > 0,
+      noteLabel: note.length > 0 ? note : 'Add note',
+      menuItems: this.menuItemsFor(person),
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.html
@@ -1,0 +1,28 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4" data-testid="mentorship-mentee-note-dialog">
+  <p class="text-sm text-gray-600">
+    Shared note for <span class="font-semibold text-gray-900">{{ data.menteeName }}</span
+    >. {{ noteVisibility }}
+  </p>
+
+  <div class="flex flex-col gap-1">
+    <label class="sr-only" for="dialog-mentee-note">Reviewer note</label>
+    <lfx-textarea
+      [form]="form"
+      control="note"
+      inputId="dialog-mentee-note"
+      [placeholder]="notePlaceholder"
+      [rows]="7"
+      [maxlength]="noteMax"
+      styleClass="w-full min-h-40"
+      dataTest="mentorship-mentee-note-input" />
+    <span class="self-end text-xs text-gray-400" aria-hidden="true">{{ noteLength() }}/{{ noteMax }}</span>
+  </div>
+
+  <div class="flex items-center justify-end gap-2">
+    <lfx-button label="Cancel" severity="secondary" size="small" [text]="true" (onClick)="onCancel()" data-testid="mentorship-mentee-note-cancel" />
+    <lfx-button label="Save" severity="primary" size="small" (onClick)="onSave()" data-testid="mentorship-mentee-note-save" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.html
@@ -3,7 +3,7 @@
 
 <div class="flex flex-col gap-4" data-testid="mentorship-mentee-note-dialog">
   <p class="text-sm text-gray-600">
-    Shared note for <span class="font-semibold text-gray-900">{{ data.menteeName }}</span
+    Shared note for <span class="font-semibold text-gray-900">{{ data.personName }}</span
     >. {{ noteVisibility }}
   </p>
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.spec.ts
@@ -4,19 +4,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MENTORSHIP_MENTEE_NOTE_MAX } from '@lfx-one/shared/constants';
-import { MentorshipMenteeNoteDialogData } from '@lfx-one/shared/interfaces';
+import { MentorshipNoteDialogData } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MenteeNoteDialogComponent } from './mentee-note-dialog.component';
 
 describe('MenteeNoteDialogComponent', () => {
-  const data: MentorshipMenteeNoteDialogData = { menteeId: 'mnt_1', menteeName: 'Alex Rivera', note: 'the existing note' };
+  const data: MentorshipNoteDialogData = { personName: 'Alex Rivera', note: 'the existing note' };
 
   let fixture: ComponentFixture<MenteeNoteDialogComponent>;
   let close: ReturnType<typeof vi.fn>;
 
-  const build = (overrides: Partial<MentorshipMenteeNoteDialogData> = {}): void => {
+  const build = (overrides: Partial<MentorshipNoteDialogData> = {}): void => {
     close = vi.fn();
 
     TestBed.resetTestingModule();

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.spec.ts
@@ -1,0 +1,77 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MENTORSHIP_MENTEE_NOTE_MAX } from '@lfx-one/shared/constants';
+import { MentorshipMenteeNoteDialogData } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MenteeNoteDialogComponent } from './mentee-note-dialog.component';
+
+describe('MenteeNoteDialogComponent', () => {
+  const data: MentorshipMenteeNoteDialogData = { menteeId: 'mnt_1', menteeName: 'Alex Rivera', note: 'the existing note' };
+
+  let fixture: ComponentFixture<MenteeNoteDialogComponent>;
+  let close: ReturnType<typeof vi.fn>;
+
+  const build = (overrides: Partial<MentorshipMenteeNoteDialogData> = {}): void => {
+    close = vi.fn();
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [MenteeNoteDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: { ...data, ...overrides } } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(MenteeNoteDialogComponent);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => build());
+
+  it('opens on the note the mentee already has', () => {
+    expect(fixture.componentInstance['form'].controls.note.value).toBe('the existing note');
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Alex Rivera');
+  });
+
+  it('closes with the trimmed note when saved', () => {
+    fixture.componentInstance['form'].controls.note.setValue('  a revised note  ');
+    fixture.componentInstance['onSave']();
+
+    expect(close).toHaveBeenCalledWith('a revised note');
+  });
+
+  it('closes with an empty string when the note is cleared, which is an explicit clear', () => {
+    fixture.componentInstance['form'].controls.note.setValue('');
+    fixture.componentInstance['onSave']();
+
+    expect(close).toHaveBeenCalledWith('');
+  });
+
+  it('closes with no value when dismissed, so the caller leaves the note untouched', () => {
+    fixture.componentInstance['form'].controls.note.setValue('an abandoned edit');
+    fixture.componentInstance['onCancel']();
+
+    expect(close).toHaveBeenCalledWith();
+  });
+
+  it('refuses to save a note past the character cap', () => {
+    fixture.componentInstance['form'].controls.note.setValue('x'.repeat(MENTORSHIP_MENTEE_NOTE_MAX + 1));
+    fixture.componentInstance['onSave']();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('counts the characters typed so far', () => {
+    fixture.componentInstance['form'].controls.note.setValue('four');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['noteLength']()).toBe(4);
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { TextareaComponent } from '@components/textarea/textarea.component';
+import { MENTORSHIP_MENTEE_NOTE_MAX, MENTORSHIP_MENTEE_NOTE_PLACEHOLDER, MENTORSHIP_MENTEE_NOTE_VISIBILITY } from '@lfx-one/shared/constants';
+import { MentorshipMenteeNoteDialogData } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+/**
+ * Reviewer-note dialog for a Current Mentees row. Closes with the trimmed note so
+ * the caller can store it — an empty string clears the note, `undefined` (dismissed)
+ * leaves it untouched.
+ */
+@Component({
+  selector: 'lfx-mentorship-mentee-note-dialog',
+  imports: [ReactiveFormsModule, ButtonComponent, TextareaComponent],
+  templateUrl: './mentee-note-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MenteeNoteDialogComponent {
+  private readonly dialogRef = inject(DynamicDialogRef);
+  private readonly dialogConfig = inject<DynamicDialogConfig<MentorshipMenteeNoteDialogData>>(DynamicDialogConfig);
+
+  protected readonly data: MentorshipMenteeNoteDialogData = this.dialogConfig.data ?? { menteeId: '', menteeName: '', note: '' };
+  protected readonly noteMax = MENTORSHIP_MENTEE_NOTE_MAX;
+  protected readonly notePlaceholder = MENTORSHIP_MENTEE_NOTE_PLACEHOLDER;
+  protected readonly noteVisibility = MENTORSHIP_MENTEE_NOTE_VISIBILITY;
+
+  protected readonly form = new FormGroup({
+    note: new FormControl(this.data.note, { nonNullable: true, validators: [Validators.maxLength(MENTORSHIP_MENTEE_NOTE_MAX)] }),
+  });
+
+  private readonly formSnapshot = toSignal(this.form.valueChanges, { initialValue: this.form.getRawValue() });
+
+  protected readonly noteLength = computed(() => String(this.formSnapshot().note ?? '').length);
+
+  protected onSave(): void {
+    if (this.form.invalid) return;
+    this.dialogRef.close(this.form.controls.note.value.trim());
+  }
+
+  protected onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentee-note-dialog/mentee-note-dialog.component.ts
@@ -7,13 +7,13 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonComponent } from '@components/button/button.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
 import { MENTORSHIP_MENTEE_NOTE_MAX, MENTORSHIP_MENTEE_NOTE_PLACEHOLDER, MENTORSHIP_MENTEE_NOTE_VISIBILITY } from '@lfx-one/shared/constants';
-import { MentorshipMenteeNoteDialogData } from '@lfx-one/shared/interfaces';
+import { MentorshipNoteDialogData } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 /**
- * Reviewer-note dialog for a Current Mentees row. Closes with the trimmed note so
- * the caller can store it — an empty string clears the note, `undefined` (dismissed)
- * leaves it untouched.
+ * Reviewer-note dialog for a program-detail person row — both the Current Mentees and
+ * Applicants tabs open it. Closes with the trimmed note so the caller can store it: an
+ * empty string clears the note, `undefined` (dismissed) leaves it untouched.
  */
 @Component({
   selector: 'lfx-mentorship-mentee-note-dialog',
@@ -23,9 +23,9 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 })
 export class MenteeNoteDialogComponent {
   private readonly dialogRef = inject(DynamicDialogRef);
-  private readonly dialogConfig = inject<DynamicDialogConfig<MentorshipMenteeNoteDialogData>>(DynamicDialogConfig);
+  private readonly dialogConfig = inject<DynamicDialogConfig<MentorshipNoteDialogData>>(DynamicDialogConfig);
 
-  protected readonly data: MentorshipMenteeNoteDialogData = this.dialogConfig.data ?? { menteeId: '', menteeName: '', note: '' };
+  protected readonly data: MentorshipNoteDialogData = this.dialogConfig.data ?? { personName: '', note: '' };
   protected readonly noteMax = MENTORSHIP_MENTEE_NOTE_MAX;
   protected readonly notePlaceholder = MENTORSHIP_MENTEE_NOTE_PLACEHOLDER;
   protected readonly noteVisibility = MENTORSHIP_MENTEE_NOTE_VISIBILITY;

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
@@ -75,7 +75,7 @@
               </div>
             </td>
             <td class="px-4 py-3">
-              <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+              <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">
                 {{ row.statusLabel }}
               </span>
             </td>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.html
@@ -41,6 +41,7 @@
         size="small"
         [disabled]="!canInvite()"
         (onClick)="onInviteMentor()"
+        styleClass="whitespace-nowrap !py-2.5"
         data-testid="mentorship-mentors-invite" />
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
@@ -8,14 +8,9 @@ import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import {
-  MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES,
-  MENTORSHIP_MENTOR_STATUS_LABELS,
-  MENTORSHIP_PROGRAM_AVATAR_PALETTE,
-  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-} from '@lfx-one/shared/constants';
+import { MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES, MENTORSHIP_MENTOR_STATUS_LABELS, MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
 import { MentorshipInvitableUser, MentorshipProgramMentor } from '@lfx-one/shared/interfaces';
-import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonInitials } from '@lfx-one/shared/utils';
+import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials } from '@lfx-one/shared/utils';
 import { MentorshipService } from '@services/mentorship.service';
 import { MessageService } from 'primeng/api';
 import { map, startWith } from 'rxjs';
@@ -90,11 +85,10 @@ export class MentorsTabComponent {
   }
 
   private toRow(person: MentorshipProgramMentor) {
-    const seed = person.name.length > 0 ? person.name.charCodeAt(0) : 0;
     return {
       ...person,
       initials: mentorshipPersonInitials(person.name),
-      avatarStyleClass: MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length],
+      avatarStyleClass: mentorshipPersonAvatarClass(person.name),
       statusLabel: MENTORSHIP_MENTOR_STATUS_LABELS[person.status],
       statusBadgeClass: MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES[person.status],
       invitationLabel: person.invitedOn ? formatIsoDateLabel(person.invitedOn) : '—',

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
@@ -8,12 +8,13 @@ import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES, MENTORSHIP_MENTOR_STATUS_LABELS, MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
+import { MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES, MENTORSHIP_MENTOR_STATUS_LABELS } from '@lfx-one/shared/constants';
 import { MentorshipInvitableUser, MentorshipProgramMentor } from '@lfx-one/shared/interfaces';
 import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials } from '@lfx-one/shared/utils';
 import { MentorshipService } from '@services/mentorship.service';
-import { MessageService } from 'primeng/api';
 import { map, startWith } from 'rxjs';
+
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 
 /**
  * Mentors tab — invitation status, dates, and profile-created flag. The toolbar
@@ -28,10 +29,10 @@ import { map, startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MentorsTabComponent {
-  public readonly mentors = input.required<MentorshipProgramMentor[]>();
-
-  private readonly messageService = inject(MessageService);
+  private readonly comingSoon = inject(MentorshipComingSoonService);
   private readonly mentorshipService = inject(MentorshipService);
+
+  public readonly mentors = input.required<MentorshipProgramMentor[]>();
 
   protected readonly form = new FormGroup({
     search: new FormControl('', { nonNullable: true }),
@@ -59,29 +60,20 @@ export class MentorsTabComponent {
     const inviteeId = this.form.controls.invitee.value;
     if (!inviteeId) return;
     const invitee = this.invitableUsers().find((user) => user.id === inviteeId);
-    this.toastComingSoon(`Invite ${invitee?.name ?? 'mentor'}`);
+    this.comingSoon.notify(`Invite ${invitee?.name ?? 'mentor'}`);
     this.form.controls.invitee.reset(null);
   }
 
   protected onAcceptMentor(name: string): void {
-    this.toastComingSoon(`Accept ${name}`);
+    this.comingSoon.notify(`Accept ${name}`);
   }
 
   protected onDeclineMentor(name: string): void {
-    this.toastComingSoon(`Decline ${name}`);
+    this.comingSoon.notify(`Decline ${name}`);
   }
 
   protected onDeleteMentor(name: string): void {
-    this.toastComingSoon(`Remove ${name}`);
-  }
-
-  private toastComingSoon(summary: string): void {
-    this.messageService.add({
-      severity: 'info',
-      summary,
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-      life: 4000,
-    });
+    this.comingSoon.notify(`Remove ${name}`);
   }
 
   private toRow(person: MentorshipProgramMentor) {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
@@ -73,8 +73,8 @@
 
       <ng-template #body let-row>
         <tr [attr.data-testid]="'mentorship-past-mentee-row-' + row.id">
-          <td class="px-4 py-3">
-            <div class="flex items-center gap-3 min-w-0">
+          <td class="px-4 py-3 max-w-[46%]">
+            <div class="flex items-center gap-3 min-w-0 w-full">
               <lfx-avatar
                 [image]="row.avatarUrl ?? ''"
                 [label]="row.initials"
@@ -82,9 +82,8 @@
                 size="normal"
                 [styleClass]="row.avatarStyleClass"
                 [ariaLabel]="row.name" />
-              <div class="flex flex-col min-w-0">
-                <span class="text-sm font-medium text-blue-600 truncate" [title]="row.name">{{ row.name }}</span>
-                <span class="text-xs text-gray-500 truncate" [title]="row.email">{{ row.email }}</span>
+              <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
+                <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="row.name">{{ row.name }}</span>
               </div>
             </div>
           </td>
@@ -93,7 +92,9 @@
               {{ row.statusLabel }}
             </span>
           </td>
-          <td class="px-4 py-3 text-sm text-gray-700">{{ row.termName }}</td>
+          <td class="px-4 py-3 max-w-[27%]">
+            <span class="max-w-full block truncate text-sm text-gray-700" [title]="row.termName">{{ row.termName }}</span>
+          </td>
         </tr>
       </ng-template>
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
@@ -56,6 +56,8 @@
       dataKey="id"
       size="small"
       [paginator]="true"
+      [first]="first()"
+      (onPage)="first.set($event.first)"
       [rows]="pageSize"
       [rowsPerPageOptions]="rowsPerPageOptions"
       [showCurrentPageReport]="true"

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
@@ -1,0 +1,107 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4" data-testid="mentorship-past-mentees-tab">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+    <!-- min-w-0 + flex-1: the search takes the leftover width without squeezing the
+         filter and export controls, which otherwise wrap their labels. -->
+    <label class="w-full min-w-0 sm:flex-1">
+      <span class="sr-only">Search past mentees</span>
+      <lfx-input-text [form]="form" control="search" placeholder="Search" icon="fa-light fa-magnifying-glass" dataTest="mentorship-past-mentees-search" />
+    </label>
+
+    <div class="flex shrink-0 items-center gap-2">
+      <div class="w-full sm:w-48">
+        <lfx-select
+          [form]="form"
+          control="status"
+          [options]="statusOptions"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Filter By Status"
+          ariaLabel="Filter past mentees by status"
+          styleClass="w-full"
+          dataTest="mentorship-past-mentees-status" />
+      </div>
+
+      <div class="w-full sm:w-44">
+        <lfx-select
+          [form]="form"
+          control="term"
+          [options]="termOptions()"
+          optionLabel="label"
+          optionValue="value"
+          placeholder="Filter by Term"
+          ariaLabel="Filter past mentees by term"
+          styleClass="w-full"
+          dataTest="mentorship-past-mentees-term" />
+      </div>
+
+      <lfx-button
+        label="Download By Status"
+        icon="fa-light fa-download"
+        iconPos="left"
+        severity="secondary"
+        size="small"
+        [outlined]="true"
+        styleClass="whitespace-nowrap !py-2.5"
+        (onClick)="onDownloadByStatus()"
+        data-testid="mentorship-past-mentees-download" />
+    </div>
+  </div>
+
+  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+    <lfx-table
+      [value]="rows()"
+      dataKey="id"
+      size="small"
+      [paginator]="true"
+      [rows]="pageSize"
+      [rowsPerPageOptions]="rowsPerPageOptions"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+      tableStyleClass="table-fixed"
+      paginatorDropdownAppendTo="body"
+      ariaLabel="Past mentees">
+      <ng-template #header>
+        <tr>
+          <th class="w-[46%] px-4 py-3 !text-sm !font-medium !text-gray-600">Mentee</th>
+          <th class="w-[27%] px-4 py-3 !text-sm !font-medium !text-gray-600">Status</th>
+          <th class="w-[27%] px-4 py-3 !text-sm !font-medium !text-gray-600">Term</th>
+        </tr>
+      </ng-template>
+
+      <ng-template #body let-row>
+        <tr [attr.data-testid]="'mentorship-past-mentee-row-' + row.id">
+          <td class="px-4 py-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <lfx-avatar
+                [image]="row.avatarUrl ?? ''"
+                [label]="row.initials"
+                shape="circle"
+                size="normal"
+                [styleClass]="row.avatarStyleClass"
+                [ariaLabel]="row.name" />
+              <div class="flex flex-col min-w-0">
+                <span class="text-sm font-medium text-blue-600 truncate" [title]="row.name">{{ row.name }}</span>
+                <span class="text-xs text-gray-500 truncate" [title]="row.email">{{ row.email }}</span>
+              </div>
+            </div>
+          </td>
+          <td class="px-4 py-3">
+            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+              {{ row.statusLabel }}
+            </span>
+          </td>
+          <td class="px-4 py-3 text-sm text-gray-700">{{ row.termName }}</td>
+        </tr>
+      </ng-template>
+
+      <ng-template #emptymessage>
+        <tr>
+          <td colspan="3" class="px-4 py-10 text-center text-sm text-gray-500" data-testid="mentorship-past-mentees-empty">No past mentees.</td>
+        </tr>
+      </ng-template>
+    </lfx-table>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
@@ -45,7 +45,7 @@
         size="small"
         [outlined]="true"
         styleClass="whitespace-nowrap !py-2.5"
-        (onClick)="onDownloadByStatus()"
+        (onClick)="onAction('Download by status')"
         data-testid="mentorship-past-mentees-download" />
     </div>
   </div>
@@ -88,7 +88,7 @@
             </div>
           </td>
           <td class="px-4 py-3">
-            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+            <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">
               {{ row.statusLabel }}
             </span>
           </td>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.html
@@ -50,7 +50,7 @@
     </div>
   </div>
 
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white">
     <lfx-table
       [value]="rows()"
       dataKey="id"
@@ -60,7 +60,7 @@
       [rowsPerPageOptions]="rowsPerPageOptions"
       [showCurrentPageReport]="true"
       currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-      tableStyleClass="table-fixed"
+      tableStyleClass="table-fixed min-w-[36rem]"
       paginatorDropdownAppendTo="body"
       ariaLabel="Past mentees">
       <ng-template #header>
@@ -74,18 +74,7 @@
       <ng-template #body let-row>
         <tr [attr.data-testid]="'mentorship-past-mentee-row-' + row.id">
           <td class="px-4 py-3 max-w-[46%]">
-            <div class="flex items-center gap-3 min-w-0 w-full">
-              <lfx-avatar
-                [image]="row.avatarUrl ?? ''"
-                [label]="row.initials"
-                shape="circle"
-                size="normal"
-                [styleClass]="row.avatarStyleClass"
-                [ariaLabel]="row.name" />
-              <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
-                <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="row.name">{{ row.name }}</span>
-              </div>
-            </div>
+            <lfx-mentorship-person-cell [name]="row.name" [initials]="row.initials" [avatarStyleClass]="row.avatarStyleClass" [avatarUrl]="row.avatarUrl" />
           </td>
           <td class="px-4 py-3">
             <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.spec.ts
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PastMenteesTabComponent } from './past-mentees-tab.component';
+
+describe('PastMenteesTabComponent', () => {
+  const mentee = (overrides: Partial<MentorshipProgramMentee> = {}): MentorshipProgramMentee => ({
+    id: 'mnt_1',
+    name: 'Dilan Ferreira',
+    email: 'dilan.ferreira@example.com',
+    status: 'graduated',
+    termName: 'Summer 2026',
+    ...overrides,
+  });
+
+  let fixture: ComponentFixture<PastMenteesTabComponent>;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [PastMenteesTabComponent],
+      providers: [provideNoopAnimations(), MessageService],
+    });
+
+    fixture = TestBed.createComponent(PastMenteesTabComponent);
+    fixture.componentRef.setInput('mentees', [
+      mentee(),
+      mentee({ id: 'mnt_2', name: 'Omar Haddad', status: 'withdrawn' }),
+      mentee({ id: 'mnt_3', name: 'Ines Duarte', status: 'declined', termName: 'Spring 2026' }),
+    ]);
+    fixture.detectChanges();
+  });
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+
+  it('renders Mentee, Status, and Term — and none of the current-mentee columns', () => {
+    const headers = Array.from(element().querySelectorAll('thead th')).map((th) => (th.textContent ?? '').trim());
+
+    expect(headers).toEqual(['Mentee', 'Status', 'Term']);
+    expect(headers).not.toContain('Tasks');
+    expect(headers).not.toContain('Create Task');
+    expect(headers).not.toContain('Actions');
+  });
+
+  it('shows the term each mentee took part in', () => {
+    const row = element().querySelector('[data-testid="mentorship-past-mentee-row-mnt_3"]');
+
+    expect(row?.textContent).toContain('Spring 2026');
+    expect(row?.textContent).toContain('Declined');
+  });
+
+  it('offers no note, task, or row-action controls', () => {
+    expect(element().querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')).toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-mentee-tasks-mnt_1"]')).toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-mentee-create-task-mnt_1"]')).toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-mentee-actions-mnt_1"]')).toBeNull();
+  });
+
+  it('filters by both status and term', () => {
+    const component = fixture.componentInstance;
+
+    expect(component['statusOptions'].map((option) => option.label)).toEqual(['All statuses', 'Withdrawn', 'Declined', 'Graduated']);
+    expect(component['termOptions']().map((option) => option.label)).toEqual(['All terms', 'Summer 2026', 'Spring 2026']);
+
+    component['form'].controls.status.setValue('withdrawn');
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['mnt_2']);
+
+    component['form'].controls.status.reset(null);
+    component['form'].controls.term.setValue('Spring 2026');
+    fixture.detectChanges();
+    expect(component['rows']().map((row) => row.id)).toEqual(['mnt_3']);
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -1,0 +1,102 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
+import { TableComponent } from '@components/table/table.component';
+import {
+  MENTORSHIP_MENTEE_PAGE_SIZE,
+  MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS,
+  MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
+  MENTORSHIP_MENTEE_STATUS_LABELS,
+  MENTORSHIP_PAST_MENTEE_STATUSES,
+  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+} from '@lfx-one/shared/constants';
+import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials } from '@lfx-one/shared/utils';
+import { MessageService } from 'primeng/api';
+import { startWith } from 'rxjs';
+
+/**
+ * Past mentees tab — replaces Current Mentees once a program is completed. Finished
+ * participations are read-only history, so unlike the current-mentee table this one
+ * carries no tasks, Create Task, row actions, or reviewer note; it adds the term the
+ * mentee took part in and filters by both status and term.
+ */
+@Component({
+  selector: 'lfx-mentorship-past-mentees-tab',
+  imports: [ReactiveFormsModule, AvatarComponent, ButtonComponent, InputTextComponent, SelectComponent, TableComponent],
+  templateUrl: './past-mentees-tab.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PastMenteesTabComponent {
+  public readonly mentees = input.required<MentorshipProgramMentee[]>();
+
+  private readonly messageService = inject(MessageService);
+
+  protected readonly pageSize = MENTORSHIP_MENTEE_PAGE_SIZE;
+  protected readonly rowsPerPageOptions = MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS;
+
+  /** Fixed rather than derived from the rows: the statuses a finished mentee can hold. */
+  protected readonly statusOptions = [
+    { label: 'All statuses', value: null },
+    ...MENTORSHIP_PAST_MENTEE_STATUSES.map((status) => ({ label: MENTORSHIP_MENTEE_STATUS_LABELS[status], value: status })),
+  ];
+
+  protected readonly form = new FormGroup({
+    search: new FormControl('', { nonNullable: true }),
+    status: new FormControl<MentorshipMenteeStatus | null>(null),
+    term: new FormControl<string | null>(null),
+  });
+
+  private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
+    initialValue: this.form.getRawValue(),
+  });
+
+  protected readonly termOptions = this.initTermOptions();
+
+  protected readonly rows = this.initRows();
+
+  protected onDownloadByStatus(): void {
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Download by status',
+      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      life: 4000,
+    });
+  }
+
+  /** Derived from the rows: a completed program's terms are whatever its mentees ran in. */
+  private initTermOptions() {
+    return computed(() => {
+      const terms = [...new Set(this.mentees().map((person) => person.termName))];
+      return [{ label: 'All terms', value: null }, ...terms.map((term) => ({ label: term, value: term }))];
+    });
+  }
+
+  private initRows() {
+    return computed(() => {
+      const { search, status, term } = this.filters();
+      return this.mentees()
+        .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
+        .filter((person) => !status || person.status === status)
+        .filter((person) => !term || person.termName === term)
+        .map((person) => this.toRow(person));
+    });
+  }
+
+  private toRow(person: MentorshipProgramMentee) {
+    return {
+      ...person,
+      initials: mentorshipPersonInitials(person.name),
+      avatarStyleClass: mentorshipPersonAvatarClass(person.name),
+      statusLabel: MENTORSHIP_MENTEE_STATUS_LABELS[person.status],
+      statusBadgeClass: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES[person.status],
+    };
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -10,8 +10,8 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
-  MENTORSHIP_MENTEE_PAGE_SIZE,
-  MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS,
+  MENTORSHIP_PERSON_PAGE_SIZE,
+  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
   MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTEE_STATUS_LABELS,
   MENTORSHIP_PAST_MENTEE_STATUSES,
@@ -39,8 +39,8 @@ export class PastMenteesTabComponent {
 
   private readonly messageService = inject(MessageService);
 
-  protected readonly pageSize = MENTORSHIP_MENTEE_PAGE_SIZE;
-  protected readonly rowsPerPageOptions = MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS;
+  protected readonly pageSize = MENTORSHIP_PERSON_PAGE_SIZE;
+  protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
 
   /** Fixed rather than derived from the rows: the statuses a finished mentee can hold. */
   protected readonly statusOptions = [

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -17,7 +17,7 @@ import {
   MENTORSHIP_PERSON_PAGE_SIZE,
   MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
 } from '@lfx-one/shared/constants';
-import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
+import { FilterOption, MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials, mentorshipTermFilterOptions } from '@lfx-one/shared/utils';
 import { startWith } from 'rxjs';
 
@@ -45,7 +45,7 @@ export class PastMenteesTabComponent {
   protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
 
   /** Fixed rather than derived from the rows: the statuses a finished mentee can hold. */
-  protected readonly statusOptions = [
+  protected readonly statusOptions: FilterOption<MentorshipMenteeStatus | null>[] = [
     { label: MENTORSHIP_ALL_STATUSES_OPTION_LABEL, value: null },
     ...MENTORSHIP_PAST_MENTEE_STATUSES.map((status) => ({ label: MENTORSHIP_MENTEE_STATUS_LABELS[status], value: status })),
   ];

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -10,17 +10,19 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import {
-  MENTORSHIP_PERSON_PAGE_SIZE,
-  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
+  MENTORSHIP_ALL_STATUSES_OPTION_LABEL,
+  MENTORSHIP_ALL_TERMS_OPTION_LABEL,
   MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTEE_STATUS_LABELS,
   MENTORSHIP_PAST_MENTEE_STATUSES,
-  MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+  MENTORSHIP_PERSON_PAGE_SIZE,
+  MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS,
 } from '@lfx-one/shared/constants';
 import { MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
-import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials } from '@lfx-one/shared/utils';
-import { MessageService } from 'primeng/api';
+import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials, mentorshipTermFilterOptions } from '@lfx-one/shared/utils';
 import { startWith } from 'rxjs';
+
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 
 /**
  * Past mentees tab — replaces Current Mentees once a program is completed. Finished
@@ -35,16 +37,16 @@ import { startWith } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PastMenteesTabComponent {
-  public readonly mentees = input.required<MentorshipProgramMentee[]>();
+  private readonly comingSoon = inject(MentorshipComingSoonService);
 
-  private readonly messageService = inject(MessageService);
+  public readonly mentees = input.required<MentorshipProgramMentee[]>();
 
   protected readonly pageSize = MENTORSHIP_PERSON_PAGE_SIZE;
   protected readonly rowsPerPageOptions = MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS;
 
   /** Fixed rather than derived from the rows: the statuses a finished mentee can hold. */
   protected readonly statusOptions = [
-    { label: 'All statuses', value: null },
+    { label: MENTORSHIP_ALL_STATUSES_OPTION_LABEL, value: null },
     ...MENTORSHIP_PAST_MENTEE_STATUSES.map((status) => ({ label: MENTORSHIP_MENTEE_STATUS_LABELS[status], value: status })),
   ];
 
@@ -62,32 +64,28 @@ export class PastMenteesTabComponent {
 
   protected readonly rows = this.initRows();
 
-  protected onDownloadByStatus(): void {
-    this.messageService.add({
-      severity: 'info',
-      summary: 'Download by status',
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-      life: 4000,
-    });
+  protected onAction(summary: string): void {
+    this.comingSoon.notify(summary);
   }
 
-  /** Derived from the rows: a completed program's terms are whatever its mentees ran in. */
   private initTermOptions() {
-    return computed(() => {
-      const terms = [...new Set(this.mentees().map((person) => person.termName))];
-      return [{ label: 'All terms', value: null }, ...terms.map((term) => ({ label: term, value: term }))];
-    });
+    return computed(() => mentorshipTermFilterOptions(this.rowSource(), MENTORSHIP_ALL_TERMS_OPTION_LABEL));
   }
 
   private initRows() {
     return computed(() => {
       const { search, status, term } = this.filters();
-      return this.mentees()
+      return this.rowSource()
         .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
         .filter((person) => !status || person.status === status)
         .filter((person) => !term || person.termName === term)
         .map((person) => this.toRow(person));
     });
+  }
+
+  /** Only finished participations belong here; anyone still pending is an applicant. */
+  private rowSource(): MentorshipProgramMentee[] {
+    return this.mentees().filter((person) => MENTORSHIP_PAST_MENTEE_STATUSES.includes(person.status));
   }
 
   private toRow(person: MentorshipProgramMentee) {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
@@ -19,7 +19,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { FilterOption, MentorshipMenteeStatus, MentorshipProgramMentee } from '@lfx-one/shared/interfaces';
 import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials, mentorshipTermFilterOptions } from '@lfx-one/shared/utils';
-import { startWith } from 'rxjs';
+import { startWith, tap } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 import { PersonCellComponent } from '../person-cell/person-cell.component';
@@ -56,9 +56,20 @@ export class PastMenteesTabComponent {
     term: new FormControl<string | null>(null),
   });
 
-  private readonly filters = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
-    initialValue: this.form.getRawValue(),
-  });
+  /**
+   * Paginator offset. Tracked so that narrowing the list can send the table back to the
+   * first page — PrimeNG keeps its own offset when the value array shrinks underneath it,
+   * which would otherwise leave the admin on a page that no longer exists.
+   */
+  protected readonly first = signal(0);
+
+  private readonly filters = toSignal(
+    this.form.valueChanges.pipe(
+      tap(() => this.first.set(0)),
+      startWith(this.form.getRawValue())
+    ),
+    { initialValue: this.form.getRawValue() }
+  );
 
   protected readonly termOptions = this.initTermOptions();
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -4,7 +4,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
@@ -23,6 +22,7 @@ import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipP
 import { startWith } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { PersonCellComponent } from '../person-cell/person-cell.component';
 
 /**
  * Past mentees tab — replaces Current Mentees once a program is completed. Finished
@@ -32,7 +32,7 @@ import { MentorshipComingSoonService } from '../../services/mentorship-coming-so
  */
 @Component({
   selector: 'lfx-mentorship-past-mentees-tab',
-  imports: [ReactiveFormsModule, AvatarComponent, ButtonComponent, InputTextComponent, SelectComponent, TableComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent, PersonCellComponent, SelectComponent, TableComponent],
   templateUrl: './past-mentees-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -69,23 +69,18 @@ export class PastMenteesTabComponent {
   }
 
   private initTermOptions() {
-    return computed(() => mentorshipTermFilterOptions(this.rowSource(), MENTORSHIP_ALL_TERMS_OPTION_LABEL));
+    return computed(() => mentorshipTermFilterOptions(this.mentees(), MENTORSHIP_ALL_TERMS_OPTION_LABEL));
   }
 
   private initRows() {
     return computed(() => {
       const { search, status, term } = this.filters();
-      return this.rowSource()
+      return this.mentees()
         .filter((person) => matchesMentorshipPersonSearch(person, search ?? ''))
         .filter((person) => !status || person.status === status)
         .filter((person) => !term || person.termName === term)
         .map((person) => this.toRow(person));
     });
-  }
-
-  /** Only finished participations belong here; anyone still pending is an applicant. */
-  private rowSource(): MentorshipProgramMentee[] {
-    return this.mentees().filter((person) => MENTORSHIP_PAST_MENTEE_STATUSES.includes(person.status));
   }
 
   private toRow(person: MentorshipProgramMentee) {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/person-cell/person-cell.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/person-cell/person-cell.component.html
@@ -1,0 +1,20 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex items-center gap-3 min-w-0 w-full">
+  <lfx-avatar [image]="avatarUrl() ?? ''" [label]="initials()" shape="circle" size="normal" [styleClass]="avatarStyleClass()" [ariaLabel]="name()" />
+  <div class="flex flex-col min-w-0 w-[calc(100%-2rem)]">
+    <span class="max-w-full block truncate text-sm font-medium text-blue-600" [title]="name()">{{ name() }}</span>
+    @if (noteLabel(); as label) {
+      <button
+        type="button"
+        class="max-w-full block truncate text-xs text-gray-500 text-left transition-colors hover:text-blue-600"
+        [title]="hasNote() ? label : 'Add a reviewer note for ' + name()"
+        [attr.aria-label]="(hasNote() ? 'Edit' : 'Add') + ' reviewer note for ' + name()"
+        (click)="noteClick.emit()"
+        [attr.data-testid]="noteTestId()">
+        {{ label }}
+      </button>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/person-cell/person-cell.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/person-cell/person-cell.component.spec.ts
@@ -1,0 +1,75 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PersonCellComponent } from './person-cell.component';
+
+describe('PersonCellComponent', () => {
+  let fixture: ComponentFixture<PersonCellComponent>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const noteButton = (): HTMLButtonElement | null => element().querySelector<HTMLButtonElement>('button');
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [PersonCellComponent],
+      providers: [provideNoopAnimations()],
+    });
+
+    fixture = TestBed.createComponent(PersonCellComponent);
+    fixture.componentRef.setInput('name', 'Alex Rivera');
+    fixture.componentRef.setInput('initials', 'AR');
+    fixture.componentRef.setInput('avatarStyleClass', 'bg-blue-100 text-blue-700');
+    fixture.detectChanges();
+  });
+
+  it('renders the person name with a tooltip, since the cell truncates it', () => {
+    // Scoped to the text column: the avatar renders its own span of initials first.
+    const name = element().querySelector('div.flex-col > span');
+
+    expect(name?.textContent?.trim()).toBe('Alex Rivera');
+    expect(name?.getAttribute('title')).toBe('Alex Rivera');
+  });
+
+  it('omits the note line entirely for a read-only table', () => {
+    expect(noteButton()).toBeNull();
+  });
+
+  it('prompts for a note when the row has none, naming the person for a screen reader', () => {
+    fixture.componentRef.setInput('noteLabel', 'Add note');
+    fixture.componentRef.setInput('noteTestId', 'mentorship-mentee-note-mnt_1');
+    fixture.detectChanges();
+
+    const button = noteButton();
+    expect(button?.textContent?.trim()).toBe('Add note');
+    // The prompt is the tooltip, because "Add note" alone says nothing on hover.
+    expect(button?.getAttribute('title')).toBe('Add a reviewer note for Alex Rivera');
+    expect(button?.getAttribute('aria-label')).toBe('Add reviewer note for Alex Rivera');
+    expect(button?.getAttribute('data-testid')).toBe('mentorship-mentee-note-mnt_1');
+  });
+
+  it('shows the note itself as the tooltip once one exists, and offers to edit it', () => {
+    fixture.componentRef.setInput('noteLabel', 'Strong prerequisite work so far');
+    fixture.componentRef.setInput('hasNote', true);
+    fixture.detectChanges();
+
+    const button = noteButton();
+    expect(button?.getAttribute('title')).toBe('Strong prerequisite work so far');
+    expect(button?.getAttribute('aria-label')).toBe('Edit reviewer note for Alex Rivera');
+  });
+
+  it('emits on click rather than owning the dialog', () => {
+    fixture.componentRef.setInput('noteLabel', 'Add note');
+    fixture.detectChanges();
+
+    let emitted = 0;
+    fixture.componentInstance.noteClick.subscribe(() => (emitted += 1));
+    noteButton()?.click();
+
+    expect(emitted).toBe(1);
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/person-cell/person-cell.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/person-cell/person-cell.component.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+
+/**
+ * The leading person cell shared by the program-detail people tables — avatar, the
+ * person's name, and an optional reviewer-note line beneath it. Extracted because the
+ * truncation chain it relies on (`min-w-0` on the flex child, a width that leaves room
+ * for the avatar) is easy to get subtly wrong in one table and not the others.
+ *
+ * Omit `noteLabel` for a read-only table, such as Past Mentees.
+ */
+@Component({
+  selector: 'lfx-mentorship-person-cell',
+  imports: [AvatarComponent],
+  templateUrl: './person-cell.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PersonCellComponent {
+  public readonly name = input.required<string>();
+  public readonly initials = input.required<string>();
+  public readonly avatarStyleClass = input.required<string>();
+  public readonly avatarUrl = input<string | undefined>(undefined);
+  /** Test id for the note button; required whenever `noteLabel` is set. */
+  public readonly noteTestId = input<string | undefined>(undefined);
+  /** The note preview, or the "Add note" prompt. Absent means the row shows no note line. */
+  public readonly noteLabel = input<string | undefined>(undefined);
+  public readonly hasNote = input(false);
+  public readonly noteClick = output<void>();
+}

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/program-detail-header/program-detail-header.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/program-detail-header/program-detail-header.component.html
@@ -10,7 +10,7 @@
       <div class="flex items-center gap-2 flex-wrap">
         <span class="text-sm text-gray-500" data-testid="mentorship-program-detail-season">{{ seasonLine() }}</span>
         <span
-          class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full"
+          class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg"
           [class]="statusBadgeClass()"
           data-testid="mentorship-program-detail-status">
           {{ statusLabel() }}

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/program-detail-header/program-detail-header.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/program-detail-header/program-detail-header.component.spec.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MentorshipProgram, MentorshipProgramStatus } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ProgramDetailHeaderComponent } from './program-detail-header.component';
+
+describe('ProgramDetailHeaderComponent — mentees tab label', () => {
+  const program = (status: MentorshipProgramStatus): MentorshipProgram => ({
+    id: 'mp_1',
+    slug: 'thanos-fan-out-query-observability',
+    name: 'Thanos: Fan-Out Query Observability',
+    projectName: 'CNCF',
+    term: 'Summer 2026',
+    status,
+    stats: { mentors: 2, mentees: 0, graduated: 3 },
+    createdOn: '2026-03-01T00:00:00.000Z',
+    updatedOn: '2026-07-30T00:00:00.000Z',
+  });
+
+  let fixture: ComponentFixture<ProgramDetailHeaderComponent>;
+
+  const render = (status: MentorshipProgramStatus): void => {
+    fixture = TestBed.createComponent(ProgramDetailHeaderComponent);
+    fixture.componentRef.setInput('program', program(status));
+    fixture.componentRef.setInput('tabCounts', { mentees: 4, applicants: 0, mentors: 2, terms: 2 });
+    fixture.componentRef.setInput('activeTab', 'mentees');
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ProgramDetailHeaderComponent],
+      providers: [provideNoopAnimations()],
+    });
+  });
+
+  const menteesTabText = (): string =>
+    ((fixture.nativeElement as HTMLElement).querySelector('[data-testid="mentorship-program-detail-tab-mentees"]')?.textContent ?? '').trim();
+
+  it('labels the tab "Current Mentees" while the program is open', () => {
+    render('open');
+
+    expect(menteesTabText()).toContain('Current Mentees');
+  });
+
+  it('labels the tab "Past Mentees" once the program is completed, keeping its count', () => {
+    render('completed');
+
+    expect(menteesTabText()).toContain('Past Mentees');
+    expect(menteesTabText()).not.toContain('Current Mentees');
+    // The tab keeps its `mentees` value, so the count badge is unaffected by the relabel.
+    expect(menteesTabText()).toContain('4');
+  });
+
+  it('leaves the other tab labels alone when completed', () => {
+    render('completed');
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('[data-testid="mentorship-program-detail-tab-applicants"]')?.textContent).toContain('Applicants');
+    expect(element.querySelector('[data-testid="mentorship-program-detail-tab-mentors"]')?.textContent).toContain('Mentors');
+    expect(element.querySelector('[data-testid="mentorship-program-detail-tab-terms"]')?.textContent).toContain('Terms');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/program-detail-header/program-detail-header.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/program-detail-header/program-detail-header.component.ts
@@ -4,7 +4,12 @@
 import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, output, PLATFORM_ID, viewChildren } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
-import { MENTORSHIP_PROGRAM_DETAIL_TABS, MENTORSHIP_PROGRAM_STATUS_BADGE_CLASSES, MENTORSHIP_PROGRAM_STATUS_LABELS } from '@lfx-one/shared/constants';
+import {
+  MENTORSHIP_PAST_MENTEES_TAB_LABEL,
+  MENTORSHIP_PROGRAM_DETAIL_TABS,
+  MENTORSHIP_PROGRAM_STATUS_BADGE_CLASSES,
+  MENTORSHIP_PROGRAM_STATUS_LABELS,
+} from '@lfx-one/shared/constants';
 import { MentorshipProgram, MentorshipProgramDetailTab, MentorshipProgramTabCounts } from '@lfx-one/shared/interfaces';
 
 /**
@@ -36,10 +41,17 @@ export class ProgramDetailHeaderComponent {
   protected readonly statusLabel = computed(() => MENTORSHIP_PROGRAM_STATUS_LABELS[this.program().status]);
   protected readonly statusBadgeClass = computed(() => MENTORSHIP_PROGRAM_STATUS_BADGE_CLASSES[this.program().status]);
 
+  /**
+   * A completed program has no enrolled mentees left, so the `mentees` tab is
+   * relabelled "Past Mentees". Only the label changes — the value stays `mentees`
+   * so counts, keyboard navigation, and the ARIA wiring are untouched.
+   */
   protected readonly tabItems = computed(() => {
     const counts = this.tabCounts();
+    const isCompleted = this.program().status === 'completed';
     return MENTORSHIP_PROGRAM_DETAIL_TABS.map((tab) => ({
       ...tab,
+      label: tab.value === 'mentees' && isCompleted ? MENTORSHIP_PAST_MENTEES_TAB_LABEL : tab.label,
       count: counts[tab.value],
     }));
   });

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.html
@@ -1,0 +1,20 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex items-center justify-end">
+  @if (menuItems().length > 0) {
+    <div class="relative inline-block">
+      <lfx-button
+        icon="fa-light fa-ellipsis"
+        severity="secondary"
+        size="small"
+        [outlined]="true"
+        [ariaLabel]="'Actions for ' + personName()"
+        (onClick)="actionMenu.toggle($event)"
+        [attr.data-testid]="testId()" />
+      <lfx-menu #actionMenu [model]="menuItems()" [popup]="true" appendTo="body" styleClass="!min-w-[10rem]" />
+    </div>
+  } @else {
+    <span class="text-sm text-gray-500">-</span>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.spec.ts
@@ -1,0 +1,52 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { RowActionsComponent } from './row-actions.component';
+
+describe('RowActionsComponent', () => {
+  let fixture: ComponentFixture<RowActionsComponent>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const trigger = (): HTMLButtonElement | null => element().querySelector<HTMLButtonElement>('button');
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [RowActionsComponent],
+      providers: [provideNoopAnimations(), MessageService],
+    });
+
+    fixture = TestBed.createComponent(RowActionsComponent);
+    fixture.componentRef.setInput('personName', 'Alex Rivera');
+    fixture.componentRef.setInput('testId', 'mentorship-mentee-actions-mnt_1');
+    fixture.componentRef.setInput('actions', [
+      { label: 'Withdraw', icon: 'fa-light fa-user-minus' },
+      { label: 'Graduate', icon: 'fa-light fa-graduation-cap' },
+    ]);
+    fixture.detectChanges();
+  });
+
+  it('names the person in the trigger for a screen reader, and carries the row test id', () => {
+    expect(trigger()?.getAttribute('aria-label')).toBe('Actions for Alex Rivera');
+    // The test id binds to the wrapper host, which is what the tab specs query.
+    expect(element().querySelector('[data-testid="mentorship-mentee-actions-mnt_1"]')).not.toBeNull();
+  });
+
+  it('builds one menu item per action, keeping the order it was given', () => {
+    expect(fixture.componentInstance['menuItems']().map((item) => item.label)).toEqual(['Withdraw', 'Graduate']);
+    expect(fixture.componentInstance['menuItems']().map((item) => item.icon)).toEqual(['fa-light fa-user-minus', 'fa-light fa-graduation-cap']);
+  });
+
+  it('falls back to an em dash when a row has no action left', () => {
+    fixture.componentRef.setInput('actions', []);
+    fixture.detectChanges();
+
+    expect(trigger()).toBeNull();
+    expect(element().textContent?.trim()).toBe('-');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.ts
@@ -1,0 +1,40 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { MenuComponent } from '@components/menu/menu.component';
+import { MentorshipRowAction } from '@lfx-one/shared/interfaces';
+import { MenuItem } from 'primeng/api';
+
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+
+/**
+ * The trailing row-actions cell shared by the program-detail people tables — an
+ * ellipsis trigger and its popup menu, or an em dash when a row has no action left.
+ *
+ * The tabs pass resolved labels and icons rather than their own status unions, which
+ * differ. Every action currently raises the shared "coming soon" toast, so the command
+ * lives here; when the write endpoints land this gains an output and the tabs handle it.
+ */
+@Component({
+  selector: 'lfx-mentorship-row-actions',
+  imports: [ButtonComponent, MenuComponent],
+  templateUrl: './row-actions.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RowActionsComponent {
+  private readonly comingSoon = inject(MentorshipComingSoonService);
+
+  public readonly personName = input.required<string>();
+  public readonly actions = input.required<MentorshipRowAction[]>();
+  public readonly testId = input.required<string>();
+
+  protected readonly menuItems = computed<MenuItem[]>(() =>
+    this.actions().map((action) => ({
+      label: action.label,
+      icon: action.icon,
+      command: () => this.comingSoon.notify(`${action.label} ${this.personName()}`),
+    }))
+  );
+}

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/terms-tab/terms-tab.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/terms-tab/terms-tab.component.html
@@ -47,7 +47,7 @@
               </div>
             </td>
             <td class="px-4 py-3">
-              <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-full" [class]="row.statusBadgeClass">
+              <span class="inline-flex items-center text-xs font-semibold px-2 py-0.5 rounded-lg" [class]="row.statusBadgeClass">
                 {{ row.statusLabel }}
               </span>
             </td>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.html
@@ -32,11 +32,11 @@
             @if (isCompleted()) {
               <lfx-mentorship-past-mentees-tab [mentees]="mentees()" />
             } @else {
-              <lfx-mentorship-current-mentees-tab [mentees]="mentees()" />
+              <lfx-mentorship-current-mentees-tab [mentees]="mentees()" [noteDrafts]="noteDrafts()" (noteRequested)="onNoteRequested($event)" />
             }
           }
           @case ('applicants') {
-            <lfx-mentorship-applicants-tab [applicants]="applicants()" />
+            <lfx-mentorship-applicants-tab [applicants]="applicants()" [noteDrafts]="noteDrafts()" (noteRequested)="onNoteRequested($event)" />
           }
           @case ('mentors') {
             <lfx-mentorship-mentors-tab [mentors]="mentors()" />

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.html
@@ -29,7 +29,11 @@
         [attr.aria-labelledby]="'mentorship-program-detail-tab-trigger-' + activeTab()">
         @switch (activeTab()) {
           @case ('mentees') {
-            <lfx-mentorship-current-mentees-tab [mentees]="mentees()" />
+            @if (isCompleted()) {
+              <lfx-mentorship-past-mentees-tab [mentees]="mentees()" />
+            } @else {
+              <lfx-mentorship-current-mentees-tab [mentees]="mentees()" />
+            }
           }
           @case ('applicants') {
             <lfx-mentorship-applicants-tab [applicants]="applicants()" />

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.spec.ts
@@ -12,6 +12,7 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { Observable, of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MenteeNoteDialogComponent } from './components/mentee-note-dialog/mentee-note-dialog.component';
 import { ProgramDetailComponent } from './program-detail.component';
 
 describe('ProgramDetailComponent', () => {
@@ -49,7 +50,7 @@ describe('ProgramDetailComponent', () => {
 
   // Takes the observable rather than the value: a dismissed dialog closes with `undefined`,
   // and passing that through a defaulted parameter would silently restore the default.
-  const buildWith = (onClose: Observable<string | undefined>): void => {
+  const buildWith = (onClose: Observable<string | undefined>, program: MentorshipProgramDetail = detail()): void => {
     dialogOpen = vi.fn(() => ({ onClose }));
 
     TestBed.resetTestingModule();
@@ -64,7 +65,7 @@ describe('ProgramDetailComponent', () => {
           provide: MentorshipService,
           // The Mentors tab loads its invite picker on construction, and the persistence
           // test renders that tab to prove notes survive one being destroyed.
-          useValue: { getProgram: () => of(detail()), getInvitableUsers: () => of(EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE) },
+          useValue: { getProgram: () => of(program), getInvitableUsers: () => of(EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE) },
         },
         { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['programId', 'mp_gridflow_fall26']]) as never) } },
       ],
@@ -119,5 +120,79 @@ describe('ProgramDetailComponent', () => {
 
     expect(fixture.componentInstance['noteDrafts']()).toEqual({});
     expect(element().querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('Add note');
+  });
+
+  it('swaps the mentees tab for past mentees once the program is completed', () => {
+    const completed = detail('completed');
+    completed.mentees = [{ id: 'mnt_1', name: 'Alex Rivera', email: 'alex.rivera@example.com', status: 'withdrawn', termName: 'Fall 2026' }];
+    buildWith(of('a saved note'), completed);
+
+    expect(element().querySelector('[data-testid="mentorship-past-mentees-tab"]')).not.toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-current-mentees-tab"]')).toBeNull();
+    // Past mentees are history, so none of the live tab's write affordances come with them.
+    expect(element().querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')).toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-mentee-actions-mnt_1"]')).toBeNull();
+  });
+
+  it('renders the live mentees tab while the program is open', () => {
+    expect(element().querySelector('[data-testid="mentorship-current-mentees-tab"]')).not.toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-past-mentees-tab"]')).toBeNull();
+  });
+
+  it('seeds the dialog with the row note, then with the draft once one exists', () => {
+    const withNote = detail();
+    withNote.mentees = [
+      { id: 'mnt_1', name: 'Alex Rivera', email: 'alex.rivera@example.com', status: 'accepted', termName: 'Fall 2026', note: 'from the server' },
+    ];
+    buildWith(of('a saved note'), withNote);
+
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_1"]')?.click();
+    fixture.detectChanges();
+
+    expect(dialogOpen).toHaveBeenLastCalledWith(
+      MenteeNoteDialogComponent,
+      expect.objectContaining({ data: { personName: 'Alex Rivera', note: 'from the server' } })
+    );
+
+    // Reopening the same row must offer the draft, not the note it started with.
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_1"]')?.click();
+    fixture.detectChanges();
+
+    expect(dialogOpen).toHaveBeenLastCalledWith(
+      MenteeNoteDialogComponent,
+      expect.objectContaining({ data: { personName: 'Alex Rivera', note: 'a saved note' } })
+    );
+  });
+
+  it('survives the dialog service declining to open a second dialog', () => {
+    // PrimeNG returns null when a dialog of the same component is still registered,
+    // which a quick second click on another row can do.
+    dialogOpen = vi.fn(() => null);
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ProgramDetailComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        MessageService,
+        { provide: DialogService, useValue: { open: dialogOpen } },
+        {
+          provide: MentorshipService,
+          useValue: { getProgram: () => of(detail()), getInvitableUsers: () => of(EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE) },
+        },
+        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['programId', 'mp_gridflow_fall26']]) as never) } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ProgramDetailComponent);
+    fixture.detectChanges();
+
+    expect(() => {
+      element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_1"]')?.click();
+      fixture.detectChanges();
+    }).not.toThrow();
+
+    expect(fixture.componentInstance['noteDrafts']()).toEqual({});
   });
 });

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.spec.ts
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE } from '@lfx-one/shared/constants';
+import { MentorshipProgramDetail } from '@lfx-one/shared/interfaces';
+import { MentorshipService } from '@services/mentorship.service';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { Observable, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProgramDetailComponent } from './program-detail.component';
+
+describe('ProgramDetailComponent', () => {
+  const detail = (status: MentorshipProgramDetail['program']['status'] = 'open'): MentorshipProgramDetail => ({
+    program: {
+      id: 'mp_gridflow_fall26',
+      slug: 'gridflow-time-series-ingestion-pipeline',
+      name: 'GridFlow: Time-Series Ingestion Pipeline',
+      projectName: 'LF Energy',
+      term: 'Fall 2026',
+      status,
+      stats: { mentors: 2, mentees: 1, graduated: 0 },
+      createdOn: '2026-05-01',
+      updatedOn: '2026-07-02',
+    },
+    mentees: [{ id: 'mnt_1', name: 'Alex Rivera', email: 'alex.rivera@example.com', status: 'accepted', termName: 'Fall 2026' }],
+    applicants: [
+      {
+        id: 'app_1',
+        name: 'Ifeoma Adeyemi',
+        email: 'ifeoma.adeyemi@example.com',
+        status: 'pending',
+        termName: 'Fall 2026',
+        createdOn: '2026-06-28',
+        updatedOn: '2026-07-02',
+      },
+    ],
+    mentors: [],
+    terms: [],
+    tabCounts: { mentees: 1, applicants: 1, mentors: 0, terms: 0 },
+  });
+
+  let fixture: ComponentFixture<ProgramDetailComponent>;
+  let dialogOpen: ReturnType<typeof vi.fn>;
+
+  // Takes the observable rather than the value: a dismissed dialog closes with `undefined`,
+  // and passing that through a defaulted parameter would silently restore the default.
+  const buildWith = (onClose: Observable<string | undefined>): void => {
+    dialogOpen = vi.fn(() => ({ onClose }));
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ProgramDetailComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        MessageService,
+        { provide: DialogService, useValue: { open: dialogOpen } },
+        {
+          provide: MentorshipService,
+          // The Mentors tab loads its invite picker on construction, and the persistence
+          // test renders that tab to prove notes survive one being destroyed.
+          useValue: { getProgram: () => of(detail()), getInvitableUsers: () => of(EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE) },
+        },
+        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['programId', 'mp_gridflow_fall26']]) as never) } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ProgramDetailComponent);
+    fixture.detectChanges();
+  };
+
+  const build = (): void => buildWith(of('a saved note'));
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const showTab = (tab: string): void => {
+    fixture.componentInstance['activeTab'].set(tab as never);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => build());
+
+  it('keeps a reviewer note when the admin leaves the tab and comes back', () => {
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_1"]')?.click();
+    fixture.detectChanges();
+
+    expect(dialogOpen).toHaveBeenCalledTimes(1);
+    expect(element().querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('a saved note');
+
+    // The tab panel is an `@switch`, so this destroys the tab component outright.
+    showTab('mentors');
+    showTab('mentees');
+
+    expect(element().querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('a saved note');
+  });
+
+  it('holds notes per person, across both tabs that have them', () => {
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_1"]')?.click();
+    fixture.detectChanges();
+
+    showTab('applicants');
+    expect(element().querySelector('[data-testid="mentorship-applicant-note-app_1"]')?.textContent?.trim()).toBe('Add note');
+
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-applicant-note-app_1"]')?.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['noteDrafts']()).toEqual({ mnt_1: 'a saved note', app_1: 'a saved note' });
+  });
+
+  it('leaves the note untouched when the dialog is dismissed', () => {
+    buildWith(of(undefined));
+
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentee-note-mnt_1"]')?.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['noteDrafts']()).toEqual({});
+    expect(element().querySelector('[data-testid="mentorship-mentee-note-mnt_1"]')?.textContent?.trim()).toBe('Add note');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
@@ -7,23 +7,29 @@ import { ActivatedRoute } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { RouteLoadingComponent } from '@components/loading/route-loading.component';
-import { MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
-import { MentorshipProgramDetail, MentorshipProgramDetailTab } from '@lfx-one/shared/interfaces';
+import { MENTORSHIP_NOTE_DIALOG_HEADER } from '@lfx-one/shared/constants';
+import { MentorshipNoteRequest, MentorshipProgramDetail, MentorshipProgramDetailTab } from '@lfx-one/shared/interfaces';
 import { MentorshipService } from '@services/mentorship.service';
-import { MessageService } from 'primeng/api';
-import { filter, map, switchMap, tap } from 'rxjs';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { filter, map, switchMap, take, tap } from 'rxjs';
 
 import { ApplicantsTabComponent } from './components/applicants-tab/applicants-tab.component';
 import { CurrentMenteesTabComponent } from './components/current-mentees-tab/current-mentees-tab.component';
+import { MenteeNoteDialogComponent } from './components/mentee-note-dialog/mentee-note-dialog.component';
 import { MentorsTabComponent } from './components/mentors-tab/mentors-tab.component';
 import { PastMenteesTabComponent } from './components/past-mentees-tab/past-mentees-tab.component';
 import { ProgramDetailHeaderComponent } from './components/program-detail-header/program-detail-header.component';
 import { TermsTabComponent } from './components/terms-tab/terms-tab.component';
+import { MentorshipComingSoonService } from './services/mentorship-coming-soon.service';
 
 /**
  * Admin program-detail page. Loads a program by id (default) or slug and hosts
  * the four underline tabs (mentees, applicants, mentors, terms). The mentees tab
  * shows current mentees for a live program and past mentees once it is completed.
+ *
+ * Reviewer notes are owned here rather than in the tabs: the tab panel is an
+ * `@switch`, so a tab component is destroyed the moment the admin looks at another
+ * tab, and note drafts held inside one would not survive the trip back.
  */
 @Component({
   selector: 'lfx-mentorship-program-detail',
@@ -44,10 +50,17 @@ import { TermsTabComponent } from './components/terms-tab/terms-tab.component';
 export class ProgramDetailComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly mentorshipService = inject(MentorshipService);
-  private readonly messageService = inject(MessageService);
+  private readonly dialogService = inject(DialogService);
+  private readonly comingSoon = inject(MentorshipComingSoonService);
 
   protected readonly isLoading = signal(true);
   protected readonly activeTab = signal<MentorshipProgramDetailTab>('mentees');
+
+  /**
+   * Notes edited this session, keyed by person id. Local until a write endpoint
+   * exists; a person absent from the map falls back to the note their row arrived with.
+   */
+  protected readonly noteDrafts = signal<Record<string, string>>({});
 
   protected readonly programId = toSignal(this.route.paramMap.pipe(map((params) => params.get('programId') ?? '')), { initialValue: '' });
   protected readonly detail: Signal<MentorshipProgramDetail | null> = this.initDetail();
@@ -65,12 +78,34 @@ export class ProgramDetailComponent {
   }
 
   protected onEditProgram(): void {
-    this.messageService.add({
-      severity: 'info',
-      summary: 'Edit program',
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
-      life: 4000,
+    this.comingSoon.notify('Edit program');
+  }
+
+  protected onNoteRequested(request: MentorshipNoteRequest): void {
+    const dialogRef = this.dialogService.open(MenteeNoteDialogComponent, {
+      header: MENTORSHIP_NOTE_DIALOG_HEADER,
+      width: '34rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { menteeId: request.personId, menteeName: request.personName, note: this.noteFor(request.personId) },
+    }) as DynamicDialogRef;
+
+    dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
+      // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
+      // an empty string is an explicit clear.
+      if (note === undefined) return;
+      this.noteDrafts.update((drafts) => ({ ...drafts, [request.personId]: note }));
     });
+  }
+
+  /** The draft if this session edited one, otherwise whatever the row arrived with. */
+  private noteFor(personId: string): string {
+    const draft = this.noteDrafts()[personId];
+    if (draft !== undefined) return draft;
+
+    const person = [...this.mentees(), ...this.applicants()].find((candidate) => candidate.id === personId);
+    return person?.note ?? '';
   }
 
   private initDetail(): Signal<MentorshipProgramDetail | null> {

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
@@ -91,7 +91,7 @@ export class ProgramDetailComponent {
       modal: true,
       closable: true,
       dismissableMask: true,
-      data: { menteeId: request.personId, menteeName: request.personName, note: this.noteFor(request.personId) },
+      data: { personName: request.personName, note: this.noteFor(request.personId) },
     });
     if (!dialogRef) return;
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
@@ -16,12 +16,14 @@ import { filter, map, switchMap, tap } from 'rxjs';
 import { ApplicantsTabComponent } from './components/applicants-tab/applicants-tab.component';
 import { CurrentMenteesTabComponent } from './components/current-mentees-tab/current-mentees-tab.component';
 import { MentorsTabComponent } from './components/mentors-tab/mentors-tab.component';
+import { PastMenteesTabComponent } from './components/past-mentees-tab/past-mentees-tab.component';
 import { ProgramDetailHeaderComponent } from './components/program-detail-header/program-detail-header.component';
 import { TermsTabComponent } from './components/terms-tab/terms-tab.component';
 
 /**
  * Admin program-detail page. Loads a program by id (default) or slug and hosts
- * the four underline tabs (mentees, applicants, mentors, terms).
+ * the four underline tabs (mentees, applicants, mentors, terms). The mentees tab
+ * shows current mentees for a live program and past mentees once it is completed.
  */
 @Component({
   selector: 'lfx-mentorship-program-detail',
@@ -31,6 +33,7 @@ import { TermsTabComponent } from './components/terms-tab/terms-tab.component';
     RouteLoadingComponent,
     ProgramDetailHeaderComponent,
     CurrentMenteesTabComponent,
+    PastMenteesTabComponent,
     ApplicantsTabComponent,
     MentorsTabComponent,
     TermsTabComponent,
@@ -53,6 +56,9 @@ export class ProgramDetailComponent {
   protected readonly applicants = computed(() => this.detail()?.applicants ?? []);
   protected readonly mentors = computed(() => this.detail()?.mentors ?? []);
   protected readonly tabCounts = computed(() => this.detail()?.tabCounts ?? { mentees: 0, applicants: 0, mentors: 0, terms: 0 });
+
+  /** A completed program has no enrolled mentees, so the first tab shows past ones. */
+  protected readonly isCompleted = computed(() => this.detail()?.program.status === 'completed');
 
   protected onTabChange(tab: MentorshipProgramDetailTab): void {
     this.activeTab.set(tab);

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
@@ -82,14 +82,17 @@ export class ProgramDetailComponent {
   }
 
   protected onNoteRequested(request: MentorshipNoteRequest): void {
-    const dialogRef = this.dialogService.open(MenteeNoteDialogComponent, {
+    // `open()` returns null when a dialog of the same component is still registered,
+    // which a quick second click on another row's note can do.
+    const dialogRef: DynamicDialogRef | null = this.dialogService.open(MenteeNoteDialogComponent, {
       header: MENTORSHIP_NOTE_DIALOG_HEADER,
       width: '34rem',
       modal: true,
       closable: true,
       dismissableMask: true,
       data: { menteeId: request.personId, menteeName: request.personName, note: this.noteFor(request.personId) },
-    }) as DynamicDialogRef;
+    });
+    if (!dialogRef) return;
 
     dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
       // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
@@ -97,15 +100,6 @@ export class ProgramDetailComponent {
       if (note === undefined) return;
       this.noteDrafts.update((drafts) => ({ ...drafts, [request.personId]: note }));
     });
-  }
-
-  /** The draft if this session edited one, otherwise whatever the row arrived with. */
-  private noteFor(personId: string): string {
-    const draft = this.noteDrafts()[personId];
-    if (draft !== undefined) return draft;
-
-    const person = [...this.mentees(), ...this.applicants()].find((candidate) => candidate.id === personId);
-    return person?.note ?? '';
   }
 
   private initDetail(): Signal<MentorshipProgramDetail | null> {
@@ -117,5 +111,14 @@ export class ProgramDetailComponent {
       ),
       { initialValue: null }
     );
+  }
+
+  /** The draft if this session edited one, otherwise whatever the row arrived with. */
+  private noteFor(personId: string): string {
+    const draft = this.noteDrafts()[personId];
+    if (draft !== undefined) return draft;
+
+    const person = [...this.mentees(), ...this.applicants()].find((candidate) => candidate.id === personId);
+    return person?.note ?? '';
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -52,6 +52,7 @@ export class ProgramDetailComponent {
   private readonly mentorshipService = inject(MentorshipService);
   private readonly dialogService = inject(DialogService);
   private readonly comingSoon = inject(MentorshipComingSoonService);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly isLoading = signal(true);
   protected readonly activeTab = signal<MentorshipProgramDetailTab>('mentees');
@@ -94,7 +95,9 @@ export class ProgramDetailComponent {
     });
     if (!dialogRef) return;
 
-    dialogRef.onClose.pipe(take(1)).subscribe((note: string | undefined) => {
+    // `takeUntilDestroyed` as well as `take(1)`: this is a long-lived page, so navigating
+    // away mid-edit would otherwise leave the handler alive to write to a destroyed host.
+    dialogRef.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((note: string | undefined) => {
       // Dismissing the dialog resolves to `undefined` and must leave the note untouched;
       // an empty string is an explicit clear.
       if (note === undefined) return;

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/services/mentorship-coming-soon.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/services/mentorship-coming-soon.service.spec.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TestBed } from '@angular/core/testing';
+import { MENTORSHIP_COMING_SOON_TOAST_LIFE, MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MentorshipComingSoonService } from './mentorship-coming-soon.service';
+
+describe('MentorshipComingSoonService', () => {
+  let service: MentorshipComingSoonService;
+  let add: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    add = vi.fn();
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [MentorshipComingSoonService, { provide: MessageService, useValue: { add } }],
+    });
+
+    service = TestBed.inject(MentorshipComingSoonService);
+  });
+
+  it('raises the caller summary with the shared stub detail and duration', () => {
+    service.notify('Decline Alex Rivera');
+
+    expect(add).toHaveBeenCalledWith({
+      severity: 'info',
+      summary: 'Decline Alex Rivera',
+      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      life: MENTORSHIP_COMING_SOON_TOAST_LIFE,
+    });
+  });
+
+  it('raises one toast per call, so repeated attempts each get feedback', () => {
+    service.notify('Create a task for Priya Shah');
+    service.notify('Create a task for Priya Shah');
+
+    expect(add).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes an empty summary through rather than substituting a default', () => {
+    service.notify('');
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ summary: '' }));
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/services/mentorship-coming-soon.service.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/services/mentorship-coming-soon.service.ts
@@ -1,0 +1,26 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject, Injectable } from '@angular/core';
+import { MENTORSHIP_COMING_SOON_TOAST_LIFE, MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
+import { MessageService } from 'primeng/api';
+
+/**
+ * Every write action on the program-detail tabs is stubbed until the mentorship service
+ * exists. One place to say so, rather than the same toast payload in each tab — delete
+ * this along with the last caller once the endpoints land.
+ */
+@Injectable({ providedIn: 'root' })
+export class MentorshipComingSoonService {
+  private readonly messageService = inject(MessageService);
+
+  /** `summary` names the attempted action, e.g. `Decline Alex Rivera`. */
+  public notify(summary: string): void {
+    this.messageService.add({
+      severity: 'info',
+      summary,
+      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      life: MENTORSHIP_COMING_SOON_TOAST_LIFE,
+    });
+  }
+}

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -16,6 +16,7 @@ import {
   lfxFontSizes,
   MENTION_PLATFORM_CONFIG,
   MENTION_SENTIMENT_CONFIG,
+  MENTORSHIP_APPLICANT_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES,
   MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES,
   MENTORSHIP_PROGRAM_AVATAR_PALETTE,
@@ -47,6 +48,7 @@ export default {
     // spreads are what guarantees they survive purging regardless of usage elsewhere.
     ...Object.values(MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     ...Object.values(MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
+    ...Object.values(MENTORSHIP_APPLICANT_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     ...Object.values(MENTORSHIP_TERM_ROW_STATUS_BADGE_CLASSES).flatMap((classes) => classes.split(' ')),
     // Social Listening platform icon colors (MENTION_PLATFORM_CONFIG in @lfx-one/shared, not scanned here)
     ...Object.values(MENTION_PLATFORM_CONFIG).map((c) => c.colorClass),

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -41,8 +41,13 @@ export const MENTORSHIP_MENTEE_NOTE_MAX = 2000;
 
 export const MENTORSHIP_MENTEE_NOTE_PLACEHOLDER = 'Add context for the other reviewers — screening outcome, strengths, concerns.';
 
-/** Trailing half of the dialog's subtitle; the leading half names the mentee. */
-export const MENTORSHIP_MENTEE_NOTE_VISIBILITY = 'Visible to all admins and mentors on this program.';
+/**
+ * Trailing half of the dialog's subtitle; the leading half names the mentee.
+ * States the present truth rather than the intended one: the note lives only in
+ * this browser session until the mentorship service can store it. Update this
+ * the moment a write endpoint exists — not before.
+ */
+export const MENTORSHIP_MENTEE_NOTE_VISIBILITY = 'Kept on this page for now — saving and sharing with admins and mentors is coming soon.';
 
 const gridflowMentees: MentorshipProgramMentee[] = [
   {

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -4,6 +4,7 @@
 import type {
   MentorshipInvitableUser,
   MentorshipInvitableUsersResponse,
+  MentorshipProgramApplicant,
   MentorshipProgramLists,
   MentorshipProgramMentee,
   MentorshipProgramMentor,
@@ -22,9 +23,9 @@ export const EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE: MentorshipInvitableUsers
 /** Default page size for the Mentors-tab invite picker. */
 export const MENTORSHIP_INVITABLE_USER_PAGE_SIZE = 50;
 
-/** Paginator defaults for the Current Mentees table. */
-export const MENTORSHIP_MENTEE_PAGE_SIZE = 10;
-export const MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+/** Paginator defaults shared by the program-detail people tables. */
+export const MENTORSHIP_PERSON_PAGE_SIZE = 10;
+export const MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 
 /** Character cap on the reviewer note, mirrored by the dialog's counter. */
 export const MENTORSHIP_MENTEE_NOTE_MAX = 2000;
@@ -41,7 +42,6 @@ const gridflowMentees: MentorshipProgramMentee[] = [
     email: 'alex.rivera@example.com',
     status: 'accepted',
     termName: 'Fall 2026',
-    appliedOn: '2026-07-18',
     tasksSubmitted: 7,
     tasksTotal: 12,
     note: 'Strong Go background; paired well during the screening exercise.',
@@ -52,84 +52,106 @@ const gridflowMentees: MentorshipProgramMentee[] = [
     email: 'priya.shah@example.com',
     status: 'accepted',
     termName: 'Fall 2026',
-    appliedOn: '2026-07-21',
     tasksSubmitted: 4,
     tasksTotal: 12,
   },
 ];
 
-const gridflowApplicants: MentorshipProgramMentee[] = [
+/**
+ * Covers every Applicants-tab display status: `pending` with tasks outstanding reads as
+ * Applied, `pending` with all tasks in reads as Tasks Completed, and the four resolved
+ * statuses display as themselves.
+ */
+const gridflowApplicants: MentorshipProgramApplicant[] = [
   {
-    id: 'app_jordan_hale',
-    name: 'Jordan Hale',
-    email: 'jordan.hale@example.com',
+    id: 'app_ifeoma_adeyemi',
+    name: 'Ifeoma Adeyemi',
+    email: 'ifeoma.adeyemi@example.com',
     status: 'pending',
     termName: 'Fall 2026',
-    appliedOn: '2026-08-02',
+    createdOn: '2026-06-28',
+    updatedOn: '2026-07-02',
+    tasksSubmitted: 2,
+    tasksTotal: 5,
+    otherApplications: [
+      { programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'applied' },
+      { programId: 'mp_janusgraph_fall26', programName: 'JanusGraph', status: 'applied' },
+    ],
   },
   {
-    id: 'app_sam_okonkwo',
-    name: 'Sam Okonkwo',
-    email: 'sam.okonkwo@example.com',
+    id: 'app_diego_souza',
+    name: 'Diego Souza',
+    email: 'diego.souza@example.com',
     status: 'pending',
     termName: 'Fall 2026',
-    appliedOn: '2026-08-04',
+    createdOn: '2026-07-01',
+    updatedOn: '2026-07-12',
+    tasksSubmitted: 5,
+    tasksTotal: 5,
+    otherApplications: [{ programId: 'mp_thanos_summer26', programName: 'Thanos', status: 'applied' }],
   },
   {
-    id: 'app_mei_chen',
-    name: 'Mei Chen',
-    email: 'mei.chen@example.com',
-    status: 'pending',
-    termName: 'Fall 2026',
-    appliedOn: '2026-08-05',
-  },
-  {
-    id: 'app_luca_rossi',
-    name: 'Luca Rossi',
-    email: 'luca.rossi@example.com',
-    status: 'pending',
-    termName: 'Fall 2026',
-    appliedOn: '2026-08-06',
-  },
-  {
-    id: 'app_aisha_rahman',
-    name: 'Aisha Rahman',
-    email: 'aisha.rahman@example.com',
-    status: 'pending',
-    termName: 'Fall 2026',
-    appliedOn: '2026-08-07',
-  },
-  {
-    id: 'app_noah_berg',
-    name: 'Noah Berg',
-    email: 'noah.berg@example.com',
+    id: 'app_nadia_rahman',
+    name: 'Nadia Rahman',
+    email: 'nadia.rahman@example.com',
     status: 'declined',
-    termName: 'Fall 2026',
-    appliedOn: '2026-07-28',
+    termName: 'Spring 2026',
+    createdOn: '2025-11-12',
+    updatedOn: '2026-01-22',
   },
   {
-    id: 'app_elena_popov',
-    name: 'Elena Popov',
-    email: 'elena.popov@example.com',
-    status: 'pending',
-    termName: 'Fall 2026',
-    appliedOn: '2026-08-09',
+    id: 'app_ines_duarte',
+    name: 'Ines Duarte',
+    email: 'ines.duarte@example.com',
+    status: 'withdrawn',
+    termName: 'Summer 2026',
+    createdOn: '2026-02-18',
+    updatedOn: '2026-04-03',
   },
   {
-    id: 'app_chris_nguyen',
-    name: 'Chris Nguyen',
-    email: 'chris.nguyen@example.com',
-    status: 'pending',
+    id: 'app_hana_suzuki',
+    name: 'Hana Suzuki',
+    email: 'hana.suzuki@example.com',
+    status: 'accepted',
     termName: 'Fall 2026',
-    appliedOn: '2026-08-10',
+    createdOn: '2026-06-21',
+    updatedOn: '2026-07-08',
   },
   {
-    id: 'app_fatima_alsayed',
-    name: 'Fatima Al-Sayed',
-    email: 'fatima.alsayed@example.com',
-    status: 'declined',
+    id: 'app_marco_bianchi',
+    name: 'Marco Bianchi',
+    email: 'marco.bianchi@example.com',
+    status: 'accepted',
     termName: 'Fall 2026',
-    appliedOn: '2026-07-30',
+    createdOn: '2026-06-24',
+    updatedOn: '2026-07-10',
+  },
+  {
+    id: 'app_grace_wanjiru',
+    name: 'Grace Wanjiru',
+    email: 'grace.wanjiru@example.com',
+    status: 'graduated',
+    termName: 'Summer 2026',
+    createdOn: '2026-02-10',
+    updatedOn: '2026-08-24',
+  },
+  {
+    id: 'app_ravi_menon',
+    name: 'Ravi Menon',
+    email: 'ravi.menon@example.com',
+    status: 'graduated',
+    termName: 'Summer 2026',
+    createdOn: '2026-02-14',
+    updatedOn: '2026-08-24',
+  },
+  {
+    id: 'app_aiko_tanaka',
+    name: 'Aiko Tanaka',
+    email: 'aiko.tanaka@example.com',
+    status: 'graduated',
+    termName: 'Spring 2026',
+    createdOn: '2025-11-08',
+    updatedOn: '2026-05-25',
   },
 ];
 
@@ -243,7 +265,10 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'riley.thompson@example.com',
         status: 'pending',
         termName: 'Winter 2026',
-        appliedOn: '2026-08-12',
+        createdOn: '2026-08-12',
+        updatedOn: '2026-08-20',
+        tasksSubmitted: 1,
+        tasksTotal: 4,
       },
       {
         id: 'app_apicurio_2',
@@ -251,7 +276,10 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'kai.nakamura@example.com',
         status: 'pending',
         termName: 'Winter 2026',
-        appliedOn: '2026-08-15',
+        createdOn: '2026-08-15',
+        updatedOn: '2026-08-28',
+        tasksSubmitted: 4,
+        tasksTotal: 4,
       },
     ],
     mentors: [
@@ -296,7 +324,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'taylor.brooks@example.com',
         status: 'accepted',
         termName: 'Fall 2026',
-        appliedOn: '2026-07-10',
         tasksSubmitted: 9,
         tasksTotal: 9,
       },
@@ -308,7 +335,10 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'ivy.moreau@example.com',
         status: 'pending',
         termName: 'Fall 2026',
-        appliedOn: '2026-08-03',
+        createdOn: '2026-08-03',
+        updatedOn: '2026-08-19',
+        tasksSubmitted: 3,
+        tasksTotal: 6,
       },
       {
         id: 'app_janus_2',
@@ -316,7 +346,8 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'diego.santos@example.com',
         status: 'declined',
         termName: 'Fall 2026',
-        appliedOn: '2026-07-25',
+        createdOn: '2026-07-25',
+        updatedOn: '2026-08-05',
       },
     ],
     mentors: [
@@ -367,7 +398,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'dilan.ferreira@example.com',
         status: 'graduated',
         termName: 'Summer 2026',
-        appliedOn: '2026-03-20',
       },
       {
         id: 'mnt_thanos_2',
@@ -375,7 +405,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'yuki.tanaka@example.com',
         status: 'graduated',
         termName: 'Summer 2026',
-        appliedOn: '2026-03-22',
       },
       {
         id: 'mnt_thanos_3',
@@ -383,7 +412,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'omar.haddad@example.com',
         status: 'withdrawn',
         termName: 'Summer 2026',
-        appliedOn: '2026-03-25',
       },
       {
         id: 'mnt_thanos_4',
@@ -391,7 +419,6 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         email: 'ines.duarte@example.com',
         status: 'declined',
         termName: 'Spring 2026',
-        appliedOn: '2026-01-15',
       },
     ],
     applicants: [],

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -359,7 +359,41 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
     ],
   },
   'thanos-fan-out-query-observability': {
-    mentees: [],
+    // Completed program: these surface on the Past Mentees tab rather than Current Mentees.
+    mentees: [
+      {
+        id: 'mnt_thanos_1',
+        name: 'Dilan Ferreira',
+        email: 'dilan.ferreira@example.com',
+        status: 'graduated',
+        termName: 'Summer 2026',
+        appliedOn: '2026-03-20',
+      },
+      {
+        id: 'mnt_thanos_2',
+        name: 'Yuki Tanaka',
+        email: 'yuki.tanaka@example.com',
+        status: 'graduated',
+        termName: 'Summer 2026',
+        appliedOn: '2026-03-22',
+      },
+      {
+        id: 'mnt_thanos_3',
+        name: 'Omar Haddad',
+        email: 'omar.haddad@example.com',
+        status: 'withdrawn',
+        termName: 'Summer 2026',
+        appliedOn: '2026-03-25',
+      },
+      {
+        id: 'mnt_thanos_4',
+        name: 'Ines Duarte',
+        email: 'ines.duarte@example.com',
+        status: 'declined',
+        termName: 'Spring 2026',
+        appliedOn: '2026-01-15',
+      },
+    ],
     applicants: [],
     mentors: [
       {

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -27,6 +27,15 @@ export const MENTORSHIP_INVITABLE_USER_PAGE_SIZE = 50;
 export const MENTORSHIP_PERSON_PAGE_SIZE = 10;
 export const MENTORSHIP_PERSON_ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 
+/** How long the stubbed-action toasts stay up, in milliseconds. */
+export const MENTORSHIP_COMING_SOON_TOAST_LIFE = 4000;
+
+/** Shared filter/table copy — inlining these let the three people tabs drift apart. */
+export const MENTORSHIP_ALL_STATUSES_OPTION_LABEL = 'All statuses';
+export const MENTORSHIP_ALL_TERMS_OPTION_LABEL = 'All terms';
+export const MENTORSHIP_ADD_NOTE_LABEL = 'Add note';
+export const MENTORSHIP_NOTE_DIALOG_HEADER = 'Reviewer note';
+
 /** Character cap on the reviewer note, mirrored by the dialog's counter. */
 export const MENTORSHIP_MENTEE_NOTE_MAX = 2000;
 
@@ -74,8 +83,8 @@ const gridflowApplicants: MentorshipProgramApplicant[] = [
     tasksSubmitted: 2,
     tasksTotal: 5,
     otherApplications: [
-      { programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'applied' },
-      { programId: 'mp_janusgraph_fall26', programName: 'JanusGraph', status: 'applied' },
+      { programId: 'mp_apicurio_winter26', programName: 'Apicurio Registry', status: 'pending', tasksSubmitted: 1, tasksTotal: 3 },
+      { programId: 'mp_janusgraph_fall26', programName: 'JanusGraph', status: 'pending', tasksSubmitted: 0, tasksTotal: 6 },
     ],
   },
   {
@@ -88,7 +97,7 @@ const gridflowApplicants: MentorshipProgramApplicant[] = [
     updatedOn: '2026-07-12',
     tasksSubmitted: 5,
     tasksTotal: 5,
-    otherApplications: [{ programId: 'mp_thanos_summer26', programName: 'Thanos', status: 'applied' }],
+    otherApplications: [{ programId: 'mp_thanos_summer26', programName: 'Thanos', status: 'pending', tasksSubmitted: 2, tasksTotal: 4 }],
   },
   {
     id: 'app_nadia_rahman',

--- a/packages/shared/src/constants/mentorship-program-detail.constants.ts
+++ b/packages/shared/src/constants/mentorship-program-detail.constants.ts
@@ -22,6 +22,18 @@ export const EMPTY_MENTORSHIP_INVITABLE_USERS_RESPONSE: MentorshipInvitableUsers
 /** Default page size for the Mentors-tab invite picker. */
 export const MENTORSHIP_INVITABLE_USER_PAGE_SIZE = 50;
 
+/** Paginator defaults for the Current Mentees table. */
+export const MENTORSHIP_MENTEE_PAGE_SIZE = 10;
+export const MENTORSHIP_MENTEE_ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+
+/** Character cap on the reviewer note, mirrored by the dialog's counter. */
+export const MENTORSHIP_MENTEE_NOTE_MAX = 2000;
+
+export const MENTORSHIP_MENTEE_NOTE_PLACEHOLDER = 'Add context for the other reviewers — screening outcome, strengths, concerns.';
+
+/** Trailing half of the dialog's subtitle; the leading half names the mentee. */
+export const MENTORSHIP_MENTEE_NOTE_VISIBILITY = 'Visible to all admins and mentors on this program.';
+
 const gridflowMentees: MentorshipProgramMentee[] = [
   {
     id: 'mnt_alex_rivera',
@@ -30,6 +42,9 @@ const gridflowMentees: MentorshipProgramMentee[] = [
     status: 'accepted',
     termName: 'Fall 2026',
     appliedOn: '2026-07-18',
+    tasksSubmitted: 7,
+    tasksTotal: 12,
+    note: 'Strong Go background; paired well during the screening exercise.',
   },
   {
     id: 'mnt_priya_shah',
@@ -38,6 +53,8 @@ const gridflowMentees: MentorshipProgramMentee[] = [
     status: 'accepted',
     termName: 'Fall 2026',
     appliedOn: '2026-07-21',
+    tasksSubmitted: 4,
+    tasksTotal: 12,
   },
 ];
 
@@ -280,6 +297,8 @@ export const MOCK_MENTORSHIP_PROGRAM_LISTS: Record<string, MentorshipProgramList
         status: 'accepted',
         termName: 'Fall 2026',
         appliedOn: '2026-07-10',
+        tasksSubmitted: 9,
+        tasksTotal: 9,
       },
     ],
     applicants: [

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -109,13 +109,18 @@ export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStat
 };
 
 /**
- * Status-filter options on the admin Current Mentees tab — the statuses an admin is
- * most likely to narrow a live program to. These pick what is *shown*, never which
- * rows exist: scoping the data by them would hide any mentee holding another status.
+ * Statuses the admin Current Mentees tab covers: a live program shows the mentees
+ * taking part, plus any who graduated early. Doubles as the tab's status-filter
+ * options and as the set `mentorshipMenteesForProgram` scopes its rows to, so the
+ * header count and the table can never disagree.
  */
 export const MENTORSHIP_CURRENT_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['accepted', 'graduated'];
 
-/** Status-filter options on the Past Mentees tab — the ways a participation ends. */
+/**
+ * Statuses the Past Mentees tab covers — the three ways a participation ends.
+ * `accepted` is not one of them: a program cannot be completed until every accepted
+ * mentee has been graduated or declined, so that combination never reaches the tab.
+ */
 export const MENTORSHIP_PAST_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['withdrawn', 'declined', 'graduated'];
 
 /**

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  MentorshipApplicantAction,
+  MentorshipApplicantDisplayStatus,
   MentorshipMenteeAction,
   MentorshipMenteeStatus,
   MentorshipMentorStatus,
@@ -142,6 +144,56 @@ export const MENTORSHIP_MENTEE_ACTION_ICONS: Record<MentorshipMenteeAction, stri
   withdrawn: 'fa-light fa-circle-minus',
   declined: 'fa-light fa-circle-xmark',
   graduated: 'fa-light fa-graduation-cap',
+};
+
+/**
+ * Statuses the Applicants tab displays. These are not wire statuses: an application
+ * stays `pending` throughout the prerequisite work, and the tab splits that one status
+ * into `applied` (tasks still outstanding) and `tasks-completed` (all submitted). The
+ * remaining four are the mentee statuses unchanged.
+ */
+export const MENTORSHIP_APPLICANT_DISPLAY_STATUSES = ['applied', 'tasks-completed', 'accepted', 'declined', 'withdrawn', 'graduated'] as const;
+
+export const MENTORSHIP_APPLICANT_STATUS_LABELS: Record<MentorshipApplicantDisplayStatus, string> = {
+  applied: 'Applied',
+  'tasks-completed': 'Tasks Completed',
+  accepted: 'Accepted',
+  declined: 'Declined',
+  withdrawn: 'Withdrawn',
+  graduated: 'Graduated',
+};
+
+/** The four shared statuses reuse the mentee classes so the two palettes can't drift apart. */
+export const MENTORSHIP_APPLICANT_STATUS_BADGE_CLASSES: Record<MentorshipApplicantDisplayStatus, string> = {
+  applied: 'bg-amber-50 text-amber-700',
+  'tasks-completed': 'bg-blue-50 text-blue-700',
+  accepted: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES.accepted,
+  declined: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES.declined,
+  withdrawn: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES.withdrawn,
+  graduated: MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES.graduated,
+};
+
+/** Explains the Applied / Tasks Completed split; rendered above the Applicants table. */
+export const MENTORSHIP_APPLICANT_STATUS_NOTE =
+  'Application status stays “Applied” while a mentee works on prerequisite tasks. When all prerequisites are complete, “Tasks Completed” appears above the status and the program admin is notified by email to review the submission and make the admission decision.';
+
+/**
+ * Row actions on the Applicants tab. Source of the `MentorshipApplicantAction`
+ * union; each action moves the application to the same-named status.
+ */
+export const MENTORSHIP_APPLICANT_ACTIONS = ['accepted', 'declined', 'withdrawn'] as const;
+
+/** Menu labels for the Applicants row actions — imperative, unlike the status labels. */
+export const MENTORSHIP_APPLICANT_ACTION_LABELS: Record<MentorshipApplicantAction, string> = {
+  accepted: 'Accept',
+  declined: 'Decline',
+  withdrawn: 'Withdraw',
+};
+
+export const MENTORSHIP_APPLICANT_ACTION_ICONS: Record<MentorshipApplicantAction, string> = {
+  accepted: 'fa-light fa-circle-check',
+  declined: 'fa-light fa-circle-xmark',
+  withdrawn: 'fa-light fa-circle-minus',
 };
 
 export const MENTORSHIP_TERM_ROW_STATUSES = ['open', 'closed'] as const;

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -109,15 +109,13 @@ export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStat
 };
 
 /**
- * Statuses the admin Current Mentees tab can list. The tab covers enrolled mentees
- * only, so its status filter offers these two rather than the full mentee lifecycle.
+ * Status-filter options on the admin Current Mentees tab — the statuses an admin is
+ * most likely to narrow a live program to. These pick what is *shown*, never which
+ * rows exist: scoping the data by them would hide any mentee holding another status.
  */
 export const MENTORSHIP_CURRENT_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['accepted', 'graduated'];
 
-/**
- * Statuses the Past Mentees tab can list. A completed program has no enrolled
- * mentees left, so the first tab shows finished participations instead.
- */
+/** Status-filter options on the Past Mentees tab — the ways a participation ends. */
 export const MENTORSHIP_PAST_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['withdrawn', 'declined', 'graduated'];
 
 /**

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -121,6 +121,13 @@ export const MENTORSHIP_CURRENT_MENTEE_STATUSES: readonly MentorshipMenteeStatus
 export const MENTORSHIP_PAST_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['withdrawn', 'declined', 'graduated'];
 
 /**
+ * Statuses the Applicants tab's "Other Active Applications" column lists. Graduating
+ * counts: it says the person saw a program through, which is worth showing an admin
+ * reviewing them. Only the two rejections — declined and withdrawn — are left out.
+ */
+export const MENTORSHIP_ACTIVE_APPLICATION_STATUSES: readonly MentorshipMenteeStatus[] = ['pending', 'accepted', 'graduated'];
+
+/**
  * Label the `mentees` tab takes on for a completed program. The tab keeps its
  * `mentees` value so counts, routing, and ARIA wiring are unchanged.
  */

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  MentorshipMenteeAction,
   MentorshipMenteeStatus,
   MentorshipMentorStatus,
   MentorshipProgram,
@@ -103,6 +104,32 @@ export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStat
   declined: 'bg-red-50 text-red-600',
   withdrawn: 'bg-gray-100 text-gray-600',
   graduated: 'bg-violet-50 text-violet-700',
+};
+
+/**
+ * Statuses the admin Current Mentees tab can list. The tab covers enrolled mentees
+ * only, so its status filter offers these two rather than the full mentee lifecycle.
+ */
+export const MENTORSHIP_CURRENT_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['accepted', 'graduated'];
+
+/**
+ * Row actions on the admin Current Mentees tab. Source of the
+ * `MentorshipMenteeAction` union; each action moves the mentee to the
+ * same-named terminal status.
+ */
+export const MENTORSHIP_MENTEE_ACTIONS = ['withdrawn', 'declined', 'graduated'] as const;
+
+/** Menu labels for the Current Mentees row actions — imperative, unlike the status labels. */
+export const MENTORSHIP_MENTEE_ACTION_LABELS: Record<MentorshipMenteeAction, string> = {
+  withdrawn: 'Withdraw',
+  declined: 'Decline',
+  graduated: 'Graduate',
+};
+
+export const MENTORSHIP_MENTEE_ACTION_ICONS: Record<MentorshipMenteeAction, string> = {
+  withdrawn: 'fa-light fa-circle-minus',
+  declined: 'fa-light fa-circle-xmark',
+  graduated: 'fa-light fa-graduation-cap',
 };
 
 export const MENTORSHIP_TERM_ROW_STATUSES = ['open', 'closed'] as const;

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -103,7 +103,7 @@ export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStat
   accepted: 'bg-emerald-50 text-emerald-700',
   declined: 'bg-red-50 text-red-600',
   withdrawn: 'bg-gray-100 text-gray-600',
-  graduated: 'bg-violet-50 text-violet-700',
+  graduated: 'bg-emerald-50 text-emerald-700',
 };
 
 /**
@@ -111,6 +111,18 @@ export const MENTORSHIP_MENTEE_STATUS_BADGE_CLASSES: Record<MentorshipMenteeStat
  * only, so its status filter offers these two rather than the full mentee lifecycle.
  */
 export const MENTORSHIP_CURRENT_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['accepted', 'graduated'];
+
+/**
+ * Statuses the Past Mentees tab can list. A completed program has no enrolled
+ * mentees left, so the first tab shows finished participations instead.
+ */
+export const MENTORSHIP_PAST_MENTEE_STATUSES: readonly MentorshipMenteeStatus[] = ['withdrawn', 'declined', 'graduated'];
+
+/**
+ * Label the `mentees` tab takes on for a completed program. The tab keeps its
+ * `mentees` value so counts, routing, and ARIA wiring are unchanged.
+ */
+export const MENTORSHIP_PAST_MENTEES_TAB_LABEL = 'Past Mentees';
 
 /**
  * Row actions on the admin Current Mentees tab. Source of the

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  MENTORSHIP_MENTEE_ACTIONS,
   MENTORSHIP_MENTEE_STATUSES,
   MENTORSHIP_MENTOR_STATUSES,
   MENTORSHIP_PROGRAM_DETAIL_TABS,
@@ -219,7 +220,22 @@ export interface MentorshipProgramMentee extends MentorshipProgramPersonBase {
   /** ISO `YYYY-MM-DD` application date. */
   appliedOn?: string;
   termName: string;
+  /** Tasks the mentee has submitted out of `tasksTotal`. Only accepted mentees carry tasks. */
+  tasksSubmitted?: number;
+  tasksTotal?: number;
+  /** Reviewer note shared with the program's admins and mentors. */
+  note?: string;
 }
+
+/** Payload for the Current Mentees reviewer-note dialog. */
+export interface MentorshipMenteeNoteDialogData {
+  menteeId: string;
+  menteeName: string;
+  note: string;
+}
+
+/** Row action on the Current Mentees tab. Each maps to a terminal mentee status. */
+export type MentorshipMenteeAction = (typeof MENTORSHIP_MENTEE_ACTIONS)[number];
 
 /** Term lifecycle on the admin program-detail Terms tab. */
 export type MentorshipTermRowStatus = (typeof MENTORSHIP_TERM_ROW_STATUSES)[number];

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  MENTORSHIP_APPLICANT_ACTIONS,
+  MENTORSHIP_APPLICANT_DISPLAY_STATUSES,
   MENTORSHIP_MENTEE_ACTIONS,
   MENTORSHIP_MENTEE_STATUSES,
   MENTORSHIP_MENTOR_STATUSES,
@@ -214,11 +216,9 @@ export interface MentorshipProgramMentor extends MentorshipProgramPersonBase {
   profileCreated?: boolean;
 }
 
-/** Mentee row on the Current Mentees / Applicants tabs. */
+/** Mentee row on the Current Mentees / Past Mentees / Applicants tabs. */
 export interface MentorshipProgramMentee extends MentorshipProgramPersonBase {
   status: MentorshipMenteeStatus;
-  /** ISO `YYYY-MM-DD` application date. */
-  appliedOn?: string;
   termName: string;
   /** Tasks the mentee has submitted out of `tasksTotal`. Only accepted mentees carry tasks. */
   tasksSubmitted?: number;
@@ -236,6 +236,32 @@ export interface MentorshipMenteeNoteDialogData {
 
 /** Row action on the Current Mentees tab. Each maps to a terminal mentee status. */
 export type MentorshipMenteeAction = (typeof MENTORSHIP_MENTEE_ACTIONS)[number];
+
+/**
+ * Status as shown on the Applicants tab. `applied` and `tasks-completed` are both the
+ * `pending` wire status, split by whether every prerequisite task has been submitted.
+ */
+export type MentorshipApplicantDisplayStatus = (typeof MENTORSHIP_APPLICANT_DISPLAY_STATUSES)[number];
+
+/** Row action on the Applicants tab. Each maps to the same-named application status. */
+export type MentorshipApplicantAction = (typeof MENTORSHIP_APPLICANT_ACTIONS)[number];
+
+/** An application the same person holds on another program, listed alongside this one. */
+export interface MentorshipApplicantOtherApplication {
+  /** Target of the row's link — `/mentorship/admin/:programId`. */
+  programId: string;
+  /** Short program name; the full name is too long for the column. */
+  programName: string;
+  status: MentorshipApplicantDisplayStatus;
+}
+
+/** Applicant row on the Applicants tab — a mentee row plus its application metadata. */
+export interface MentorshipProgramApplicant extends MentorshipProgramMentee {
+  /** ISO `YYYY-MM-DD` dates behind the Application Dates column. */
+  createdOn: string;
+  updatedOn: string;
+  otherApplications?: MentorshipApplicantOtherApplication[];
+}
 
 /** Term lifecycle on the admin program-detail Terms tab. */
 export type MentorshipTermRowStatus = (typeof MENTORSHIP_TERM_ROW_STATUSES)[number];
@@ -258,7 +284,7 @@ export interface MentorshipProgramTermRow {
 /** Tab lists returned with a program-detail payload. */
 export interface MentorshipProgramLists {
   mentees: MentorshipProgramMentee[];
-  applicants: MentorshipProgramMentee[];
+  applicants: MentorshipProgramApplicant[];
   mentors: MentorshipProgramMentor[];
   terms: MentorshipProgramTermRow[];
 }

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -223,10 +223,14 @@ export interface MentorshipProgramMentee extends MentorshipProgramPersonBase, Me
   note?: string;
 }
 
-/** Payload for the Current Mentees reviewer-note dialog. */
-export interface MentorshipMenteeNoteDialogData {
-  menteeId: string;
-  menteeName: string;
+/**
+ * Payload for the reviewer-note dialog, which serves any program-detail person row —
+ * Current Mentees and Applicants both open it. Carries no id: the parent opens the
+ * dialog and already holds the person it asked about, so echoing an id back would only
+ * offer a second, divergent source for the same fact.
+ */
+export interface MentorshipNoteDialogData {
+  personName: string;
   note: string;
 }
 
@@ -266,6 +270,23 @@ export interface MentorshipApplicantOtherApplication extends MentorshipApplicati
 export interface MentorshipNoteRequest {
   personId: string;
   personName: string;
+}
+
+/**
+ * One entry in a program-detail row's action menu, already resolved to what the menu
+ * renders. The tabs' action unions differ, so they map their own labels and icons and
+ * hand over this shape rather than the status the action came from.
+ */
+export interface MentorshipRowAction {
+  label: string;
+  icon: string;
+}
+
+/** Display fields for a row's reviewer-note line, resolved from the session's drafts. */
+export interface MentorshipNoteDisplay {
+  hasNote: boolean;
+  /** The note itself when there is one, otherwise the "Add note" prompt. */
+  noteLabel: string;
 }
 
 /** Applicant row on the Applicants tab — a mentee row plus its application metadata. */

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -217,12 +217,8 @@ export interface MentorshipProgramMentor extends MentorshipProgramPersonBase {
 }
 
 /** Mentee row on the Current Mentees / Past Mentees / Applicants tabs. */
-export interface MentorshipProgramMentee extends MentorshipProgramPersonBase {
-  status: MentorshipMenteeStatus;
+export interface MentorshipProgramMentee extends MentorshipProgramPersonBase, MentorshipApplicationProgress {
   termName: string;
-  /** Tasks the mentee has submitted out of `tasksTotal`. Only accepted mentees carry tasks. */
-  tasksSubmitted?: number;
-  tasksTotal?: number;
   /** Reviewer note shared with the program's admins and mentors. */
   note?: string;
 }
@@ -246,13 +242,30 @@ export type MentorshipApplicantDisplayStatus = (typeof MENTORSHIP_APPLICANT_DISP
 /** Row action on the Applicants tab. Each maps to the same-named application status. */
 export type MentorshipApplicantAction = (typeof MENTORSHIP_APPLICANT_ACTIONS)[number];
 
+/**
+ * The stored status of an application plus the prerequisite progress that splits its
+ * `pending` state into Applied / Tasks Completed. Every application-shaped row derives
+ * its display status from these three fields and nothing else.
+ */
+export interface MentorshipApplicationProgress {
+  status: MentorshipMenteeStatus;
+  /** Prerequisite tasks the applicant has submitted out of `tasksTotal`. */
+  tasksSubmitted?: number;
+  tasksTotal?: number;
+}
+
 /** An application the same person holds on another program, listed alongside this one. */
-export interface MentorshipApplicantOtherApplication {
+export interface MentorshipApplicantOtherApplication extends MentorshipApplicationProgress {
   /** Target of the row's link — `/mentorship/admin/:programId`. */
   programId: string;
   /** Short program name; the full name is too long for the column. */
   programName: string;
-  status: MentorshipApplicantDisplayStatus;
+}
+
+/** Emitted by a program-detail tab when a row asks to open its reviewer note. */
+export interface MentorshipNoteRequest {
+  personId: string;
+  personName: string;
 }
 
 /** Applicant row on the Applicants tab — a mentee row plus its application metadata. */

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   formatMentorshipDateRange,
   formatMentorshipMonthYear,
   formatMentorshipShortMonthYear,
+  formatMentorshipTaskProgress,
   getMentorshipEnrollStepErrors,
   getMentorshipTermDateErrors,
   isMentorshipTermEnded,
@@ -22,6 +23,7 @@ import {
   isMentorshipLogoFileName,
   isMentorshipTermsAccepted,
   matchesMentorshipPersonSearch,
+  mentorshipMenteeActionsFor,
   mentorshipMonthYearToStartDate,
   mentorshipPersonInitials,
   mentorshipProgramSlug,
@@ -394,6 +396,26 @@ describe('program detail helpers', () => {
 
   it('formats an inclusive UTC date range', () => {
     expect(formatMentorshipDateRange('2026-07-01', '2026-08-31')).toBe('Jul 1, 2026 – Aug 31, 2026');
+  });
+
+  it('offers mentee row actions that exclude the current status, and none once graduated', () => {
+    expect(mentorshipMenteeActionsFor('accepted')).toEqual(['withdrawn', 'declined', 'graduated']);
+    // Only an accepted mentee can graduate.
+    expect(mentorshipMenteeActionsFor('pending')).toEqual(['withdrawn', 'declined']);
+    expect(mentorshipMenteeActionsFor('declined')).toEqual(['withdrawn']);
+    expect(mentorshipMenteeActionsFor('withdrawn')).toEqual(['declined']);
+    // `graduated` is terminal.
+    expect(mentorshipMenteeActionsFor('graduated')).toEqual([]);
+  });
+
+  it('formats task progress, and reports no label when nothing is assigned', () => {
+    expect(formatMentorshipTaskProgress(7, 12)).toBe('7 of 12 submitted');
+    expect(formatMentorshipTaskProgress(0, 12)).toBe('0 of 12 submitted');
+    // A missing count is a mentee with tasks assigned but none submitted yet.
+    expect(formatMentorshipTaskProgress(undefined, 9)).toBe('0 of 9 submitted');
+    // No assigned tasks must not render as "0 of 0 submitted".
+    expect(formatMentorshipTaskProgress(0, 0)).toBeNull();
+    expect(formatMentorshipTaskProgress(3, undefined)).toBeNull();
   });
 
   it('builds two-letter initials from a display name', () => {

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -27,6 +27,7 @@ import {
   mentorshipApplicantActionsFor,
   mentorshipApplicantDisplayStatus,
   mentorshipMenteeActionsFor,
+  mentorshipMenteesForProgram,
   mentorshipMonthYearToStartDate,
   mentorshipPersonInitials,
   mentorshipProgramSlug,
@@ -383,6 +384,47 @@ describe('program detail helpers', () => {
     );
 
     expect(detail.tabCounts).toEqual({ mentees: 1, applicants: 0, mentors: 2, terms: 0 });
+  });
+
+  it('scopes mentees to the tab that will render them, so the badge never over-counts', () => {
+    const program = {
+      id: 'mp_test',
+      slug: 'test',
+      name: 'Test',
+      projectName: 'LF Energy',
+      term: 'Fall 2026',
+      stats: { mentors: 0, mentees: 0, graduated: 0 },
+      createdOn: '2026-01-01T00:00:00.000Z',
+      updatedOn: '2026-01-01T00:00:00.000Z',
+    };
+    const mentees: MentorshipProgramMentee[] = [
+      { id: '1', name: 'A', email: 'a@example.com', status: 'accepted', termName: 'Fall 2026' },
+      // Still an applicant, so it belongs to neither mentee tab.
+      { id: '2', name: 'B', email: 'b@example.com', status: 'pending', termName: 'Fall 2026' },
+      { id: '3', name: 'C', email: 'c@example.com', status: 'withdrawn', termName: 'Fall 2026' },
+    ];
+    const lists = { mentees, applicants: [], mentors: [], terms: [] };
+
+    const open = buildMentorshipProgramDetail({ ...program, status: 'open' as const }, lists);
+    expect(open.mentees.map((person) => person.id)).toEqual(['1']);
+    expect(open.tabCounts.mentees).toBe(open.mentees.length);
+
+    const completed = buildMentorshipProgramDetail({ ...program, status: 'completed' as const }, lists);
+    expect(completed.mentees.map((person) => person.id)).toEqual(['3']);
+    expect(completed.tabCounts.mentees).toBe(completed.mentees.length);
+  });
+
+  it('splits mentees between the live and completed tabs', () => {
+    const mentees: MentorshipProgramMentee[] = [
+      { id: '1', name: 'A', email: 'a@example.com', status: 'accepted', termName: 'Fall 2026' },
+      { id: '2', name: 'B', email: 'b@example.com', status: 'pending', termName: 'Fall 2026' },
+      { id: '3', name: 'C', email: 'c@example.com', status: 'graduated', termName: 'Fall 2026' },
+      { id: '4', name: 'D', email: 'd@example.com', status: 'declined', termName: 'Fall 2026' },
+    ];
+
+    expect(mentorshipMenteesForProgram(mentees, false).map((person) => person.id)).toEqual(['1', '3']);
+    expect(mentorshipMenteesForProgram(mentees, true).map((person) => person.id)).toEqual(['3', '4']);
+    expect(mentorshipMenteesForProgram([], false)).toEqual([]);
   });
 
   it('matches people by name or email, but not by term', () => {

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -405,16 +405,20 @@ describe('program detail helpers', () => {
     ];
     const lists = { mentees, applicants: [], mentors: [], terms: [] };
 
+    // A live program answers "who is taking part", so the withdrawal is out and the
+    // accepted mentee is in. Whatever the tab renders is what the badge counts.
     const open = buildMentorshipProgramDetail({ ...program, status: 'open' as const }, lists);
     expect(open.mentees.map((person) => person.id)).toEqual(['1']);
     expect(open.tabCounts.mentees).toBe(open.mentees.length);
 
+    // Completing the program inverts it: the withdrawal is now history worth showing,
+    // and no mentee can still be `accepted` by the time a program closes.
     const completed = buildMentorshipProgramDetail({ ...program, status: 'completed' as const }, lists);
     expect(completed.mentees.map((person) => person.id)).toEqual(['3']);
     expect(completed.tabCounts.mentees).toBe(completed.mentees.length);
   });
 
-  it('splits mentees between the live and completed tabs', () => {
+  it('splits mentees between the live and completed tabs, keeping graduates on both', () => {
     const mentees: MentorshipProgramMentee[] = [
       { id: '1', name: 'A', email: 'a@example.com', status: 'accepted', termName: 'Fall 2026' },
       { id: '2', name: 'B', email: 'b@example.com', status: 'pending', termName: 'Fall 2026' },
@@ -422,7 +426,10 @@ describe('program detail helpers', () => {
       { id: '4', name: 'D', email: 'd@example.com', status: 'declined', termName: 'Fall 2026' },
     ];
 
+    // Live: taking part or finished early. The declined mentee waits for completion.
     expect(mentorshipMenteesForProgram(mentees, false).map((person) => person.id)).toEqual(['1', '3']);
+    // Completed: how each participation ended, so the graduate carries over and the
+    // decline appears. `pending` is an applicant either way.
     expect(mentorshipMenteesForProgram(mentees, true).map((person) => person.id)).toEqual(['3', '4']);
     expect(mentorshipMenteesForProgram([], false)).toEqual([]);
   });

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { createDefaultMentorshipTerm, createEmptyMentorshipEnrollForm } from '../constants/mentorship-enroll.constants';
+import { MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
 import type { MentorshipProgramMentee } from '../interfaces/mentorship.interface';
 import {
   buildMentorshipProgramDetail,
@@ -29,8 +30,11 @@ import {
   mentorshipMenteeActionsFor,
   mentorshipMenteesForProgram,
   mentorshipMonthYearToStartDate,
+  mentorshipNoteDisplay,
+  mentorshipPersonAvatarClass,
   mentorshipPersonInitials,
   mentorshipProgramSlug,
+  mentorshipRowActions,
   parseMentorshipDateOnly,
   parseMentorshipMonthYear,
   toMentorshipDateOnly,
@@ -432,6 +436,48 @@ describe('program detail helpers', () => {
     // decline appears. `pending` is an applicant either way.
     expect(mentorshipMenteesForProgram(mentees, true).map((person) => person.id)).toEqual(['3', '4']);
     expect(mentorshipMenteesForProgram([], false)).toEqual([]);
+  });
+
+  it('tints an avatar deterministically, and survives an empty name', () => {
+    // The guard matters: without it an empty name indexes the palette by NaN and the
+    // avatar renders with an undefined class.
+    expect(mentorshipPersonAvatarClass('')).toBe(MENTORSHIP_PROGRAM_AVATAR_PALETTE[0]);
+
+    expect(MENTORSHIP_PROGRAM_AVATAR_PALETTE).toContain(mentorshipPersonAvatarClass('Alex Rivera'));
+    expect(MENTORSHIP_PROGRAM_AVATAR_PALETTE).toContain(mentorshipPersonAvatarClass('Ifeoma Adeyemi'));
+
+    // Same person, same colour on every tab that renders them.
+    expect(mentorshipPersonAvatarClass('Alex Rivera')).toBe(mentorshipPersonAvatarClass('Alex Rivera'));
+  });
+
+  it('resolves a row note, preferring this session draft over the stored one', () => {
+    const addLabel = 'Add note';
+
+    expect(mentorshipNoteDisplay({}, { id: 'mnt_1' }, addLabel)).toEqual({ hasNote: false, noteLabel: addLabel });
+    expect(mentorshipNoteDisplay({}, { id: 'mnt_1', note: 'from the server' }, addLabel)).toEqual({ hasNote: true, noteLabel: 'from the server' });
+    expect(mentorshipNoteDisplay({ mnt_1: 'edited here' }, { id: 'mnt_1', note: 'from the server' }, addLabel)).toEqual({
+      hasNote: true,
+      noteLabel: 'edited here',
+    });
+    // An explicit clear is a draft too, so it must beat the stored note.
+    expect(mentorshipNoteDisplay({ mnt_1: '' }, { id: 'mnt_1', note: 'from the server' }, addLabel)).toEqual({ hasNote: false, noteLabel: addLabel });
+    // Whitespace is not a note.
+    expect(mentorshipNoteDisplay({ mnt_1: '   ' }, { id: 'mnt_1' }, addLabel)).toEqual({ hasNote: false, noteLabel: addLabel });
+    // A neighbour's draft never leaks into this row.
+    expect(mentorshipNoteDisplay({ mnt_2: 'theirs' }, { id: 'mnt_1' }, addLabel)).toEqual({ hasNote: false, noteLabel: addLabel });
+  });
+
+  it('resolves row actions against the caller label and icon maps', () => {
+    const labels = { accepted: 'Accept', declined: 'Decline' };
+    const icons = { accepted: 'fa-check', declined: 'fa-xmark' };
+
+    expect(mentorshipRowActions(['accepted', 'declined'], labels, icons)).toEqual([
+      { label: 'Accept', icon: 'fa-check' },
+      { label: 'Decline', icon: 'fa-xmark' },
+    ]);
+    // Order follows the caller's list, and an empty list means the row shows no menu.
+    expect(mentorshipRowActions(['declined'], labels, icons)).toEqual([{ label: 'Decline', icon: 'fa-xmark' }]);
+    expect(mentorshipRowActions([], labels, icons)).toEqual([]);
   });
 
   it('matches people by name or email, but not by term', () => {

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { createDefaultMentorshipTerm, createEmptyMentorshipEnrollForm } from '../constants/mentorship-enroll.constants';
+import type { MentorshipProgramMentee } from '../interfaces/mentorship.interface';
 import {
   buildMentorshipProgramDetail,
   formatMentorshipDateRange,
@@ -23,6 +24,8 @@ import {
   isMentorshipLogoFileName,
   isMentorshipTermsAccepted,
   matchesMentorshipPersonSearch,
+  mentorshipApplicantActionsFor,
+  mentorshipApplicantDisplayStatus,
   mentorshipMenteeActionsFor,
   mentorshipMonthYearToStartDate,
   mentorshipPersonInitials,
@@ -406,6 +409,33 @@ describe('program detail helpers', () => {
     expect(mentorshipMenteeActionsFor('withdrawn')).toEqual(['declined']);
     // `graduated` is terminal.
     expect(mentorshipMenteeActionsFor('graduated')).toEqual([]);
+  });
+
+  it('reads an application as Applied until every prerequisite is submitted', () => {
+    const applicant = (overrides: Partial<MentorshipProgramMentee>): MentorshipProgramMentee => ({
+      id: 'app_1',
+      name: 'Ifeoma Adeyemi',
+      email: 'ifeoma.adeyemi@example.com',
+      status: 'pending',
+      termName: 'Fall 2026',
+      ...overrides,
+    });
+
+    expect(mentorshipApplicantDisplayStatus(applicant({ tasksSubmitted: 2, tasksTotal: 5 }))).toBe('applied');
+    expect(mentorshipApplicantDisplayStatus(applicant({ tasksSubmitted: 5, tasksTotal: 5 }))).toBe('tasks-completed');
+    // No prerequisites assigned is not the same as having completed them.
+    expect(mentorshipApplicantDisplayStatus(applicant({}))).toBe('applied');
+    // Every resolved status displays as itself, whatever the task counts say.
+    expect(mentorshipApplicantDisplayStatus(applicant({ status: 'accepted', tasksSubmitted: 1, tasksTotal: 5 }))).toBe('accepted');
+    expect(mentorshipApplicantDisplayStatus(applicant({ status: 'graduated' }))).toBe('graduated');
+  });
+
+  it('offers applicant row actions that exclude the current status, and never re-accepts a graduate', () => {
+    expect(mentorshipApplicantActionsFor('pending')).toEqual(['accepted', 'declined', 'withdrawn']);
+    expect(mentorshipApplicantActionsFor('accepted')).toEqual(['declined', 'withdrawn']);
+    expect(mentorshipApplicantActionsFor('declined')).toEqual(['accepted', 'withdrawn']);
+    expect(mentorshipApplicantActionsFor('withdrawn')).toEqual(['accepted', 'declined']);
+    expect(mentorshipApplicantActionsFor('graduated')).toEqual(['declined', 'withdrawn']);
   });
 
   it('formats task progress, and reports no label when nothing is assigned', () => {

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -16,7 +16,13 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_TERM_NAME_MAX,
 } from '../constants/mentorship-enroll.constants';
-import { MENTORSHIP_APPLICANT_ACTIONS, MENTORSHIP_MENTEE_ACTIONS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
+import {
+  MENTORSHIP_APPLICANT_ACTIONS,
+  MENTORSHIP_CURRENT_MENTEE_STATUSES,
+  MENTORSHIP_MENTEE_ACTIONS,
+  MENTORSHIP_PAST_MENTEE_STATUSES,
+  MENTORSHIP_PROGRAM_AVATAR_PALETTE,
+} from '../constants/mentorship.constants';
 import type {
   MentorshipApplicantAction,
   MentorshipApplicantDisplayStatus,
@@ -308,11 +314,30 @@ export function buildMentorshipProgramTabCounts(lists: MentorshipProgramLists): 
   };
 }
 
+/**
+ * The mentees the program's first tab can show. A live program lists the enrolled
+ * ones and a completed program lists finished participations, so anyone still
+ * `pending` belongs to the Applicants tab rather than either mentee tab.
+ */
+export function mentorshipMenteesForProgram(mentees: MentorshipProgramMentee[], isCompleted: boolean): MentorshipProgramMentee[] {
+  const statuses = isCompleted ? MENTORSHIP_PAST_MENTEE_STATUSES : MENTORSHIP_CURRENT_MENTEE_STATUSES;
+  return mentees.filter((person) => statuses.includes(person.status));
+}
+
+/**
+ * Scopes the mentee list to the tab that will render it *before* the counts are
+ * taken, so the badge can never promise a row the tab does not show.
+ */
 export function buildMentorshipProgramDetail(program: MentorshipProgram, lists: MentorshipProgramLists): MentorshipProgramDetail {
+  const scoped: MentorshipProgramLists = {
+    ...lists,
+    mentees: mentorshipMenteesForProgram(lists.mentees, program.status === 'completed'),
+  };
+
   return {
     program,
-    tabCounts: buildMentorshipProgramTabCounts(lists),
-    ...lists,
+    tabCounts: buildMentorshipProgramTabCounts(scoped),
+    ...scoped,
   };
 }
 

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -20,6 +20,7 @@ import { MENTORSHIP_APPLICANT_ACTIONS, MENTORSHIP_MENTEE_ACTIONS, MENTORSHIP_PRO
 import type {
   MentorshipApplicantAction,
   MentorshipApplicantDisplayStatus,
+  MentorshipApplicationProgress,
   MentorshipEnrollFieldErrors,
   MentorshipEnrollRequest,
   MentorshipEnrollStep,
@@ -323,28 +324,34 @@ export function matchesMentorshipPersonSearch(person: MentorshipProgramMentee | 
 }
 
 /**
- * Row actions offered for a mentee's current status on the Current Mentees tab.
- * Each action moves the mentee to the same-named status, so the status a mentee is
- * already in is never offered. `graduated` is terminal, and only an accepted mentee
- * can graduate.
- */
-/**
  * Whether every prerequisite task has been submitted. A person with no tasks assigned
  * has not completed anything, so an empty assignment is never "complete".
  */
-export function mentorshipPrerequisitesComplete(person: Pick<MentorshipProgramMentee, 'tasksSubmitted' | 'tasksTotal'>): boolean {
+function mentorshipPrerequisitesComplete(person: MentorshipApplicationProgress): boolean {
   const total = person.tasksTotal ?? 0;
   return total > 0 && (person.tasksSubmitted ?? 0) >= total;
 }
 
 /**
- * Status to show for an applicant row. An application stays `pending` while the mentee
+ * Status to show for an application. It stays `pending` on the wire while the mentee
  * works through the prerequisites, so the tab reads that as `applied` until every task
  * is in and `tasks-completed` once they are. Every other status displays as-is.
+ *
+ * Takes the progress fields rather than a whole row so a cross-program application,
+ * which carries the same three fields and nothing else, derives its label the same way.
  */
-export function mentorshipApplicantDisplayStatus(applicant: MentorshipProgramMentee): MentorshipApplicantDisplayStatus {
-  if (applicant.status !== 'pending') return applicant.status;
-  return mentorshipPrerequisitesComplete(applicant) ? 'tasks-completed' : 'applied';
+export function mentorshipApplicantDisplayStatus(application: MentorshipApplicationProgress): MentorshipApplicantDisplayStatus {
+  if (application.status !== 'pending') return application.status;
+  return mentorshipPrerequisitesComplete(application) ? 'tasks-completed' : 'applied';
+}
+
+/**
+ * Term filter options for a program-detail tab, derived from the rows themselves — a
+ * program's terms are whichever ones its people took part in.
+ */
+export function mentorshipTermFilterOptions(people: { termName: string }[], allLabel: string): { label: string; value: string | null }[] {
+  const terms = [...new Set(people.map((person) => person.termName))];
+  return [{ label: allLabel, value: null }, ...terms.map((term) => ({ label: term, value: term }))];
 }
 
 /**
@@ -359,6 +366,12 @@ export function mentorshipApplicantActionsFor(status: MentorshipMenteeStatus): M
   });
 }
 
+/**
+ * Row actions offered for a mentee's current status on the Current Mentees tab.
+ * Each action moves the mentee to the same-named status, so the status a mentee is
+ * already in is never offered. `graduated` is terminal, and only an accepted mentee
+ * can graduate.
+ */
 export function mentorshipMenteeActionsFor(status: MentorshipMenteeStatus): MentorshipMenteeAction[] {
   if (status === 'graduated') return [];
   return MENTORSHIP_MENTEE_ACTIONS.filter((action) => {

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -16,8 +16,10 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_TERM_NAME_MAX,
 } from '../constants/mentorship-enroll.constants';
-import { MENTORSHIP_MENTEE_ACTIONS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
+import { MENTORSHIP_APPLICANT_ACTIONS, MENTORSHIP_MENTEE_ACTIONS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
 import type {
+  MentorshipApplicantAction,
+  MentorshipApplicantDisplayStatus,
   MentorshipEnrollFieldErrors,
   MentorshipEnrollRequest,
   MentorshipEnrollStep,
@@ -326,6 +328,37 @@ export function matchesMentorshipPersonSearch(person: MentorshipProgramMentee | 
  * already in is never offered. `graduated` is terminal, and only an accepted mentee
  * can graduate.
  */
+/**
+ * Whether every prerequisite task has been submitted. A person with no tasks assigned
+ * has not completed anything, so an empty assignment is never "complete".
+ */
+export function mentorshipPrerequisitesComplete(person: Pick<MentorshipProgramMentee, 'tasksSubmitted' | 'tasksTotal'>): boolean {
+  const total = person.tasksTotal ?? 0;
+  return total > 0 && (person.tasksSubmitted ?? 0) >= total;
+}
+
+/**
+ * Status to show for an applicant row. An application stays `pending` while the mentee
+ * works through the prerequisites, so the tab reads that as `applied` until every task
+ * is in and `tasks-completed` once they are. Every other status displays as-is.
+ */
+export function mentorshipApplicantDisplayStatus(applicant: MentorshipProgramMentee): MentorshipApplicantDisplayStatus {
+  if (applicant.status !== 'pending') return applicant.status;
+  return mentorshipPrerequisitesComplete(applicant) ? 'tasks-completed' : 'applied';
+}
+
+/**
+ * Row actions offered for an application's current status on the Applicants tab. Each
+ * action moves the application to the same-named status, so the one it already holds is
+ * never offered, and a mentee who has already graduated can no longer be accepted.
+ */
+export function mentorshipApplicantActionsFor(status: MentorshipMenteeStatus): MentorshipApplicantAction[] {
+  return MENTORSHIP_APPLICANT_ACTIONS.filter((action) => {
+    if (action === status) return false;
+    return action !== 'accepted' || status !== 'graduated';
+  });
+}
+
 export function mentorshipMenteeActionsFor(status: MentorshipMenteeStatus): MentorshipMenteeAction[] {
   if (status === 'graduated') return [];
   return MENTORSHIP_MENTEE_ACTIONS.filter((action) => {

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -316,9 +316,20 @@ export function buildMentorshipProgramTabCounts(lists: MentorshipProgramLists): 
 }
 
 /**
- * The mentees the program's first tab can show. A live program lists the enrolled
- * ones and a completed program lists finished participations, so anyone still
- * `pending` belongs to the Applicants tab rather than either mentee tab.
+ * The mentees the program's first tab can show, which is a narrower set than
+ * "everyone who is not an applicant".
+ *
+ * A live program lists the mentees actually taking part — `accepted`, plus the
+ * `graduated` ones who finished early. A completed program lists how each
+ * participation ended: `withdrawn`, `declined` or `graduated`. `accepted` is
+ * deliberately absent from that second set, because closing a program requires
+ * every accepted mentee to have been graduated or declined first, so an
+ * `accepted` mentee on a completed program is a state the domain does not
+ * produce rather than a row to render.
+ *
+ * A mentee who withdraws or is declined mid-program is therefore not shown while
+ * the program is still running, and appears on Past Mentees once it completes.
+ * That is intended: the live tab answers "who is taking part", not "who ever was".
  */
 export function mentorshipMenteesForProgram(mentees: MentorshipProgramMentee[], isCompleted: boolean): MentorshipProgramMentee[] {
   const statuses = isCompleted ? MENTORSHIP_PAST_MENTEE_STATUSES : MENTORSHIP_CURRENT_MENTEE_STATUSES;

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -16,10 +16,13 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_TERM_NAME_MAX,
 } from '../constants/mentorship-enroll.constants';
+import { MENTORSHIP_MENTEE_ACTIONS } from '../constants/mentorship.constants';
 import type {
   MentorshipEnrollFieldErrors,
   MentorshipEnrollRequest,
   MentorshipEnrollStep,
+  MentorshipMenteeAction,
+  MentorshipMenteeStatus,
   MentorshipProgram,
   MentorshipProgramDetail,
   MentorshipProgramLists,
@@ -315,6 +318,30 @@ export function matchesMentorshipPersonSearch(person: MentorshipProgramMentee | 
   const needle = search.trim().toLowerCase();
   if (!needle) return true;
   return person.name.toLowerCase().includes(needle) || person.email.toLowerCase().includes(needle);
+}
+
+/**
+ * Row actions offered for a mentee's current status on the Current Mentees tab.
+ * Each action moves the mentee to the same-named status, so the status a mentee is
+ * already in is never offered. `graduated` is terminal, and only an accepted mentee
+ * can graduate.
+ */
+export function mentorshipMenteeActionsFor(status: MentorshipMenteeStatus): MentorshipMenteeAction[] {
+  if (status === 'graduated') return [];
+  return MENTORSHIP_MENTEE_ACTIONS.filter((action) => {
+    if (action === status) return false;
+    return action !== 'graduated' || status === 'accepted';
+  });
+}
+
+/**
+ * Task column label on the Current Mentees tab, e.g. `7 of 12 submitted`.
+ * Returns null when no tasks are assigned so the cell can render a dash instead
+ * of the misleading `0 of 0 submitted`.
+ */
+export function formatMentorshipTaskProgress(submitted?: number, total?: number): string | null {
+  if (!total || total <= 0) return null;
+  return `${submitted ?? 0} of ${total} submitted`;
 }
 
 /** Inclusive UTC date range for term / invitation columns, e.g. `Jul 1, 2026 – Aug 31, 2026`. */

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -23,6 +23,7 @@ import {
   MENTORSHIP_PAST_MENTEE_STATUSES,
   MENTORSHIP_PROGRAM_AVATAR_PALETTE,
 } from '../constants/mentorship.constants';
+import type { FilterOption } from '../interfaces/filter.interface';
 import type {
   MentorshipApplicantAction,
   MentorshipApplicantDisplayStatus,
@@ -374,7 +375,7 @@ export function mentorshipApplicantDisplayStatus(application: MentorshipApplicat
  * Term filter options for a program-detail tab, derived from the rows themselves — a
  * program's terms are whichever ones its people took part in.
  */
-export function mentorshipTermFilterOptions(people: { termName: string }[], allLabel: string): { label: string; value: string | null }[] {
+export function mentorshipTermFilterOptions(people: { termName: string }[], allLabel: string): FilterOption[] {
   const terms = [...new Set(people.map((person) => person.termName))];
   return [{ label: allLabel, value: null }, ...terms.map((term) => ({ label: term, value: term }))];
 }

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -16,7 +16,7 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_TERM_NAME_MAX,
 } from '../constants/mentorship-enroll.constants';
-import { MENTORSHIP_MENTEE_ACTIONS } from '../constants/mentorship.constants';
+import { MENTORSHIP_MENTEE_ACTIONS, MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
 import type {
   MentorshipEnrollFieldErrors,
   MentorshipEnrollRequest,
@@ -366,6 +366,15 @@ export function mentorshipOpenTermCount(terms: ReadonlyArray<Pick<MentorshipProg
 
 export function mentorshipTermHasApplications(term: Pick<MentorshipProgramTermRow, 'pending' | 'declined' | 'accepted' | 'graduated'>): boolean {
   return term.pending + term.declined + term.accepted + term.graduated > 0;
+}
+
+/**
+ * Deterministic avatar tint for a person, seeded from their display name so the
+ * same person keeps the same colour across every program-detail tab.
+ */
+export function mentorshipPersonAvatarClass(name: string): string {
+  const seed = name.length > 0 ? name.charCodeAt(0) : 0;
+  return MENTORSHIP_PROGRAM_AVATAR_PALETTE[seed % MENTORSHIP_PROGRAM_AVATAR_PALETTE.length];
 }
 
 /** Two-letter initials from the first two whitespace-delimited tokens, e.g. "Alex Rivera" → "AR". */

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -33,6 +33,7 @@ import type {
   MentorshipEnrollStep,
   MentorshipMenteeAction,
   MentorshipMenteeStatus,
+  MentorshipNoteDisplay,
   MentorshipProgram,
   MentorshipProgramDetail,
   MentorshipProgramLists,
@@ -41,6 +42,7 @@ import type {
   MentorshipProgramTabCounts,
   MentorshipProgramTerm,
   MentorshipProgramTermRow,
+  MentorshipRowAction,
   MentorshipTermDateErrors,
 } from '../interfaces/mentorship.interface';
 import { formatIsoDateLabel, monthYearToIsoDate } from './date-time.utils';
@@ -449,6 +451,25 @@ export function mentorshipOpenTermCount(terms: ReadonlyArray<Pick<MentorshipProg
 
 export function mentorshipTermHasApplications(term: Pick<MentorshipProgramTermRow, 'pending' | 'declined' | 'accepted' | 'graduated'>): boolean {
   return term.pending + term.declined + term.accepted + term.graduated > 0;
+}
+
+/**
+ * Resolves a row's action statuses into what its menu renders. Each tab has its own
+ * action union and its own label and icon maps, so this takes them as arguments rather
+ * than choosing; the shape it returns is what `lfx-mentorship-row-actions` consumes.
+ */
+export function mentorshipRowActions<T extends string>(actions: readonly T[], labels: Record<T, string>, icons: Record<T, string>): MentorshipRowAction[] {
+  return actions.map((action) => ({ label: labels[action], icon: icons[action] }));
+}
+
+/**
+ * The reviewer-note line for a row. A draft edited this session wins over the note the
+ * row arrived with, whitespace alone counts as no note, and an absent note falls back
+ * to the "Add note" prompt. Shared so the tabs cannot disagree on what a note is.
+ */
+export function mentorshipNoteDisplay(drafts: Record<string, string>, person: { id: string; note?: string }, addLabel: string): MentorshipNoteDisplay {
+  const note = (drafts[person.id] ?? person.note ?? '').trim();
+  return { hasNote: note.length > 0, noteLabel: note.length > 0 ? note : addLabel };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the admin program detail page at `/mentorship/admin/:programId`, which
accepts either a program id (the default) or a slug. The page hosts four
underline tabs, each its own component, with live counts in the header.

JIRA: https://linuxfoundation.atlassian.net/browse/LFXV2-XXXX

## What's included

| Tab | Behaviour |
| --- | --- |
| **Mentees** | Splits by program status. A live program shows Current Mentees — task progress, Create Task, and Withdraw / Decline / Graduate row actions. A completed program shows Past Mentees instead: read-only history with a Term column and no tasks, actions, or notes. |
| **Applicants** | Derives its display status from the wire status — an application stays `pending` while prerequisites are outstanding, showing as "Applied", and flips to "Tasks Completed" once every task is submitted. Lists the applicant's other active applications with links to those programs. Accept / Decline / Withdraw actions. |
| **Mentors** | Invite picker backed by a new BFF endpoint, plus Accept / Decline / Remove row actions. |
| **Terms** | Create and edit reuse the existing `EnrollTermDialogComponent` so term validation stays in one place. Edit / Close / Re-Open / Delete actions follow the [manage-terms docs](https://docs.linuxfoundation.org/lfx/mentorship/administrators/manage-terms). |

All four tabs support search, status filtering, and client-side pagination.

## Notable decisions

- **Reviewer notes live on the parent page, not the tabs.** The tab panel is an
  `@switch`, so a tab component is destroyed as soon as the admin looks at
  another tab. Note drafts held inside one would not survive the trip back, so
  `ProgramDetailComponent` owns them and the tabs emit `noteRequested`. Notes
  are in-memory only for now, and the dialog copy says so.
- **Mentee rows are scoped by excluding `pending` only**, never by a tab's
  status-filter options. Scoping by the filter lists would silently drop a
  mid-program withdrawal from every tab, and because the tab badge derives from
  the same list, the count would have agreed with the truncated table and hidden
  the problem.
- **The invitable-users endpoint is global, not program-scoped** — it returns
  users, and the client excludes those already on the program.
- **Person search no longer matches on term name.** Searching "Fall 2026"
  returned every mentee in that term, which is what the term filter is for.
- **Every write action is stubbed** behind a shared "coming soon" toast until
  the mentorship service exists.

## Data source

There is no mentorship microservice yet, so the page is backed by mock fixtures
in `@lfx-one/shared` constants. This is a deliberate, temporary exception to the
no-mock-data rule — tracked for removal in LFXV2-YYYY, which will replace the
fixtures with real endpoints.

## PR size

2,118 insertions across 35 files, above the 1,000-line target. The four tabs
share the header, the routing, the note dialog, and the shared types, so
splitting them into separate PRs would have meant either merging dead tabs or
duplicating that foundation and reworking it each time. Roughly 600 lines are
new specs.

## Testing

- 43 shared unit tests and 38 Angular component specs, all passing
- `yarn check-types`, `yarn lint:check`, and Prettier all clean
- Manually verified both mentee tab variants, the derived applicant statuses,
  note persistence across tab switches, and every filter combination

## Screenshots

<!-- add before opening -->