### PR TITLE
feat(meetings): classify preferred-email errors via type/code fields

### DIFF
--- a/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
@@ -231,7 +231,14 @@ describe('MeetingPreferenceService', () => {
     // #2269/#2270: once the meeting-service reply carries `type`/`code`, those are authoritative
     // over the message text — even text that would otherwise match a different heuristic above.
     it.each([
-      ['code: email_not_synced overrides an unrelated message', { error: 'boom', code: 'email_not_synced' }, 'sync_pending'],
+      // The real upstream envelope sends `type: 'unavailable'` alongside `code: 'email_not_synced'`
+      // (they share the same domain.ErrorType) — include both so this locks down `code` taking
+      // precedence over `type`, not just "code alone works".
+      [
+        'code: email_not_synced overrides type: unavailable and an unrelated message',
+        { error: 'boom', type: 'unavailable', code: 'email_not_synced' },
+        'sync_pending',
+      ],
       ['type: validation overrides an unrelated message', { error: 'boom', type: 'validation' }, 'validation'],
       // "not yet available" would match the sync_pending fallback by text, but a bare `type` of
       // unavailable (no `code`) is the generic-outage case, not the finer sync-pending one.

--- a/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
@@ -246,7 +246,8 @@ describe('MeetingPreferenceService', () => {
       ['type: internal maps to unavailable', { error: 'boom', type: 'internal' }, 'unavailable'],
       ['type: not_found maps to unavailable', { error: 'boom', type: 'not_found' }, 'unavailable'],
       ['type: conflict maps to unavailable', { error: 'boom', type: 'conflict' }, 'unavailable'],
-      // A `type` outside the 5 values above (a future meeting-service ErrorType self-serve doesn't
+      ['type: forbidden maps to unavailable', { error: 'boom', type: 'forbidden' }, 'unavailable'],
+      // A `type` outside the 6 values above (a future meeting-service ErrorType self-serve doesn't
       // know about yet, or a non-string wire value) must not be trusted as "generically unavailable"
       // — it's normalized away in extractPreferredEmailError so this falls through to the message
       // heuristics below, same as no `type` at all.

--- a/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
@@ -239,6 +239,12 @@ describe('MeetingPreferenceService', () => {
       ['type: internal maps to unavailable', { error: 'boom', type: 'internal' }, 'unavailable'],
       ['type: not_found maps to unavailable', { error: 'boom', type: 'not_found' }, 'unavailable'],
       ['type: conflict maps to unavailable', { error: 'boom', type: 'conflict' }, 'unavailable'],
+      // A `type` outside the 5 values above (a future meeting-service ErrorType self-serve doesn't
+      // know about yet, or a non-string wire value) must not be trusted as "generically unavailable"
+      // — it's normalized away in extractPreferredEmailError so this falls through to the message
+      // heuristics below, same as no `type` at all.
+      ['unrecognized type falls through to the message heuristics', { error: 'is not an active, verified address', type: 'invalid_request' }, 'validation'],
+      ['non-string type falls through to the message heuristics', { error: 'is not an active, verified address', type: 123 }, 'validation'],
     ])('classifies %s', async (_label, body, reason) => {
       natsRequest.mockResolvedValue(reply(body));
 

--- a/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
@@ -253,6 +253,9 @@ describe('MeetingPreferenceService', () => {
       // heuristics below, same as no `type` at all.
       ['unrecognized type falls through to the message heuristics', { error: 'is not an active, verified address', type: 'invalid_request' }, 'validation'],
       ['non-string type falls through to the message heuristics', { error: 'is not an active, verified address', type: 123 }, 'validation'],
+      // Same normalization applies to `code` — only the exact 'email_not_synced' value is trusted.
+      ['unrecognized code falls through to the message heuristics', { error: 'is not an active, verified address', code: 'some_future_code' }, 'validation'],
+      ['non-string code falls through to the message heuristics', { error: 'is not an active, verified address', code: 123 }, 'validation'],
     ])('classifies %s', async (_label, body, reason) => {
       natsRequest.mockResolvedValue(reply(body));
 

--- a/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.spec.ts
@@ -218,13 +218,34 @@ describe('MeetingPreferenceService', () => {
       // real permanent failure, so unrecognized text also falls to the retryable default (Copilot
       // review, PR #1073): this only changes which "please try again" copy the user sees.
       ['something else broke', 'unavailable'],
-    ])('classifies the upstream error %j as %s', async (upstreamError, reason) => {
+    ])('classifies the upstream error %j as %s when the reply has no type/code (pre-#2269 fallback)', async (upstreamError, reason) => {
       natsRequest.mockResolvedValue(reply({ error: upstreamError }));
 
       await expect(service.setMeetingInviteEmail(req, V1_TOKEN, ALTERNATE_EMAIL)).resolves.toEqual({
         success: false,
         reason,
         error: upstreamError,
+      });
+    });
+
+    // #2269/#2270: once the meeting-service reply carries `type`/`code`, those are authoritative
+    // over the message text — even text that would otherwise match a different heuristic above.
+    it.each([
+      ['code: email_not_synced overrides an unrelated message', { error: 'boom', code: 'email_not_synced' }, 'sync_pending'],
+      ['type: validation overrides an unrelated message', { error: 'boom', type: 'validation' }, 'validation'],
+      // "not yet available" would match the sync_pending fallback by text, but a bare `type` of
+      // unavailable (no `code`) is the generic-outage case, not the finer sync-pending one.
+      ['type: unavailable wins over a sync_pending-sounding message', { error: 'not yet available', type: 'unavailable' }, 'unavailable'],
+      ['type: internal maps to unavailable', { error: 'boom', type: 'internal' }, 'unavailable'],
+      ['type: not_found maps to unavailable', { error: 'boom', type: 'not_found' }, 'unavailable'],
+      ['type: conflict maps to unavailable', { error: 'boom', type: 'conflict' }, 'unavailable'],
+    ])('classifies %s', async (_label, body, reason) => {
+      natsRequest.mockResolvedValue(reply(body));
+
+      await expect(service.setMeetingInviteEmail(req, V1_TOKEN, ALTERNATE_EMAIL)).resolves.toEqual({
+        success: false,
+        reason,
+        error: body.error,
       });
     });
 

--- a/apps/lfx-one/src/server/services/meeting-preference.service.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.ts
@@ -3,7 +3,7 @@
 
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { MeetingInviteEmail, SetMeetingInviteResult } from '@lfx-one/shared/interfaces';
+import { MeetingInviteEmail, PreferredEmailErrorReply, SetMeetingInviteResult } from '@lfx-one/shared/interfaces';
 import { isMeetingInvitePrimarySentinel, redactEmailAddresses } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
@@ -18,7 +18,7 @@ import { NatsService } from './nats.service';
  * API-gateway token in the `token` field of the payload (the service forwards it as a Bearer
  * token to v1 /v1/me). The reply is the selected email directly (`{ email_id, email }`), with
  * both fields null when the user has no override (meeting invitations fall back to primary),
- * or `{ error }` on failure.
+ * or `{ error }` on failure — `set` failures may also carry `type`/`code` (see #2269/#2270).
  */
 export class MeetingPreferenceService {
   private natsService: NatsService;
@@ -129,15 +129,15 @@ export class MeetingPreferenceService {
       return { success: false, reason: 'upstream', error: 'Internal server error' };
     }
 
-    const setError = this.extractUpstreamError(parsed);
+    const setError = this.extractPreferredEmailError(parsed);
     if (setError !== null) {
       // Warning-level logs are emitted in production; redact the address the validation copy
       // can embed rather than persisting it as PII. The returned `error` stays raw — the
       // controller substitutes fixed user-facing copy per `reason`, so nothing leaks to the client.
       logger.warning(req, 'set_meeting_invite_email', 'NATS preferred_email.set returned an error', {
-        error: redactEmailAddresses(setError),
+        error: redactEmailAddresses(setError.error),
       });
-      return { success: false, reason: this.classifyPreferredEmailError(setError), error: setError };
+      return { success: false, reason: this.classifyPreferredEmailError(setError), error: setError.error };
     }
 
     if (!this.isValidMeetingInviteReply(parsed)) {
@@ -165,6 +165,20 @@ export class MeetingPreferenceService {
     return typeof error === 'string' ? error : null;
   }
 
+  // Same shape guard as extractUpstreamError, but also carries the optional `type`/`code` fields
+  // the meeting-service envelope may add (#2269) — only `set` classifies on them, so `get` keeps
+  // using the simpler extractUpstreamError above.
+  private extractPreferredEmailError(value: unknown): PreferredEmailErrorReply | null {
+    if (typeof value !== 'object' || value === null) {
+      return null;
+    }
+    const { error, type, code } = value as Record<string, unknown>;
+    if (typeof error !== 'string') {
+      return null;
+    }
+    return { error, type: typeof type === 'string' ? type : undefined, code: typeof code === 'string' ? code : undefined };
+  }
+
   // The upstream contract always emits both keys as strings (an override) or both as null (no
   // override) on a non-error reply. Anything else — a missing key, a wrong type, or a mixed
   // null/string pair — is a contract break, not a valid "no override": callers must fail rather
@@ -180,10 +194,24 @@ export class MeetingPreferenceService {
     return typeof email_id === 'string' && typeof email === 'string';
   }
 
-  // Classify the upstream error string (the NATS reply carries only `{ error }`, no code) so the
-  // controller can map it to an HTTP status: validation → 4xx, sync_pending/unavailable → 503,
-  // anything else → 503 (see the fallback comment below for why unrecognized text lands there too).
-  private classifyPreferredEmailError(error: string): SetMeetingInviteResult['reason'] {
+  // Classify the upstream error so the controller can map it to an HTTP status: validation → 4xx,
+  // sync_pending/unavailable → 503, anything else → 503. `type`/`code` (see #2269) are trusted
+  // first when present; `error` message-matching is kept only as a fallback for a meeting-service
+  // deploy that hasn't shipped them yet, so behavior never regresses below what it is today.
+  private classifyPreferredEmailError({ error, type, code }: PreferredEmailErrorReply): SetMeetingInviteResult['reason'] {
+    // `code` is the finer signal — it's only set for the retryable "email not yet synced from
+    // Auth0 to SFDC" case, which otherwise shares `type: 'unavailable'` with a generic outage.
+    if (code === 'email_not_synced') {
+      return 'sync_pending';
+    }
+    if (type === 'validation') {
+      return 'validation';
+    }
+    if (type !== undefined) {
+      return 'unavailable';
+    }
+
+    // No structured signal on this reply — fall back to the original message-matching heuristics.
     const normalized = error.toLowerCase();
     if (normalized.includes('not an active, verified address')) {
       return 'validation';
@@ -192,16 +220,15 @@ export class MeetingPreferenceService {
       return 'sync_pending';
     }
     // The meeting-service's user-service client maps network failures and HTTP 429/502/503/504 to
-    // a retryable error, but the NATS envelope only carries `err.Error()` — no error-type field —
-    // so recognize its known message shapes here rather than falling through to the default below.
+    // a retryable error, but pre-#2269 the NATS envelope only carries `err.Error()` — no error-type
+    // field — so recognize its known message shapes here rather than falling through to the default.
     if (normalized.includes('user-service request failed') || /\bhttp (429|502|503|504)\b/.test(normalized)) {
       return 'unavailable';
     }
     // A structured user-service error body (e.g. `{"Message":"boom"}`) reaches here as opaque text
-    // with none of the markers above — matching it by string is fundamentally unreliable without an
-    // upstream envelope change (tracked separately). Default to the retryable path: an unrecognized
-    // failure from a downstream write is more often transient than a validation problem we'd have
-    // already caught above, so this only changes which "please try again" copy the user sees.
+    // with none of the markers above. Default to the retryable path: an unrecognized failure from a
+    // downstream write is more often transient than a validation problem we'd have already caught
+    // above, so this only changes which "please try again" copy the user sees.
     return 'unavailable';
   }
 }

--- a/apps/lfx-one/src/server/services/meeting-preference.service.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG, PREFERRED_EMAIL_ERROR_TYPE } from '@lfx-one/shared/constants';
+import { NATS_CONFIG, PREFERRED_EMAIL_ERROR_CODE, PREFERRED_EMAIL_ERROR_TYPE } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { MeetingInviteEmail, PreferredEmailErrorReply, PreferredEmailErrorType, SetMeetingInviteResult } from '@lfx-one/shared/interfaces';
 import { isMeetingInvitePrimarySentinel, redactEmailAddresses } from '@lfx-one/shared/utils';
@@ -171,7 +171,7 @@ export class MeetingPreferenceService {
     if (typeof error !== 'string') {
       return null;
     }
-    return { error, type: this.asKnownErrorType(type), code: code === 'email_not_synced' ? code : undefined };
+    return { error, type: this.asKnownErrorType(type), code: code === PREFERRED_EMAIL_ERROR_CODE.EMAIL_NOT_SYNCED ? code : undefined };
   }
 
   private asKnownErrorType(value: unknown): PreferredEmailErrorType | undefined {
@@ -203,7 +203,7 @@ export class MeetingPreferenceService {
   private classifyPreferredEmailError({ error, type, code }: PreferredEmailErrorReply): SetMeetingInviteResult['reason'] {
     // `code` is the finer signal — it's only set for the retryable "email not yet synced from
     // Auth0 to SFDC" case, which otherwise shares `type: 'unavailable'` with a generic outage.
-    if (code === 'email_not_synced') {
+    if (code === PREFERRED_EMAIL_ERROR_CODE.EMAIL_NOT_SYNCED) {
       return 'sync_pending';
     }
     if (type === 'validation') {

--- a/apps/lfx-one/src/server/services/meeting-preference.service.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG } from '@lfx-one/shared/constants';
+import { NATS_CONFIG, PREFERRED_EMAIL_ERROR_TYPE } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import { MeetingInviteEmail, PreferredEmailErrorReply, PreferredEmailErrorType, SetMeetingInviteResult } from '@lfx-one/shared/interfaces';
 import { isMeetingInvitePrimarySentinel, redactEmailAddresses } from '@lfx-one/shared/utils';
@@ -175,8 +175,8 @@ export class MeetingPreferenceService {
   }
 
   private asKnownErrorType(value: unknown): PreferredEmailErrorType | undefined {
-    const KNOWN_TYPES: PreferredEmailErrorType[] = ['validation', 'forbidden', 'not_found', 'conflict', 'internal', 'unavailable'];
-    return KNOWN_TYPES.includes(value as PreferredEmailErrorType) ? (value as PreferredEmailErrorType) : undefined;
+    const knownTypes: PreferredEmailErrorType[] = Object.values(PREFERRED_EMAIL_ERROR_TYPE);
+    return knownTypes.includes(value as PreferredEmailErrorType) ? (value as PreferredEmailErrorType) : undefined;
   }
 
   // The upstream contract always emits both keys as strings (an override) or both as null (no

--- a/apps/lfx-one/src/server/services/meeting-preference.service.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.ts
@@ -3,7 +3,7 @@
 
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { MeetingInviteEmail, PreferredEmailErrorReply, SetMeetingInviteResult } from '@lfx-one/shared/interfaces';
+import { MeetingInviteEmail, PreferredEmailErrorReply, PreferredEmailErrorType, SetMeetingInviteResult } from '@lfx-one/shared/interfaces';
 import { isMeetingInvitePrimarySentinel, redactEmailAddresses } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
@@ -54,7 +54,7 @@ export class MeetingPreferenceService {
         return null;
       }
 
-      const getError = this.extractUpstreamError(parsed);
+      const getError = this.extractPreferredEmailError(parsed)?.error ?? null;
       if (getError !== null) {
         // Upstream error copy can embed the mailbox (e.g. validation messages) — redact before
         // it reaches the WARN log, which persists in production.
@@ -156,18 +156,13 @@ export class MeetingPreferenceService {
   // valid JSON can also decode to null, a primitive, or `{ error: <non-string> }`, and accessing
   // `.error` on the former or handing the latter to the string-only redactor would throw, turning
   // a handled contract failure into an uncaught exception. Anything that doesn't match falls
-  // through to the shape-validation branch below instead.
-  private extractUpstreamError(value: unknown): string | null {
-    if (typeof value !== 'object' || value === null) {
-      return null;
-    }
-    const { error } = value as Record<string, unknown>;
-    return typeof error === 'string' ? error : null;
-  }
-
-  // Same shape guard as extractUpstreamError, but also carries the optional `type`/`code` fields
-  // the meeting-service envelope may add (#2269) — only `set` classifies on them, so `get` keeps
-  // using the simpler extractUpstreamError above.
+  // through to the shape-validation branch below instead. Shared by both `get` and `set` — `get`
+  // only needs `.error`; `set` also classifies on `type`/`code` (#2269).
+  //
+  // `type`/`code` are normalized to `undefined` unless they match a value classifyPreferredEmailError
+  // actually recognizes today, rather than trusting any string the wire sends: a meeting-service that
+  // adds a new `domain.ErrorType` (or a malformed reply) must fall through to the message-matching
+  // fallback below, not get bucketed by an unrecognized value as if it were a known one.
   private extractPreferredEmailError(value: unknown): PreferredEmailErrorReply | null {
     if (typeof value !== 'object' || value === null) {
       return null;
@@ -176,7 +171,12 @@ export class MeetingPreferenceService {
     if (typeof error !== 'string') {
       return null;
     }
-    return { error, type: typeof type === 'string' ? type : undefined, code: typeof code === 'string' ? code : undefined };
+    return { error, type: this.asKnownErrorType(type), code: code === 'email_not_synced' ? code : undefined };
+  }
+
+  private asKnownErrorType(value: unknown): PreferredEmailErrorType | undefined {
+    const KNOWN_TYPES: PreferredEmailErrorType[] = ['validation', 'not_found', 'conflict', 'internal', 'unavailable'];
+    return KNOWN_TYPES.includes(value as PreferredEmailErrorType) ? (value as PreferredEmailErrorType) : undefined;
   }
 
   // The upstream contract always emits both keys as strings (an override) or both as null (no
@@ -196,8 +196,10 @@ export class MeetingPreferenceService {
 
   // Classify the upstream error so the controller can map it to an HTTP status: validation → 4xx,
   // sync_pending/unavailable → 503, anything else → 503. `type`/`code` (see #2269) are trusted
-  // first when present; `error` message-matching is kept only as a fallback for a meeting-service
-  // deploy that hasn't shipped them yet, so behavior never regresses below what it is today.
+  // first when present; `error` message-matching is kept as a fallback both for a meeting-service
+  // deploy that hasn't shipped them yet and for a `type` extractPreferredEmailError didn't
+  // recognize (already normalized to `undefined` there), so behavior never regresses below what
+  // it is today.
   private classifyPreferredEmailError({ error, type, code }: PreferredEmailErrorReply): SetMeetingInviteResult['reason'] {
     // `code` is the finer signal — it's only set for the retryable "email not yet synced from
     // Auth0 to SFDC" case, which otherwise shares `type: 'unavailable'` with a generic outage.

--- a/apps/lfx-one/src/server/services/meeting-preference.service.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.ts
@@ -18,7 +18,8 @@ import { NatsService } from './nats.service';
  * API-gateway token in the `token` field of the payload (the service forwards it as a Bearer
  * token to v1 /v1/me). The reply is the selected email directly (`{ email_id, email }`), with
  * both fields null when the user has no override (meeting invitations fall back to primary),
- * or `{ error }` on failure — `set` failures may also carry `type`/`code` (see #2269/#2270).
+ * or `{ error }` on failure — both `get` and `set` failures may carry `type`/`code` (see
+ * #2269/#2270), though only `set` classifies on them today.
  */
 export class MeetingPreferenceService {
   private natsService: NatsService;

--- a/apps/lfx-one/src/server/services/meeting-preference.service.ts
+++ b/apps/lfx-one/src/server/services/meeting-preference.service.ts
@@ -175,7 +175,7 @@ export class MeetingPreferenceService {
   }
 
   private asKnownErrorType(value: unknown): PreferredEmailErrorType | undefined {
-    const KNOWN_TYPES: PreferredEmailErrorType[] = ['validation', 'not_found', 'conflict', 'internal', 'unavailable'];
+    const KNOWN_TYPES: PreferredEmailErrorType[] = ['validation', 'forbidden', 'not_found', 'conflict', 'internal', 'unavailable'];
     return KNOWN_TYPES.includes(value as PreferredEmailErrorType) ? (value as PreferredEmailErrorType) : undefined;
   }
 

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -111,3 +111,4 @@ export * from './formation.constants';
 export * from './formation-template.constants';
 export * from './github-url.constants';
 export * from './health-metrics-overview.constants';
+export * from './user-profile.constants';

--- a/packages/shared/src/constants/user-profile.constants.ts
+++ b/packages/shared/src/constants/user-profile.constants.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * The upstream `domain.ErrorType` values (#2269/lfx-v2-meeting-service#281), stringified. Single
+ * source of truth for both the compile-time `PreferredEmailErrorType` union (see
+ * `user-profile.interface.ts`) and the runtime allow-list `asKnownErrorType` validates against, so
+ * the two can't drift independently — adding a value here is enough for both.
+ */
+export const PREFERRED_EMAIL_ERROR_TYPE = {
+  VALIDATION: 'validation',
+  FORBIDDEN: 'forbidden',
+  NOT_FOUND: 'not_found',
+  CONFLICT: 'conflict',
+  INTERNAL: 'internal',
+  UNAVAILABLE: 'unavailable',
+} as const;

--- a/packages/shared/src/constants/user-profile.constants.ts
+++ b/packages/shared/src/constants/user-profile.constants.ts
@@ -15,3 +15,13 @@ export const PREFERRED_EMAIL_ERROR_TYPE = {
   INTERNAL: 'internal',
   UNAVAILABLE: 'unavailable',
 } as const;
+
+/**
+ * The upstream `code` value for "email not yet synced from Auth0 to SFDC" (#2269/#2270) — the one
+ * case that needs finer resolution than `type` gives. Single source of truth shared by
+ * `PreferredEmailErrorCode` (`user-profile.interface.ts`) and the runtime checks in
+ * `meeting-preference.service.ts`, so they can't drift independently.
+ */
+export const PREFERRED_EMAIL_ERROR_CODE = {
+  EMAIL_NOT_SYNCED: 'email_not_synced',
+} as const;

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -55,18 +55,24 @@ export interface MeetingInviteEmail {
   email: string | null;
 }
 
+// The upstream `domain.ErrorType` values (#2269), stringified. Not exhaustive forever — the
+// meeting-service may add a value before self-serve knows about it — so callers must treat an
+// unrecognized wire string as absent rather than trust it, see extractPreferredEmailError.
+export type PreferredEmailErrorType = 'validation' | 'not_found' | 'conflict' | 'internal' | 'unavailable';
+
+// The one case that needs finer resolution than `type` gives: "email not yet synced from Auth0
+// to SFDC" otherwise shares `type: 'unavailable'` with a generic outage.
+export type PreferredEmailErrorCode = 'email_not_synced';
+
 /**
  * Error reply from the meeting-service `preferred_email.set` NATS RPC. `type` and `code` are
  * optional because an older meeting-service deploy (or a malformed reply) may only send `error`
- * — see #2269/#2270. `type` mirrors the upstream `domain.ErrorType` (e.g. `'validation'`,
- * `'unavailable'`); `code` is a finer signal set only for the retryable "email not yet synced
- * from Auth0 to SFDC" case (`'email_not_synced'`), which otherwise shares `type` with a generic
- * unavailable error.
+ * — see #2269/#2270.
  */
 export interface PreferredEmailErrorReply {
   error: string;
-  type?: string;
-  code?: string;
+  type?: PreferredEmailErrorType;
+  code?: PreferredEmailErrorCode;
 }
 
 /**

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { PREFERRED_EMAIL_ERROR_TYPE } from '../constants/user-profile.constants';
+import { PREFERRED_EMAIL_ERROR_CODE, PREFERRED_EMAIL_ERROR_TYPE } from '../constants/user-profile.constants';
 
 /**
  * Minimal user identity fields for displaying initials
@@ -63,9 +63,11 @@ export interface MeetingInviteEmail {
 // rather than trust it, see extractPreferredEmailError.
 export type PreferredEmailErrorType = (typeof PREFERRED_EMAIL_ERROR_TYPE)[keyof typeof PREFERRED_EMAIL_ERROR_TYPE];
 
-// The one case that needs finer resolution than `type` gives: "email not yet synced from Auth0
-// to SFDC" otherwise shares `type: 'unavailable'` with a generic outage.
-export type PreferredEmailErrorCode = 'email_not_synced';
+// Derived from PREFERRED_EMAIL_ERROR_CODE (single source of truth shared with the runtime checks
+// in extractPreferredEmailError/classifyPreferredEmailError). The one case that needs finer
+// resolution than `type` gives: "email not yet synced from Auth0 to SFDC" otherwise shares
+// `type: 'unavailable'` with a generic outage.
+export type PreferredEmailErrorCode = (typeof PREFERRED_EMAIL_ERROR_CODE)[keyof typeof PREFERRED_EMAIL_ERROR_CODE];
 
 /**
  * Error reply from the meeting-service `preferred_email.set` NATS RPC. `type` and `code` are

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -70,9 +70,11 @@ export type PreferredEmailErrorType = (typeof PREFERRED_EMAIL_ERROR_TYPE)[keyof 
 export type PreferredEmailErrorCode = (typeof PREFERRED_EMAIL_ERROR_CODE)[keyof typeof PREFERRED_EMAIL_ERROR_CODE];
 
 /**
- * Error reply from the meeting-service `preferred_email.set` NATS RPC. `type` and `code` are
- * optional because an older meeting-service deploy (or a malformed reply) may only send `error`
- * — see #2269/#2270.
+ * Error reply from the meeting-service `preferred_email.get`/`.set` NATS RPCs. `type` and `code`
+ * are optional because an older meeting-service deploy (or a malformed reply) may only send
+ * `error` — see #2269/#2270. Self-serve currently classifies on `type`/`code` for the `set` path
+ * only (see `classifyPreferredEmailError`); `get` failures are logged and treated as failure
+ * regardless of `type`/`code`.
  */
 export interface PreferredEmailErrorReply {
   error: string;

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { PREFERRED_EMAIL_ERROR_TYPE } from '../constants/user-profile.constants';
+
 /**
  * Minimal user identity fields for displaying initials
  */
@@ -55,10 +57,11 @@ export interface MeetingInviteEmail {
   email: string | null;
 }
 
-// The upstream `domain.ErrorType` values (#2269), stringified. Not exhaustive forever — the
-// meeting-service may add a value before self-serve knows about it — so callers must treat an
-// unrecognized wire string as absent rather than trust it, see extractPreferredEmailError.
-export type PreferredEmailErrorType = 'validation' | 'forbidden' | 'not_found' | 'conflict' | 'internal' | 'unavailable';
+// Derived from PREFERRED_EMAIL_ERROR_TYPE (single source of truth shared with the runtime
+// allow-list in asKnownErrorType). Not exhaustive forever — the meeting-service may add a value
+// before self-serve knows about it — so callers must treat an unrecognized wire string as absent
+// rather than trust it, see extractPreferredEmailError.
+export type PreferredEmailErrorType = (typeof PREFERRED_EMAIL_ERROR_TYPE)[keyof typeof PREFERRED_EMAIL_ERROR_TYPE];
 
 // The one case that needs finer resolution than `type` gives: "email not yet synced from Auth0
 // to SFDC" otherwise shares `type: 'unavailable'` with a generic outage.

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -58,7 +58,7 @@ export interface MeetingInviteEmail {
 // The upstream `domain.ErrorType` values (#2269), stringified. Not exhaustive forever — the
 // meeting-service may add a value before self-serve knows about it — so callers must treat an
 // unrecognized wire string as absent rather than trust it, see extractPreferredEmailError.
-export type PreferredEmailErrorType = 'validation' | 'not_found' | 'conflict' | 'internal' | 'unavailable';
+export type PreferredEmailErrorType = 'validation' | 'forbidden' | 'not_found' | 'conflict' | 'internal' | 'unavailable';
 
 // The one case that needs finer resolution than `type` gives: "email not yet synced from Auth0
 // to SFDC" otherwise shares `type: 'unavailable'` with a generic outage.

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -56,6 +56,20 @@ export interface MeetingInviteEmail {
 }
 
 /**
+ * Error reply from the meeting-service `preferred_email.set` NATS RPC. `type` and `code` are
+ * optional because an older meeting-service deploy (or a malformed reply) may only send `error`
+ * — see #2269/#2270. `type` mirrors the upstream `domain.ErrorType` (e.g. `'validation'`,
+ * `'unavailable'`); `code` is a finer signal set only for the retryable "email not yet synced
+ * from Auth0 to SFDC" case (`'email_not_synced'`), which otherwise shares `type` with a generic
+ * unavailable error.
+ */
+export interface PreferredEmailErrorReply {
+  error: string;
+  type?: string;
+  code?: string;
+}
+
+/**
  * Email-settings state loaded as one unit. The address list and the meeting-invitation
  * preference must land together — a partially-loaded pair briefly guards the wrong
  * address (stale badge, stale delete guard).


### PR DESCRIPTION
## Summary

- Add an optional `type`/`code` pair to the shared `PreferredEmailErrorReply` interface, describing the preferred_email NATS error contract.
- Rewrite `classifyPreferredEmailError` to classify primarily off `type`/`code` when present (`code === 'email_not_synced'` → `sync_pending`, `type === 'validation'` → `validation`, any other recognized `type` → `unavailable`), falling back to the existing message-string heuristics when neither field is present, or when `type`/`code` carries an unrecognized value.
- Extend `meeting-preference.service.spec.ts` with cases for type/code-driven classification, keeping every existing string-matching case passing.

This PR is safe to merge independently of the upstream change: until `lfx-v2-meeting-service` actually sends `type`/`code` on the wire, classification falls back to today's behavior unchanged. The upstream envelope change is tracked separately as #2269 (filed in this repo since `lfx-v2-meeting-service` has no issue tracker of its own).

Closes #2270
Part of #2240