### PR TITLE
feat(meetings): add composer rail navigation and live preview

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, InputSignal, output, OutputEmitterRef, signal, Signal, untracked, WritableSignal } from '@angular/core';
+import { Component, computed, inject, input, InputSignal, output, OutputEmitterRef, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
@@ -46,9 +46,7 @@ export class MeetingCommitteeManagerComponent {
   public readonly committeesLoading = signal<boolean>(true);
 
   /**
-   * Emission gate for `committeeMembersChange`, kept as plain fields so reading them in the emit
-   * pipeline's `filter` doesn't make them reactive dependencies of it (`membersFetchError` is a signal
-   * because the template needs it, so the same `filter` reads it inside `untracked`).
+   * Emission gate for `committeeMembersChange`.
    * @description Consumers reconcile their guest list against every emission, so an emission that
    * isn't a truthful picture of the selected groups' membership would queue saved guests for
    * deletion. `membersResolved` only flips once a fetch settles; an empty selection counts as settled
@@ -60,7 +58,8 @@ export class MeetingCommitteeManagerComponent {
   private selectionApplied = false;
 
   /** Whether the last member fetch failed — blocks emission, and the template says so rather than failing silently. */
-  public readonly membersFetchError = signal(false);
+  private readonly _membersFetchError = signal(false);
+  public readonly membersFetchError = this._membersFetchError.asReadonly();
 
   // Committee options loaded from API
   public readonly committeeOptions: Signal<Committee[]> = this.initCommitteeOptions();
@@ -134,7 +133,7 @@ export class MeetingCommitteeManagerComponent {
     // Emit committee members whenever they change
     toObservable(this.filteredCommitteeMembers)
       .pipe(
-        filter(() => this.membersResolved && !untracked(this.membersFetchError)),
+        filter(() => this.membersResolved && !this.membersFetchError()),
         takeUntilDestroyed()
       )
       .subscribe((members) => this.committeeMembersChange.emit(members));
@@ -249,7 +248,7 @@ export class MeetingCommitteeManagerComponent {
       toObservable(this.selectedCommitteeIds).pipe(
         switchMap((committeeIds) => {
           this.membersResolved = false;
-          this.membersFetchError.set(false);
+          this._membersFetchError.set(false);
 
           if (!committeeIds || committeeIds.length === 0) {
             this.membersResolved = this.selectionApplied;
@@ -268,7 +267,7 @@ export class MeetingCommitteeManagerComponent {
               ),
               catchError((error) => {
                 console.error(`Failed to load members for committee ${id}:`, error);
-                this.membersFetchError.set(true);
+                this._membersFetchError.set(true);
                 return of([]);
               })
             );

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -203,7 +203,9 @@ export class MeetingComposerFormService {
 
   /**
    * Replaces the guest list and re-derives the pending registrant changes from it.
-   * @description Single write path, so `registrantUpdates` can never drift from `guests`.
+   * @description Single write path, so `registrantUpdates` can never drift from `guests`. `toUpdate` is
+   * always empty today — the composer has no guest-edit affordance, so nothing produces a `'modified'`
+   * guest; it stays wired so adding that affordance is a change to the Guests section alone.
    */
   public setGuests(next: MeetingRegistrantWithState[]): void {
     this.guests.set(next);
@@ -221,7 +223,7 @@ export class MeetingComposerFormService {
     this.setGuests(reducer(this.guests()));
   }
 
-  /** Records a removed guest's email so group reconciliation treats the removal as intentional. */
+  /** Records a removed group guest's email so group reconciliation treats the removal as intentional. */
   public suppressGuestEmail(email: string | null | undefined): void {
     if (!email) {
       return;
@@ -391,12 +393,12 @@ export class MeetingComposerFormService {
     this.pendingAttachmentDeletions.update((current) => [...current, attachmentId]);
   }
 
-  // Private initializer functions
-
   /** Recurrence the current form state would submit — for read-only summaries such as the preview. */
   public recurrencePayload(): MeetingRecurrence | null {
     return this.buildRecurrencePayload(this.form().getRawValue());
   }
+
+  // Private initializer functions
 
   private createMeetingFormGroup(): FormGroup {
     const defaultDateTime = getDefaultStartDateTime();

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -393,6 +393,11 @@ export class MeetingComposerFormService {
 
   // Private initializer functions
 
+  /** Recurrence the current form state would submit — for read-only summaries such as the preview. */
+  public recurrencePayload(): MeetingRecurrence | null {
+    return this.buildRecurrencePayload(this.form().getRawValue());
+  }
+
   private createMeetingFormGroup(): FormGroup {
     const defaultDateTime = getDefaultStartDateTime();
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -20,27 +20,19 @@
     </div>
   </ng-template>
 
-  <div class="flex h-full flex-col gap-4">
-    <!-- Temporary flat section switcher — replaced by the rail in LFXV2-3240 -->
-    <nav class="flex flex-wrap gap-2 border-b border-gray-200 pb-3" aria-label="Composer sections" data-testid="meeting-composer-sections">
-      @for (section of sections; track section.id) {
-        <button
-          type="button"
-          class="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium"
-          [ngClass]="section.id === composer.activeSection() ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-50'"
-          [attr.aria-current]="section.id === composer.activeSection() ? 'true' : null"
-          [attr.data-testid]="'meeting-composer-section-' + section.id"
-          (click)="onSectionChange(section.id)">
-          <i [class]="section.icon" aria-hidden="true"></i>
-          {{ section.label }}
-        </button>
+  <div class="flex h-full min-h-0 gap-6">
+    <div class="flex w-[262px] shrink-0 flex-col gap-4 overflow-y-auto">
+      <lfx-meeting-composer-rail />
+
+      @if (!composer.isEditMode()) {
+        <lfx-meeting-composer-preview />
       }
-    </nav>
+    </div>
 
     @if (formService.loading()) {
       <p class="text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
     } @else {
-      <div class="flex flex-1 flex-col gap-6 overflow-y-auto">
+      <div class="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto">
         @switch (composer.activeSection()) {
           @case ('details-access') {
             <lfx-composer-details-access [form]="formService.form()" />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -21,7 +21,8 @@
   </ng-template>
 
   <div class="flex h-full min-h-0 gap-6">
-    <div class="flex w-[262px] shrink-0 flex-col gap-4 overflow-y-auto">
+    <!-- Narrow viewports navigate with the footer buttons only; LFXV2-3243 refines the collapsed layout. -->
+    <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
       <lfx-meeting-composer-rail />
 
       @if (!composer.isEditMode()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -1,18 +1,19 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NgClass } from '@angular/common';
 import { Component, computed, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
-import type { MeetingComposerSection, MeetingComposerSectionId } from '@lfx-one/shared/interfaces';
+import type { MeetingComposerSection } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { filter, pairwise } from 'rxjs';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerPreviewComponent } from './meeting-composer-preview.component';
+import { MeetingComposerRailComponent } from './meeting-composer-rail.component';
 import { MeetingComposerService } from './meeting-composer.service';
 import { ComposerAgendaResourcesComponent } from './sections/composer-agenda-resources.component';
 import { ComposerDateScheduleComponent } from './sections/composer-date-schedule.component';
@@ -23,14 +24,15 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
 /**
  * Globally mounted host for the meeting composer drawer (LFXV2-3234).
  * @description Mounted on first open via `@defer` in `app.component.html` and retained thereafter, so
- * opening the composer never unmounts the page underneath. The section rail and live preview land in
- * LFXV2-3240; until then the sections are driven by the footer navigation.
+ * opening the composer never unmounts the page underneath. Sections are reachable from both the rail
+ * and the footer navigation; the live preview is create-mode only.
  */
 @Component({
   selector: 'lfx-meeting-composer-host',
   imports: [
-    NgClass,
     DrawerModule,
+    MeetingComposerRailComponent,
+    MeetingComposerPreviewComponent,
     ButtonComponent,
     ComposerDetailsAccessComponent,
     ComposerDateScheduleComponent,
@@ -87,10 +89,6 @@ export class MeetingComposerHostComponent {
     if (!visible) {
       this.composer.close();
     }
-  }
-
-  protected onSectionChange(section: MeetingComposerSectionId): void {
-    this.composer.setSection(section);
   }
 
   protected onNext(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.html
@@ -1,0 +1,88 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="meeting-composer-preview">
+  <span class="text-[10px] font-semibold uppercase tracking-wider text-gray-400">Preview</span>
+
+  <div class="flex items-start gap-3">
+    <div class="flex w-10 flex-col overflow-hidden rounded-md border border-gray-200 text-center">
+      <span class="bg-blue-600 py-0.5 text-[10px] font-semibold uppercase leading-tight text-white">{{ dateChip().month }}</span>
+      <span class="py-0.5 text-base font-semibold leading-tight text-gray-900">{{ dateChip().day }}</span>
+    </div>
+
+    <div class="flex min-w-0 flex-col gap-1">
+      <span class="truncate text-sm font-semibold text-gray-900" data-testid="meeting-composer-preview-title">{{ title() }}</span>
+      <span class="text-xs text-gray-500" data-testid="meeting-composer-preview-when">{{ whenSummary() }}</span>
+    </div>
+  </div>
+
+  <div class="h-px bg-gray-100"></div>
+
+  <dl class="flex flex-col gap-2 text-xs">
+    <div class="flex items-center justify-between gap-2">
+      <dt class="text-gray-500">Type</dt>
+      @if (typeLabel()) {
+        <dd class="truncate font-medium text-gray-900" data-testid="meeting-composer-preview-type">{{ typeLabel() }}</dd>
+      } @else {
+        <dd class="w-24"><p-skeleton height="0.75rem" /></dd>
+      }
+    </div>
+
+    <div class="flex items-center justify-between gap-2">
+      <dt class="text-gray-500">Visibility</dt>
+      @if (visibility(); as visibilityRow) {
+        <dd class="flex items-center gap-1.5 font-medium text-gray-900" data-testid="meeting-composer-preview-visibility">
+          <i [class]="visibilityRow.icon" class="text-gray-400"></i>
+          <span class="truncate">{{ visibilityRow.label }}</span>
+        </dd>
+      } @else {
+        <dd class="w-24"><p-skeleton height="0.75rem" /></dd>
+      }
+    </div>
+
+    @if (restricted()) {
+      <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-restricted">
+        <dt class="text-gray-500">Access</dt>
+        <dd class="font-medium text-gray-900">Restricted</dd>
+      </div>
+    }
+
+    @if (recurrenceSummary(); as recurrence) {
+      <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-recurrence">
+        <dt class="text-gray-500">Repeats</dt>
+        <dd class="truncate font-medium text-gray-900">{{ recurrence }}</dd>
+      </div>
+    }
+
+    <div class="flex items-center justify-between gap-2">
+      <dt class="text-gray-500">Platform</dt>
+      @if (platformLabel(); as platform) {
+        <dd class="truncate font-medium text-gray-900" data-testid="meeting-composer-preview-platform">{{ platform }}</dd>
+      } @else {
+        <dd class="w-24"><p-skeleton height="0.75rem" /></dd>
+      }
+    </div>
+
+    @for (feature of features(); track feature.label) {
+      <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-feature">
+        <dt class="flex items-center gap-1.5 text-gray-500">
+          <i [class]="feature.icon" class="text-gray-400"></i>
+          <span class="truncate">{{ feature.label }}</span>
+        </dt>
+        <dd class="font-medium text-emerald-600">On</dd>
+      </div>
+    }
+
+    <div class="flex items-center justify-between gap-2">
+      <dt class="text-gray-500">Guests</dt>
+      <dd class="font-medium text-gray-900" data-testid="meeting-composer-preview-guests">{{ guestCount() }} invited</dd>
+    </div>
+
+    @if (resourceCount() > 0) {
+      <div class="flex items-center justify-between gap-2">
+        <dt class="text-gray-500">Resources</dt>
+        <dd class="font-medium text-gray-900" data-testid="meeting-composer-preview-resources">{{ resourceCount() }}</dd>
+      </div>
+    }
+  </dl>
+</section>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.html
@@ -11,8 +11,12 @@
     </div>
 
     <div class="flex min-w-0 flex-col gap-1">
-      <span class="truncate text-sm font-semibold text-gray-900" data-testid="meeting-composer-preview-title">{{ title() }}</span>
-      <span class="text-xs text-gray-500" data-testid="meeting-composer-preview-when">{{ whenSummary() }}</span>
+      <span class="truncate text-sm font-semibold text-gray-900" [title]="title()" data-testid="meeting-composer-preview-title">{{ title() }}</span>
+      @if (whenSummary(); as when) {
+        <span class="text-xs text-gray-500" data-testid="meeting-composer-preview-when">{{ when }}</span>
+      } @else {
+        <span class="w-28"><span class="sr-only">Date and time not set</span><p-skeleton height="0.75rem" /></span>
+      }
     </div>
   </div>
 
@@ -24,21 +28,19 @@
       @if (typeLabel()) {
         <dd class="truncate font-medium text-gray-900" data-testid="meeting-composer-preview-type">{{ typeLabel() }}</dd>
       } @else {
-        <dd class="w-24"><p-skeleton height="0.75rem" /></dd>
+        <dd class="w-24"><span class="sr-only">Not set</span><p-skeleton height="0.75rem" /></dd>
       }
     </div>
 
-    <div class="flex items-center justify-between gap-2">
-      <dt class="text-gray-500">Visibility</dt>
-      @if (visibility(); as visibilityRow) {
+    @if (visibility(); as visibilityRow) {
+      <div class="flex items-center justify-between gap-2">
+        <dt class="text-gray-500">Visibility</dt>
         <dd class="flex items-center gap-1.5 font-medium text-gray-900" data-testid="meeting-composer-preview-visibility">
-          <i [class]="visibilityRow.icon" class="text-gray-400"></i>
+          <i [ngClass]="visibilityRow.icon" class="text-gray-400" aria-hidden="true"></i>
           <span class="truncate">{{ visibilityRow.label }}</span>
         </dd>
-      } @else {
-        <dd class="w-24"><p-skeleton height="0.75rem" /></dd>
-      }
-    </div>
+      </div>
+    }
 
     @if (restricted()) {
       <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-restricted">
@@ -59,14 +61,14 @@
       @if (platformLabel(); as platform) {
         <dd class="truncate font-medium text-gray-900" data-testid="meeting-composer-preview-platform">{{ platform }}</dd>
       } @else {
-        <dd class="w-24"><p-skeleton height="0.75rem" /></dd>
+        <dd class="w-24"><span class="sr-only">Not set</span><p-skeleton height="0.75rem" /></dd>
       }
     </div>
 
     @for (feature of features(); track feature.label) {
       <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-feature">
         <dt class="flex items-center gap-1.5 text-gray-500">
-          <i [class]="feature.icon" class="text-gray-400"></i>
+          <i [ngClass]="feature.icon" class="text-gray-400" aria-hidden="true"></i>
           <span class="truncate">{{ feature.label }}</span>
         </dt>
         <dd class="font-medium text-emerald-600">On</dd>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
@@ -1,0 +1,172 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, type Signal } from '@angular/core';
+import type { FormArray } from '@angular/forms';
+import { MEETING_COMPOSER_PREVIEW_FEATURES, MEETING_PLATFORMS, MEETING_TYPE_OPTIONS, MEETING_VISIBILITY_OPTIONS } from '@lfx-one/shared/constants';
+import type { MeetingVisibility } from '@lfx-one/shared/enums';
+import type { MeetingComposerPreviewDateChip, MeetingComposerPreviewFeature, MeetingComposerPreviewVisibility } from '@lfx-one/shared/interfaces';
+import { buildRecurrenceSummary, convertRecurrenceToPattern } from '@lfx-one/shared/utils';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerService } from './meeting-composer.service';
+
+/**
+ * Live preview of the meeting being created (LFXV2-3240).
+ * @description Create mode only — in edit mode the meeting already exists and the sections themselves
+ * show its saved state. Fields the organizer hasn't reached yet render as skeleton bars rather than
+ * placeholder words, so the card never reads as a value that was actually chosen.
+ */
+@Component({
+  selector: 'lfx-meeting-composer-preview',
+  imports: [SkeletonModule],
+  templateUrl: './meeting-composer-preview.component.html',
+})
+export class MeetingComposerPreviewComponent {
+  private readonly composer = inject(MeetingComposerService);
+  private readonly formService = inject(MeetingComposerFormService);
+
+  protected readonly dateChip: Signal<MeetingComposerPreviewDateChip> = this.initDateChip();
+  protected readonly title: Signal<string> = this.initTitle();
+  protected readonly whenSummary: Signal<string> = this.initWhenSummary();
+  protected readonly typeLabel: Signal<string | null> = this.initTypeLabel();
+  protected readonly visibility: Signal<MeetingComposerPreviewVisibility | null> = this.initVisibility();
+  protected readonly restricted: Signal<boolean> = this.initRestricted();
+  protected readonly recurrenceSummary: Signal<string | null> = this.initRecurrenceSummary();
+  protected readonly platformLabel: Signal<string | null> = this.initPlatformLabel();
+  protected readonly features: Signal<MeetingComposerPreviewFeature[]> = this.initFeatures();
+  protected readonly guestCount: Signal<number> = this.initGuestCount();
+  protected readonly resourceCount: Signal<number> = this.initResourceCount();
+
+  private initDateChip(): Signal<MeetingComposerPreviewDateChip> {
+    return computed(() => {
+      const startDate = this.startDate();
+
+      if (!startDate) {
+        return { day: '··', month: '—' };
+      }
+
+      return {
+        day: startDate.toLocaleDateString('en-US', { day: 'numeric' }),
+        month: startDate.toLocaleDateString('en-US', { month: 'short' }).toUpperCase(),
+      };
+    });
+  }
+
+  private initTitle(): Signal<string> {
+    return computed(() => {
+      const title = (this.controlValue('title') as string | null)?.trim();
+
+      return title || 'Untitled meeting';
+    });
+  }
+
+  private initWhenSummary(): Signal<string> {
+    return computed(() => {
+      const startDate = this.startDate();
+      const startTime = (this.controlValue('startTime') as string | null) ?? '';
+      const date = startDate ? startDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) : '';
+      const summary = [date, startTime].filter(Boolean).join(' · ');
+
+      return summary || 'No date set';
+    });
+  }
+
+  private initTypeLabel(): Signal<string | null> {
+    return computed(() => {
+      const meetingType = this.controlValue('meeting_type');
+
+      return MEETING_TYPE_OPTIONS.find((option) => option.value === meetingType)?.label ?? null;
+    });
+  }
+
+  private initVisibility(): Signal<MeetingComposerPreviewVisibility | null> {
+    return computed(() => {
+      const visibility = this.controlValue('visibility') as MeetingVisibility | null;
+      const option = MEETING_VISIBILITY_OPTIONS.find((candidate) => candidate.value === visibility);
+
+      if (!option) {
+        return null;
+      }
+
+      return { label: option.label, icon: option.info?.icon ?? '' };
+    });
+  }
+
+  private initRestricted(): Signal<boolean> {
+    return computed(() => this.controlValue('restricted') === true);
+  }
+
+  private initRecurrenceSummary(): Signal<string | null> {
+    return computed(() => {
+      if (this.controlValue('isRecurring') !== true) {
+        return null;
+      }
+
+      const recurrence = this.formService.recurrencePayload();
+
+      if (!recurrence) {
+        return null;
+      }
+
+      return buildRecurrenceSummary(convertRecurrenceToPattern(recurrence)).fullSummary;
+    });
+  }
+
+  /**
+   * Platform label, or `null` while the Platform & Features section is still unvisited.
+   * @description The control is pre-filled with a default, so showing it before the organizer has seen
+   * the section would present a choice they never made.
+   */
+  private initPlatformLabel(): Signal<string | null> {
+    return computed(() => {
+      if (!this.composer.visitedSections().has('platform-features')) {
+        return null;
+      }
+
+      const platform = this.controlValue('platform');
+
+      return MEETING_PLATFORMS.find((option) => option.value === platform)?.label ?? null;
+    });
+  }
+
+  private initFeatures(): Signal<MeetingComposerPreviewFeature[]> {
+    return computed(() =>
+      MEETING_COMPOSER_PREVIEW_FEATURES.filter((feature) => this.controlValue(feature.control) === true).map((feature) => ({
+        label: feature.label,
+        icon: feature.icon,
+      }))
+    );
+  }
+
+  private initGuestCount(): Signal<number> {
+    return computed(() => this.formService.guests().filter((guest) => guest.state !== 'deleted').length);
+  }
+
+  private initResourceCount(): Signal<number> {
+    return computed(() => {
+      this.formService.revision();
+
+      const pendingAttachments = (this.formService.form().get('attachments')?.value as unknown[] | null) ?? [];
+      const links = (this.formService.form().get('important_links') as FormArray | null)?.length ?? 0;
+      const pendingDeletions = new Set(this.formService.pendingAttachmentDeletions());
+      const savedAttachments = this.formService.attachments().filter((attachment) => !pendingDeletions.has(attachment.uid));
+
+      return pendingAttachments.length + links + savedAttachments.length;
+    });
+  }
+
+  private startDate(): Date | null {
+    const value = this.controlValue('startDate');
+
+    return value instanceof Date && !Number.isNaN(value.getTime()) ? value : null;
+  }
+
+  /** Reads a control's value through `revision()`, which is what makes form state reactive here. */
+  private controlValue(control: string): unknown {
+    this.formService.revision();
+
+    return this.formService.form().get(control)?.value ?? null;
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
@@ -1,11 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NgClass } from '@angular/common';
 import { Component, computed, inject, type Signal } from '@angular/core';
 import type { FormArray } from '@angular/forms';
 import { MEETING_COMPOSER_PREVIEW_FEATURES, MEETING_PLATFORMS, MEETING_TYPE_OPTIONS, MEETING_VISIBILITY_OPTIONS } from '@lfx-one/shared/constants';
 import type { MeetingVisibility } from '@lfx-one/shared/enums';
-import type { MeetingComposerPreviewDateChip, MeetingComposerPreviewFeature, MeetingComposerPreviewVisibility } from '@lfx-one/shared/interfaces';
+import type { ImportantLinkFormValue, MeetingComposerPreviewDateChip, MeetingComposerPreviewRow } from '@lfx-one/shared/interfaces';
 import { buildRecurrenceSummary, convertRecurrenceToPattern } from '@lfx-one/shared/utils';
 import { SkeletonModule } from 'primeng/skeleton';
 
@@ -15,12 +16,14 @@ import { MeetingComposerService } from './meeting-composer.service';
 /**
  * Live preview of the meeting being created (LFXV2-3240).
  * @description Create mode only — in edit mode the meeting already exists and the sections themselves
- * show its saved state. Fields the organizer hasn't reached yet render as skeleton bars rather than
- * placeholder words, so the card never reads as a value that was actually chosen.
+ * show its saved state. Several controls are pre-filled with defaults, so a row only resolves once its
+ * owning section has been visited; until then it renders as a skeleton bar rather than presenting a
+ * default as a choice the organizer made. Details & Access is where the composer opens, so its rows
+ * resolve as soon as they have a value.
  */
 @Component({
   selector: 'lfx-meeting-composer-preview',
-  imports: [SkeletonModule],
+  imports: [NgClass, SkeletonModule],
   templateUrl: './meeting-composer-preview.component.html',
 })
 export class MeetingComposerPreviewComponent {
@@ -29,13 +32,13 @@ export class MeetingComposerPreviewComponent {
 
   protected readonly dateChip: Signal<MeetingComposerPreviewDateChip> = this.initDateChip();
   protected readonly title: Signal<string> = this.initTitle();
-  protected readonly whenSummary: Signal<string> = this.initWhenSummary();
+  protected readonly whenSummary: Signal<string | null> = this.initWhenSummary();
   protected readonly typeLabel: Signal<string | null> = this.initTypeLabel();
-  protected readonly visibility: Signal<MeetingComposerPreviewVisibility | null> = this.initVisibility();
+  protected readonly visibility: Signal<MeetingComposerPreviewRow | null> = this.initVisibility();
   protected readonly restricted: Signal<boolean> = this.initRestricted();
   protected readonly recurrenceSummary: Signal<string | null> = this.initRecurrenceSummary();
   protected readonly platformLabel: Signal<string | null> = this.initPlatformLabel();
-  protected readonly features: Signal<MeetingComposerPreviewFeature[]> = this.initFeatures();
+  protected readonly features: Signal<MeetingComposerPreviewRow[]> = this.initFeatures();
   protected readonly guestCount: Signal<number> = this.initGuestCount();
   protected readonly resourceCount: Signal<number> = this.initResourceCount();
 
@@ -62,14 +65,13 @@ export class MeetingComposerPreviewComponent {
     });
   }
 
-  private initWhenSummary(): Signal<string> {
+  private initWhenSummary(): Signal<string | null> {
     return computed(() => {
       const startDate = this.startDate();
-      const startTime = (this.controlValue('startTime') as string | null) ?? '';
+      const startTime = startDate ? ((this.controlValue('startTime') as string | null) ?? '') : '';
       const date = startDate ? startDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) : '';
-      const summary = [date, startTime].filter(Boolean).join(' · ');
 
-      return summary || 'No date set';
+      return [date, startTime].filter(Boolean).join(' · ') || null;
     });
   }
 
@@ -81,16 +83,17 @@ export class MeetingComposerPreviewComponent {
     });
   }
 
-  private initVisibility(): Signal<MeetingComposerPreviewVisibility | null> {
+  /** Visibility row, or `null` when the stored value isn't one of the offered options. */
+  private initVisibility(): Signal<MeetingComposerPreviewRow | null> {
     return computed(() => {
       const visibility = this.controlValue('visibility') as MeetingVisibility | null;
       const option = MEETING_VISIBILITY_OPTIONS.find((candidate) => candidate.value === visibility);
 
-      if (!option) {
+      if (!option?.info?.icon) {
         return null;
       }
 
-      return { label: option.label, icon: option.info?.icon ?? '' };
+      return { label: option.label, icon: option.info.icon };
     });
   }
 
@@ -131,7 +134,7 @@ export class MeetingComposerPreviewComponent {
     });
   }
 
-  private initFeatures(): Signal<MeetingComposerPreviewFeature[]> {
+  private initFeatures(): Signal<MeetingComposerPreviewRow[]> {
     return computed(() =>
       MEETING_COMPOSER_PREVIEW_FEATURES.filter((feature) => this.controlValue(feature.control) === true).map((feature) => ({
         label: feature.label,
@@ -144,20 +147,24 @@ export class MeetingComposerPreviewComponent {
     return computed(() => this.formService.guests().filter((guest) => guest.state !== 'deleted').length);
   }
 
+  /** Documents and links staged for upload. Saved attachments are ignored — nothing is saved yet in create mode. */
   private initResourceCount(): Signal<number> {
     return computed(() => {
       this.formService.revision();
 
       const pendingAttachments = (this.formService.form().get('attachments')?.value as unknown[] | null) ?? [];
-      const links = (this.formService.form().get('important_links') as FormArray | null)?.length ?? 0;
-      const pendingDeletions = new Set(this.formService.pendingAttachmentDeletions());
-      const savedAttachments = this.formService.attachments().filter((attachment) => !pendingDeletions.has(attachment.uid));
+      const links = ((this.formService.form().get('important_links') as FormArray | null)?.value ?? []) as ImportantLinkFormValue[];
 
-      return pendingAttachments.length + links + savedAttachments.length;
+      return pendingAttachments.length + links.filter((link) => !!link.url?.trim()).length;
     });
   }
 
+  /** Start date, or `null` while Date & Schedule is unvisited — the control opens pre-filled with a default. */
   private startDate(): Date | null {
+    if (!this.composer.visitedSections().has('date-schedule')) {
+      return null;
+    }
+
     const value = this.controlValue('startDate');
 
     return value instanceof Date && !Number.isNaN(value.getTime()) ? value : null;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -9,10 +9,10 @@
         type="button"
         class="flex items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm font-medium transition-colors"
         [ngClass]="row.active ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-50'"
-        [attr.aria-current]="row.active ? 'step' : null"
+        [attr.aria-current]="row.active ? 'true' : null"
         [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
         (click)="onSelect(row)">
-        <i class="w-4 text-center" [class]="row.section.icon" aria-hidden="true"></i>
+        <i class="w-4 text-center" [ngClass]="row.section.icon" aria-hidden="true"></i>
         <span class="truncate">{{ row.section.label }}</span>
       </button>
     } @else {
@@ -33,17 +33,15 @@
           }
           <span
             class="relative z-10 flex h-8 w-8 items-center justify-center rounded-full border text-xs"
-            [ngClass]="
-              row.active
-                ? 'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50'
-                : row.complete
-                  ? 'border-blue-600 bg-white text-blue-600'
-                  : 'border-gray-200 bg-white text-gray-400'
-            ">
+            [ngClass]="{
+              'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50': row.active,
+              'border-blue-600 bg-white text-blue-600': !row.active && row.complete,
+              'border-gray-200 bg-white text-gray-400': !row.active && !row.complete,
+            }">
             @if (row.complete) {
               <i class="fa-light fa-check" aria-hidden="true"></i>
             } @else {
-              <i [class]="row.section.icon" aria-hidden="true"></i>
+              <i [ngClass]="row.section.icon" aria-hidden="true"></i>
             }
           </span>
         </span>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -1,0 +1,66 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- Composer section rail (LFXV2-3240) -->
+<nav class="flex flex-col" aria-label="Composer sections" data-testid="meeting-composer-rail">
+  @for (row of rows(); track row.section.id) {
+    @if (composer.isEditMode()) {
+      <button
+        type="button"
+        class="flex items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm font-medium transition-colors"
+        [ngClass]="row.active ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-50'"
+        [attr.aria-current]="row.active ? 'step' : null"
+        [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
+        (click)="onSelect(row)">
+        <i class="w-4 text-center" [class]="row.section.icon" aria-hidden="true"></i>
+        <span class="truncate">{{ row.section.label }}</span>
+      </button>
+    } @else {
+      <button
+        type="button"
+        class="group relative flex items-start gap-3 rounded-md py-2 pl-1 pr-3 text-left"
+        [ngClass]="row.locked ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
+        [disabled]="row.locked"
+        [attr.aria-current]="row.active ? 'step' : null"
+        [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
+        (click)="onSelect(row)">
+        <span class="relative flex w-8 shrink-0 justify-center self-stretch">
+          @if (!row.isLast) {
+            <span
+              class="absolute left-1/2 top-8 h-full w-0.5 -translate-x-1/2"
+              [ngClass]="row.lineBelowComplete ? 'bg-blue-600' : 'bg-gray-200'"
+              aria-hidden="true"></span>
+          }
+          <span
+            class="relative z-10 flex h-8 w-8 items-center justify-center rounded-full border text-xs"
+            [ngClass]="
+              row.active
+                ? 'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50'
+                : row.complete
+                  ? 'border-blue-600 bg-white text-blue-600'
+                  : 'border-gray-200 bg-white text-gray-400'
+            ">
+            @if (row.complete) {
+              <i class="fa-light fa-check" aria-hidden="true"></i>
+            } @else {
+              <i [class]="row.section.icon" aria-hidden="true"></i>
+            }
+          </span>
+        </span>
+
+        <span class="flex min-w-0 flex-col gap-0.5 pt-1.5">
+          <span class="flex items-center gap-1.5 text-sm font-medium" [ngClass]="row.active ? 'text-gray-900' : 'text-gray-600'">
+            <span class="truncate">{{ row.section.label }}</span>
+            @if (row.needsAttention) {
+              <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="'meeting-composer-rail-attention-' + row.section.id"></span>
+              <span class="sr-only">Required fields still missing</span>
+            }
+          </span>
+          @if (row.locked) {
+            <span class="text-xs text-gray-400">Complete earlier sections first</span>
+          }
+        </span>
+      </button>
+    }
+  }
+</nav>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -24,6 +24,8 @@ export class MeetingComposerRailComponent {
   protected readonly composer = inject(MeetingComposerService);
   private readonly formService = inject(MeetingComposerFormService);
 
+  private readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
+
   protected readonly rows: Signal<MeetingComposerRailRow[]> = this.initRows();
 
   protected onSelect(row: MeetingComposerRailRow): void {
@@ -39,29 +41,27 @@ export class MeetingComposerRailComponent {
       // FormGroup validity isn't reactive on its own — the revision signal is what makes it one.
       this.formService.revision();
 
-      const sections = MEETING_COMPOSER_SECTIONS as readonly MeetingComposerSection[];
+      const sections = this.sections;
       const activeSection = this.composer.activeSection();
       const visited = this.composer.visitedSections();
       const isEditMode = this.composer.isEditMode();
-      const completeById = new Map<MeetingComposerSectionId, boolean>(
-        sections.map((section) => [section.id, section.required ? this.formService.isSectionValid(section.id) : visited.has(section.id)])
-      );
+      const validById = new Map<MeetingComposerSectionId, boolean>(sections.map((section) => [section.id, this.formService.isSectionValid(section.id)]));
+      const isComplete = (section: MeetingComposerSection): boolean => (section.required ? (validById.get(section.id) ?? false) : visited.has(section.id));
 
       return sections.map((section, index) => {
         const active = section.id === activeSection;
-        const valid = this.formService.isSectionValid(section.id);
-        const locked = !isEditMode && sections.slice(0, index).some((earlier) => earlier.required && !this.formService.isSectionValid(earlier.id));
-        const previous = sections[index - 1];
+        const valid = validById.get(section.id) ?? false;
+        const blockedByEarlier = sections.slice(0, index).some((earlier) => earlier.required && !validById.get(earlier.id));
 
         return {
           section,
           active,
-          complete: (completeById.get(section.id) ?? false) && !active,
-          locked,
-          needsAttention: !isEditMode && section.required && active && !valid,
-          lineAboveComplete: index > 0 && (completeById.get(previous.id) ?? false),
-          lineBelowComplete: completeById.get(section.id) ?? false,
-          isFirst: index === 0,
+          complete: isComplete(section) && !active,
+          // The organizer can be standing on a section an out-of-section validator has just invalidated
+          // (enabling YouTube upload tightens the title's max length), so never lock the row they're on.
+          locked: !isEditMode && blockedByEarlier && !active,
+          needsAttention: !isEditMode && section.required && visited.has(section.id) && !valid,
+          lineBelowComplete: isComplete(section),
           isLast: index === sections.length - 1,
         };
       });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, type Signal } from '@angular/core';
+import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
+import type { MeetingComposerRailRow, MeetingComposerSection, MeetingComposerSectionId } from '@lfx-one/shared/interfaces';
+
+import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerService } from './meeting-composer.service';
+
+/**
+ * Left-rail section navigation for the meeting composer (LFXV2-3240).
+ * @description Create mode is a progress stepper: later sections stay locked until every earlier
+ * required section is valid, so the organizer can't skip past a section that would block submit.
+ * Edit mode is a flat menu — the meeting already exists, so every section is reachable.
+ */
+@Component({
+  selector: 'lfx-meeting-composer-rail',
+  imports: [NgClass],
+  templateUrl: './meeting-composer-rail.component.html',
+})
+export class MeetingComposerRailComponent {
+  protected readonly composer = inject(MeetingComposerService);
+  private readonly formService = inject(MeetingComposerFormService);
+
+  protected readonly rows: Signal<MeetingComposerRailRow[]> = this.initRows();
+
+  protected onSelect(row: MeetingComposerRailRow): void {
+    if (row.locked || row.active) {
+      return;
+    }
+
+    this.composer.setSection(row.section.id);
+  }
+
+  private initRows(): Signal<MeetingComposerRailRow[]> {
+    return computed(() => {
+      // FormGroup validity isn't reactive on its own — the revision signal is what makes it one.
+      this.formService.revision();
+
+      const sections = MEETING_COMPOSER_SECTIONS as readonly MeetingComposerSection[];
+      const activeSection = this.composer.activeSection();
+      const visited = this.composer.visitedSections();
+      const isEditMode = this.composer.isEditMode();
+      const completeById = new Map<MeetingComposerSectionId, boolean>(
+        sections.map((section) => [section.id, section.required ? this.formService.isSectionValid(section.id) : visited.has(section.id)])
+      );
+
+      return sections.map((section, index) => {
+        const active = section.id === activeSection;
+        const valid = this.formService.isSectionValid(section.id);
+        const locked = !isEditMode && sections.slice(0, index).some((earlier) => earlier.required && !this.formService.isSectionValid(earlier.id));
+        const previous = sections[index - 1];
+
+        return {
+          section,
+          active,
+          complete: (completeById.get(section.id) ?? false) && !active,
+          locked,
+          needsAttention: !isEditMode && section.required && active && !valid,
+          lineAboveComplete: index > 0 && (completeById.get(previous.id) ?? false),
+          lineBelowComplete: completeById.get(section.id) ?? false,
+          isFirst: index === 0,
+          isLast: index === sections.length - 1,
+        };
+      });
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -22,20 +22,32 @@ export class MeetingComposerService {
   private readonly _activeSection = signal<MeetingComposerSectionId>(FIRST_SECTION);
   public readonly activeSection = this._activeSection.asReadonly();
 
+  /**
+   * Sections the organizer has landed on during this open.
+   * @description The rail's only completion signal for optional sections, which are always valid and so
+   * can't be told apart from untouched ones by validity alone.
+   */
+  private readonly _visitedSections = signal<ReadonlySet<MeetingComposerSectionId>>(new Set([FIRST_SECTION]));
+  public readonly visitedSections = this._visitedSections.asReadonly();
+
   public readonly isOpen = computed(() => this._context() !== null);
   public readonly isEditMode = computed(() => this._context()?.mode === 'edit');
 
   public open(context: MeetingComposerContext): void {
-    this._activeSection.set(context.section ?? FIRST_SECTION);
+    const section = context.section ?? FIRST_SECTION;
+    this._activeSection.set(section);
+    this._visitedSections.set(new Set([section]));
     this._context.set(context);
   }
 
   public close(): void {
     this._context.set(null);
     this._activeSection.set(FIRST_SECTION);
+    this._visitedSections.set(new Set([FIRST_SECTION]));
   }
 
   public setSection(section: MeetingComposerSectionId): void {
     this._activeSection.set(section);
+    this._visitedSections.update((visited) => new Set(visited).add(section));
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
@@ -138,7 +138,7 @@
                 [title]="attachment.name">
                 {{ attachment.name }}
               </span>
-              @if (attachment.file_size !== undefined) {
+              @if (attachment.file_size) {
                 <span class="flex-shrink-0 text-xs text-gray-400">{{ attachment.file_size | fileSize }}</span>
               }
             </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -252,14 +252,18 @@ export class ComposerAgendaResourcesComponent {
 
   /**
    * Applies a template's or AI draft's estimated duration to the schedule controls.
-   * @description Three outcomes: an estimate outside the allowed range is dropped with a warning
-   * (writing it would trip the form service's min/max validators and deaden submit from a section the
-   * organizer can't see); an estimate that already matches the current duration is a silent no-op; any
-   * other estimate is written and announced, since the duration they picked has just been overwritten.
-   * Estimates outside the chip values go to `customDuration` rather than being clamped.
+   * @description The estimate is rounded first, since the AI path can return a fractional minute count
+   * and the duration controls only accept whole minutes. Three outcomes then follow: an estimate outside
+   * the allowed range is dropped with a warning (writing it would trip the form service's min/max
+   * validators and deaden submit from a section the organizer can't see); an estimate that already
+   * matches the current duration is a silent no-op; any other estimate is written and announced, since
+   * the duration they picked has just been overwritten. Estimates outside the chip values go to
+   * `customDuration` rather than being clamped.
    */
-  private applyEstimatedDuration(estimatedDuration: number): void {
-    if (!Number.isInteger(estimatedDuration) || estimatedDuration < MIN_CUSTOM_DURATION || estimatedDuration > MAX_CUSTOM_DURATION) {
+  private applyEstimatedDuration(estimate: number): void {
+    const estimatedDuration = Math.round(estimate);
+
+    if (!Number.isFinite(estimatedDuration) || estimatedDuration < MIN_CUSTOM_DURATION || estimatedDuration > MAX_CUSTOM_DURATION) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Duration left unchanged',

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -339,6 +339,18 @@ export const MEETING_COMPOSER_SECTIONS = [
 ] as const;
 
 /**
+ * Feature rows the composer preview lists, in display order.
+ * @description Each entry names the form control that turns the feature on; the label is the preview's
+ * own shorter wording rather than the section's toggle title.
+ */
+export const MEETING_COMPOSER_PREVIEW_FEATURES = [
+  { control: 'recording_enabled', label: 'Recording', icon: 'fa-light fa-video' },
+  { control: 'zoom_ai_enabled', label: 'AI meeting summary', icon: 'fa-light fa-microchip-ai' },
+  { control: 'transcript_enabled', label: 'Transcript', icon: 'fa-light fa-file-lines' },
+  { control: 'youtube_upload_enabled', label: 'Auto-upload to YouTube', icon: 'fa-light fa-upload' },
+] as const;
+
+/**
  * Default meeting duration in minutes
  * @description Standard meeting length when no custom duration is specified
  */

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ArtifactVisibility, CancelOnCommitteeRemoval, MeetingType, MeetingVisibility } from '../enums';
-import type { AttachmentCategory, CardSelectorOption, MeetingTypeConfig } from '../interfaces';
+import { ArtifactVisibility, MeetingType, MeetingVisibility, CancelOnCommitteeRemoval } from '../enums';
+import type { AttachmentCategory, CardSelectorOption, MeetingTypeConfig, MeetingComposerPreviewFeature } from '../interfaces';
 import { lfxColors } from './colors.constants';
 
 /**
@@ -340,15 +340,18 @@ export const MEETING_COMPOSER_SECTIONS = [
 
 /**
  * Feature rows the composer preview lists, in display order.
- * @description Each entry names the form control that turns the feature on; the label is the preview's
- * own shorter wording rather than the section's toggle title.
+ * @description Only the labels are the preview's own — shorter wording than the section's toggle
+ * titles. Controls and icons come from {@link MEETING_FEATURE_BY_KEY}, so renaming a feature key
+ * breaks the build here rather than silently dropping the row.
  */
-export const MEETING_COMPOSER_PREVIEW_FEATURES = [
-  { control: 'recording_enabled', label: 'Recording', icon: 'fa-light fa-video' },
-  { control: 'zoom_ai_enabled', label: 'AI meeting summary', icon: 'fa-light fa-microchip-ai' },
-  { control: 'transcript_enabled', label: 'Transcript', icon: 'fa-light fa-file-lines' },
-  { control: 'youtube_upload_enabled', label: 'Auto-upload to YouTube', icon: 'fa-light fa-upload' },
-] as const;
+export const MEETING_COMPOSER_PREVIEW_FEATURES: MeetingComposerPreviewFeature[] = (
+  [
+    { control: 'recording_enabled', label: 'Recording' },
+    { control: 'zoom_ai_enabled', label: 'AI meeting summary' },
+    { control: 'transcript_enabled', label: 'Transcript' },
+    { control: 'youtube_upload_enabled', label: 'Auto-upload to YouTube' },
+  ] as const
+).map(({ control, label }) => ({ control, label, icon: MEETING_FEATURE_BY_KEY[control].icon }));
 
 /**
  * Default meeting duration in minutes

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1827,6 +1827,43 @@ export interface MeetingComposerSection {
 }
 
 /**
+ * A rail row's derived display state for one composer section.
+ * @description `complete` is validity for required sections and "has been visited" for optional ones —
+ * an optional section can never be invalid, so visiting it is the only signal that it was considered.
+ */
+export interface MeetingComposerRailRow {
+  section: MeetingComposerSection;
+  active: boolean;
+  complete: boolean;
+  locked: boolean;
+  /** Active required section that isn't valid yet — drives the row's attention dot. */
+  needsAttention: boolean;
+  /** Whether the connector above / below this row should read as completed. */
+  lineAboveComplete: boolean;
+  lineBelowComplete: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+/** One feature row in the composer preview, resolved from {@link MEETING_COMPOSER_PREVIEW_FEATURES}. */
+export interface MeetingComposerPreviewFeature {
+  label: string;
+  icon: string;
+}
+
+/** Day/month pair for the composer preview's date chip — placeholder glyphs until a date is picked. */
+export interface MeetingComposerPreviewDateChip {
+  day: string;
+  month: string;
+}
+
+/** Visibility row in the composer preview, resolved from the shared visibility options. */
+export interface MeetingComposerPreviewVisibility {
+  label: string;
+  icon: string;
+}
+
+/**
  * What the meeting composer was opened with.
  * @description Set by whichever entry point calls `MeetingComposerService.open()` — a dashboard
  * button, a meeting card's edit action, a group's meetings tab, or a `/meetings/...` deep link.

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type { MEETING_ALLOWED_VOTING_STATUSES } from '../constants/committees.constants';
-import type { MEETING_COMPOSER_SECTIONS, PAST_MEETING_SORT } from '../constants/meeting.constants';
-import type { ArtifactVisibility, CancelOnCommitteeRemoval, MeetingType, MeetingVisibility, RecurrenceType } from '../enums';
+import type { MEETING_COMPOSER_SECTIONS, PAST_MEETING_SORT, MEETING_FEATURE_BY_KEY } from '../constants/meeting.constants';
+import type { ArtifactVisibility, MeetingType, MeetingVisibility, RecurrenceType, CancelOnCommitteeRemoval } from '../enums';
 import type { TagSeverity } from './components.interface';
 import type { MeetingAttachment, PresignAttachmentResponse } from './meeting-attachment.interface';
 
@@ -1830,23 +1830,28 @@ export interface MeetingComposerSection {
  * A rail row's derived display state for one composer section.
  * @description `complete` is validity for required sections and "has been visited" for optional ones —
  * an optional section can never be invalid, so visiting it is the only signal that it was considered.
+ * It excludes the active row, which renders its own state; `lineBelowComplete` does not, so the
+ * connector below a completed-but-active row still reads as done.
  */
 export interface MeetingComposerRailRow {
   section: MeetingComposerSection;
   active: boolean;
   complete: boolean;
+  /** Blocked by an earlier invalid required section — never set on the active row. */
   locked: boolean;
-  /** Active required section that isn't valid yet — drives the row's attention dot. */
+  /** Visited required section that isn't valid yet — drives the row's attention dot. */
   needsAttention: boolean;
-  /** Whether the connector above / below this row should read as completed. */
-  lineAboveComplete: boolean;
+  /** Whether the connector drawn below this row should read as completed. */
   lineBelowComplete: boolean;
-  isFirst: boolean;
   isLast: boolean;
 }
 
-/** One feature row in the composer preview, resolved from {@link MEETING_COMPOSER_PREVIEW_FEATURES}. */
+/** Form control keys of {@link MEETING_FEATURE_BY_KEY}. */
+export type MeetingFeatureKey = keyof typeof MEETING_FEATURE_BY_KEY;
+
+/** One feature the composer preview can list, keyed by the form control that turns it on. */
 export interface MeetingComposerPreviewFeature {
+  control: MeetingFeatureKey;
   label: string;
   icon: string;
 }
@@ -1857,8 +1862,8 @@ export interface MeetingComposerPreviewDateChip {
   month: string;
 }
 
-/** Visibility row in the composer preview, resolved from the shared visibility options. */
-export interface MeetingComposerPreviewVisibility {
+/** A label + icon pair rendered as one row in the composer preview. */
+export interface MeetingComposerPreviewRow {
   label: string;
   icon: string;
 }


### PR DESCRIPTION
> **Stack 6 of 20.** Based on PR 5 (`feat/issue-1458-agenda-resources`). Followed by PR 7 (`feat/issue-1460-quick-create-toast`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Adds the composer's left rail — a vertical section stepper — and the live Preview card shown while creating.

## How

- Adds `meeting-composer-rail.component.*`: five section rows with icon circles and connectors, active/complete/invalid states, and a red dot on an active required-but-invalid section. Create mode locks later sections while an earlier required one is invalid; edit mode allows free jumping.
- Adds `meeting-composer-preview.component.*` (create only): date chip, title, when, type, visibility, recurrence, platform, one row per enabled feature, guest and resource counts.
- Unfilled preview fields render `p-skeleton` bars rather than placeholder words.

## Commits

2 commit(s), 13 files changed, 521 insertions(+), 48 deletions(-).

- `feat(meetings): add composer rail navigation and live preview`
- `fix(meetings): address composer review findings`

## Related

- Closes #1459
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
