### PR TITLE
feat(meetings): add quick create, the post-create toast and the narrow layout

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -16,6 +16,7 @@ import {
   MAX_EMAIL_REMINDER_HOURS,
   MAX_EMAIL_REMINDER_TIME,
   MEETING_AGENDA_MAX_LENGTH,
+  MEETING_DURATION_CHIP_OPTIONS,
   MIN_CUSTOM_DURATION,
   MIN_EARLY_JOIN_TIME,
   MIN_EMAIL_REMINDER_HOURS,
@@ -25,6 +26,7 @@ import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   BatchRegistrantOperationResponse,
   Committee,
+  CommitteeMember,
   CreateMeetingRequest,
   ImportantLinkFormValue,
   Meeting,
@@ -45,6 +47,7 @@ import {
   combineDateTime,
   formatTo12HourInTimezone,
   generateRecurrenceObject,
+  generateTempId,
   getDefaultStartDateTime,
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
@@ -198,6 +201,11 @@ export class MeetingComposerFormService {
     if (context.mode === 'edit' && context.meetingUid) {
       this.loadMeeting(context.meetingUid);
       this.loadGuests(context.meetingUid);
+    }
+
+    // Set after the subscriptions are wired so the type's visibility/restriction defaults still apply.
+    if (context.mode === 'create' && context.meetingType) {
+      this.form().get('meeting_type')?.setValue(context.meetingType);
     }
   }
 
@@ -396,6 +404,142 @@ export class MeetingComposerFormService {
   /** Recurrence the current form state would submit — for read-only summaries such as the preview. */
   public recurrencePayload(): MeetingRecurrence | null {
     return this.buildRecurrencePayload(this.form().getRawValue());
+  }
+
+  /**
+   * Writes a duration in minutes across the chip control and its custom companion.
+   * @description Duration lives in two controls, so every writer outside Date & Schedule — the agenda
+   * template estimate, the AI estimate, the quick create prefill — has to set both or leave the pair
+   * inconsistent. Values off the chip scale land in `customDuration` and mark it touched, so its
+   * range error is visible rather than silently deadening submit.
+   */
+  public setDuration(minutes: number): void {
+    const isChipValue = MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === minutes);
+    const form = this.form();
+
+    form.get('duration')?.setValue(isChipValue ? minutes : 'custom');
+    form.get('customDuration')?.setValue(isChipValue ? null : minutes);
+
+    if (!isChipValue) {
+      form.get('customDuration')?.markAsTouched();
+    }
+  }
+
+  /**
+   * Reconciles the guest list against the members of the currently selected groups.
+   * @description Members already invited keep their saved state so they aren't deleted and re-created,
+   * members that dropped out of every selected group are queued for deletion, and the rest are added.
+   * Lives here rather than in the Guests section because the quick create dialog selects groups too.
+   */
+  public syncCommitteeMembers(members: CommitteeMember[]): void {
+    const memberByEmail = new Map<string, CommitteeMember>();
+    members.forEach((member) => {
+      if (member.email) {
+        memberByEmail.set(member.email.toLowerCase(), member);
+      }
+    });
+
+    const suppressed = this.suppressedGuestEmails();
+
+    this.updateGuests((current) => {
+      const reconciled = current.reduce<MeetingRegistrantWithState[]>((kept, guest) => {
+        if (guest.type !== 'committee') {
+          kept.push(guest);
+          return kept;
+        }
+
+        const email = guest.email?.toLowerCase() ?? '';
+        if (memberByEmail.has(email)) {
+          memberByEmail.delete(email);
+          // Reconciliation has to be idempotent: a guest queued for deletion because they left every
+          // selected group is restored when they turn up in one again. A guest the organizer removed by
+          // hand is suppressed, so their deletion survives re-emission.
+          const restore = guest.state === 'deleted' && !suppressed.has(email);
+          kept.push(restore ? { ...guest, state: 'existing' } : guest);
+          return kept;
+        }
+
+        if (guest.state !== 'new') {
+          kept.push({ ...guest, state: 'deleted' });
+        }
+
+        return kept;
+      }, []);
+
+      const invited = new Set(reconciled.filter((guest) => guest.state !== 'deleted').map((guest) => guest.email?.toLowerCase() ?? ''));
+
+      // Whatever is left in the map is a member nobody has invited or explicitly removed yet.
+      const additions = Array.from(memberByEmail.values())
+        .filter((member) => {
+          const email = member.email?.toLowerCase() ?? '';
+          return !invited.has(email) && !suppressed.has(email);
+        })
+        .map((member) => this.toGroupGuest(member));
+
+      return [...reconciled, ...additions];
+    });
+  }
+
+  /** Fields shared by every locally-added guest; `created_at` / `updated_at` are stamped upstream. */
+  public newGuestDefaults(): MeetingRegistrantWithState {
+    return {
+      uid: '',
+      meeting_id: this.meetingId() ?? '',
+      occurrence_id: null,
+      email: '',
+      first_name: '',
+      last_name: '',
+      job_title: null,
+      org_name: null,
+      host: false,
+      org_is_member: false,
+      org_is_project_member: false,
+      avatar_url: null,
+      username: null,
+      linkedin_profile: null,
+      created_at: '',
+      updated_at: '',
+      type: 'direct',
+      invite_accepted: null,
+      attended: null,
+      state: 'new',
+      tempId: generateTempId(),
+    };
+  }
+
+  /**
+   * Minutes the form currently resolves to, whichever of the two duration controls holds it.
+   * @description `customDuration` starts out as an empty string and holds whatever the numeric input
+   * produces, so it is coerced rather than cast.
+   */
+  public effectiveDuration(): number | null {
+    const duration = this.form().get('duration')?.value as number | 'custom' | null;
+
+    if (duration !== 'custom') {
+      return duration ?? null;
+    }
+
+    const customDuration = Number(this.form().get('customDuration')?.value);
+
+    return Number.isFinite(customDuration) && customDuration > 0 ? customDuration : null;
+  }
+
+  private toGroupGuest(member: CommitteeMember): MeetingRegistrantWithState {
+    return {
+      ...this.newGuestDefaults(),
+      email: member.email,
+      first_name: member.first_name,
+      last_name: member.last_name,
+      job_title: member.job_title || null,
+      org_name: member.organization?.name || null,
+      username: member.username || null,
+      linkedin_profile: member.linkedin_profile || null,
+      type: 'committee',
+      committee_uid: member.committee_uid,
+      committee_name: member.committee_name,
+      committee_role: member.role?.name || null,
+      committee_voting_status: member.voting?.status || null,
+    };
   }
 
   // Private initializer functions

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -43,7 +43,7 @@
   position="right"
   [modal]="true"
   [showCloseIcon]="true"
-  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full">
+  styleClass="xl:w-[45%] lg:w-[55%] w-full">
   <ng-template #header>
     <div class="flex min-w-0 flex-col" data-testid="meeting-composer-header">
       <span class="truncate text-lg font-semibold text-gray-900">
@@ -56,7 +56,7 @@
   </ng-template>
 
   <div class="flex h-full min-h-0 gap-6">
-    <!-- Narrow viewports navigate with the footer buttons only; LFXV2-3243 refines the collapsed layout. -->
+    <!-- Rail and preview are desktop-only; below `lg` the composer is one column navigated from the footer (LFXV2-3243) -->
     <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
       <lfx-meeting-composer-rail />
 
@@ -69,6 +69,23 @@
       <p class="text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
     } @else {
       <div class="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto">
+        <!-- Stands in for the hidden rail: where you are, what's done, and what still needs fixing -->
+        <div class="flex flex-col gap-2 border-b border-gray-200 pb-3 lg:hidden" data-testid="meeting-composer-compact-progress">
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-medium text-gray-500">Step {{ activeIndex() + 1 }} of {{ sections.length }}</span>
+            <span class="truncate text-sm font-semibold text-gray-900">{{ activeSectionLabel() }}</span>
+
+            @if (hasAttention()) {
+              <span class="ml-auto flex shrink-0 items-center gap-1 text-xs font-medium text-red-600" data-testid="meeting-composer-compact-attention">
+                <i class="fa-light fa-circle-exclamation" aria-hidden="true"></i>
+                <span>Needs attention</span>
+              </span>
+            }
+          </div>
+
+          <lfx-meeting-composer-rail [compact]="true" />
+        </div>
+
         @switch (composer.activeSection()) {
           @case ('details-access') {
             <lfx-composer-details-access [form]="formService.form()" />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -5,6 +5,37 @@
   <lfx-quick-create-dialog (create)="onSubmit()" />
 }
 
+<!-- Post-create toast (LFXV2-3242): creating no longer navigates, so this is the way back to the meeting -->
+<p-toast [key]="toastKey" position="top-right">
+  <ng-template let-message pTemplate="message">
+    <div class="flex w-full items-start gap-3" data-testid="meeting-composer-toast">
+      <i class="fa-light fa-circle-check mt-0.5 shrink-0 text-xl text-emerald-500" aria-hidden="true"></i>
+      <div class="flex min-w-0 flex-1 flex-col gap-1">
+        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
+        <span class="break-words text-xs text-gray-600">{{ message.detail }}</span>
+        <div class="mt-1 flex items-center gap-3">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            data-testid="meeting-composer-toast-edit"
+            (click)="onEditCreatedMeeting(message.data)">
+            <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
+            <span>Edit meeting</span>
+          </button>
+          <a
+            [routerLink]="message.data.meetingUrl"
+            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            data-testid="meeting-composer-toast-details"
+            (click)="onDismissToast()">
+            <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
+            <span>Meeting details</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </ng-template>
+</p-toast>
+
 <!-- Meeting composer drawer (LFXV2-3234) -->
 <p-drawer
   [visible]="composer.isOpen() && !composer.isQuickCreate()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -1,9 +1,13 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+@if (composer.isQuickCreate()) {
+  <lfx-quick-create-dialog (create)="onSubmit()" />
+}
+
 <!-- Meeting composer drawer (LFXV2-3234) -->
 <p-drawer
-  [visible]="composer.isOpen()"
+  [visible]="composer.isOpen() && !composer.isQuickCreate()"
   (visibleChange)="onVisibleChange($event)"
   position="right"
   [modal]="true"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -28,7 +28,9 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
  * Globally mounted host for the meeting composer drawer (LFXV2-3234).
  * @description Mounted on first open via `@defer` in `app.component.html` and retained thereafter, so
  * opening the composer never unmounts the page underneath. Sections are reachable from both the rail
- * and the footer navigation; the live preview is create-mode only.
+ * and the footer navigation; the live preview is create-mode only. Below `lg` the drawer goes full
+ * width, the rail column and the preview drop out, and the rail's compact chip row takes over section
+ * navigation — the preview has no narrow-viewport equivalent.
  */
 @Component({
   selector: 'lfx-meeting-composer-host',
@@ -69,6 +71,14 @@ export class MeetingComposerHostComponent {
   protected readonly canSubmit: Signal<boolean> = computed(() => {
     this.formService.revision();
     return this.sections.filter((section) => section.required).every((section) => this.formService.isSectionValid(section.id));
+  });
+  protected readonly activeSectionLabel: Signal<string> = computed(() => this.sections[this.activeIndex()]?.label ?? '');
+  /** Whether a required section the organizer has already been through is currently invalid. */
+  protected readonly hasAttention: Signal<boolean> = computed(() => {
+    this.formService.revision();
+    const visited = this.composer.visitedSections();
+
+    return this.sections.some((section) => section.required && visited.has(section.id) && !this.formService.isSectionValid(section.id));
   });
 
   public constructor() {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -15,6 +15,7 @@ import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerPreviewComponent } from './meeting-composer-preview.component';
 import { MeetingComposerRailComponent } from './meeting-composer-rail.component';
 import { MeetingComposerService } from './meeting-composer.service';
+import { QuickCreateDialogComponent } from './quick-create-dialog.component';
 import { ComposerAgendaResourcesComponent } from './sections/composer-agenda-resources.component';
 import { ComposerDateScheduleComponent } from './sections/composer-date-schedule.component';
 import { ComposerDetailsAccessComponent } from './sections/composer-details-access.component';
@@ -39,6 +40,7 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
     ComposerPlatformFeaturesComponent,
     ComposerGuestsComponent,
     ComposerAgendaResourcesComponent,
+    QuickCreateDialogComponent,
   ],
   templateUrl: './meeting-composer-host.component.html',
   providers: [MeetingComposerFormService],

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -3,12 +3,14 @@
 
 import { Component, computed, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
-import type { MeetingComposerSection } from '@lfx-one/shared/interfaces';
+import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_LIFE } from '@lfx-one/shared/constants';
+import type { Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
+import { ToastModule } from 'primeng/toast';
 import { filter, pairwise } from 'rxjs';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
@@ -41,6 +43,8 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
     ComposerGuestsComponent,
     ComposerAgendaResourcesComponent,
     QuickCreateDialogComponent,
+    ToastModule,
+    RouterLink,
   ],
   templateUrl: './meeting-composer-host.component.html',
   providers: [MeetingComposerFormService],
@@ -53,6 +57,7 @@ export class MeetingComposerHostComponent {
   protected readonly formService = inject(MeetingComposerFormService);
 
   protected readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
+  protected readonly toastKey = MEETING_COMPOSER_TOAST_KEY;
 
   protected readonly activeIndex: Signal<number> = computed(() => this.sections.findIndex((section) => section.id === this.composer.activeSection()));
   protected readonly isLastSection: Signal<boolean> = computed(() => this.activeIndex() === this.sections.length - 1);
@@ -121,14 +126,52 @@ export class MeetingComposerHostComponent {
 
     // `submit()` completes without emitting when the save outlived its open, so reaching here always
     // means the current open is the one that was saved.
-    this.formService.submit().subscribe(() => {
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Success',
-        detail: wasEditMode ? 'Meeting updated successfully' : 'Meeting created successfully',
-      });
+    this.formService.submit().subscribe((meeting) => {
+      if (wasEditMode) {
+        this.messageService.add({ severity: 'success', summary: 'Meeting updated', detail: 'Your changes have been saved.' });
+      } else {
+        this.announceCreatedMeeting(meeting);
+      }
 
       this.composer.close();
+    });
+  }
+
+  /** Reopens the composer on the meeting the toast was raised for. */
+  protected onEditCreatedMeeting(data: MeetingComposerToastData): void {
+    this.messageService.clear(this.toastKey);
+    this.composer.open({ mode: 'edit', meetingUid: data.meetingUid });
+  }
+
+  protected onDismissToast(): void {
+    this.messageService.clear(this.toastKey);
+  }
+
+  /**
+   * Raises the post-create toast (LFXV2-3242).
+   * @description Creating no longer navigates to the saved meeting, so this toast is the only route back
+   * to it. A create that returned no meeting has nothing to link to, and falls back to a plain
+   * confirmation rather than a toast whose actions would dead-end.
+   */
+  private announceCreatedMeeting(meeting: Meeting | null): void {
+    if (!meeting?.id) {
+      this.messageService.add({ severity: 'success', summary: 'Meeting created', detail: 'Open it from the list to review the details.' });
+      return;
+    }
+
+    const data: MeetingComposerToastData = {
+      meetingUid: meeting.id,
+      meetingTitle: meeting.title ?? 'Untitled meeting',
+      meetingUrl: `/meetings/${meeting.id}`,
+    };
+
+    this.messageService.add({
+      key: this.toastKey,
+      severity: 'success',
+      summary: 'Meeting created',
+      detail: data.meetingTitle,
+      life: MEETING_COMPOSER_TOAST_LIFE,
+      data,
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -1,10 +1,38 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<!-- Composer section rail (LFXV2-3240) -->
-<nav class="flex flex-col" aria-label="Composer sections" data-testid="meeting-composer-rail">
+<!-- Composer section rail (LFXV2-3240), with the collapsed chip row for narrow viewports (LFXV2-3243) -->
+<nav
+  [ngClass]="compact() ? 'flex items-center gap-1 overflow-x-auto pb-1' : 'flex flex-col'"
+  aria-label="Composer sections"
+  [attr.data-testid]="testIdPrefix()">
   @for (row of rows(); track row.section.id) {
-    @if (composer.isEditMode()) {
+    @if (compact()) {
+      <button
+        type="button"
+        class="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
+        [ngClass]="{
+          'border-blue-600 bg-blue-600 text-white': row.active,
+          'border-blue-200 bg-white text-blue-700': !row.active && row.complete,
+          'border-gray-200 bg-white text-gray-600': !row.active && !row.complete,
+          'cursor-not-allowed opacity-50': row.locked,
+        }"
+        [disabled]="row.locked"
+        [attr.aria-current]="row.active ? 'step' : null"
+        [attr.data-testid]="testIdPrefix() + '-' + row.section.id"
+        (click)="onSelect(row)">
+        @if (row.complete) {
+          <i class="fa-light fa-check" aria-hidden="true"></i>
+        } @else {
+          <i [ngClass]="row.section.icon" aria-hidden="true"></i>
+        }
+        <span class="whitespace-nowrap">{{ row.section.label }}</span>
+        @if (row.needsAttention) {
+          <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="testIdPrefix() + '-attention-' + row.section.id"></span>
+          <span class="sr-only">Required fields still missing</span>
+        }
+      </button>
+    } @else if (composer.isEditMode()) {
       <button
         type="button"
         class="flex items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm font-medium transition-colors"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, type Signal } from '@angular/core';
+import { Component, computed, inject, input, type Signal } from '@angular/core';
 import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
 import type { MeetingComposerRailRow, MeetingComposerSection, MeetingComposerSectionId } from '@lfx-one/shared/interfaces';
 
@@ -24,9 +24,18 @@ export class MeetingComposerRailComponent {
   protected readonly composer = inject(MeetingComposerService);
   private readonly formService = inject(MeetingComposerFormService);
 
+  /**
+   * Renders as a horizontal chip row instead of a vertical stepper.
+   * @description What the composer shows below `lg`, where the rail column is hidden: the same rows and
+   * the same locking, laid out to fit above the section content.
+   */
+  public readonly compact = input(false);
+
   private readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
 
   protected readonly rows: Signal<MeetingComposerRailRow[]> = this.initRows();
+  // Both layouts can be in the DOM at once, so their test ids have to differ.
+  protected readonly testIdPrefix: Signal<string> = computed(() => (this.compact() ? 'meeting-composer-rail-compact' : 'meeting-composer-rail'));
 
   protected onSelect(row: MeetingComposerRailRow): void {
     if (row.locked || row.active) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -32,6 +32,7 @@ export class MeetingComposerService {
 
   public readonly isOpen = computed(() => this._context() !== null);
   public readonly isEditMode = computed(() => this._context()?.mode === 'edit');
+  public readonly isQuickCreate = computed(() => this._context()?.variant === 'quick');
 
   public open(context: MeetingComposerContext): void {
     const section = context.section ?? FIRST_SECTION;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -1,0 +1,68 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- Quick create dialog (LFXV2-3241) -->
+<p-dialog
+  [visible]="composer.isOpen()"
+  (visibleChange)="onVisibleChange($event)"
+  [modal]="true"
+  [draggable]="false"
+  [dismissableMask]="true"
+  header="Create meeting"
+  styleClass="w-[min(1024px,94vw)]">
+  <div class="grid grid-cols-1 gap-6 lg:grid-cols-2" data-testid="quick-create-body">
+    <div class="flex min-w-0 flex-col gap-6">
+      <lfx-composer-details-access [form]="formService.form()" [showHeading]="false" />
+
+      @if (prefilledType()) {
+        <p class="text-xs text-gray-500" data-testid="quick-create-prefill-hint">Pre-filled for this meeting type — edit freely.</p>
+      }
+
+      <div class="flex flex-col gap-2">
+        <label for="quick-create-agenda" class="text-sm font-medium text-gray-900">Agenda</label>
+        <lfx-textarea
+          [form]="formService.form()"
+          control="description"
+          id="quick-create-agenda"
+          placeholder="Enter meeting agenda and key discussion points"
+          styleClass="w-full"
+          [rows]="6"
+          [maxlength]="agendaMaxLength"
+          data-testid="quick-create-agenda-textarea" />
+        <div class="flex items-center justify-between gap-2">
+          @if (prefilledType()) {
+            <p class="text-xs text-gray-500" data-testid="quick-create-agenda-hint">Suggested agenda template — adjust as needed.</p>
+          }
+          <p class="ml-auto text-xs" [ngClass]="agendaCounterClass()">{{ agendaLength() }}/{{ agendaMaxLength }}</p>
+        </div>
+      </div>
+
+      <lfx-meeting-committee-manager
+        [selectedCommittees]="formService.form().get('committees')?.value || []"
+        [form]="formService.form()"
+        [committeeContext]="formService.committeeContext()"
+        (committeeMembersChange)="onCommitteeMembersChange($event)" />
+    </div>
+
+    <div class="flex min-w-0 flex-col gap-6">
+      <lfx-composer-date-schedule [form]="formService.form()" [showHeading]="false" [showEarlyJoin]="false" />
+    </div>
+  </div>
+
+  <ng-template #footer>
+    <div class="flex w-full items-center justify-between gap-2" data-testid="quick-create-footer">
+      <p class="text-xs text-gray-500">You can configure advanced settings later.</p>
+
+      <div class="flex items-center gap-2">
+        <lfx-button label="Cancel" severity="secondary" [text]="true" size="small" data-testid="quick-create-cancel" (onClick)="composer.close()" />
+        <lfx-button
+          label="Create meeting"
+          size="small"
+          [loading]="formService.submitting()"
+          [disabled]="!canSubmit()"
+          data-testid="quick-create-submit"
+          (onClick)="onCreate()" />
+      </div>
+    </div>
+  </ng-template>
+</p-dialog>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -1,0 +1,136 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, output, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { ButtonComponent } from '@components/button/button.component';
+import { TextareaComponent } from '@components/textarea/textarea.component';
+import { DEFAULT_DURATION, MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_WARNING_LENGTH, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
+import type { CommitteeMember, MeetingTemplate } from '@lfx-one/shared/interfaces';
+import { DialogModule } from 'primeng/dialog';
+import { startWith, switchMap } from 'rxjs';
+
+import { MeetingCommitteeManagerComponent } from '../components/meeting-committee-manager/meeting-committee-manager.component';
+import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerService } from './meeting-composer.service';
+import { ComposerDateScheduleComponent } from './sections/composer-date-schedule.component';
+import { ComposerDetailsAccessComponent } from './sections/composer-details-access.component';
+
+/**
+ * Quick create dialog (LFXV2-3241).
+ * @description The condensed create surface: the same form and the same submit path as the drawer, laid
+ * out as two columns with no rail and no per-section gating. It composes the drawer's Details & Access
+ * and Date & Schedule sections rather than reimplementing their controls, so validators, hint copy and
+ * type-driven defaults can't drift between the two surfaces. Platform, features and resources keep
+ * their form defaults and are edited later in the drawer.
+ */
+@Component({
+  selector: 'lfx-quick-create-dialog',
+  imports: [
+    NgClass,
+    DialogModule,
+    ButtonComponent,
+    TextareaComponent,
+    ComposerDetailsAccessComponent,
+    ComposerDateScheduleComponent,
+    MeetingCommitteeManagerComponent,
+  ],
+  templateUrl: './quick-create-dialog.component.html',
+})
+export class QuickCreateDialogComponent {
+  protected readonly composer = inject(MeetingComposerService);
+  protected readonly formService = inject(MeetingComposerFormService);
+
+  /** Submit stays with the host, so both surfaces save through one path. */
+  public readonly create = output<void>();
+
+  protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
+
+  /** Meeting type whose template was applied, so the prefill hints only claim what was actually filled. */
+  protected readonly prefilledType = signal<MeetingType | null>(null);
+
+  protected readonly agendaLength: Signal<number> = computed(() => {
+    this.formService.revision();
+    return (this.formService.form().get('description')?.value as string | null)?.length ?? 0;
+  });
+  protected readonly agendaCounterClass: Signal<string> = computed(() => {
+    const length = this.agendaLength();
+
+    if (length >= MEETING_AGENDA_MAX_LENGTH) {
+      return 'text-red-600';
+    }
+
+    return length >= MEETING_AGENDA_WARNING_LENGTH ? 'text-amber-600' : 'text-gray-500';
+  });
+  protected readonly canSubmit: Signal<boolean> = computed(() => {
+    // FormGroup validity is not reactive; `revision` is what makes this recompute.
+    this.formService.revision();
+    return this.formService.form().valid;
+  });
+
+  public constructor() {
+    // The form instance is replaced on every open, and the type can be seeded by the entry point before
+    // this dialog mounts, so the current value is replayed rather than waiting for the next change.
+    toObservable(this.formService.form)
+      .pipe(
+        switchMap((form) => {
+          const control = form.get('meeting_type');
+          return control ? control.valueChanges.pipe(startWith(control.value as MeetingType | null)) : [];
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((meetingType: MeetingType | null) => this.applyTypeTemplate(meetingType));
+  }
+
+  protected onVisibleChange(visible: boolean): void {
+    if (!visible) {
+      this.composer.close();
+    }
+  }
+
+  protected onCommitteeMembersChange(members: CommitteeMember[]): void {
+    this.formService.syncCommitteeMembers(members);
+  }
+
+  protected onCreate(): void {
+    this.create.emit();
+  }
+
+  /**
+   * Seeds title, agenda and duration from the meeting type's first template.
+   * @description Only untouched fields are written — switching type after typing a title must not discard
+   * it — so duration is seeded only while it still holds the form default.
+   */
+  private applyTypeTemplate(meetingType: MeetingType | null): void {
+    const template = meetingType ? this.firstTemplate(meetingType) : null;
+
+    if (!template) {
+      this.prefilledType.set(null);
+      return;
+    }
+
+    const form = this.formService.form();
+    const title = form.get('title');
+    const description = form.get('description');
+
+    if (!(title?.value as string | null)?.trim()) {
+      title?.setValue(template.title);
+    }
+
+    if (!(description?.value as string | null)?.trim()) {
+      description?.setValue(template.content);
+    }
+
+    if (this.formService.effectiveDuration() === DEFAULT_DURATION) {
+      this.formService.setDuration(template.estimatedDuration);
+    }
+
+    this.prefilledType.set(meetingType);
+  }
+
+  private firstTemplate(meetingType: MeetingType): MeetingTemplate | null {
+    return MEETING_TEMPLATES.find((group) => group.meetingType === meetingType)?.templates[0] ?? null;
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -15,7 +15,6 @@ import {
   MAX_FILE_SIZE_MB,
   MEETING_AGENDA_MAX_LENGTH,
   MEETING_AGENDA_WARNING_LENGTH,
-  MEETING_DURATION_CHIP_OPTIONS,
   MIN_CUSTOM_DURATION,
 } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
@@ -257,8 +256,7 @@ export class ComposerAgendaResourcesComponent {
    * the allowed range is dropped with a warning (writing it would trip the form service's min/max
    * validators and deaden submit from a section the organizer can't see); an estimate that already
    * matches the current duration is a silent no-op; any other estimate is written and announced, since
-   * the duration they picked has just been overwritten. Estimates outside the chip values go to
-   * `customDuration` rather than being clamped.
+   * the duration they picked has just been overwritten.
    */
   private applyEstimatedDuration(estimate: number): void {
     const estimatedDuration = Math.round(estimate);
@@ -272,43 +270,17 @@ export class ComposerAgendaResourcesComponent {
       return;
     }
 
-    if (this.effectiveDuration() === estimatedDuration) {
+    if (this.formService.effectiveDuration() === estimatedDuration) {
       return;
     }
 
-    const isChipValue = MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === estimatedDuration);
-    const customDuration = this.form().get('customDuration');
-    const durationControl = this.form().get('duration');
-
-    durationControl?.setValue(isChipValue ? estimatedDuration : 'custom');
-    customDuration?.setValue(isChipValue ? null : estimatedDuration);
-
-    if (!isChipValue) {
-      customDuration?.markAsTouched();
-    }
+    this.formService.setDuration(estimatedDuration);
 
     this.messageService.add({
       severity: 'info',
       summary: 'Duration updated',
       detail: `Meeting duration set to ${estimatedDuration} minutes. Change it in Date & Schedule if that's not right.`,
     });
-  }
-
-  /**
-   * Minutes the form currently resolves to, whichever of the two duration controls holds it.
-   * @description `customDuration` starts out as an empty string and holds whatever the numeric input
-   * produces, so it is coerced rather than cast.
-   */
-  private effectiveDuration(): number | null {
-    const duration = this.form().get('duration')?.value as number | 'custom' | null;
-
-    if (duration !== 'custom') {
-      return duration ?? null;
-    }
-
-    const customDuration = Number(this.form().get('customDuration')?.value);
-
-    return Number.isFinite(customDuration) && customDuration > 0 ? customDuration : null;
   }
 
   private validateFile(file: File, queued: PendingAttachment[]): string | null {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -2,10 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6" data-testid="composer-date-schedule">
-  <div class="flex flex-col gap-1">
-    <h2>Date &amp; Schedule</h2>
-    <p class="text-sm text-gray-500">When it happens and how often it repeats.</p>
-  </div>
+  @if (showHeading()) {
+    <div class="flex flex-col gap-1">
+      <h2>Date &amp; Schedule</h2>
+      <p class="text-sm text-gray-500">When it happens and how often it repeats.</p>
+    </div>
+  }
 
   <!-- Start date + start time -->
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -103,29 +105,31 @@
   </div>
 
   <!-- Early join -->
-  <div class="flex flex-col gap-2">
-    <span id="composer-early-join-label" class="flex items-center gap-2 text-sm font-medium text-gray-900">
-      Early join
-      <i
-        class="fa-light fa-info-circle cursor-help text-gray-400"
-        tabindex="0"
-        role="img"
-        [attr.aria-label]="earlyJoinTooltip"
-        [pTooltip]="earlyJoinTooltip"
-        tooltipEvent="both"
-        tooltipPosition="right"
-        tooltipStyleClass="text-xs max-w-xs"></i>
-    </span>
-    <div role="group" aria-labelledby="composer-early-join-label" data-testid="composer-early-join-chips">
-      <lfx-select-button [form]="form()" control="early_join_time_minutes" [options]="earlyJoinOptions" [unselectable]="false" />
+  @if (showEarlyJoin()) {
+    <div class="flex flex-col gap-2">
+      <span id="composer-early-join-label" class="flex items-center gap-2 text-sm font-medium text-gray-900">
+        Early join
+        <i
+          class="fa-light fa-info-circle cursor-help text-gray-400"
+          tabindex="0"
+          role="img"
+          [attr.aria-label]="earlyJoinTooltip"
+          [pTooltip]="earlyJoinTooltip"
+          tooltipEvent="both"
+          tooltipPosition="right"
+          tooltipStyleClass="text-xs max-w-xs"></i>
+      </span>
+      <div role="group" aria-labelledby="composer-early-join-label" data-testid="composer-early-join-chips">
+        <lfx-select-button [form]="form()" control="early_join_time_minutes" [options]="earlyJoinOptions" [unselectable]="false" />
+      </div>
+      @if (form().get('early_join_time_minutes')?.errors?.['min'] && form().get('early_join_time_minutes')?.touched) {
+        <p class="text-sm text-red-600" data-testid="composer-early-join-min-error">Early join time must be at least {{ minEarlyJoinTime }} minutes</p>
+      }
+      @if (form().get('early_join_time_minutes')?.errors?.['max'] && form().get('early_join_time_minutes')?.touched) {
+        <p class="text-sm text-red-600" data-testid="composer-early-join-max-error">Early join time cannot exceed {{ maxEarlyJoinTime }} minutes</p>
+      }
     </div>
-    @if (form().get('early_join_time_minutes')?.errors?.['min'] && form().get('early_join_time_minutes')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-early-join-min-error">Early join time must be at least {{ minEarlyJoinTime }} minutes</p>
-    }
-    @if (form().get('early_join_time_minutes')?.errors?.['max'] && form().get('early_join_time_minutes')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-early-join-max-error">Early join time cannot exceed {{ maxEarlyJoinTime }} minutes</p>
-    }
-  </div>
+  }
 
   <hr class="border-gray-200" />
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -54,6 +54,10 @@ export class ComposerDateScheduleComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   public readonly form = input.required<FormGroup>();
+  /** Quick create labels its own columns and has no room for the section heading. */
+  public readonly showHeading = input(true);
+  /** Early join is an advanced setting the quick create dialog leaves at its default. */
+  public readonly showEarlyJoin = input(true);
 
   protected readonly durationOptions = MEETING_DURATION_CHIP_OPTIONS;
   protected readonly earlyJoinOptions = EARLY_JOIN_CHIP_OPTIONS;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -2,10 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6" data-testid="composer-details-access">
-  <div class="flex flex-col gap-1">
-    <h2>Details &amp; Access</h2>
-    <p class="text-sm text-gray-500">Name the meeting and set who it's for.</p>
-  </div>
+  @if (showHeading()) {
+    <div class="flex flex-col gap-1">
+      <h2>Details &amp; Access</h2>
+      <p class="text-sm text-gray-500">Name the meeting and set who it's for.</p>
+    </div>
+  }
 
   <!-- Meeting title -->
   <div class="flex flex-col gap-2">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -40,6 +40,8 @@ export class ComposerDetailsAccessComponent {
   private readonly formService = inject(MeetingComposerFormService);
 
   public readonly form = input.required<FormGroup>();
+  /** Quick create labels its own columns and has no room for the section heading. */
+  public readonly showHeading = input(true);
 
   protected readonly visibilityOptions = MEETING_VISIBILITY_OPTIONS;
   protected readonly joinRestrictionOptions = MEETING_JOIN_RESTRICTION_OPTIONS;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -8,7 +8,7 @@ import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggl
 import { UserSearchComponent } from '@components/user-search/user-search.component';
 import { COMMITTEE_LABEL, SHOW_MEETING_ATTENDEES_FEATURE } from '@lfx-one/shared/constants';
 import type { CommitteeMember, ManualGuestDialogResult, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
-import { avatarInitials, generateTempId } from '@lfx-one/shared/utils';
+import { avatarInitials } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -108,58 +108,8 @@ export class ComposerGuestsComponent {
     );
   }
 
-  /**
-   * Reconciles the guest list against the members of the currently selected groups.
-   * @description Members already invited keep their saved state so they aren't deleted and re-created,
-   * members that dropped out of every selected group are queued for deletion, and the rest are added.
-   */
   protected onCommitteeMembersChange(members: CommitteeMember[]): void {
-    const memberByEmail = new Map<string, CommitteeMember>();
-    members.forEach((member) => {
-      if (member.email) {
-        memberByEmail.set(member.email.toLowerCase(), member);
-      }
-    });
-
-    const suppressed = this.formService.suppressedGuestEmails();
-
-    this.formService.updateGuests((current) => {
-      const reconciled = current.reduce<MeetingRegistrantWithState[]>((kept, guest) => {
-        if (guest.type !== 'committee') {
-          kept.push(guest);
-          return kept;
-        }
-
-        const email = guest.email?.toLowerCase() ?? '';
-        if (memberByEmail.has(email)) {
-          memberByEmail.delete(email);
-          // Reconciliation has to be idempotent: a guest queued for deletion because they left every
-          // selected group is restored when they turn up in one again. A guest the organizer removed by
-          // hand is suppressed, so their deletion survives re-emission.
-          const restore = guest.state === 'deleted' && !suppressed.has(email);
-          kept.push(restore ? { ...guest, state: 'existing' } : guest);
-          return kept;
-        }
-
-        if (guest.state !== 'new') {
-          kept.push({ ...guest, state: 'deleted' });
-        }
-
-        return kept;
-      }, []);
-
-      const invited = new Set(reconciled.filter((guest) => guest.state !== 'deleted').map((guest) => guest.email?.toLowerCase() ?? ''));
-
-      // Whatever is left in the map is a member nobody has invited or explicitly removed yet.
-      const additions = Array.from(memberByEmail.values())
-        .filter((member) => {
-          const email = member.email?.toLowerCase() ?? '';
-          return !invited.has(email) && !suppressed.has(email);
-        })
-        .map((member) => this.toGroupGuest(member));
-
-      return [...reconciled, ...additions];
-    });
+    this.formService.syncCommitteeMembers(members);
   }
 
   private openManualDialog(prefill: Record<string, unknown> | null): void {
@@ -188,7 +138,7 @@ export class ComposerGuestsComponent {
     }
 
     const guest: MeetingRegistrantWithState = {
-      ...this.baseGuest(),
+      ...this.formService.newGuestDefaults(),
       email,
       first_name: (formValue['first_name'] as string | null) ?? '',
       last_name: (formValue['last_name'] as string | null) ?? '',
@@ -199,50 +149,5 @@ export class ComposerGuestsComponent {
     };
 
     this.formService.updateGuests((current) => [guest, ...current]);
-  }
-
-  private toGroupGuest(member: CommitteeMember): MeetingRegistrantWithState {
-    return {
-      ...this.baseGuest(),
-      email: member.email,
-      first_name: member.first_name,
-      last_name: member.last_name,
-      job_title: member.job_title || null,
-      org_name: member.organization?.name || null,
-      username: member.username || null,
-      linkedin_profile: member.linkedin_profile || null,
-      type: 'committee',
-      committee_uid: member.committee_uid,
-      committee_name: member.committee_name,
-      committee_role: member.role?.name || null,
-      committee_voting_status: member.voting?.status || null,
-    };
-  }
-
-  /** Fields shared by every locally-added guest; `created_at` / `updated_at` are stamped upstream. */
-  private baseGuest(): MeetingRegistrantWithState {
-    return {
-      uid: '',
-      meeting_id: this.formService.meetingId() ?? '',
-      occurrence_id: null,
-      email: '',
-      first_name: '',
-      last_name: '',
-      job_title: null,
-      org_name: null,
-      host: false,
-      org_is_member: false,
-      org_is_project_member: false,
-      avatar_url: null,
-      username: null,
-      linkedin_profile: null,
-      created_at: '',
-      updated_at: '',
-      type: 'direct',
-      invite_accepted: null,
-      attended: null,
-      state: 'new',
-      tempId: generateTempId(),
-    };
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -31,14 +31,26 @@
               </lfx-button>
             }
             @if (activeLens() !== 'me' && canWriteMeetings()) {
-              <lfx-button
-                icon="fa-light fa-calendar"
-                severity="info"
-                [attr.data-testid]="'meeting-create-button'"
-                label="Create Meeting"
-                size="small"
-                (onClick)="onCreateMeeting()">
-              </lfx-button>
+              <div class="flex items-center gap-1">
+                <lfx-button
+                  icon="fa-light fa-calendar"
+                  severity="info"
+                  [attr.data-testid]="'meeting-create-button'"
+                  label="Create Meeting"
+                  size="small"
+                  (onClick)="onCreateMeeting()">
+                </lfx-button>
+                <lfx-button
+                  icon="fa-light fa-chevron-down"
+                  severity="info"
+                  [outlined]="true"
+                  size="small"
+                  ariaLabel="More create options"
+                  [attr.data-testid]="'meeting-create-options-button'"
+                  (onClick)="createMenu.toggle($event)">
+                </lfx-button>
+                <lfx-menu #createMenu [model]="createMenuItems" [popup]="true" appendTo="body"></lfx-menu>
+              </div>
             }
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -12,9 +12,11 @@ import { FullCalendarComponent } from '@app/shared/components/fullcalendar/fullc
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { MenuComponent } from '@components/menu/menu.component';
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
+import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS, MEETING_TYPE_OPTIONS } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
 import { Lens, MeLensMeetingFilters, Meeting, MeetingCalendarClickProps, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
 import {
   getCurrentOrNextOccurrence,
@@ -36,6 +38,7 @@ import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
 import { hasMeetingWriteAccess } from '@shared/utils/write-access.util';
+import { MenuItem } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import {
@@ -74,6 +77,7 @@ import { MeetingsTopBarComponent } from './components/meetings-top-bar/meetings-
     EmptyStateComponent,
     FullCalendarComponent,
     SkeletonModule,
+    MenuComponent,
   ],
   providers: [DialogService],
   templateUrl: './meetings-dashboard.component.html',
@@ -91,6 +95,27 @@ export class MeetingsDashboardComponent {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly dialogService = inject(DialogService);
   private readonly composer = inject(MeetingComposerService);
+
+  /**
+   * Create Meeting dropdown: a quick start per meeting type, then the full drawer.
+   * @description A type row opens the quick dialog pre-selected, so its template prefill runs immediately.
+   */
+  public readonly createMenuItems: MenuItem[] = [
+    {
+      label: 'Quick start',
+      items: MEETING_TYPE_OPTIONS.map((option) => ({
+        label: option.label,
+        icon: option.info.icon,
+        command: () => this.onQuickCreateMeeting(option.value),
+      })),
+    },
+    { separator: true },
+    {
+      label: 'Advanced',
+      icon: 'fa-light fa-sliders',
+      command: () => this.onAdvancedCreateMeeting(),
+    },
+  ];
 
   public readonly activeLens: Signal<Lens> = this.lensService.activeLens;
   protected readonly personaLoaded = this.personaService.personaLoaded;
@@ -259,7 +284,16 @@ export class MeetingsDashboardComponent {
     );
   }
 
+  /** Main button: the quick create dialog. The dropdown covers per-type quick starts and the drawer. */
   public onCreateMeeting(): void {
+    this.composer.open({ mode: 'create', variant: 'quick' });
+  }
+
+  public onQuickCreateMeeting(meetingType: MeetingType): void {
+    this.composer.open({ mode: 'create', variant: 'quick', meetingType });
+  }
+
+  public onAdvancedCreateMeeting(): void {
     this.composer.open({ mode: 'create' });
   }
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -354,6 +354,16 @@ export const MEETING_COMPOSER_PREVIEW_FEATURES: MeetingComposerPreviewFeature[] 
 ).map(({ control, label }) => ({ control, label, icon: MEETING_FEATURE_BY_KEY[control].icon }));
 
 /**
+ * Toast key for the composer's post-save confirmation.
+ * @description Its own key so the action-bearing create toast renders through the composer's template
+ * rather than the app-wide `p-toast`.
+ */
+export const MEETING_COMPOSER_TOAST_KEY = 'meeting-composer-toast';
+
+/** How long the post-create toast stays up, in ms — longer than a plain toast because it carries actions. */
+export const MEETING_COMPOSER_TOAST_LIFE = 10000;
+
+/**
  * Default meeting duration in minutes
  * @description Standard meeting length when no custom duration is specified
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1884,9 +1884,16 @@ export interface MeetingComposerContext {
    * @description Takes precedence over the ambient project context, which resolves asynchronously.
    */
   projectUid?: string;
-  /** Section to land on; defaults to the first section. */
+  /** Section to land on; defaults to the first section. Ignored by the quick create dialog. */
   section?: MeetingComposerSectionId;
+  /** Surface to open — the full drawer (default) or the quick create dialog. */
+  variant?: MeetingComposerVariant;
+  /** Meeting type the quick create dialog opens pre-selected with, so its template prefill runs immediately. */
+  meetingType?: MeetingType;
 }
+
+/** Composer surface: the full sectioned drawer, or the condensed quick create dialog. */
+export type MeetingComposerVariant = 'drawer' | 'quick';
 
 /** Dialog data for the composer's manual guest entry dialog. */
 export interface ManualGuestDialogData {

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1895,6 +1895,18 @@ export interface MeetingComposerContext {
 /** Composer surface: the full sectioned drawer, or the condensed quick create dialog. */
 export type MeetingComposerVariant = 'drawer' | 'quick';
 
+/**
+ * What the post-create toast needs to render its actions.
+ * @description Carried on the PrimeNG message's `data`, since creating no longer navigates anywhere —
+ * the toast is the only route back to the meeting that was just created.
+ */
+export interface MeetingComposerToastData {
+  meetingUid: string;
+  meetingTitle: string;
+  /** Router link to the meeting's details page. */
+  meetingUrl: string;
+}
+
 /** Dialog data for the composer's manual guest entry dialog. */
 export interface ManualGuestDialogData {
   /** Values carried over from the search field, when the directory result was incomplete. */


### PR DESCRIPTION
> **Stack 7 of 20.** Based on PR 6 (`feat/issue-1459-rail-preview`). Followed by PR 8 (`fix/issue-1451-composer-review`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Adds the Quick create dialog for the common case, replaces post-create navigation with a toast, and collapses the composer to a single column on narrow viewports.

## How

- Adds `quick-create-dialog.component.*` — a two-column `p-dialog` whose meeting-type selection prefills title, duration, visibility, restriction and group from the shared `MEETING_TEMPLATES`. It submits through the same `MeetingComposerFormService` path as the drawer.
- Replaces `navigateAfterMeetingSave()` with a keyed toast: create shows `Meeting created: {title}` with "Edit meeting" and "Meeting details" actions; edit shows a plain confirmation.
- Below the rail's breakpoint the rail and preview collapse away and the drawer goes full width with footer-only navigation.

## Notes for reviewers

- **Behaviour change:** creating a meeting no longer auto-navigates to the Guests step. The composer closes and the toast offers the follow-up actions. Worth calling out in QA.
- **Reviewed and kept:** quick create uses a declarative `<p-dialog>` rather than `DialogService.open()`. The repo checklist prefers the service, but that path renders into a detached component with no host injector, and this dialog has to share the host-provided `MeetingComposerFormService` instance so "switch to advanced" can hand the live form to the drawer (PR 15). The rationale is recorded in a comment on the template.

## Commits

3 commit(s), 18 files changed, 642 insertions(+), 185 deletions(-).

- `feat(meetings): add quick create meeting dialog`
- `feat(meetings): replace post-create navigation with toast`
- `feat(meetings): collapse composer rail on narrow viewports`

## Related

- Closes #1460
- Closes #1461
- Closes #1462
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
