### PR TITLE
fix(meetings): address composer review findings across all sections

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/add-link-dialog/add-link-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/add-link-dialog/add-link-dialog.component.ts
@@ -10,7 +10,7 @@ import { httpsUrlValidator, trimmedRequired } from '@lfx-one/shared/validators';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 
 /**
- * Add-link entry for the composer's Agenda & Resources section (LFXV2-3239).
+ * Add-link entry for the composer's Agenda & Resources section (GH-1458).
  * @description Opened through `DialogService` so the overlay outlives the section, which the composer's
  * `@switch` destroys on every section change.
  */

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/manual-guest-dialog/manual-guest-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/manual-guest-dialog/manual-guest-dialog.component.ts
@@ -10,7 +10,7 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { RegistrantFormComponent } from '../../components/registrant-form/registrant-form.component';
 
 /**
- * Manual guest entry for the composer's Guests section (LFXV2-3238).
+ * Manual guest entry for the composer's Guests section (GH-1457).
  * @description Opened through `DialogService` rather than an inline `<p-dialog>`, so the overlay lives
  * outside the section that the composer's `@switch` destroys on every section change.
  */

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -3,12 +3,12 @@
 
 import { TestBed } from '@angular/core/testing';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
-import type { Meeting, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
+import type { Meeting, MeetingRegistrant, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
@@ -202,5 +202,79 @@ describe('MeetingComposerFormService — guest list', () => {
 
     expect(service.guests()).toEqual([]);
     expect(service.registrantUpdates()).toEqual({ toAdd: [], toUpdate: [], toDelete: [] });
+  });
+});
+
+/**
+ * Covers the retry behind the edit-mode load-failure state. `meetingId` is also set by a successful
+ * create, so an unguarded retry would hydrate a create form from the meeting it just saved.
+ */
+describe('MeetingComposerFormService — load retry', () => {
+  let service: MeetingComposerFormService;
+  let getMeeting: ReturnType<typeof vi.fn>;
+  let getMeetingRegistrants: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getMeeting = vi.fn().mockReturnValue(throwError(() => new Error('not found')));
+    getMeetingRegistrants = vi.fn().mockReturnValue(of([] as MeetingRegistrant[]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        {
+          provide: MeetingService,
+          useValue: {
+            getMeeting,
+            getMeetingAttachments: vi.fn().mockReturnValue(of([])),
+            getMeetingRegistrants,
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+  });
+
+  it('re-fetches the meeting after a failed edit-mode load', () => {
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    expect(service.meetingLoadFailed()).toBe(true);
+    expect(getMeeting).toHaveBeenCalledTimes(1);
+
+    service.retryLoadMeeting();
+
+    expect(getMeeting).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves a guest list that loaded fine alone on retry', () => {
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+    expect(getMeetingRegistrants).toHaveBeenCalledTimes(1);
+
+    service.retryLoadMeeting();
+
+    expect(getMeetingRegistrants).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches the guests too when their own request failed', () => {
+    getMeetingRegistrants.mockReturnValueOnce(throwError(() => new Error('boom')));
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    expect(service.guestsLoadFailed()).toBe(true);
+
+    service.retryLoadMeeting();
+
+    expect(getMeetingRegistrants).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-fetch in create mode, where meetingId comes from the save', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.meetingId.set('meeting-1');
+
+    service.retryLoadMeeting();
+
+    expect(getMeeting).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -269,6 +269,37 @@ describe('MeetingComposerFormService — load retry', () => {
     expect(getMeetingRegistrants).toHaveBeenCalledTimes(2);
   });
 
+  it('clears the failure and hydrates the form when the retry succeeds', () => {
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+    expect(service.meetingLoadFailed()).toBe(true);
+
+    getMeeting.mockReturnValue(of({ id: 'meeting-1', title: 'Retried meeting' } as Meeting));
+    service.retryLoadMeeting();
+
+    expect(service.meetingLoadFailed()).toBe(false);
+    expect(service.meeting()?.title).toBe('Retried meeting');
+    expect(service.form().get('title')?.value).toBe('Retried meeting');
+  });
+
+  it('ignores a retry while a load is still in flight', () => {
+    // A pending fetch leaves `loading` true, which is the state a second click on Try again would hit.
+    getMeeting.mockReturnValue(new Subject<Meeting>());
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+    expect(service.loading()).toBe(true);
+
+    service.retryLoadMeeting();
+
+    expect(getMeeting).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fetch an edit-mode open that never had a meeting uid', () => {
+    service.initialize({ mode: 'edit' });
+
+    service.retryLoadMeeting();
+
+    expect(getMeeting).not.toHaveBeenCalled();
+  });
+
   it('does not re-fetch in create mode, where meetingId comes from the save', () => {
     service.initialize({ mode: 'create', projectUid: 'project-1' });
     service.meetingId.set('meeting-1');

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -81,7 +81,7 @@ import {
 } from 'rxjs';
 
 /**
- * Form state and persistence for the meeting composer (LFXV2-3234).
+ * Form state and persistence for the meeting composer (GH-1452).
  * @description Owns the single meeting FormGroup, edit-mode hydration, the create/update request
  * payload, and the attachment + registrant operations that run alongside the meeting save.
  * Provided by `MeetingComposerHostComponent`, so `initialize()` fully resets state on every open.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -139,8 +139,8 @@ export class MeetingComposerFormService {
    * @description FormGroup state is not reactive, so template computeds that depend on section validity —
    * or on a control's `pristine` flag — must read this signal to re-evaluate. `validateForSubmit()` needs
    * the explicit bump because `markAsTouched`/`markAsDirty` emit on neither `valueChanges` nor
-   * `statusChanges`; the only other writer that marks — `setDuration()` — orders its mark before a
-   * `setValue` that does emit.
+   * `statusChanges`, and it writes no values of its own. The only other writer that marks —
+   * `setDuration()` — needs no bump: its own `setValue` calls provide one.
    */
   public readonly revision = signal<number>(0);
 
@@ -474,9 +474,9 @@ export class MeetingComposerFormService {
     const isChipValue = MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === minutes);
     const form = this.form();
 
-    // The mark goes first so the `setValue` below is what bumps `revision`: marks emit on neither
-    // `valueChanges` nor `statusChanges`, and the range error is gated on `touched`, so marking last
-    // would leave the error unrendered until some unrelated edit happened to bump the revision.
+    // The mark sits with the writes rather than after them purely for reading order: it needs no
+    // `revision` bump of its own, since the `setValue` calls below bump it in the same synchronous task
+    // and change detection reads `touched` only once that task has finished.
     if (!isChipValue) {
       form.get('customDuration')?.markAsTouched();
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -135,10 +135,11 @@ export class MeetingComposerFormService {
   private readonly contextProjectUid = signal<string | null>(null);
 
   /**
-   * Bumped on every form value/status change, and by the methods here that mark controls
-   * touched/dirty/pristine without emitting either.
-   * @description FormGroup state is not reactive, so template computeds that depend on section
-   * validity — or on a control's `pristine` flag — must read this signal to re-evaluate.
+   * Bumped on every form value/status change, and explicitly by `validateForSubmit()`.
+   * @description FormGroup state is not reactive, so template computeds that depend on section validity —
+   * or on a control's `pristine` flag — must read this signal to re-evaluate. `validateForSubmit()` needs
+   * the explicit bump because `markAsTouched`/`markAsDirty` emit on neither `valueChanges` nor
+   * `statusChanges`; every other writer here pairs its marks with a `setValue` that does emit.
    */
   public readonly revision = signal<number>(0);
 
@@ -304,16 +305,24 @@ export class MeetingComposerFormService {
     return (isEditMode || visitedSections.has(section.id)) && !this.isSectionValid(section.id);
   }
 
-  /** Re-runs the edit-mode fetch after a failure, so retrying doesn't mean reopening the composer. */
+  /**
+   * Re-runs the edit-mode fetch after a failure, so retrying doesn't mean reopening the composer.
+   * @description Edit mode only: `meetingId` is also set by a successful create, and re-fetching there
+   * would hydrate a create form from the meeting it just saved. Guests are re-fetched only if their own
+   * request failed too — the two calls are independent, and one can fail while the other succeeds.
+   */
   public retryLoadMeeting(): void {
     const meetingUid = this.meetingId();
 
-    if (!meetingUid || this.loading()) {
+    if (!this.isEditMode() || !meetingUid || this.loading()) {
       return;
     }
 
     this.loadMeeting(meetingUid);
-    this.loadGuests(meetingUid);
+
+    if (this.guestsLoadFailed()) {
+      this.loadGuests(meetingUid);
+    }
   }
 
   /** Marks the whole form touched so validation messages surface; returns whether submit may proceed. */

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -34,6 +34,7 @@ import {
   MeetingAttachmentOperationResults,
   MeetingComposerContext,
   MeetingComposerMode,
+  MeetingComposerSection,
   MeetingComposerSectionId,
   MeetingRecurrence,
   MeetingRegistrant,
@@ -101,6 +102,8 @@ export class MeetingComposerFormService {
 
   public readonly meeting = signal<Meeting | null>(null);
   public readonly loading = signal<boolean>(false);
+  /** Whether the edit-mode fetch failed, so the drawer can say so instead of showing an empty form. */
+  public readonly meetingLoadFailed = signal<boolean>(false);
   public readonly submitting = signal<boolean>(false);
 
   public readonly attachments = signal<MeetingAttachment[]>([]);
@@ -132,8 +135,10 @@ export class MeetingComposerFormService {
   private readonly contextProjectUid = signal<string | null>(null);
 
   /**
-   * Bumped on every form value/status change. FormGroup validity is not reactive, so template
-   * computeds that depend on section validity must read this signal to re-evaluate.
+   * Bumped on every form value/status change, and by the methods here that mark controls
+   * touched/dirty/pristine without emitting either.
+   * @description FormGroup state is not reactive, so template computeds that depend on section
+   * validity — or on a control's `pristine` flag — must read this signal to re-evaluate.
    */
   public readonly revision = signal<number>(0);
 
@@ -181,6 +186,7 @@ export class MeetingComposerFormService {
     this.pendingAttachmentDeletions.set([]);
     this.registrantUpdates.set({ toAdd: [], toUpdate: [], toDelete: [] });
     this.guests.set([]);
+    this.meetingLoadFailed.set(false);
     this.guestsLoading.set(false);
     this.guestsLoadFailed.set(false);
     this.suppressedGuestEmails.set(new Set());
@@ -274,6 +280,42 @@ export class MeetingComposerFormService {
     }
   }
 
+  /**
+   * Whether a section should be flagged as blocking save, for both the rail's dots and the compact badge.
+   * @description Single rule so the two surfaces can't drift. Create mode only counts sections already
+   * visited — flagging one the stepper hasn't reached yet would report the form as broken before it has
+   * been filled. Edit mode drops that gate: every section is reachable from the start and Save is gated
+   * on all of them, so an unvisited invalid one is exactly the case where the organizer has no other way
+   * to find out why Save is disabled. An edit whose meeting hasn't arrived is excluded — that form is
+   * empty because of the fetch, not because of anything the organizer did. Callers must read `revision`
+   * themselves: this is a plain method, so it carries no reactive dependency of its own.
+   */
+  public sectionNeedsAttention(section: MeetingComposerSection, visitedSections: ReadonlySet<MeetingComposerSectionId>): boolean {
+    if (!section.required) {
+      return false;
+    }
+
+    const isEditMode = this.isEditMode();
+
+    if (isEditMode && !this.meeting()) {
+      return false;
+    }
+
+    return (isEditMode || visitedSections.has(section.id)) && !this.isSectionValid(section.id);
+  }
+
+  /** Re-runs the edit-mode fetch after a failure, so retrying doesn't mean reopening the composer. */
+  public retryLoadMeeting(): void {
+    const meetingUid = this.meetingId();
+
+    if (!meetingUid || this.loading()) {
+      return;
+    }
+
+    this.loadMeeting(meetingUid);
+    this.loadGuests(meetingUid);
+  }
+
   /** Marks the whole form touched so validation messages surface; returns whether submit may proceed. */
   public validateForSubmit(): boolean {
     const form = this.form();
@@ -282,6 +324,10 @@ export class MeetingComposerFormService {
       control?.markAsTouched();
       control?.markAsDirty();
     });
+
+    // `markAsTouched`/`markAsDirty` emit on neither `valueChanges` nor `statusChanges`, so the bump has
+    // to be explicit for anything reading control state through `revision`.
+    this.revision.update((value) => value + 1);
 
     return form.valid;
   }
@@ -681,6 +727,7 @@ export class MeetingComposerFormService {
 
   private loadMeeting(meetingUid: string): void {
     this.loading.set(true);
+    this.meetingLoadFailed.set(false);
 
     forkJoin({
       meeting: this.meetingService.getMeeting(meetingUid),
@@ -700,6 +747,9 @@ export class MeetingComposerFormService {
         },
         error: (error: unknown) => {
           console.error('Error getting meeting:', error);
+          // The toast is transient, so the drawer keeps its own flag — otherwise the organizer is left
+          // with an empty form and a disabled Save and nothing saying why.
+          this.meetingLoadFailed.set(true);
           this.messageService.add({
             severity: 'error',
             summary: 'Error',

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -139,7 +139,8 @@ export class MeetingComposerFormService {
    * @description FormGroup state is not reactive, so template computeds that depend on section validity —
    * or on a control's `pristine` flag — must read this signal to re-evaluate. `validateForSubmit()` needs
    * the explicit bump because `markAsTouched`/`markAsDirty` emit on neither `valueChanges` nor
-   * `statusChanges`; every other writer here pairs its marks with a `setValue` that does emit.
+   * `statusChanges`; the only other writer that marks — `setDuration()` — orders its mark before a
+   * `setValue` that does emit.
    */
   public readonly revision = signal<number>(0);
 
@@ -308,8 +309,9 @@ export class MeetingComposerFormService {
   /**
    * Re-runs the edit-mode fetch after a failure, so retrying doesn't mean reopening the composer.
    * @description Edit mode only: `meetingId` is also set by a successful create, and re-fetching there
-   * would hydrate a create form from the meeting it just saved. Guests are re-fetched only if their own
-   * request failed too — the two calls are independent, and one can fail while the other succeeds.
+   * would hydrate a create form from the meeting it just saved. The two fetches are independent, so a
+   * guest list that arrived fine isn't thrown away here; a guests-only failure has no retry of its own,
+   * since the only caller is the meeting-level error state.
    */
   public retryLoadMeeting(): void {
     const meetingUid = this.meetingId();
@@ -472,12 +474,15 @@ export class MeetingComposerFormService {
     const isChipValue = MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === minutes);
     const form = this.form();
 
-    form.get('duration')?.setValue(isChipValue ? minutes : 'custom');
-    form.get('customDuration')?.setValue(isChipValue ? null : minutes);
-
+    // The mark goes first so the `setValue` below is what bumps `revision`: marks emit on neither
+    // `valueChanges` nor `statusChanges`, and the range error is gated on `touched`, so marking last
+    // would leave the error unrendered until some unrelated edit happened to bump the revision.
     if (!isChipValue) {
       form.get('customDuration')?.markAsTouched();
     }
+
+    form.get('duration')?.setValue(isChipValue ? minutes : 'custom');
+    form.get('customDuration')?.setValue(isChipValue ? null : minutes);
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -13,24 +13,28 @@
       <div class="flex min-w-0 flex-1 flex-col gap-1">
         <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
         <span class="break-words text-xs text-gray-600">{{ message.detail }}</span>
-        <div class="mt-1 flex items-center gap-3">
-          <button
-            type="button"
-            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
-            data-testid="meeting-composer-toast-edit"
-            (click)="onEditCreatedMeeting(message.data)">
-            <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
-            <span>Edit meeting</span>
-          </button>
-          <a
-            [routerLink]="message.data.meetingUrl"
-            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
-            data-testid="meeting-composer-toast-details"
-            (click)="onDismissToast()">
-            <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
-            <span>Meeting details</span>
-          </a>
-        </div>
+        <!-- `toastKey` is exported, so a message could reach this template without the data the actions need -->
+        @if (message.data; as toastData) {
+          <div class="mt-1 flex items-center gap-3">
+            <button
+              type="button"
+              class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              data-testid="meeting-composer-toast-edit"
+              (click)="onEditCreatedMeeting(toastData)">
+              <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
+              <span>Edit meeting</span>
+            </button>
+            <a
+              [routerLink]="toastData.meetingUrl"
+              [queryParams]="toastData.meetingQueryParams"
+              class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              data-testid="meeting-composer-toast-details"
+              (click)="onDismissToast()">
+              <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
+              <span>View meeting</span>
+            </a>
+          </div>
+        }
       </div>
     </div>
   </ng-template>
@@ -56,7 +60,7 @@
   </ng-template>
 
   <div class="flex h-full min-h-0 gap-6">
-    <!-- Rail and preview are desktop-only; below `lg` the composer is one column navigated from the footer (LFXV2-3243) -->
+    <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (LFXV2-3243) -->
     <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
       <lfx-meeting-composer-rail />
 
@@ -69,10 +73,13 @@
       <p class="text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
     } @else {
       <div class="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto">
-        <!-- Stands in for the hidden rail: where you are, what's done, and what still needs fixing -->
-        <div class="flex flex-col gap-2 border-b border-gray-200 pb-3 lg:hidden" data-testid="meeting-composer-compact-progress">
+        <!-- Stands in for the hidden rail: where you are, what's done, and what still needs fixing.
+             Sticky because it is the only section navigation at this width. -->
+        <div class="sticky top-0 z-10 flex flex-col gap-2 border-b border-gray-200 bg-white pb-3 lg:hidden" data-testid="meeting-composer-compact-progress">
           <div class="flex items-center gap-2">
-            <span class="text-xs font-medium text-gray-500">Step {{ activeIndex() + 1 }} of {{ sections.length }}</span>
+            @if (!composer.isEditMode()) {
+              <span class="text-xs font-medium text-gray-500">Step {{ activeIndex() + 1 }} of {{ sections.length }}</span>
+            }
             <span class="truncate text-sm font-semibold text-gray-900">{{ activeSectionLabel() }}</span>
 
             @if (hasAttention()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -16,14 +16,21 @@
         <!-- `MEETING_COMPOSER_TOAST_KEY` is exported, so a message could reach this template without the data the actions need -->
         @if (message.data; as toastData) {
           <div class="mt-1 flex items-center gap-3">
+            <!-- `aria-disabled` rather than `disabled`, matching the rail: the toast auto-dismisses, so an
+                 unreachable control here would leave a screen-reader user no way to hear why it did nothing.
+                 `onEditCreatedMeeting` is the real guard. -->
             <button
               type="button"
-              class="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-800 hover:underline disabled:text-gray-400 disabled:no-underline"
-              [disabled]="!canEditFromToast()"
+              class="inline-flex items-center gap-1 text-xs font-medium"
+              [ngClass]="canEditFromToast() ? 'text-blue-700 hover:text-blue-800 hover:underline' : 'cursor-not-allowed text-gray-500'"
+              [attr.aria-disabled]="canEditFromToast() ? null : 'true'"
               data-testid="meeting-composer-toast-edit"
               (click)="onEditCreatedMeeting(toastData)">
               <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
               <span>Edit meeting</span>
+              @if (!canEditFromToast()) {
+                <span class="sr-only">Close the open composer first</span>
+              }
             </button>
             <a
               [routerLink]="toastData.meetingUrl"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -18,19 +18,20 @@
           <div class="mt-1 flex items-center gap-3">
             <!-- `aria-disabled` rather than `disabled`, matching the rail: the toast auto-dismisses, so an
                  unreachable control here would leave a screen-reader user no way to hear why it did nothing.
-                 `onEditCreatedMeeting` is the real guard. -->
+                 The reason rides on `aria-label`/`title` rather than an sr-only child, because PrimeNG's
+                 toast item is an `aria-atomic` live region — adding or removing a child re-announces the
+                 whole toast. `onEditCreatedMeeting` is the real guard. -->
             <button
               type="button"
               class="inline-flex items-center gap-1 text-xs font-medium"
-              [ngClass]="canEditFromToast() ? 'text-blue-700 hover:text-blue-800 hover:underline' : 'cursor-not-allowed text-gray-500'"
-              [attr.aria-disabled]="canEditFromToast() ? null : 'true'"
+              [ngClass]="editFromToastBlockedReason() ? 'cursor-not-allowed text-gray-600' : 'text-blue-700 hover:text-blue-800 hover:underline'"
+              [attr.aria-disabled]="editFromToastBlockedReason() ? 'true' : null"
+              [attr.aria-label]="editFromToastBlockedReason() ? 'Edit meeting — ' + editFromToastBlockedReason() : null"
+              [attr.title]="editFromToastBlockedReason()"
               data-testid="meeting-composer-toast-edit"
               (click)="onEditCreatedMeeting(toastData)">
               <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
               <span>Edit meeting</span>
-              @if (!canEditFromToast()) {
-                <span class="sr-only">Close the open composer first</span>
-              }
             </button>
             <a
               [routerLink]="toastData.meetingUrl"
@@ -79,6 +80,22 @@
 
     @if (formService.loading()) {
       <p class="text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
+    } @else if (formService.meetingLoadFailed()) {
+      <!-- Without this the failed fetch leaves an empty form and a disabled Save with nothing saying why -->
+      <div class="flex min-w-0 flex-1 flex-col items-start gap-3" data-testid="meeting-composer-load-error">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm font-semibold text-gray-900">Couldn't load this meeting</span>
+          <span class="text-sm text-gray-600">It may have been deleted, or you may not have permission to edit it.</span>
+        </div>
+
+        <lfx-button
+          label="Try again"
+          severity="secondary"
+          [outlined]="true"
+          size="small"
+          data-testid="meeting-composer-load-retry"
+          (onClick)="formService.retryLoadMeeting()" />
+      </div>
     } @else {
       <div class="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto">
         <!-- Stands in for the hidden rail: where you are, what's done, and what still needs fixing.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -5,7 +5,7 @@
   <lfx-quick-create-dialog (create)="onSubmit()" />
 }
 
-<!-- Post-create toast (LFXV2-3242): creating no longer navigates, so this is the way back to the meeting -->
+<!-- Post-create toast (GH-1461): creating no longer navigates, so this is the way back to the meeting -->
 <p-toast [key]="toastKey" position="top-right">
   <ng-template let-message pTemplate="message">
     <div class="flex w-full items-start gap-3" data-testid="meeting-composer-toast">
@@ -51,7 +51,7 @@
   </ng-template>
 </p-toast>
 
-<!-- Meeting composer drawer (LFXV2-3234) -->
+<!-- Meeting composer drawer (GH-1452) -->
 <p-drawer
   [visible]="composer.isOpen() && !composer.isQuickCreate()"
   (visibleChange)="onVisibleChange($event)"
@@ -71,7 +71,7 @@
   </ng-template>
 
   <div class="flex h-full min-h-0 gap-6">
-    <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (LFXV2-3243).
+    <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (GH-1462).
          The column is hidden when the edit-mode fetch failed: there is no form behind the rail, so every row
          would report empty and clicking one would swap a section the organizer can't see. -->
     @if (!formService.meetingLoadFailed()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -62,9 +62,9 @@
   <ng-template #header>
     <div class="flex min-w-0 flex-col" data-testid="meeting-composer-header">
       <span class="truncate text-lg font-semibold text-gray-900">
-        {{ composer.isEditMode() ? 'Edit meeting' : 'Create meeting' }}
+        {{ isEditMode() ? 'Edit meeting' : 'Create meeting' }}
       </span>
-      @if (composer.isEditMode() && formService.meeting(); as meeting) {
+      @if (isEditMode() && formService.meeting(); as meeting) {
         <span class="truncate text-sm text-gray-500">{{ meeting.title }}</span>
       }
     </div>
@@ -78,7 +78,7 @@
       <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
         <lfx-meeting-composer-rail />
 
-        @if (!composer.isEditMode()) {
+        @if (!isEditMode()) {
           <lfx-meeting-composer-preview />
         }
       </div>
@@ -108,7 +108,7 @@
              Sticky because it is the only section navigation at this width. -->
         <div class="sticky top-0 z-10 flex flex-col gap-2 border-b border-gray-200 bg-white pb-3 lg:hidden" data-testid="meeting-composer-compact-progress">
           <div class="flex items-center gap-2">
-            @if (!composer.isEditMode()) {
+            @if (!isEditMode()) {
               <span class="text-xs font-medium text-gray-500">Step {{ activeIndex() + 1 }} of {{ sections.length }}</span>
             }
             <span class="truncate text-sm font-semibold text-gray-900">{{ activeSectionLabel() }}</span>
@@ -150,11 +150,11 @@
       <lfx-button label="Cancel" severity="secondary" [text]="true" size="small" data-testid="meeting-composer-cancel" (onClick)="composer.close()" />
 
       <div class="flex items-center gap-2">
-        @if (!composer.isEditMode() && activeIndex() > 0) {
+        @if (!isEditMode() && activeIndex() > 0) {
           <lfx-button label="Back" severity="secondary" [outlined]="true" size="small" data-testid="meeting-composer-back" (onClick)="onBack()" />
         }
 
-        @if (composer.isEditMode()) {
+        @if (isEditMode()) {
           <lfx-button
             label="Save changes"
             size="small"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -15,6 +15,8 @@
         <span class="break-words text-xs text-gray-600">{{ message.detail }}</span>
         <!-- `MEETING_COMPOSER_TOAST_KEY` is exported, so a message could reach this template without the data the actions need -->
         @if (message.data; as toastData) {
+          @let editBlockedReason = editFromToastBlockedReason();
+
           <div class="mt-1 flex items-center gap-3">
             <!-- `aria-disabled` rather than `disabled`, matching the rail: the toast auto-dismisses, so an
                  unreachable control here would leave a screen-reader user no way to hear why it did nothing.
@@ -24,10 +26,10 @@
             <button
               type="button"
               class="inline-flex items-center gap-1 text-xs font-medium"
-              [ngClass]="editFromToastBlockedReason() ? 'cursor-not-allowed text-gray-600' : 'text-blue-700 hover:text-blue-800 hover:underline'"
-              [attr.aria-disabled]="editFromToastBlockedReason() ? 'true' : null"
-              [attr.aria-label]="editFromToastBlockedReason() ? 'Edit meeting — ' + editFromToastBlockedReason() : null"
-              [attr.title]="editFromToastBlockedReason()"
+              [ngClass]="editBlockedReason ? 'cursor-not-allowed text-gray-600' : 'text-blue-700 hover:text-blue-800 hover:underline'"
+              [attr.aria-disabled]="editBlockedReason ? 'true' : null"
+              [attr.aria-label]="editBlockedReason ? 'Edit meeting — ' + editBlockedReason : null"
+              [attr.title]="editBlockedReason"
               data-testid="meeting-composer-toast-edit"
               (click)="onEditCreatedMeeting(toastData)">
               <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
@@ -69,14 +71,18 @@
   </ng-template>
 
   <div class="flex h-full min-h-0 gap-6">
-    <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (LFXV2-3243) -->
-    <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
-      <lfx-meeting-composer-rail />
+    <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (LFXV2-3243).
+         Both are hidden when the fetch failed: there is no form behind them, so every row would report empty and
+         clicking one would swap a section the organizer can't see. -->
+    @if (!formService.meetingLoadFailed()) {
+      <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
+        <lfx-meeting-composer-rail />
 
-      @if (!composer.isEditMode()) {
-        <lfx-meeting-composer-preview />
-      }
-    </div>
+        @if (!composer.isEditMode()) {
+          <lfx-meeting-composer-preview />
+        }
+      </div>
+    }
 
     @if (formService.loading()) {
       <p class="text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -72,8 +72,8 @@
 
   <div class="flex h-full min-h-0 gap-6">
     <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (LFXV2-3243).
-         Both are hidden when the fetch failed: there is no form behind them, so every row would report empty and
-         clicking one would swap a section the organizer can't see. -->
+         The column is hidden when the edit-mode fetch failed: there is no form behind the rail, so every row
+         would report empty and clicking one would swap a section the organizer can't see. -->
     @if (!formService.meetingLoadFailed()) {
       <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
         <lfx-meeting-composer-rail />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -13,12 +13,13 @@
       <div class="flex min-w-0 flex-1 flex-col gap-1">
         <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
         <span class="break-words text-xs text-gray-600">{{ message.detail }}</span>
-        <!-- `toastKey` is exported, so a message could reach this template without the data the actions need -->
+        <!-- `MEETING_COMPOSER_TOAST_KEY` is exported, so a message could reach this template without the data the actions need -->
         @if (message.data; as toastData) {
           <div class="mt-1 flex items-center gap-3">
             <button
               type="button"
-              class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              class="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-800 hover:underline disabled:text-gray-400 disabled:no-underline"
+              [disabled]="!canEditFromToast()"
               data-testid="meeting-composer-toast-edit"
               (click)="onEditCreatedMeeting(toastData)">
               <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
@@ -27,7 +28,7 @@
             <a
               [routerLink]="toastData.meetingUrl"
               [queryParams]="toastData.meetingQueryParams"
-              class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              class="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-800 hover:underline"
               data-testid="meeting-composer-toast-details"
               (click)="onDismissToast()">
               <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -75,29 +75,20 @@ export class MeetingComposerHostComponent {
     return this.sections.filter((section) => section.required).every((section) => this.formService.isSectionValid(section.id));
   });
   protected readonly activeSectionLabel: Signal<string> = computed(() => this.sections[this.activeIndex()]?.label ?? '');
-  /**
-   * Whether a required section is currently invalid, matching the rail's dots.
-   * @description Create mode only counts sections already visited — flagging a section the stepper hasn't
-   * reached yet would report the form as broken before it has been filled. Edit mode drops that gate:
-   * every section is reachable from the start and Save is gated on all of them, so an unvisited invalid
-   * one is exactly the case where the organizer has no other way to find out why Save is disabled. An
-   * edit whose meeting never arrived is excluded — that form is empty because the fetch failed, not
-   * because of anything the organizer did.
-   */
+  /** Whether any required section is flagged as blocking save, on the same rule as the rail's dots. */
   protected readonly hasAttention: Signal<boolean> = computed(() => {
     this.formService.revision();
 
-    const isEditMode = this.composer.isEditMode();
     const visited = this.composer.visitedSections();
 
-    if (isEditMode && !this.formService.meeting()) {
-      return false;
-    }
-
-    return this.sections.some((section) => section.required && (isEditMode || visited.has(section.id)) && !this.formService.isSectionValid(section.id));
+    return this.sections.some((section) => this.formService.sectionNeedsAttention(section, visited));
   });
-  /** Whether the toast's Edit action can act — a composer already open would lose its draft to it. */
-  protected readonly canEditFromToast: Signal<boolean> = computed(() => !this.composer.isOpen() && this.projectContextService.canWrite());
+  /**
+   * Why the toast's Edit action can't act, or `null` when it can.
+   * @description Doubles as the enabled check. Reopening while another meeting is part-way through the
+   * composer would discard that draft, and reopening after write access was lost would only fail on save.
+   */
+  protected readonly editFromToastBlockedReason: Signal<string | null> = this.initEditFromToastBlockedReason();
 
   public constructor() {
     toObservable(this.composer.context)
@@ -168,12 +159,11 @@ export class MeetingComposerHostComponent {
 
   /**
    * Reopens the composer on the meeting the toast was raised for.
-   * @description Guarded by `canEditFromToast`, which the template also reflects as `aria-disabled` —
-   * reopening while another meeting is part-way through the composer would discard that draft, and
-   * reopening after write access was lost would only fail on save.
+   * @description Guarded by `editFromToastBlockedReason`, which the template also reflects as
+   * `aria-disabled` plus a tooltip naming the reason.
    */
   protected onEditCreatedMeeting(data: MeetingComposerToastData): void {
-    if (!this.canEditFromToast()) {
+    if (this.editFromToastBlockedReason()) {
       return;
     }
 
@@ -183,6 +173,16 @@ export class MeetingComposerHostComponent {
 
   protected onDismissToast(): void {
     this.messageService.clear(this.toastKey);
+  }
+
+  private initEditFromToastBlockedReason(): Signal<string | null> {
+    return computed(() => {
+      if (this.composer.isOpen()) {
+        return 'Close the open composer first';
+      }
+
+      return this.projectContextService.canWrite() ? null : 'You no longer have write access';
+    });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -74,21 +74,23 @@ export class MeetingComposerHostComponent {
   });
   protected readonly activeSectionLabel: Signal<string> = computed(() => this.sections[this.activeIndex()]?.label ?? '');
   /**
-   * Whether a required section the organizer has already been through is currently invalid.
-   * @description Create mode only, matching the rail's per-section dots — an edit-mode badge would have
-   * no dot to point at, and a past meeting fails the future-date validator the moment it loads.
+   * Whether a required section is currently invalid and the organizer has been shown it.
+   * @description Mirrors the rail's per-section dots, so the badge always has a dot to point at. Create
+   * mode only counts sections already visited — flagging a section the stepper hasn't reached yet would
+   * report the form as broken before it has been filled. Edit mode drops that gate: every section is
+   * reachable from the start and Save is gated on all of them, so an unvisited invalid one is exactly the
+   * case where the organizer has no other way to find out why Save is disabled.
    */
   protected readonly hasAttention: Signal<boolean> = computed(() => {
     this.formService.revision();
 
-    if (this.composer.isEditMode()) {
-      return false;
-    }
-
+    const isEditMode = this.composer.isEditMode();
     const visited = this.composer.visitedSections();
 
-    return this.sections.some((section) => section.required && visited.has(section.id) && !this.formService.isSectionValid(section.id));
+    return this.sections.some((section) => section.required && (isEditMode || visited.has(section.id)) && !this.formService.isSectionValid(section.id));
   });
+  /** Whether the toast's Edit action can act — a composer already open would lose its draft to it. */
+  protected readonly canEditFromToast: Signal<boolean> = computed(() => !this.composer.isOpen() && this.projectContextService.canWrite());
 
   public constructor() {
     toObservable(this.composer.context)
@@ -159,13 +161,12 @@ export class MeetingComposerHostComponent {
 
   /**
    * Reopens the composer on the meeting the toast was raised for.
-   * @description The toast outlives the composer that raised it, so the organizer can already be part-way
-   * through another meeting by the time it is clicked — reopening would discard that draft. Losing write
-   * access in the meantime is the other case, where the save would only fail upstream. Both leave the
-   * toast standing rather than swallowing the click.
+   * @description Guarded by `canEditFromToast`, which also disables the action — reopening while another
+   * meeting is part-way through the composer would discard that draft, and reopening after write access
+   * was lost would only fail on save.
    */
   protected onEditCreatedMeeting(data: MeetingComposerToastData): void {
-    if (this.composer.isOpen() || !this.projectContextService.canWrite()) {
+    if (!this.canEditFromToast()) {
       return;
     }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -65,14 +65,13 @@ export class MeetingComposerHostComponent {
 
   /**
    * Single mode source for the chrome, matching what the rail reads.
-   * @description Taken from the form service so the header, footer and rail can never describe different
-   * modes: `initialize()` runs from a subscription in this constructor, which Angular flushes after the
-   * template that opened it, so `composer.context()` leads `formService.mode()` by one refresh pass. The
-   * two agree again before the tick ends — reading both sources wouldn't flash, it would just let an edit
-   * header sit above create-mode locked rows in an intermediate pass. It also means the chrome is the
-   * lagging side, so mode changes are picked up a pass late rather than early; closing that window for
-   * real means deriving the form service's own `mode` from the context instead of writing it in
-   * `initialize()`.
+   * @description Taken from the form service, which is also what the rail and `isSectionValid` read, so
+   * the header, footer and section rows cannot describe different modes. `composer.context()` is the other
+   * candidate and is written first — `initialize()` only runs from the subscription in this constructor —
+   * so the two are briefly out of step on every open; the enforceable part is that nothing reads both.
+   * The form service is the lagging side, and because `initialize()` is the only writer of `mode` and only
+   * runs for a non-null context, it also keeps the previous mode across a close. Fixing that means
+   * deriving `mode` from the context rather than writing it in `initialize()`.
    */
   protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -26,7 +26,7 @@ import { ComposerGuestsComponent } from './sections/composer-guests.component';
 import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-features.component';
 
 /**
- * Globally mounted host for the meeting composer drawer (LFXV2-3234).
+ * Globally mounted host for the meeting composer drawer (GH-1452).
  * @description Mounted on first open via `@defer` in `app.component.html` and retained thereafter, so
  * opening the composer never unmounts the page underneath. Sections are reachable from both the rail
  * and the footer navigation; the live preview is create-mode only. Below `lg` the drawer goes full
@@ -200,7 +200,7 @@ export class MeetingComposerHostComponent {
   }
 
   /**
-   * Raises the post-create toast (LFXV2-3242).
+   * Raises the post-create toast (GH-1461).
    * @description Creating no longer navigates to the saved meeting, so this toast is the only route back
    * to it. A create that returned no meeting has nothing to link to, and falls back to a plain
    * confirmation rather than a toast whose actions would dead-end.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -73,9 +73,18 @@ export class MeetingComposerHostComponent {
     return this.sections.filter((section) => section.required).every((section) => this.formService.isSectionValid(section.id));
   });
   protected readonly activeSectionLabel: Signal<string> = computed(() => this.sections[this.activeIndex()]?.label ?? '');
-  /** Whether a required section the organizer has already been through is currently invalid. */
+  /**
+   * Whether a required section the organizer has already been through is currently invalid.
+   * @description Create mode only, matching the rail's per-section dots — an edit-mode badge would have
+   * no dot to point at, and a past meeting fails the future-date validator the moment it loads.
+   */
   protected readonly hasAttention: Signal<boolean> = computed(() => {
     this.formService.revision();
+
+    if (this.composer.isEditMode()) {
+      return false;
+    }
+
     const visited = this.composer.visitedSections();
 
     return this.sections.some((section) => section.required && visited.has(section.id) && !this.formService.isSectionValid(section.id));
@@ -143,12 +152,23 @@ export class MeetingComposerHostComponent {
         this.announceCreatedMeeting(meeting);
       }
 
+      this.composer.notifySaved();
       this.composer.close();
     });
   }
 
-  /** Reopens the composer on the meeting the toast was raised for. */
+  /**
+   * Reopens the composer on the meeting the toast was raised for.
+   * @description The toast outlives the composer that raised it, so the organizer can already be part-way
+   * through another meeting by the time it is clicked — reopening would discard that draft. Losing write
+   * access in the meantime is the other case, where the save would only fail upstream. Both leave the
+   * toast standing rather than swallowing the click.
+   */
   protected onEditCreatedMeeting(data: MeetingComposerToastData): void {
+    if (this.composer.isOpen() || !this.projectContextService.canWrite()) {
+      return;
+    }
+
     this.messageService.clear(this.toastKey);
     this.composer.open({ mode: 'edit', meetingUid: data.meetingUid });
   }
@@ -173,6 +193,9 @@ export class MeetingComposerHostComponent {
       meetingUid: meeting.id,
       meetingTitle: meeting.title ?? 'Untitled meeting',
       meetingUrl: `/meetings/${meeting.id}`,
+      // The join page rejects a private or restricted meeting without its password and redirects to
+      // `/meetings/not-found`, which every BOARD meeting would hit since those are forced private.
+      meetingQueryParams: meeting.password ? { password: meeting.password } : {},
     };
 
     this.messageService.add({

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -65,10 +65,12 @@ export class MeetingComposerHostComponent {
 
   /**
    * Single mode source for the chrome, matching what the rail reads.
-   * @description Taken from the form service, which is also what the rail and `isSectionValid` read, so
-   * the header, footer and section rows cannot describe different modes. `composer.context()` is the other
-   * candidate and is written first — `initialize()` only runs from the subscription in this constructor —
-   * so the two are briefly out of step on every open; the enforceable part is that nothing reads both.
+   * @description Taken from the form service, which is also what the rail's row locking and
+   * `sectionNeedsAttention` read, so the header, footer and section rows cannot describe different modes.
+   * `composer.context()` is the other candidate and is written first — `initialize()` only runs from the
+   * subscription in this constructor — so a context-derived reader would lead this one by a flush on every
+   * open, and would hold a different value whenever the new mode differs from the retained one. The
+   * enforceable part is that nothing reads both.
    * The form service is the lagging side, and because `initialize()` is the only writer of `mode` and only
    * runs for a non-null context, it also keeps the previous mode across a close. Fixing that means
    * deriving `mode` from the context rather than writing it in `initialize()`.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NgClass } from '@angular/common';
 import { Component, computed, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
@@ -35,6 +36,7 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
 @Component({
   selector: 'lfx-meeting-composer-host',
   imports: [
+    NgClass,
     DrawerModule,
     MeetingComposerRailComponent,
     MeetingComposerPreviewComponent,
@@ -74,18 +76,23 @@ export class MeetingComposerHostComponent {
   });
   protected readonly activeSectionLabel: Signal<string> = computed(() => this.sections[this.activeIndex()]?.label ?? '');
   /**
-   * Whether a required section is currently invalid and the organizer has been shown it.
-   * @description Mirrors the rail's per-section dots, so the badge always has a dot to point at. Create
-   * mode only counts sections already visited — flagging a section the stepper hasn't reached yet would
-   * report the form as broken before it has been filled. Edit mode drops that gate: every section is
-   * reachable from the start and Save is gated on all of them, so an unvisited invalid one is exactly the
-   * case where the organizer has no other way to find out why Save is disabled.
+   * Whether a required section is currently invalid, matching the rail's dots.
+   * @description Create mode only counts sections already visited — flagging a section the stepper hasn't
+   * reached yet would report the form as broken before it has been filled. Edit mode drops that gate:
+   * every section is reachable from the start and Save is gated on all of them, so an unvisited invalid
+   * one is exactly the case where the organizer has no other way to find out why Save is disabled. An
+   * edit whose meeting never arrived is excluded — that form is empty because the fetch failed, not
+   * because of anything the organizer did.
    */
   protected readonly hasAttention: Signal<boolean> = computed(() => {
     this.formService.revision();
 
     const isEditMode = this.composer.isEditMode();
     const visited = this.composer.visitedSections();
+
+    if (isEditMode && !this.formService.meeting()) {
+      return false;
+    }
 
     return this.sections.some((section) => section.required && (isEditMode || visited.has(section.id)) && !this.formService.isSectionValid(section.id));
   });
@@ -161,9 +168,9 @@ export class MeetingComposerHostComponent {
 
   /**
    * Reopens the composer on the meeting the toast was raised for.
-   * @description Guarded by `canEditFromToast`, which also disables the action — reopening while another
-   * meeting is part-way through the composer would discard that draft, and reopening after write access
-   * was lost would only fail on save.
+   * @description Guarded by `canEditFromToast`, which the template also reflects as `aria-disabled` —
+   * reopening while another meeting is part-way through the composer would discard that draft, and
+   * reopening after write access was lost would only fail on save.
    */
   protected onEditCreatedMeeting(data: MeetingComposerToastData): void {
     if (!this.canEditFromToast()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -63,6 +63,15 @@ export class MeetingComposerHostComponent {
   protected readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
   protected readonly toastKey = MEETING_COMPOSER_TOAST_KEY;
 
+  /**
+   * Single mode source for the chrome, matching what the rail reads.
+   * @description Taken from the form service rather than the composer service: this host is
+   * `@defer`-mounted and `initialize()` runs from a subscription in the constructor, so the composer
+   * context can say `edit` for a paint before the form service agrees. Reading both sources would put
+   * the edit header and Save button above a create-mode stepper with locked rows.
+   */
+  protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
+
   protected readonly activeIndex: Signal<number> = computed(() => this.sections.findIndex((section) => section.id === this.composer.activeSection()));
   protected readonly isLastSection: Signal<boolean> = computed(() => this.activeIndex() === this.sections.length - 1);
   protected readonly canProceed: Signal<boolean> = computed(() => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -65,10 +65,14 @@ export class MeetingComposerHostComponent {
 
   /**
    * Single mode source for the chrome, matching what the rail reads.
-   * @description Taken from the form service rather than the composer service: this host is
-   * `@defer`-mounted and `initialize()` runs from a subscription in the constructor, so the composer
-   * context can say `edit` for a paint before the form service agrees. Reading both sources would put
-   * the edit header and Save button above a create-mode stepper with locked rows.
+   * @description Taken from the form service so the header, footer and rail can never describe different
+   * modes: `initialize()` runs from a subscription in this constructor, which Angular flushes after the
+   * template that opened it, so `composer.context()` leads `formService.mode()` by one refresh pass. The
+   * two agree again before the tick ends — reading both sources wouldn't flash, it would just let an edit
+   * header sit above create-mode locked rows in an intermediate pass. It also means the chrome is the
+   * lagging side, so mode changes are picked up a pass late rather than early; closing that window for
+   * real means deriving the form service's own `mode` from the context instead of writing it in
+   * `initialize()`.
    */
   protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
@@ -14,7 +14,7 @@ import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerService } from './meeting-composer.service';
 
 /**
- * Live preview of the meeting being created (LFXV2-3240).
+ * Live preview of the meeting being created (GH-1459).
  * @description Create mode only — in edit mode the meeting already exists and the sections themselves
  * show its saved state. Several controls are pre-filled with defaults, so a row only resolves once its
  * owning section has been visited; until then it renders as a skeleton bar rather than presenting a

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -76,7 +76,7 @@
               'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50': row.active,
               'border-blue-600 bg-white text-blue-600': !row.active && row.complete && !row.locked,
               'border-gray-200 bg-white text-gray-400': !row.active && !row.complete && !row.locked,
-              'border-gray-200 bg-gray-100 text-gray-500': row.locked,
+              'border-gray-200 bg-gray-100 text-gray-600': row.locked,
             }">
             @if (row.complete) {
               <i class="fa-light fa-check" aria-hidden="true"></i>
@@ -96,8 +96,9 @@
           </span>
           @if (row.locked) {
             <!-- The only text saying why the row won't respond, and the row stays keyboard-reachable, so it
-                 carries no opacity and sits at `gray-500` (≈4.8:1 on white) rather than the decorative `gray-400` -->
-            <span class="text-xs text-gray-500">Complete earlier sections first</span>
+                 carries no opacity and sits at `gray-600` on the row's `gray-50` surface (7.2:1) rather than
+                 the decorative `gray-400` it used to use -->
+            <span class="text-xs text-gray-600">Complete earlier sections first</span>
           }
         </span>
       </button>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -14,7 +14,7 @@
         class="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
         [ngClass]="{
           'border-blue-700 bg-blue-700 text-white': row.active,
-          'border-blue-200 bg-white text-blue-700': !row.active && row.complete && !row.locked,
+          'border-blue-200 bg-white text-blue-700': row.complete,
           'border-gray-200 bg-white text-gray-600': !row.active && !row.complete && !row.locked,
           'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-600': row.locked,
         }"
@@ -37,7 +37,7 @@
           <span class="sr-only">Complete earlier sections first</span>
         }
       </button>
-    } @else if (composer.isEditMode()) {
+    } @else if (isEditMode()) {
       <button
         type="button"
         class="flex items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm font-medium transition-colors"
@@ -74,7 +74,7 @@
             class="relative z-10 flex h-8 w-8 items-center justify-center rounded-full border text-xs"
             [ngClass]="{
               'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50': row.active,
-              'border-blue-600 bg-white text-blue-600': !row.active && row.complete && !row.locked,
+              'border-blue-600 bg-white text-blue-600': row.complete,
               'border-gray-200 bg-white text-gray-400': !row.active && !row.complete && !row.locked,
               'border-gray-200 bg-gray-100 text-gray-600': row.locked,
             }">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<!-- Composer section rail (LFXV2-3240), with the collapsed chip row for narrow viewports (LFXV2-3243) -->
+<!-- Composer section rail (GH-1459), with the collapsed chip row for narrow viewports (GH-1462) -->
 <nav
   [ngClass]="compact() ? 'flex items-center gap-1 overflow-x-auto pb-1' : 'flex flex-col'"
   aria-label="Composer sections"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -12,13 +12,14 @@
         type="button"
         class="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
         [ngClass]="{
-          'border-blue-600 bg-blue-600 text-white': row.active,
+          'border-blue-700 bg-blue-700 text-white': row.active,
           'border-blue-200 bg-white text-blue-700': !row.active && row.complete,
           'border-gray-200 bg-white text-gray-600': !row.active && !row.complete,
           'cursor-not-allowed opacity-50': row.locked,
         }"
-        [disabled]="row.locked"
-        [attr.aria-current]="row.active ? 'step' : null"
+        [attr.aria-disabled]="row.locked ? 'true' : null"
+        [attr.aria-current]="row.active ? activeChipAriaCurrent() : null"
+        [attr.data-active-chip]="row.active ? 'true' : null"
         [attr.data-testid]="testIdPrefix() + '-' + row.section.id"
         (click)="onSelect(row)">
         @if (row.complete) {
@@ -30,6 +31,9 @@
         @if (row.needsAttention) {
           <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="testIdPrefix() + '-attention-' + row.section.id"></span>
           <span class="sr-only">Required fields still missing</span>
+        }
+        @if (row.locked) {
+          <span class="sr-only">Complete earlier sections first</span>
         }
       </button>
     } @else if (composer.isEditMode()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -14,7 +14,7 @@
         class="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
         [ngClass]="{
           'border-blue-700 bg-blue-700 text-white': row.active,
-          'border-blue-200 bg-white text-blue-700': !row.active && row.complete,
+          'border-blue-200 bg-white text-blue-700': !row.active && row.complete && !row.locked,
           'border-gray-200 bg-white text-gray-600': !row.active && !row.complete && !row.locked,
           'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-600': row.locked,
         }"
@@ -56,7 +56,7 @@
       <button
         type="button"
         class="group relative flex items-start gap-3 rounded-md py-2 pl-1 pr-3 text-left"
-        [ngClass]="row.locked ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
+        [ngClass]="row.locked ? 'cursor-not-allowed' : 'cursor-pointer'"
         [attr.aria-disabled]="row.locked ? 'true' : null"
         [attr.aria-current]="row.active ? 'step' : null"
         [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
@@ -92,7 +92,9 @@
             }
           </span>
           @if (row.locked) {
-            <span class="text-xs text-gray-400">Complete earlier sections first</span>
+            <!-- The only text saying why the row won't respond, and the row stays keyboard-reachable, so it
+                 carries no opacity and sits at `gray-500` (≈4.8:1 on white) rather than the decorative `gray-400` -->
+            <span class="text-xs text-gray-500">Complete earlier sections first</span>
           }
         </span>
       </button>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -8,14 +8,15 @@
   [attr.data-testid]="testIdPrefix()">
   @for (row of rows(); track row.section.id) {
     @if (compact()) {
+      <!-- Locked chips are greyed by surface rather than opacity: they stay keyboard-reachable, so the label has to stay legible -->
       <button
         type="button"
         class="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
         [ngClass]="{
           'border-blue-700 bg-blue-700 text-white': row.active,
           'border-blue-200 bg-white text-blue-700': !row.active && row.complete,
-          'border-gray-200 bg-white text-gray-600': !row.active && !row.complete,
-          'cursor-not-allowed opacity-50': row.locked,
+          'border-gray-200 bg-white text-gray-600': !row.active && !row.complete && !row.locked,
+          'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-600': row.locked,
         }"
         [attr.aria-disabled]="row.locked ? 'true' : null"
         [attr.aria-current]="row.active ? activeChipAriaCurrent() : null"
@@ -46,13 +47,17 @@
         (click)="onSelect(row)">
         <i class="w-4 text-center" [ngClass]="row.section.icon" aria-hidden="true"></i>
         <span class="truncate">{{ row.section.label }}</span>
+        @if (row.needsAttention) {
+          <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="'meeting-composer-rail-attention-' + row.section.id"></span>
+          <span class="sr-only">Required fields still missing</span>
+        }
       </button>
     } @else {
       <button
         type="button"
         class="group relative flex items-start gap-3 rounded-md py-2 pl-1 pr-3 text-left"
         [ngClass]="row.locked ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
-        [disabled]="row.locked"
+        [attr.aria-disabled]="row.locked ? 'true' : null"
         [attr.aria-current]="row.active ? 'step' : null"
         [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
         (click)="onSelect(row)">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -53,10 +53,12 @@
         }
       </button>
     } @else {
+      <!-- Locked rows are greyed by surface rather than opacity: they stay keyboard-reachable, so their text
+           has to stay legible, and the tint is what separates them from a row that just isn't done yet -->
       <button
         type="button"
         class="group relative flex items-start gap-3 rounded-md py-2 pl-1 pr-3 text-left"
-        [ngClass]="row.locked ? 'cursor-not-allowed' : 'cursor-pointer'"
+        [ngClass]="row.locked ? 'cursor-not-allowed bg-gray-50' : 'cursor-pointer'"
         [attr.aria-disabled]="row.locked ? 'true' : null"
         [attr.aria-current]="row.active ? 'step' : null"
         [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
@@ -72,8 +74,9 @@
             class="relative z-10 flex h-8 w-8 items-center justify-center rounded-full border text-xs"
             [ngClass]="{
               'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50': row.active,
-              'border-blue-600 bg-white text-blue-600': !row.active && row.complete,
-              'border-gray-200 bg-white text-gray-400': !row.active && !row.complete,
+              'border-blue-600 bg-white text-blue-600': !row.active && row.complete && !row.locked,
+              'border-gray-200 bg-white text-gray-400': !row.active && !row.complete && !row.locked,
+              'border-gray-200 bg-gray-100 text-gray-500': row.locked,
             }">
             @if (row.complete) {
               <i class="fa-light fa-check" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -38,10 +38,10 @@ export class MeetingComposerRailComponent {
 
   /**
    * Single mode source for layout, locking and the active marker.
-   * @description Read from the form service because that is what `isSectionValid` /
-   * `sectionNeedsAttention` read, and because `composer.context()` is written before `initialize()` runs —
-   * so the two are briefly out of step on every open. Taking mode from both would render the flat edit
-   * rows while locking them like create-mode rows, leaving rows that look interactive and do nothing.
+   * @description Read from the form service because that is what `sectionNeedsAttention` reads — the other
+   * mode-dependent input to a row — and because `composer.context()` is written before `initialize()` runs,
+   * so a context-derived reader would lead this one by a flush. Taking mode from both would render the flat
+   * edit rows while locking them like create-mode rows, leaving rows that look interactive and do nothing.
    */
   protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -75,24 +75,29 @@ export class MeetingComposerRailComponent {
       const sections = this.sections;
       const activeSection = this.composer.activeSection();
       const visited = this.composer.visitedSections();
-      const isEditMode = this.composer.isEditMode();
+      // Read from the form service, the same source `sectionNeedsAttention` uses — two sources for one
+      // fact would flip the visited gate if they ever disagreed mid-tick.
+      const isEditMode = this.formService.isEditMode();
       const validById = new Map<MeetingComposerSectionId, boolean>(sections.map((section) => [section.id, this.formService.isSectionValid(section.id)]));
       const isComplete = (section: MeetingComposerSection): boolean => (section.required ? (validById.get(section.id) ?? false) : visited.has(section.id));
 
       return sections.map((section, index) => {
         const active = section.id === activeSection;
         const blockedByEarlier = sections.slice(0, index).some((earlier) => earlier.required && !validById.get(earlier.id));
+        // The organizer can be standing on a section an out-of-section validator has just invalidated
+        // (enabling YouTube upload tightens the title's max length), so never lock the row they're on.
+        const locked = !isEditMode && blockedByEarlier && !active;
 
         return {
           section,
           active,
           complete: isComplete(section) && !active,
-          // The organizer can be standing on a section an out-of-section validator has just invalidated
-          // (enabling YouTube upload tightens the title's max length), so never lock the row they're on.
-          locked: !isEditMode && blockedByEarlier && !active,
+          locked,
           // Shared with the compact badge in the host, so the two can't disagree about what needs fixing.
           needsAttention: this.formService.sectionNeedsAttention(section, visited),
-          lineBelowComplete: isComplete(section),
+          // A locked row is behind an invalid earlier section, so its connector can't claim the chain is done
+          // even when this section itself validates.
+          lineBelowComplete: isComplete(section) && !locked,
           isLast: index === sections.length - 1,
         };
       });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -38,11 +38,11 @@ export class MeetingComposerRailComponent {
 
   /**
    * Single mode source for layout, locking and the active marker.
-   * @description Read from the form service rather than the composer service because that is what
-   * `isSectionValid` / `sectionNeedsAttention` read. The host is `@defer`-mounted and calls `initialize()`
-   * from a context subscription in its constructor, so on the first edit-mode open the two can disagree
-   * for a paint: taking mode from both would render the flat edit rows while locking them like create-mode
-   * rows, leaving rows that look interactive and do nothing.
+   * @description Read from the form service because that is what `isSectionValid` /
+   * `sectionNeedsAttention` read, and because the host's `initialize()` runs from a constructor
+   * subscription that Angular flushes a refresh pass after the context is set — so the two sources
+   * disagree for one intermediate pass on every open. Taking mode from both would render the flat edit
+   * rows while locking them like create-mode rows, leaving rows that look interactive and do nothing.
    */
   protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -36,12 +36,22 @@ export class MeetingComposerRailComponent {
 
   private readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
 
+  /**
+   * Single mode source for layout, locking and the active marker.
+   * @description Read from the form service rather than the composer service because that is what
+   * `isSectionValid` / `sectionNeedsAttention` read. The host is `@defer`-mounted and `initialize()` runs
+   * off an effect, so on the first edit-mode open the two can disagree for a paint: taking mode from
+   * both would render the flat edit rows while locking them like create-mode rows, leaving rows that
+   * look interactive and do nothing.
+   */
+  protected readonly isEditMode: Signal<boolean> = computed(() => this.formService.isEditMode());
+
   protected readonly rows: Signal<MeetingComposerRailRow[]> = this.initRows();
   // Both layouts can be in the DOM at once, so their test ids have to differ.
   protected readonly testIdPrefix: Signal<string> = computed(() => (this.compact() ? 'meeting-composer-rail-compact' : 'meeting-composer-rail'));
   // Edit mode has no ordering and no Next/Back, so announcing a step would describe a wizard that
   // isn't there — matching what the desktop edit rows already do.
-  protected readonly activeChipAriaCurrent: Signal<'step' | 'true'> = computed(() => (this.composer.isEditMode() ? 'true' : 'step'));
+  protected readonly activeChipAriaCurrent: Signal<'step' | 'true'> = computed(() => (this.isEditMode() ? 'true' : 'step'));
 
   public constructor() {
     // The chip row is wider than a phone, so a section reached from the footer would otherwise
@@ -75,9 +85,7 @@ export class MeetingComposerRailComponent {
       const sections = this.sections;
       const activeSection = this.composer.activeSection();
       const visited = this.composer.visitedSections();
-      // Read from the form service, the same source `sectionNeedsAttention` uses — two sources for one
-      // fact would flip the visited gate if they ever disagreed mid-tick.
-      const isEditMode = this.formService.isEditMode();
+      const isEditMode = this.isEditMode();
       const validById = new Map<MeetingComposerSectionId, boolean>(sections.map((section) => [section.id, this.formService.isSectionValid(section.id)]));
       const isComplete = (section: MeetingComposerSection): boolean => (section.required ? (validById.get(section.id) ?? false) : visited.has(section.id));
 
@@ -91,7 +99,9 @@ export class MeetingComposerRailComponent {
         return {
           section,
           active,
-          complete: isComplete(section) && !active,
+          // A locked row can't claim to be done even when its own controls validate — a check inside the
+          // greyed circle would contradict the "Complete earlier sections first" text right beside it.
+          complete: isComplete(section) && !active && !locked,
           locked,
           // Shared with the compact badge in the host, so the two can't disagree about what needs fixing.
           needsAttention: this.formService.sectionNeedsAttention(section, visited),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -53,8 +53,9 @@ export class MeetingComposerRailComponent {
 
         return this.compact() ? this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]') : null;
       },
-      // Scrolling mutates the DOM, so it belongs in the write phase rather than either read phase.
-      write: (chip) => chip()?.scrollIntoView({ block: 'nearest', inline: 'center' }),
+      // `scrollIntoView` reads layout before it scrolls, so it is a mixed read/write rather than the pure
+      // write the `write` phase promises.
+      mixedReadWrite: (chip) => chip()?.scrollIntoView({ block: 'nearest', inline: 'center' }),
     });
   }
 
@@ -75,15 +76,11 @@ export class MeetingComposerRailComponent {
       const activeSection = this.composer.activeSection();
       const visited = this.composer.visitedSections();
       const isEditMode = this.composer.isEditMode();
-      // Edit mode starts on an empty form and hydrates from the fetch, so until the meeting lands every
-      // required section reads invalid — flagging that would blame the organizer for a load in progress.
-      const hydrated = !isEditMode || !!this.formService.meeting();
       const validById = new Map<MeetingComposerSectionId, boolean>(sections.map((section) => [section.id, this.formService.isSectionValid(section.id)]));
       const isComplete = (section: MeetingComposerSection): boolean => (section.required ? (validById.get(section.id) ?? false) : visited.has(section.id));
 
       return sections.map((section, index) => {
         const active = section.id === activeSection;
-        const valid = validById.get(section.id) ?? false;
         const blockedByEarlier = sections.slice(0, index).some((earlier) => earlier.required && !validById.get(earlier.id));
 
         return {
@@ -93,9 +90,8 @@ export class MeetingComposerRailComponent {
           // The organizer can be standing on a section an out-of-section validator has just invalidated
           // (enabling YouTube upload tightens the title's max length), so never lock the row they're on.
           locked: !isEditMode && blockedByEarlier && !active,
-          // Edit mode has no visited gate: every section is reachable from the start, so an invalid one the
-          // organizer hasn't opened yet is the case where the dot is the only clue Save is blocked on it.
-          needsAttention: hydrated && section.required && (isEditMode || visited.has(section.id)) && !valid,
+          // Shared with the compact badge in the host, so the two can't disagree about what needs fixing.
+          needsAttention: this.formService.sectionNeedsAttention(section, visited),
           lineBelowComplete: isComplete(section),
           isLast: index === sections.length - 1,
         };

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -10,12 +10,12 @@ import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerService } from './meeting-composer.service';
 
 /**
- * Section navigation for the meeting composer (LFXV2-3240).
+ * Section navigation for the meeting composer (GH-1459).
  * @description Create mode is a progress stepper: later sections stay locked until every earlier
  * required section is valid, so the organizer can't skip past a section that would block submit.
  * Edit mode is a flat menu — the meeting already exists, so every section is reachable. `compact`
  * renders either mode as a horizontal chip row, which is what the composer shows below `lg` where the
- * rail column is hidden (LFXV2-3243).
+ * rail column is hidden (GH-1462).
  */
 @Component({
   selector: 'lfx-meeting-composer-rail',

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -48,15 +48,13 @@ export class MeetingComposerRailComponent {
     // highlight a chip scrolled off-screen. `afterRenderEffect` so the chip carrying the marker is the
     // freshly active one, and because it never runs during SSR.
     afterRenderEffect({
-      read: () => {
+      earlyRead: () => {
         this.composer.activeSection();
 
-        if (!this.compact()) {
-          return;
-        }
-
-        this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]')?.scrollIntoView({ block: 'nearest', inline: 'center' });
+        return this.compact() ? this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]') : null;
       },
+      // Scrolling mutates the DOM, so it belongs in the write phase rather than either read phase.
+      write: (chip) => chip()?.scrollIntoView({ block: 'nearest', inline: 'center' }),
     });
   }
 
@@ -77,6 +75,9 @@ export class MeetingComposerRailComponent {
       const activeSection = this.composer.activeSection();
       const visited = this.composer.visitedSections();
       const isEditMode = this.composer.isEditMode();
+      // Edit mode starts on an empty form and hydrates from the fetch, so until the meeting lands every
+      // required section reads invalid — flagging that would blame the organizer for a load in progress.
+      const hydrated = !isEditMode || !!this.formService.meeting();
       const validById = new Map<MeetingComposerSectionId, boolean>(sections.map((section) => [section.id, this.formService.isSectionValid(section.id)]));
       const isComplete = (section: MeetingComposerSection): boolean => (section.required ? (validById.get(section.id) ?? false) : visited.has(section.id));
 
@@ -94,7 +95,7 @@ export class MeetingComposerRailComponent {
           locked: !isEditMode && blockedByEarlier && !active,
           // Edit mode has no visited gate: every section is reachable from the start, so an invalid one the
           // organizer hasn't opened yet is the case where the dot is the only clue Save is blocked on it.
-          needsAttention: section.required && (isEditMode || visited.has(section.id)) && !valid,
+          needsAttention: hydrated && section.required && (isEditMode || visited.has(section.id)) && !valid,
           lineBelowComplete: isComplete(section),
           isLast: index === sections.length - 1,
         };

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, input, type Signal } from '@angular/core';
+import { afterRenderEffect, Component, computed, ElementRef, inject, input, type Signal } from '@angular/core';
 import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
 import type { MeetingComposerRailRow, MeetingComposerSection, MeetingComposerSectionId } from '@lfx-one/shared/interfaces';
 
@@ -10,10 +10,12 @@ import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerService } from './meeting-composer.service';
 
 /**
- * Left-rail section navigation for the meeting composer (LFXV2-3240).
+ * Section navigation for the meeting composer (LFXV2-3240).
  * @description Create mode is a progress stepper: later sections stay locked until every earlier
  * required section is valid, so the organizer can't skip past a section that would block submit.
- * Edit mode is a flat menu — the meeting already exists, so every section is reachable.
+ * Edit mode is a flat menu — the meeting already exists, so every section is reachable. `compact`
+ * renders either mode as a horizontal chip row, which is what the composer shows below `lg` where the
+ * rail column is hidden (LFXV2-3243).
  */
 @Component({
   selector: 'lfx-meeting-composer-rail',
@@ -23,6 +25,7 @@ import { MeetingComposerService } from './meeting-composer.service';
 export class MeetingComposerRailComponent {
   protected readonly composer = inject(MeetingComposerService);
   private readonly formService = inject(MeetingComposerFormService);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   /**
    * Renders as a horizontal chip row instead of a vertical stepper.
@@ -36,6 +39,24 @@ export class MeetingComposerRailComponent {
   protected readonly rows: Signal<MeetingComposerRailRow[]> = this.initRows();
   // Both layouts can be in the DOM at once, so their test ids have to differ.
   protected readonly testIdPrefix: Signal<string> = computed(() => (this.compact() ? 'meeting-composer-rail-compact' : 'meeting-composer-rail'));
+  // Edit mode has no ordering and no Next/Back, so announcing a step would describe a wizard that
+  // isn't there — matching what the desktop edit rows already do.
+  protected readonly activeChipAriaCurrent: Signal<string> = computed(() => (this.composer.isEditMode() ? 'true' : 'step'));
+
+  public constructor() {
+    // The chip row is wider than a phone, so a section reached from the footer would otherwise
+    // highlight a chip scrolled off-screen. `afterRenderEffect` so the chip carrying the marker is the
+    // freshly active one, and because it never runs during SSR.
+    afterRenderEffect(() => {
+      this.composer.activeSection();
+
+      if (!this.compact()) {
+        return;
+      }
+
+      this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]')?.scrollIntoView({ block: 'nearest', inline: 'center' });
+    });
+  }
 
   protected onSelect(row: MeetingComposerRailRow): void {
     if (row.locked || row.active) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -41,20 +41,22 @@ export class MeetingComposerRailComponent {
   protected readonly testIdPrefix: Signal<string> = computed(() => (this.compact() ? 'meeting-composer-rail-compact' : 'meeting-composer-rail'));
   // Edit mode has no ordering and no Next/Back, so announcing a step would describe a wizard that
   // isn't there — matching what the desktop edit rows already do.
-  protected readonly activeChipAriaCurrent: Signal<string> = computed(() => (this.composer.isEditMode() ? 'true' : 'step'));
+  protected readonly activeChipAriaCurrent: Signal<'step' | 'true'> = computed(() => (this.composer.isEditMode() ? 'true' : 'step'));
 
   public constructor() {
     // The chip row is wider than a phone, so a section reached from the footer would otherwise
     // highlight a chip scrolled off-screen. `afterRenderEffect` so the chip carrying the marker is the
     // freshly active one, and because it never runs during SSR.
-    afterRenderEffect(() => {
-      this.composer.activeSection();
+    afterRenderEffect({
+      read: () => {
+        this.composer.activeSection();
 
-      if (!this.compact()) {
-        return;
-      }
+        if (!this.compact()) {
+          return;
+        }
 
-      this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]')?.scrollIntoView({ block: 'nearest', inline: 'center' });
+        this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]')?.scrollIntoView({ block: 'nearest', inline: 'center' });
+      },
     });
   }
 
@@ -90,7 +92,9 @@ export class MeetingComposerRailComponent {
           // The organizer can be standing on a section an out-of-section validator has just invalidated
           // (enabling YouTube upload tightens the title's max length), so never lock the row they're on.
           locked: !isEditMode && blockedByEarlier && !active,
-          needsAttention: !isEditMode && section.required && visited.has(section.id) && !valid,
+          // Edit mode has no visited gate: every section is reachable from the start, so an invalid one the
+          // organizer hasn't opened yet is the case where the dot is the only clue Save is blocked on it.
+          needsAttention: section.required && (isEditMode || visited.has(section.id)) && !valid,
           lineBelowComplete: isComplete(section),
           isLast: index === sections.length - 1,
         };

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -39,9 +39,8 @@ export class MeetingComposerRailComponent {
   /**
    * Single mode source for layout, locking and the active marker.
    * @description Read from the form service because that is what `isSectionValid` /
-   * `sectionNeedsAttention` read, and because the host's `initialize()` runs from a constructor
-   * subscription that Angular flushes a refresh pass after the context is set — so the two sources
-   * disagree for one intermediate pass on every open. Taking mode from both would render the flat edit
+   * `sectionNeedsAttention` read, and because `composer.context()` is written before `initialize()` runs —
+   * so the two are briefly out of step on every open. Taking mode from both would render the flat edit
    * rows while locking them like create-mode rows, leaving rows that look interactive and do nothing.
    */
   protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -39,12 +39,12 @@ export class MeetingComposerRailComponent {
   /**
    * Single mode source for layout, locking and the active marker.
    * @description Read from the form service rather than the composer service because that is what
-   * `isSectionValid` / `sectionNeedsAttention` read. The host is `@defer`-mounted and `initialize()` runs
-   * off an effect, so on the first edit-mode open the two can disagree for a paint: taking mode from
-   * both would render the flat edit rows while locking them like create-mode rows, leaving rows that
-   * look interactive and do nothing.
+   * `isSectionValid` / `sectionNeedsAttention` read. The host is `@defer`-mounted and calls `initialize()`
+   * from a context subscription in its constructor, so on the first edit-mode open the two can disagree
+   * for a paint: taking mode from both would render the flat edit rows while locking them like create-mode
+   * rows, leaving rows that look interactive and do nothing.
    */
-  protected readonly isEditMode: Signal<boolean> = computed(() => this.formService.isEditMode());
+  protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
 
   protected readonly rows: Signal<MeetingComposerRailRow[]> = this.initRows();
   // Both layouts can be in the DOM at once, so their test ids have to differ.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-route.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-route.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MeetingComposerService } from './meeting-composer.service';
 
 /**
- * Keeps `/meetings/create` and `/meetings/:id/edit` deep-linkable (LFXV2-3234).
+ * Keeps `/meetings/create` and `/meetings/:id/edit` deep-linkable (GH-1452).
  * @description Renders nothing: it opens the composer, then replaces the URL with the meetings
  * list so the composer sits over a real page. Composer state lives in a root service, so it
  * survives this component being destroyed by the redirect.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -40,7 +40,6 @@ export class MeetingComposerService {
   public readonly saveCount = this._saveCount.asReadonly();
 
   public readonly isOpen = computed(() => this._context() !== null);
-  public readonly isEditMode = computed(() => this._context()?.mode === 'edit');
   public readonly isQuickCreate = computed(() => this._context()?.variant === 'quick');
 
   public open(context: MeetingComposerContext): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -8,7 +8,7 @@ import type { MeetingComposerContext, MeetingComposerSectionId } from '@lfx-one/
 const FIRST_SECTION: MeetingComposerSectionId = MEETING_COMPOSER_SECTIONS[0].id;
 
 /**
- * Cross-page open state for the meeting composer (LFXV2-3234).
+ * Cross-page open state for the meeting composer (GH-1452).
  * @description Any entry point can call `open()`; `MeetingComposerHostComponent` — deferred in
  * `app.component.html` until the first open — renders the drawer, so the composer survives navigation.
  */

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -30,6 +30,15 @@ export class MeetingComposerService {
   private readonly _visitedSections = signal<ReadonlySet<MeetingComposerSectionId>>(new Set([FIRST_SECTION]));
   public readonly visitedSections = this._visitedSections.asReadonly();
 
+  /**
+   * Increments once per successful save.
+   * @description Saving no longer navigates, so the page underneath the composer would otherwise keep
+   * showing a list that predates the meeting the toast just announced. Surfaces that render meetings
+   * refresh off this rather than off `isOpen`, which also fires on a cancelled open.
+   */
+  private readonly _saveCount = signal(0);
+  public readonly saveCount = this._saveCount.asReadonly();
+
   public readonly isOpen = computed(() => this._context() !== null);
   public readonly isEditMode = computed(() => this._context()?.mode === 'edit');
   public readonly isQuickCreate = computed(() => this._context()?.variant === 'quick');
@@ -45,6 +54,10 @@ export class MeetingComposerService {
     this._context.set(null);
     this._activeSection.set(FIRST_SECTION);
     this._visitedSections.set(new Set([FIRST_SECTION]));
+  }
+
+  public notifySaved(): void {
+    this._saveCount.update((count) => count + 1);
   }
 
   public setSection(section: MeetingComposerSectionId): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -12,11 +12,12 @@
   styleClass="w-[min(1024px,94vw)]">
   <div class="grid grid-cols-1 gap-6 lg:grid-cols-2" data-testid="quick-create-body">
     <div class="flex min-w-0 flex-col gap-6">
-      <lfx-composer-details-access [form]="formService.form()" [showHeading]="false" />
-
-      @if (prefilledTitle()) {
-        <p class="text-xs text-gray-500" data-testid="quick-create-prefill-hint">Pre-filled for this meeting type — edit freely.</p>
-      }
+      <!-- The hints are passed down rather than rendered here so each one sits under the field it
+           describes and can be wired to it with `aria-describedby` -->
+      <lfx-composer-details-access
+        [form]="formService.form()"
+        [showHeading]="false"
+        [titleHint]="prefilledTitle() ? 'Pre-filled for this meeting type — edit freely.' : null" />
 
       <div class="flex flex-col gap-2">
         <label for="quick-create-agenda" class="text-sm font-medium text-gray-900">Agenda</label>
@@ -45,13 +46,13 @@
     </div>
 
     <div class="flex min-w-0 flex-col gap-6">
-      <lfx-composer-date-schedule [form]="formService.form()" [showHeading]="false" [showEarlyJoin]="false" />
-
-      <!-- Its own hint rather than sharing the title's: duration lives in this column, and only a template
-           whose estimate lands on the chip scale seeds it at all -->
-      @if (prefilledDuration()) {
-        <p class="text-xs text-gray-500" data-testid="quick-create-duration-hint">Duration pre-filled for this meeting type — edit freely.</p>
-      }
+      <!-- Its own hint rather than sharing the title's: only a template whose estimate lands on the chip
+           scale seeds duration at all, so the two go quiet independently -->
+      <lfx-composer-date-schedule
+        [form]="formService.form()"
+        [showHeading]="false"
+        [showEarlyJoin]="false"
+        [durationHint]="prefilledDuration() ? 'Pre-filled for this meeting type — edit freely.' : null" />
     </div>
   </div>
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -14,7 +14,7 @@
     <div class="flex min-w-0 flex-col gap-6">
       <lfx-composer-details-access [form]="formService.form()" [showHeading]="false" />
 
-      @if (prefilledDetails()) {
+      @if (prefilledTitle()) {
         <p class="text-xs text-gray-500" data-testid="quick-create-prefill-hint">Pre-filled for this meeting type — edit freely.</p>
       }
 
@@ -46,6 +46,12 @@
 
     <div class="flex min-w-0 flex-col gap-6">
       <lfx-composer-date-schedule [form]="formService.form()" [showHeading]="false" [showEarlyJoin]="false" />
+
+      <!-- Its own hint rather than sharing the title's: duration lives in this column, and only a template
+           whose estimate lands on the chip scale seeds it at all -->
+      @if (prefilledDuration()) {
+        <p class="text-xs text-gray-500" data-testid="quick-create-duration-hint">Duration pre-filled for this meeting type — edit freely.</p>
+      }
     </div>
   </div>
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -14,7 +14,7 @@
     <div class="flex min-w-0 flex-col gap-6">
       <lfx-composer-details-access [form]="formService.form()" [showHeading]="false" />
 
-      @if (prefilledType()) {
+      @if (prefilledDetails()) {
         <p class="text-xs text-gray-500" data-testid="quick-create-prefill-hint">Pre-filled for this meeting type — edit freely.</p>
       }
 
@@ -30,7 +30,7 @@
           [maxlength]="agendaMaxLength"
           data-testid="quick-create-agenda-textarea" />
         <div class="flex items-center justify-between gap-2">
-          @if (prefilledType()) {
+          @if (prefilledAgenda()) {
             <p class="text-xs text-gray-500" data-testid="quick-create-agenda-hint">Suggested agenda template — adjust as needed.</p>
           }
           <p class="ml-auto text-xs" [ngClass]="agendaCounterClass()">{{ agendaLength() }}/{{ agendaMaxLength }}</p>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<!-- Quick create dialog (LFXV2-3241) -->
+<!-- Quick create dialog (GH-1460) -->
 <p-dialog
   [visible]="composer.isOpen()"
   (visibleChange)="onVisibleChange($event)"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -48,8 +48,10 @@ export class QuickCreateDialogComponent {
 
   protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
 
-  /** Meeting type whose template was applied, so the prefill hints only claim what was actually filled. */
-  protected readonly prefilledType = signal<MeetingType | null>(null);
+  // Tracked per hint rather than per template, so the agenda hint can't claim a suggestion over an agenda
+  // the organizer wrote themselves just because the title next to it was seeded.
+  protected readonly prefilledDetails = signal(false);
+  protected readonly prefilledAgenda = signal(false);
 
   protected readonly agendaLength: Signal<number> = computed(() => {
     this.formService.revision();
@@ -109,7 +111,8 @@ export class QuickCreateDialogComponent {
     const template = meetingType ? this.firstTemplate(meetingType) : null;
 
     if (!template) {
-      this.prefilledType.set(null);
+      this.prefilledDetails.set(false);
+      this.prefilledAgenda.set(false);
       return;
     }
 
@@ -117,26 +120,24 @@ export class QuickCreateDialogComponent {
     const title = form.get('title');
     const description = form.get('description');
     const duration = form.get('duration');
-    let prefilled = false;
+    let prefilledDetails = false;
 
     if (title?.pristine) {
       title.setValue(template.title);
-      prefilled = true;
-    }
-
-    if (description?.pristine) {
-      description.setValue(template.content);
-      prefilled = true;
+      prefilledDetails = true;
     }
 
     if (duration?.pristine && MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === template.estimatedDuration)) {
       this.formService.setDuration(template.estimatedDuration);
-      prefilled = true;
+      prefilledDetails = true;
     }
 
-    // The hints below the fields claim a prefill happened, so they must not show when every field was
-    // already the organizer's own.
-    this.prefilledType.set(prefilled ? meetingType : null);
+    if (description?.pristine) {
+      description.setValue(template.content);
+    }
+
+    this.prefilledDetails.set(prefilledDetails);
+    this.prefilledAgenda.set(!!description?.pristine);
   }
 
   private firstTemplate(meetingType: MeetingType): MeetingTemplate | null {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, inject, output, signal, type Signal } from '@angul
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
-import { DEFAULT_DURATION, MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_WARNING_LENGTH, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
+import { MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_WARNING_LENGTH, MEETING_DURATION_CHIP_OPTIONS, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import type { CommitteeMember, MeetingTemplate } from '@lfx-one/shared/interfaces';
 import { DialogModule } from 'primeng/dialog';
@@ -100,8 +100,10 @@ export class QuickCreateDialogComponent {
 
   /**
    * Seeds title, agenda and duration from the meeting type's first template.
-   * @description Only untouched fields are written — switching type after typing a title must not discard
-   * it — so duration is seeded only while it still holds the form default.
+   * @description Guarded on `pristine` rather than on emptiness: switching type after editing a field must
+   * keep the edit, and an emptiness check would treat a prefill from the previous type as free to
+   * overwrite — leaving a Board meeting carrying the Technical template's title. Durations off the chip
+   * scale are skipped, since seeding one would drop this surface into the custom-minutes input.
    */
   private applyTypeTemplate(meetingType: MeetingType | null): void {
     const template = meetingType ? this.firstTemplate(meetingType) : null;
@@ -114,20 +116,27 @@ export class QuickCreateDialogComponent {
     const form = this.formService.form();
     const title = form.get('title');
     const description = form.get('description');
+    const duration = form.get('duration');
+    let prefilled = false;
 
-    if (!(title?.value as string | null)?.trim()) {
-      title?.setValue(template.title);
+    if (title?.pristine) {
+      title.setValue(template.title);
+      prefilled = true;
     }
 
-    if (!(description?.value as string | null)?.trim()) {
-      description?.setValue(template.content);
+    if (description?.pristine) {
+      description.setValue(template.content);
+      prefilled = true;
     }
 
-    if (this.formService.effectiveDuration() === DEFAULT_DURATION) {
+    if (duration?.pristine && MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === template.estimatedDuration)) {
       this.formService.setDuration(template.estimatedDuration);
+      prefilled = true;
     }
 
-    this.prefilledType.set(meetingType);
+    // The hints below the fields claim a prefill happened, so they must not show when every field was
+    // already the organizer's own.
+    this.prefilledType.set(prefilled ? meetingType : null);
   }
 
   private firstTemplate(meetingType: MeetingType): MeetingTemplate | null {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -19,7 +19,7 @@ import { ComposerDateScheduleComponent } from './sections/composer-date-schedule
 import { ComposerDetailsAccessComponent } from './sections/composer-details-access.component';
 
 /**
- * Quick create dialog (LFXV2-3241).
+ * Quick create dialog (GH-1460).
  * @description The condensed create surface: the same form and the same submit path as the drawer, laid
  * out as two columns with no rail and no per-section gating. It composes the drawer's Details & Access
  * and Date & Schedule sections rather than reimplementing their controls, so validators, hint copy and

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -56,8 +56,10 @@ export class QuickCreateDialogComponent {
   private readonly seededAgenda = signal(false);
 
   // Derived rather than snapshotted: a hint has to go quiet the moment the organizer rewrites the field,
-  // and that happens without any type change to recompute it on.
-  protected readonly prefilledDetails: Signal<boolean> = this.initPrefilledDetails();
+  // and that happens without any type change to recompute it on. One hint per control, since each sits
+  // next to the field it describes and the two columns are far apart on screen.
+  protected readonly prefilledTitle: Signal<boolean> = this.initPrefilledTitle();
+  protected readonly prefilledDuration: Signal<boolean> = this.initPrefilledDuration();
   protected readonly prefilledAgenda: Signal<boolean> = this.initPrefilledAgenda();
 
   protected readonly agendaLength: Signal<number> = computed(() => {
@@ -108,19 +110,21 @@ export class QuickCreateDialogComponent {
   }
 
   // Private initializer functions
-  private initPrefilledDetails(): Signal<boolean> {
+  private initPrefilledTitle(): Signal<boolean> {
     return computed(() => {
-      // `revision` is what makes control state reactive here — the form service bumps it on value and
-      // status changes and on the methods that only mark controls dirty.
+      // `revision` is what makes control state reactive here — `validateForSubmit` bumps it for the marks
+      // that emit on neither `valueChanges` nor `statusChanges`.
       this.formService.revision();
 
-      const form = this.formService.form();
-      // Each seed paired with its own control: an OR across both flags would let the never-seeded control
-      // keep the hint alive.
-      const titleStillTemplate = this.seededTitle() && !!form.get('title')?.pristine;
-      const durationStillTemplate = this.seededDuration() && !!form.get('duration')?.pristine;
+      return this.seededTitle() && !!this.formService.form().get('title')?.pristine;
+    });
+  }
 
-      return titleStillTemplate || durationStillTemplate;
+  private initPrefilledDuration(): Signal<boolean> {
+    return computed(() => {
+      this.formService.revision();
+
+      return this.seededDuration() && !!this.formService.form().get('duration')?.pristine;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -48,10 +48,15 @@ export class QuickCreateDialogComponent {
 
   protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
 
-  // Tracked per hint rather than per template, so the agenda hint can't claim a suggestion over an agenda
-  // the organizer wrote themselves just because the title next to it was seeded.
-  protected readonly prefilledDetails = signal(false);
-  protected readonly prefilledAgenda = signal(false);
+  // What the type's template wrote, tracked per hint so the agenda hint can't claim a suggestion just
+  // because the title next to it was seeded.
+  private readonly seededDetails = signal(false);
+  private readonly seededAgenda = signal(false);
+
+  // Derived rather than snapshotted: a hint has to go quiet the moment the organizer rewrites the field,
+  // and that happens without any type change to recompute it on.
+  protected readonly prefilledDetails: Signal<boolean> = this.initPrefilledDetails();
+  protected readonly prefilledAgenda: Signal<boolean> = this.initPrefilledAgenda();
 
   protected readonly agendaLength: Signal<number> = computed(() => {
     this.formService.revision();
@@ -111,8 +116,8 @@ export class QuickCreateDialogComponent {
     const template = meetingType ? this.firstTemplate(meetingType) : null;
 
     if (!template) {
-      this.prefilledDetails.set(false);
-      this.prefilledAgenda.set(false);
+      this.seededDetails.set(false);
+      this.seededAgenda.set(false);
       return;
     }
 
@@ -120,24 +125,43 @@ export class QuickCreateDialogComponent {
     const title = form.get('title');
     const description = form.get('description');
     const duration = form.get('duration');
-    let prefilledDetails = false;
+    let seededDetails = false;
 
     if (title?.pristine) {
       title.setValue(template.title);
-      prefilledDetails = true;
+      seededDetails = true;
     }
 
     if (duration?.pristine && MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === template.estimatedDuration)) {
       this.formService.setDuration(template.estimatedDuration);
-      prefilledDetails = true;
+      seededDetails = true;
     }
 
     if (description?.pristine) {
       description.setValue(template.content);
     }
 
-    this.prefilledDetails.set(prefilledDetails);
-    this.prefilledAgenda.set(!!description?.pristine);
+    this.seededDetails.set(seededDetails);
+    this.seededAgenda.set(!!description?.pristine);
+  }
+
+  private initPrefilledDetails(): Signal<boolean> {
+    return computed(() => {
+      // `revision` is what makes control state reactive here.
+      this.formService.revision();
+
+      const form = this.formService.form();
+
+      return this.seededDetails() && (!!form.get('title')?.pristine || !!form.get('duration')?.pristine);
+    });
+  }
+
+  private initPrefilledAgenda(): Signal<boolean> {
+    return computed(() => {
+      this.formService.revision();
+
+      return this.seededAgenda() && !!this.formService.form().get('description')?.pristine;
+    });
   }
 
   private firstTemplate(meetingType: MeetingType): MeetingTemplate | null {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -48,9 +48,11 @@ export class QuickCreateDialogComponent {
 
   protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
 
-  // What the type's template wrote, tracked per hint so the agenda hint can't claim a suggestion just
-  // because the title next to it was seeded.
-  private readonly seededDetails = signal(false);
+  // What the type's template wrote, tracked per control: most templates estimate a duration off the chip
+  // scale, which `applyTypeTemplate` skips, so a single flag would keep the details hint alive on the
+  // untouched `duration` control long after the organizer rewrote the title.
+  private readonly seededTitle = signal(false);
+  private readonly seededDuration = signal(false);
   private readonly seededAgenda = signal(false);
 
   // Derived rather than snapshotted: a hint has to go quiet the moment the organizer rewrites the field,
@@ -105,6 +107,32 @@ export class QuickCreateDialogComponent {
     this.create.emit();
   }
 
+  // Private initializer functions
+  private initPrefilledDetails(): Signal<boolean> {
+    return computed(() => {
+      // `revision` is what makes control state reactive here — the form service bumps it on value and
+      // status changes and on the methods that only mark controls dirty.
+      this.formService.revision();
+
+      const form = this.formService.form();
+      // Each seed paired with its own control: an OR across both flags would let the never-seeded control
+      // keep the hint alive.
+      const titleStillTemplate = this.seededTitle() && !!form.get('title')?.pristine;
+      const durationStillTemplate = this.seededDuration() && !!form.get('duration')?.pristine;
+
+      return titleStillTemplate || durationStillTemplate;
+    });
+  }
+
+  private initPrefilledAgenda(): Signal<boolean> {
+    return computed(() => {
+      this.formService.revision();
+
+      return this.seededAgenda() && !!this.formService.form().get('description')?.pristine;
+    });
+  }
+
+  // Other private helper methods
   /**
    * Seeds title, agenda and duration from the meeting type's first template.
    * @description Guarded on `pristine` rather than on emptiness: switching type after editing a field must
@@ -116,7 +144,8 @@ export class QuickCreateDialogComponent {
     const template = meetingType ? this.firstTemplate(meetingType) : null;
 
     if (!template) {
-      this.seededDetails.set(false);
+      this.seededTitle.set(false);
+      this.seededDuration.set(false);
       this.seededAgenda.set(false);
       return;
     }
@@ -125,43 +154,28 @@ export class QuickCreateDialogComponent {
     const title = form.get('title');
     const description = form.get('description');
     const duration = form.get('duration');
-    let seededDetails = false;
+    let seededTitle = false;
+    let seededDuration = false;
+    let seededAgenda = false;
 
     if (title?.pristine) {
       title.setValue(template.title);
-      seededDetails = true;
+      seededTitle = true;
     }
 
     if (duration?.pristine && MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === template.estimatedDuration)) {
       this.formService.setDuration(template.estimatedDuration);
-      seededDetails = true;
+      seededDuration = true;
     }
 
     if (description?.pristine) {
       description.setValue(template.content);
+      seededAgenda = true;
     }
 
-    this.seededDetails.set(seededDetails);
-    this.seededAgenda.set(!!description?.pristine);
-  }
-
-  private initPrefilledDetails(): Signal<boolean> {
-    return computed(() => {
-      // `revision` is what makes control state reactive here.
-      this.formService.revision();
-
-      const form = this.formService.form();
-
-      return this.seededDetails() && (!!form.get('title')?.pristine || !!form.get('duration')?.pristine);
-    });
-  }
-
-  private initPrefilledAgenda(): Signal<boolean> {
-    return computed(() => {
-      this.formService.revision();
-
-      return this.seededAgenda() && !!this.formService.form().get('description')?.pristine;
-    });
+    this.seededTitle.set(seededTitle);
+    this.seededDuration.set(seededDuration);
+    this.seededAgenda.set(seededAgenda);
   }
 
   private firstTemplate(meetingType: MeetingType): MeetingTemplate | null {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -32,7 +32,7 @@ import { AddLinkDialogComponent } from '../add-link-dialog/add-link-dialog.compo
 import { MeetingComposerFormService } from '../meeting-composer-form.service';
 
 /**
- * Agenda & Resources section of the meeting composer (LFXV2-3239).
+ * Agenda & Resources section of the meeting composer (GH-1458).
  * @description Attachments and links are read straight off the form controls rather than mirrored into
  * local signals: the host's `@switch` destroys this component on every section change, so any local
  * copy of the queue would be lost.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -50,9 +50,17 @@
   <!-- Duration -->
   <div class="flex flex-col gap-2">
     <span id="composer-duration-label" class="text-sm font-medium text-gray-900"> Duration <span class="text-red-500">*</span> </span>
-    <div role="group" aria-labelledby="composer-duration-label" data-testid="composer-duration-chips">
+    <div
+      role="group"
+      aria-labelledby="composer-duration-label"
+      [attr.aria-describedby]="durationHint() ? 'composer-duration-hint' : null"
+      data-testid="composer-duration-chips">
       <lfx-select-button [form]="form()" control="duration" [options]="durationOptions" [unselectable]="false" [required]="true" />
     </div>
+
+    @if (durationHint(); as hint) {
+      <p id="composer-duration-hint" class="text-xs text-gray-500" data-testid="composer-duration-hint">{{ hint }}</p>
+    }
     @if (form().get('duration')?.errors?.['required'] && form().get('duration')?.touched) {
       <p class="text-sm text-red-600" data-testid="composer-duration-required-error">Duration is required</p>
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -29,7 +29,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { MeetingRecurrencePatternComponent } from '../../components/meeting-recurrence-pattern/meeting-recurrence-pattern.component';
 
 /**
- * Date & Schedule section of the meeting composer (LFXV2-3236).
+ * Date & Schedule section of the meeting composer (GH-1454).
  * @description Owns `startDate`, `startTime`, `duration`/`customDuration`, `timezone`,
  * `early_join_time_minutes`, and the recurring card. Owns the simple-cadence → `recurrence` mapping
  * (daily / weekly / weekdays / monthly); `custom` is owned by `lfx-meeting-recurrence-pattern`. The

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -62,7 +62,9 @@ export class ComposerDateScheduleComponent implements OnInit {
    * Hint text for a duration that was written by something other than the organizer.
    * @description Passed in rather than derived here because only quick create prefills from the meeting
    * type. It renders directly under the chips and is wired through `aria-describedby` on their group, so
-   * the hint is reachable from the control it is about rather than from the far end of the column.
+   * the hint is reachable from the control it is about rather than from the far end of the column. The
+   * association sits on the surrounding `role="group"` rather than on the chips themselves because
+   * `lfx-select-button` exposes no `ariaDescribedBy` input to pass it through.
    */
   public readonly durationHint = input<string | null>(null);
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -58,6 +58,13 @@ export class ComposerDateScheduleComponent implements OnInit {
   public readonly showHeading = input(true);
   /** Early join is an advanced setting the quick create dialog leaves at its default. */
   public readonly showEarlyJoin = input(true);
+  /**
+   * Hint text for a duration that was written by something other than the organizer.
+   * @description Passed in rather than derived here because only quick create prefills from the meeting
+   * type. It renders directly under the chips and is wired through `aria-describedby` on their group, so
+   * the hint is reachable from the control it is about rather than from the far end of the column.
+   */
+  public readonly durationHint = input<string | null>(null);
 
   protected readonly durationOptions = MEETING_DURATION_CHIP_OPTIONS;
   protected readonly earlyJoinOptions = EARLY_JOIN_CHIP_OPTIONS;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -54,7 +54,7 @@ export class ComposerDateScheduleComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   public readonly form = input.required<FormGroup>();
-  /** Quick create labels its own columns and has no room for the section heading. */
+  /** Quick create renders these fields under its own dialog header, where a section heading only repeats it. */
   public readonly showHeading = input(true);
   /** Early join is an advanced setting the quick create dialog leaves at its default. */
   public readonly showEarlyJoin = input(true);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -43,8 +43,10 @@
       </div>
     }
 
-    <!-- `aria-describedby` on the input reaches these, so they are read on the next focus of the field
-         rather than when they appear — no composer error message is in a live region yet. -->
+    <!-- `aria-describedby` on the input reaches the two title errors below, so each is read the next time
+         the field takes focus rather than when it appears — no composer error message is in a live region
+         yet. Matters for both: `required` only shows after blur, and `maxlength` typically shows while the
+         field still has focus. -->
     @if (form().get('title')?.errors?.['required'] && form().get('title')?.touched) {
       <p id="composer-title-required-error" class="text-sm text-red-600" data-testid="composer-title-required-error">Meeting title is required</p>
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -43,6 +43,8 @@
       </div>
     }
 
+    <!-- `aria-describedby` on the input reaches these, so they are read on the next focus of the field
+         rather than when they appear — no composer error message is in a live region yet. -->
     @if (form().get('title')?.errors?.['required'] && form().get('title')?.touched) {
       <p id="composer-title-required-error" class="text-sm text-red-600" data-testid="composer-title-required-error">Meeting title is required</p>
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -19,7 +19,7 @@
       id="composer-meeting-title"
       placeholder="Enter meeting title"
       styleClass="w-full"
-      [describedBy]="titleHint() ? 'composer-title-hint' : undefined"
+      [describedBy]="titleDescribedBy()"
       data-testid="composer-title-input" />
 
     @if (titleHint(); as hint) {
@@ -44,10 +44,10 @@
     }
 
     @if (form().get('title')?.errors?.['required'] && form().get('title')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-title-required-error">Meeting title is required</p>
+      <p id="composer-title-required-error" class="text-sm text-red-600" data-testid="composer-title-required-error">Meeting title is required</p>
     }
     @if (form().get('title')?.errors?.['maxlength'] && form().get('title')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-title-maxlength-error">
+      <p id="composer-title-maxlength-error" class="text-sm text-red-600" data-testid="composer-title-maxlength-error">
         Meeting title cannot exceed {{ youtubeTitleLimit }} characters while YouTube uploads are enabled.
       </p>
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -19,7 +19,12 @@
       id="composer-meeting-title"
       placeholder="Enter meeting title"
       styleClass="w-full"
+      [describedBy]="titleHint() ? 'composer-title-hint' : undefined"
       data-testid="composer-title-input" />
+
+    @if (titleHint(); as hint) {
+      <p id="composer-title-hint" class="text-xs text-gray-500" data-testid="composer-title-hint">{{ hint }}</p>
+    }
 
     @if (form().get('youtube_upload_enabled')?.value) {
       <div class="flex items-center justify-between gap-2">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
@@ -83,6 +83,8 @@ describe('ComposerDetailsAccessComponent — title description ids', () => {
   });
 
   it('points at the maxlength error when the YouTube limit is exceeded', () => {
+    expect(describedBy()).toBe('composer-title-required-error');
+
     formService.form().get('youtube_upload_enabled')?.setValue(true);
     formService
       .form()

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
@@ -1,0 +1,82 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { YOUTUBE_MAX_MEETING_TITLE_LENGTH } from '@lfx-one/shared/constants';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
+import { ComposerDetailsAccessComponent } from './composer-details-access.component';
+
+/**
+ * Covers the title's `aria-describedby` list. The paragraphs it points at are gated on `touched`, which
+ * emits on neither `valueChanges` nor `statusChanges` — so a list that gated on it too would go stale for
+ * exactly the case the errors exist for.
+ */
+describe('ComposerDetailsAccessComponent — title description ids', () => {
+  let fixture: ComponentFixture<ComposerDetailsAccessComponent>;
+  let component: ComposerDetailsAccessComponent;
+  let formService: MeetingComposerFormService;
+
+  const describedBy = (): string | null => component['titleDescribedBy']();
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        { provide: PersonaService, useValue: { currentPersona: () => null } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerDetailsAccessComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerDetailsAccessComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('points at the required error on an empty title', () => {
+    expect(describedBy()).toBe('composer-title-required-error');
+  });
+
+  it('still points at the required error after a blur-only touch', () => {
+    // The transition the paragraph renders on. Nothing bumps `revision` here, which is the whole point.
+    formService.form().get('title')?.markAsTouched();
+
+    expect(describedBy()).toBe('composer-title-required-error');
+  });
+
+  it('drops the error once the title is filled', () => {
+    formService.form().get('title')?.setValue('Composer meeting');
+
+    expect(describedBy()).toBeNull();
+  });
+
+  it('lists the prefill hint alongside the error', () => {
+    fixture.componentRef.setInput('titleHint', 'Pre-filled for this meeting type — edit freely.');
+
+    expect(describedBy()).toBe('composer-title-hint composer-title-required-error');
+  });
+
+  it('points at the maxlength error when the YouTube limit is exceeded', () => {
+    formService.form().get('youtube_upload_enabled')?.setValue(true);
+    formService
+      .form()
+      .get('title')
+      ?.setValue('a'.repeat(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1));
+
+    expect(describedBy()).toBe('composer-title-maxlength-error');
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
@@ -52,13 +52,18 @@ describe('ComposerDetailsAccessComponent — title description ids', () => {
   });
 
   it('still points at the required error after a blur-only touch', () => {
-    // The transition the paragraph renders on. Nothing bumps `revision` here, which is the whole point.
+    // Primed first on purpose: the read is what caches the computed, and a `touched`-gated version could
+    // only be caught going stale from a cached value — nothing bumps `revision` on `markAsTouched()`.
+    expect(describedBy()).toBe('composer-title-required-error');
+
     formService.form().get('title')?.markAsTouched();
 
     expect(describedBy()).toBe('composer-title-required-error');
   });
 
   it('drops the error once the title is filled', () => {
+    expect(describedBy()).toBe('composer-title-required-error');
+
     formService.form().get('title')?.setValue('Composer meeting');
 
     expect(describedBy()).toBeNull();
@@ -68,6 +73,13 @@ describe('ComposerDetailsAccessComponent — title description ids', () => {
     fixture.componentRef.setInput('titleHint', 'Pre-filled for this meeting type — edit freely.');
 
     expect(describedBy()).toBe('composer-title-hint composer-title-required-error');
+  });
+
+  it('lists the prefill hint alone once the prefilled title validates', () => {
+    fixture.componentRef.setInput('titleHint', 'Pre-filled for this meeting type — edit freely.');
+    formService.form().get('title')?.setValue('Composer meeting');
+
+    expect(describedBy()).toBe('composer-title-hint');
   });
 
   it('points at the maxlength error when the YouTube limit is exceeded', () => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -10,15 +10,14 @@ import { RadioButtonComponent } from '@components/radio-button/radio-button.comp
 import { SelectComponent } from '@components/select/select.component';
 import {
   lfxColors,
-  MAINTAINER_MEETING_TYPES,
   MEETING_JOIN_RESTRICTION_OPTIONS,
-  MEETING_TYPE_OPTIONS,
   MEETING_VISIBILITY_OPTIONS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
   YOUTUBE_MEETING_TITLE_WARNING_LENGTH,
 } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import type { CardSelectorOption } from '@lfx-one/shared/interfaces';
+import { getSelectableMeetingTypeOptions } from '@lfx-one/shared/utils';
 import { PersonaService } from '@services/persona.service';
 import { map, of, startWith, switchMap } from 'rxjs';
 
@@ -40,7 +39,7 @@ export class ComposerDetailsAccessComponent {
   private readonly formService = inject(MeetingComposerFormService);
 
   public readonly form = input.required<FormGroup>();
-  /** Quick create labels its own columns and has no room for the section heading. */
+  /** Quick create renders these fields under its own dialog header, where a section heading only repeats it. */
   public readonly showHeading = input(true);
 
   protected readonly visibilityOptions = MEETING_VISIBILITY_OPTIONS;
@@ -80,10 +79,7 @@ export class ComposerDetailsAccessComponent {
       const hydrated = this.hydratedMeetingType();
       // Editing a meeting whose type this persona can't create would otherwise drop the stored value
       // out of the list, rendering the select as an empty placeholder over a populated control.
-      const available =
-        this.personaService.currentPersona() === 'maintainer'
-          ? MEETING_TYPE_OPTIONS.filter((option) => MAINTAINER_MEETING_TYPES.includes(option.value) || option.value === hydrated)
-          : MEETING_TYPE_OPTIONS;
+      const available = getSelectableMeetingTypeOptions(this.personaService.currentPersona(), hydrated);
 
       if (!hydrated || available.some((option) => option.value === hydrated)) {
         return available;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -41,6 +41,13 @@ export class ComposerDetailsAccessComponent {
   public readonly form = input.required<FormGroup>();
   /** Quick create renders these fields under its own dialog header, where a section heading only repeats it. */
   public readonly showHeading = input(true);
+  /**
+   * Hint text for a title that was written by something other than the organizer.
+   * @description Passed in rather than derived here because only quick create prefills from the meeting
+   * type. It renders directly under the input and is wired through `aria-describedby`, so the hint is
+   * reachable from the field it is about instead of sitting at the bottom of the column.
+   */
+  public readonly titleHint = input<string | null>(null);
 
   protected readonly visibilityOptions = MEETING_VISIBILITY_OPTIONS;
   protected readonly joinRestrictionOptions = MEETING_JOIN_RESTRICTION_OPTIONS;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -55,6 +55,13 @@ export class ComposerDetailsAccessComponent {
   protected readonly youtubeAmberThreshold = YOUTUBE_MEETING_TITLE_WARNING_LENGTH;
 
   protected readonly titleLength: Signal<number> = this.initTitleLength();
+  /**
+   * Ids the title input points at through `aria-describedby`.
+   * @description Built here rather than bound inline because the input takes a single attribute value:
+   * the prefill hint and the two error messages all describe the same field, so they have to be joined
+   * into one list instead of overwriting each other.
+   */
+  protected readonly titleDescribedBy: Signal<string | null> = this.initTitleDescribedBy();
   private readonly hydratedMeetingType: Signal<MeetingType | null> = this.initHydratedMeetingType();
   protected readonly meetingTypeOptions: Signal<CardSelectorOption<MeetingType>[]> = this.initMeetingTypeOptions();
 
@@ -72,6 +79,23 @@ export class ComposerDetailsAccessComponent {
       ),
       { initialValue: 0 }
     );
+  }
+
+  private initTitleDescribedBy(): Signal<string | null> {
+    return computed(() => {
+      // FormGroup state isn't reactive; `revision` is what re-evaluates the error gates below.
+      this.formService.revision();
+
+      const title = this.form().get('title');
+      const touched = !!title?.touched;
+      const ids = [
+        this.titleHint() ? 'composer-title-hint' : null,
+        touched && title?.errors?.['required'] ? 'composer-title-required-error' : null,
+        touched && title?.errors?.['maxlength'] ? 'composer-title-maxlength-error' : null,
+      ].filter((id): id is string => id !== null);
+
+      return ids.length ? ids.join(' ') : null;
+    });
   }
 
   // Reads the loaded meeting rather than the control: the retained option has to stay the *stored*

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -91,7 +91,10 @@ export class ComposerDetailsAccessComponent {
       // `markAsTouched()` emits on neither `valueChanges` nor `statusChanges`, so this would keep a stale
       // list through exactly the case the errors exist for — tabbing out of an empty title. An id whose
       // element isn't rendered yet is ignored when the accessibility tree resolves the list, so listing it
-      // early costs nothing and the pointer starts resolving the moment the paragraph appears.
+      // early is inert; the cost is that the attribute can name an id no element has yet, which linters
+      // like axe report even though assistive tech doesn't care. Keeping both sides gated would mean
+      // bumping `revision` on blur, and the form service owns that signal for the whole composer — a
+      // per-field blur writing to it is a wider change than the association it would buy.
       const ids = [
         this.titleHint() ? 'composer-title-hint' : null,
         title?.errors?.['required'] ? 'composer-title-required-error' : null,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -87,11 +87,15 @@ export class ComposerDetailsAccessComponent {
       this.formService.revision();
 
       const title = this.form().get('title');
-      const touched = !!title?.touched;
+      // Deliberately not gated on `touched`, unlike the paragraphs themselves: a blur-driven
+      // `markAsTouched()` emits on neither `valueChanges` nor `statusChanges`, so this would keep a stale
+      // list through exactly the case the errors exist for — tabbing out of an empty title. An id whose
+      // element isn't rendered yet is ignored when the accessibility tree resolves the list, so listing it
+      // early costs nothing and the pointer starts resolving the moment the paragraph appears.
       const ids = [
         this.titleHint() ? 'composer-title-hint' : null,
-        touched && title?.errors?.['required'] ? 'composer-title-required-error' : null,
-        touched && title?.errors?.['maxlength'] ? 'composer-title-maxlength-error' : null,
+        title?.errors?.['required'] ? 'composer-title-required-error' : null,
+        title?.errors?.['maxlength'] ? 'composer-title-maxlength-error' : null,
       ].filter((id): id is string => id !== null);
 
       return ids.length ? ids.join(' ') : null;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -24,7 +24,7 @@ import { map, of, startWith, switchMap } from 'rxjs';
 import { MeetingComposerFormService } from '../meeting-composer-form.service';
 
 /**
- * Details & Access section of the meeting composer (LFXV2-3235).
+ * Details & Access section of the meeting composer (GH-1453).
  * @description Owns `title`, `meeting_type`, `visibility`, and `restricted`. Visibility and join
  * restriction are separate API fields with separate effects, so they render as two rows of one card
  * rather than as a single "privacy" control.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -19,7 +19,7 @@ import { ManualGuestDialogComponent } from '../manual-guest-dialog/manual-guest-
 import { MeetingComposerFormService } from '../meeting-composer-form.service';
 
 /**
- * Guests section of the meeting composer (LFXV2-3238).
+ * Guests section of the meeting composer (GH-1457).
  * @description Guests are editable before the meeting exists: the list lives on
  * `MeetingComposerFormService`, which derives the `RegistrantPendingChanges` persisted in the same
  * submit that creates the meeting. That removes the wizard's "create the meeting first" gate.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.ts
@@ -27,7 +27,7 @@ import { EMPTY, switchMap } from 'rxjs';
 import { MeetingComposerFormService } from '../meeting-composer-form.service';
 
 /**
- * Platform & Features section of the meeting composer (LFXV2-3237).
+ * Platform & Features section of the meeting composer (GH-1456).
  * @description Owns `platform`, the four feature toggles, `require_ai_summary_approval`,
  * `artifact_visibility`, and the email reminder timing. The recording dependency wiring and the
  * YouTube title-length validator behaviour are unchanged from the wizard.

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -49,7 +49,7 @@
                   [attr.data-testid]="'meeting-create-options-button'"
                   (onClick)="createMenu.toggle($event)">
                 </lfx-button>
-                <lfx-menu #createMenu [model]="createMenuItems" [popup]="true" appendTo="body"></lfx-menu>
+                <lfx-menu #createMenu [model]="createMenuItems()" [popup]="true" appendTo="body"></lfx-menu>
               </div>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -3,7 +3,7 @@
 
 import { isPlatformBrowser } from '@angular/common';
 import { Component, computed, inject, PLATFORM_ID, signal, Signal, WritableSignal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { IcalSubscribeDialogComponent } from '@app/modules/committees/components/ical-subscribe-dialog/ical-subscribe-dialog.component';
 import { MeetingCardComponent } from '@app/modules/meetings/components/meeting-card/meeting-card.component';
@@ -15,7 +15,7 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { MenuComponent } from '@components/menu/menu.component';
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS, MEETING_TYPE_OPTIONS } from '@lfx-one/shared/constants';
+import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import { Lens, MeLensMeetingFilters, Meeting, MeetingCalendarClickProps, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
 import {
@@ -23,6 +23,7 @@ import {
   getLargestSessionShareUrl,
   getPastMeetingResourceId,
   getPastMeetingStartTimeMs,
+  getSelectableMeetingTypeOptions,
   hasMeetingEnded,
   isMeetingInviteResponsesEnabled,
   isMeetingOrganizedByViewer,
@@ -49,6 +50,7 @@ import {
   distinctUntilChanged,
   EMPTY,
   expand,
+  filter,
   finalize,
   from,
   map,
@@ -99,23 +101,10 @@ export class MeetingsDashboardComponent {
   /**
    * Create Meeting dropdown: a quick start per meeting type, then the full drawer.
    * @description A type row opens the quick dialog pre-selected, so its template prefill runs immediately.
+   * Types come from the same persona filter the composer's type select uses — otherwise a maintainer
+   * could seed a type here that the select then hides, leaving it set but uneditable.
    */
-  public readonly createMenuItems: MenuItem[] = [
-    {
-      label: 'Quick start',
-      items: MEETING_TYPE_OPTIONS.map((option) => ({
-        label: option.label,
-        icon: option.info.icon,
-        command: () => this.onQuickCreateMeeting(option.value),
-      })),
-    },
-    { separator: true },
-    {
-      label: 'Advanced',
-      icon: 'fa-light fa-sliders',
-      command: () => this.onAdvancedCreateMeeting(),
-    },
-  ];
+  public readonly createMenuItems: Signal<MenuItem[]> = this.initCreateMenuItems();
 
   public readonly activeLens: Signal<Lens> = this.lensService.activeLens;
   protected readonly personaLoaded = this.personaService.personaLoaded;
@@ -282,6 +271,15 @@ export class MeetingsDashboardComponent {
     this.calendarLoading = computed(() =>
       this.activeLens() === 'me' ? this.meetingsLoading() || this.pastMeetingsLoading() : this.fpUpcomingLoading() || this.fpPastLoading()
     );
+
+    // The composer saves in place instead of navigating, so this list is what the organizer looks at
+    // straight after creating a meeting — refetch rather than leave the new meeting missing from it.
+    toObservable(this.composer.saveCount)
+      .pipe(
+        filter((count) => count > 0),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.refreshMeetings());
   }
 
   /** Main button: the quick create dialog. The dropdown covers per-type quick starts and the drawer. */
@@ -409,6 +407,25 @@ export class MeetingsDashboardComponent {
       }
       return `/projects/${encodeURIComponent(slug)}/calendar`;
     });
+  }
+
+  private initCreateMenuItems(): Signal<MenuItem[]> {
+    return computed(() => [
+      {
+        label: 'Quick start',
+        items: getSelectableMeetingTypeOptions(this.personaService.currentPersona()).map((option) => ({
+          label: option.label,
+          icon: option.info.icon,
+          command: () => this.onQuickCreateMeeting(option.value),
+        })),
+      },
+      { separator: true },
+      {
+        label: 'Advanced',
+        icon: 'fa-light fa-sliders',
+        command: () => this.onAdvancedCreateMeeting(),
+      },
+    ]);
   }
 
   private initCanWriteMeetings(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -50,7 +50,6 @@ import {
   distinctUntilChanged,
   EMPTY,
   expand,
-  filter,
   finalize,
   from,
   map,
@@ -59,6 +58,7 @@ import {
   Observable,
   of,
   scan,
+  skip,
   Subject,
   switchMap,
   take,
@@ -274,11 +274,12 @@ export class MeetingsDashboardComponent {
 
     // The composer saves in place instead of navigating, so this list is what the organizer looks at
     // straight after creating a meeting — refetch rather than leave the new meeting missing from it.
+    // `skip(1)` drops the value `toObservable` replays on subscribe. The counter is monotonic and lives in
+    // a root service, so on any mount after the first save that replay is a non-zero count describing a
+    // save this instance already loaded — refetching on it would double every request the streams below
+    // just made.
     toObservable(this.composer.saveCount)
-      .pipe(
-        filter((count) => count > 0),
-        takeUntilDestroyed()
-      )
+      .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => this.refreshMeetings());
   }
 

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.ts
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.ts
@@ -29,7 +29,7 @@ export class InputTextComponent {
   public readonly = input<boolean>(false);
   public maxlength = input<number>();
   /** Id of the element describing this input (e.g. its error message) — wired to `aria-describedby`. */
-  public describedBy = input<string>();
+  public describedBy = input<string | null>();
   /** Marks the control invalid for assistive tech; the visible error text is the caller's. */
   public invalid = input<boolean>(false);
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1836,6 +1836,7 @@ export interface MeetingComposerSection {
 export interface MeetingComposerRailRow {
   section: MeetingComposerSection;
   active: boolean;
+  /** Done and reachable — never set on the active row, and never on a locked one. */
   complete: boolean;
   /** Blocked by an earlier invalid required section — never set on the active row. */
   locked: boolean;

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1903,8 +1903,10 @@ export type MeetingComposerVariant = 'drawer' | 'quick';
 export interface MeetingComposerToastData {
   meetingUid: string;
   meetingTitle: string;
-  /** Router link to the meeting's details page. */
+  /** Router link to the meeting's public join page. */
   meetingUrl: string;
+  /** Query params that page needs — the access password, for a private or restricted meeting. */
+  meetingQueryParams: Record<string, string>;
 }
 
 /** Dialog data for the composer's manual guest entry dialog. */

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -6,9 +6,11 @@ import { HttpParams } from '@angular/common/http';
 import {
   CANCELLED_COLOR,
   COMMITTEE_TO_MEETING_VOTING_STATUS,
+  MAINTAINER_MEETING_TYPES,
   MEETING_ORGANIZER_SKIP_IDENTIFIERS,
   MEETING_TO_COMMITTEE_VOTING_STATUS,
   MEETING_TYPE_COLORS,
+  MEETING_TYPE_OPTIONS,
   PAST_MEETING_CALENDAR_COLOR,
   PAST_SURVEY_CALENDAR_COLOR,
   PAST_VOTE_CALENDAR_COLOR,
@@ -18,11 +20,12 @@ import {
   VOTE_COLOR,
 } from '../constants';
 import { lfxColors } from '../constants/colors.constants';
-import { CommitteeMemberVotingStatus, RecurrenceType } from '../enums';
+import { RecurrenceType, CommitteeMemberVotingStatus, MeetingType } from '../enums';
 import { PollStatus } from '../enums/poll.enum';
 import type {
   BuildMeetingOccurrenceRouteOptions,
   CalendarColor,
+  CardSelectorOption,
   CustomRecurrencePattern,
   Meeting,
   MeetingAllowedVotingStatus,
@@ -39,6 +42,7 @@ import type {
   PastMeeting,
   PastMeetingSummary,
   PastMeetingTranscript,
+  PersonaType,
   PublicMeetingOccurrencesResponse,
   QueryServiceItem,
   RecurrenceSummary,
@@ -1481,4 +1485,19 @@ export function reconcileOptimisticPad(state: { pad: number; before: number | nu
   const absorbed = Math.max(0, state.current - state.before);
   const pad = Math.max(0, state.pad - absorbed);
   return { pad, before: pad === 0 ? null : state.current };
+}
+
+/**
+ * Meeting types the given persona may pick when creating a meeting.
+ * @description Shared by every create surface — the composer's type select and the dashboard's Quick
+ * start menu — so a persona can't reach a type through one entry point that the other hides.
+ * `hydratedMeetingType` is the type already stored on the meeting being edited: it stays selectable
+ * even when the persona couldn't have created it, or editing would silently drop it.
+ */
+export function getSelectableMeetingTypeOptions(persona: PersonaType, hydratedMeetingType: MeetingType | null = null): CardSelectorOption<MeetingType>[] {
+  if (persona !== 'maintainer') {
+    return MEETING_TYPE_OPTIONS;
+  }
+
+  return MEETING_TYPE_OPTIONS.filter((option) => MAINTAINER_MEETING_TYPES.includes(option.value) || option.value === hydratedMeetingType);
 }


### PR DESCRIPTION
> **Stack 8 of 20.** Based on PR 7 (`feat/issue-1460-quick-create-toast`). Followed by PR 9 (`feat/issue-1464-agenda-ai-attribution`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Addresses the review findings raised across all the composer sections — attention and disabled states, prefill hints, mode handling, and accessibility wiring for the title field.

## How

- Anchors each prefill hint to the control it describes instead of floating at section level.
- Reduces composer mode to a single source of truth rather than several components each deriving it.
- Keeps the title field's `aria-describedby` ids current as its error and hint elements come and go, and names both title errors in the accessibility note.
- Turns the title-description specs into real guards rather than assertions that passed vacuously.
- Repoints the in-code story references at their GitHub issues.

## Commits

12 commit(s), 26 files changed, 708 insertions(+), 138 deletions(-).

- `fix(meetings): address composer review findings`
- `fix(meetings): correct composer review-fix regressions`
- `fix(meetings): tighten composer attention and disabled states`
- `fix(meetings): fix composer prefill hints and load failure state`
- `fix(meetings): scope composer prefill hints to their fields`
- `fix(meetings): anchor composer prefill hints to their controls`
- `fix(meetings): read composer mode from one source`
- `fix(meetings): keep the title description ids current`
- `test(meetings): make the title description specs real guards`
- `docs(meetings): name the mode readers that actually read mode`
- `docs(meetings): name both title errors in the a11y note`
- `docs(meetings): point composer story refs at github issues`

## Related

- Refs #1452
- Refs #1453
- Refs #1454
- Refs #1456
- Refs #1457
- Refs #1458
- Refs #1459
- Refs #1460
- Refs #1461
- Refs #1462
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
