### PR TITLE
fix(meetings): use upstream registrant field names and surface real errors

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -564,15 +564,25 @@ export class AddMemberDialogComponent {
     if (err.status === 409) {
       return 'already a member';
     }
-    return extractErrorMessage(err, 'add failed');
+    return this.asSentenceFragment(extractErrorMessage(err, 'add failed'));
   }
 
   private inviteFailureReason(err: HttpErrorResponse): string {
     if (err.status === 409) {
       return 'already invited or a member';
     }
-    const upstream = typeof err.error?.message === 'string' ? err.error.message : null;
-    return upstream ?? 'invite failed';
+    return this.asSentenceFragment(extractErrorMessage(err, 'invite failed'));
+  }
+
+  /**
+   * Both reasons above are interpolated mid-sentence and the caller supplies the period
+   * (`Could not invite ${email}: ${reason}.`). The hard-coded reasons are written as fragments to suit
+   * that, but a server message is a whole sentence and usually ends in one — so without this a toast
+   * reads "Email address is required..". Only a trailing period is dropped; a "?" or "!" is left alone
+   * on the grounds that a server sentence ending in either is deliberate enough to keep.
+   */
+  private asSentenceFragment(reason: string): string {
+    return reason.endsWith('.') ? reason.slice(0, -1) : reason;
   }
 
   private organizationFormValue(): {

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -73,8 +73,9 @@ export class PublicRegistrationModalComponent {
           first_name: formValue.first_name,
           last_name: formValue.last_name,
           // Omitted when blank rather than sent as `null` — see the note on
-          // `CreateMeetingRegistrantRequest`. This is the path with no user session, so the BFF's
-          // null-drop is the only thing between this form and upstream; don't lean on it.
+          // `CreateMeetingRegistrantRequest`. There is no null-laundering anywhere on this path: the
+          // BFF's one such drop is `committee_uid`-specific and this endpoint doesn't send one, so a
+          // `null` here would reach upstream verbatim, onto a field it declares non-nullable.
           ...(formValue.job_title ? { job_title: formValue.job_title } : {}),
           ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -73,9 +73,10 @@ export class PublicRegistrationModalComponent {
           first_name: formValue.first_name,
           last_name: formValue.last_name,
           // Omitted when blank rather than sent as `null` — see the note on
-          // `CreateMeetingRegistrantRequest`. There is no null-laundering anywhere on this path: the
-          // BFF's one such drop is `committee_uid`-specific and this endpoint doesn't send one, so a
-          // `null` here would reach upstream verbatim, onto a field it declares non-nullable.
+          // `CreateMeetingRegistrantRequest`. Upstream declares both fields non-nullable. The BFF now
+          // drops a blank or nullish one on this path too (`toSelfRegistration`, then
+          // `toUpstreamRegistrantBody`), so this is defense in depth rather than the only guard — keep
+          // it, because neither of those exists to serve this form and both could be re-scoped.
           ...(formValue.job_title ? { job_title: formValue.job_title } : {}),
           ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -96,7 +96,12 @@ export class PublicRegistrationModalComponent {
             // `error?.error?.message` never matched: the server's error body is `{ error, code }` with
             // no `message` key (`BaseApiError.toResponse`), so every failure showed the fallback and a
             // registrant was never told which field was wrong. `extractErrorMessage` reads the body's
-            // `error` key too, so a validation message reaches the toast.
+            // `error` key too, so a validation message reaches the toast. One of its rules bites on
+            // this path today — it skips a 5xx body, and registration can 500. Its wire-key rule
+            // (prefer the reason in `errors[]` over a top-level "Validation failed for timing")
+            // does not: both `fromFieldErrors` calls in `registerForPublicMeeting` pass a message
+            // written for a person. It would apply if this path ever routed a `forField` error here,
+            // as the sibling join-url endpoint does. See `readErrorBodyMessage`.
             const errorMessage = extractErrorMessage(error, 'Failed to register for this meeting');
             this.messageService.add({
               severity: 'error',

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -9,6 +9,7 @@ import { OrganizationSearchComponent } from '@components/organization-search/org
 import { MeetingRegistrant, User } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
+import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -90,9 +91,13 @@ export class PublicRegistrationModalComponent {
             });
             this.ref.close({ registered: true, registrant });
           },
-          error: (error: any) => {
+          error: (error: unknown) => {
             this.submitting.set(false);
-            const errorMessage = error?.error?.message || 'Failed to register for this meeting';
+            // `error?.error?.message` never matched: the server's error body is `{ error, code }` with
+            // no `message` key (`BaseApiError.toResponse`), so every failure showed the fallback and a
+            // registrant was never told which field was wrong. `extractErrorMessage` reads `message`
+            // then `error`, so a validation message reaches the toast.
+            const errorMessage = extractErrorMessage(error, 'Failed to register for this meeting');
             this.messageService.add({
               severity: 'error',
               summary: 'Registration Failed',

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -95,8 +95,8 @@ export class PublicRegistrationModalComponent {
             this.submitting.set(false);
             // `error?.error?.message` never matched: the server's error body is `{ error, code }` with
             // no `message` key (`BaseApiError.toResponse`), so every failure showed the fallback and a
-            // registrant was never told which field was wrong. `extractErrorMessage` reads `message`
-            // then `error`, so a validation message reaches the toast.
+            // registrant was never told which field was wrong. `extractErrorMessage` reads the body's
+            // `error` key too, so a validation message reaches the toast.
             const errorMessage = extractErrorMessage(error, 'Failed to register for this meeting');
             this.messageService.add({
               severity: 'error',

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -72,8 +72,11 @@ export class PublicRegistrationModalComponent {
           email: formValue.email,
           first_name: formValue.first_name,
           last_name: formValue.last_name,
-          job_title: formValue.job_title || null,
-          org_name: formValue.org_name || null,
+          // Omitted when blank rather than sent as `null` — see the note on
+          // `CreateMeetingRegistrantRequest`. This is the path with no user session, so the BFF's
+          // null-drop is the only thing between this form and upstream; don't lean on it.
+          ...(formValue.job_title ? { job_title: formValue.job_title } : {}),
+          ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })
         .subscribe({
           next: (registrant: MeetingRegistrant) => {

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.spec.ts
@@ -325,7 +325,10 @@ describe('AccountSettingsComponent — meeting-invite selection & delete guard (
     fixture.componentInstance.setMeetingInvite(ALT_EMAIL);
 
     expect(fixture.componentInstance.meetingInviteError()).toBeNull();
-    expect(messageServiceMock.add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'try again later' }));
+    // The 503's own body is deliberately dropped in favour of the caller's fallback: `extractErrorMessage`
+    // stopped reading 5xx bodies because they are overwhelmingly the envelope's "Internal server error"
+    // or a Go-service string forwarded verbatim, neither of which names the action that failed.
+    expect(messageServiceMock.add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Failed to update meeting invitation email' }));
   });
 
   it('fails closed and skips the delete flow entirely when the invite lookup itself failed', async () => {

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -30,9 +30,10 @@ export class TextareaComponent {
    * `ReactiveFormsModule` this component imports, so a property binding here would silently attach
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
-   * gated declare `Validators.maxLength` on the control themselves — as the composer's agenda and
-   * the settings description do. The rest rely on the native cap alone, which holds for typing and
-   * pasting but not for a value written programmatically with `setValue`.
+   * gated declare `Validators.maxLength` on the control themselves — the composer's agenda, the
+   * settings description and the org-profile description all do. The rest rely on the native cap
+   * alone, which holds for typing and pasting but not for a value written programmatically with
+   * `setValue`.
    */
   public maxlength = input<number>();
   public dataTest = input<string>();

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -31,9 +31,9 @@ export class TextareaComponent {
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
    * gated declare `Validators.maxLength` on the control themselves — the composer's agenda, the
-   * crowdfunding initiative settings description and the org-profile description all do. The rest rely on the native cap
-   * alone, which holds for typing and pasting but not for a value written programmatically with
-   * `setValue`.
+   * crowdfunding initiative settings description and the newsletter drawer's raw content and system
+   * prompt among them. The rest rely on the native cap alone, which holds for typing and pasting but
+   * not for a value written programmatically with `setValue`.
    */
   public maxlength = input<number>();
   public dataTest = input<string>();

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -31,7 +31,7 @@ export class TextareaComponent {
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
    * gated declare `Validators.maxLength` on the control themselves — the composer's agenda, the
-   * settings description and the org-profile description all do. The rest rely on the native cap
+   * crowdfunding initiative settings description and the org-profile description all do. The rest rely on the native cap
    * alone, which holds for typing and pasting but not for a value written programmatically with
    * `setValue`.
    */

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -635,10 +635,10 @@ export class MeetingService {
    *
    * Every optional string is omitted when empty rather than sent as `null`: upstream declares
    * `committee_uid`, `job_title` and `org` alike as non-nullable optional `string`s
-   * (`CreateItxRegistrantRequestBody`). The BFF drops a stray `null` anyway, but relying on that
-   * would mean shipping an off-contract body and trusting the proxy to launder it. The create body
-   * has nothing to clear, so omission loses no meaning — unlike {@link getChangedFields}, where
-   * `null` is how an update erases a stored value.
+   * (`CreateItxRegistrantRequestBody`). Nothing downstream launders a stray `null` — the BFF's only
+   * such drop is `committee_uid`-specific, on the v2 → v1 resolution path — so a `null` here reaches
+   * upstream verbatim. The create body has nothing to clear, so omission loses no meaning — unlike
+   * {@link getChangedFields}, where `null` is how an update erases a stored value.
    */
   public stripMetadata(meetingUid: string, registrant: MeetingRegistrantWithState): CreateMeetingRegistrantRequest {
     return {

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,7 +5,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { extractErrorMessage, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
+import { extractErrorMessage, getHttpErrorDetail, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });
@@ -14,6 +14,39 @@ function httpError(status: number): HttpErrorResponse {
 function httpErrorWithBody(status: number, error: unknown): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing', error });
 }
+
+describe('getHttpErrorDetail', () => {
+  // The read that was dead before: every server error body is `{ error, code }`, so a reader that
+  // only knew `message` fell through to the hard-coded per-status string on every real failure.
+  it('reads the `error` key this server actually sends', () => {
+    const error = new HttpErrorResponse({ status: 409, error: { error: 'A member with that email already exists.', code: 'CONFLICT' } });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('A member with that email already exists.');
+  });
+
+  it('still reads a `message` key, for upstream bodies that use it', () => {
+    const error = new HttpErrorResponse({ status: 422, error: { message: 'Upstream said no' } });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('Upstream said no');
+  });
+
+  it('uses the status hint when the body carries no message', () => {
+    expect(getHttpErrorDetail(httpError(403), 'fallback')).toBe('You do not have permission to perform this action.');
+    expect(getHttpErrorDetail(httpError(404), 'fallback')).toBe('The resource was not found.');
+  });
+
+  it('uses the caller fallback for a status with no hint', () => {
+    expect(getHttpErrorDetail(httpError(500), 'Could not save your changes.')).toBe('Could not save your changes.');
+  });
+
+  // A plain-text body (an upstream 502 HTML page, say) is not a reason to show, so the status hint
+  // still wins — unlike `extractErrorMessage`, whose callers have no hint layer to fall back to.
+  it('ignores a plain-string body', () => {
+    const error = new HttpErrorResponse({ status: 404, error: 'Not Found' });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('The resource was not found.');
+  });
+});
 
 describe('isTransientHttpError', () => {
   // Each status is named rather than looped so a failure says WHICH class of

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
+import { MAX_PLAIN_TEXT_BODY_LENGTH } from '@lfx-one/shared/constants';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
@@ -39,12 +40,240 @@ describe('getHttpErrorDetail', () => {
     expect(getHttpErrorDetail(httpError(500), 'Could not save your changes.')).toBe('Could not save your changes.');
   });
 
+  // `ServiceValidationError.forField` interpolates the WIRE KEY into the top-level message, so showing
+  // it puts "Validation failed for invitee_email" in a toast. The readable reason is in `errors[0]`.
+  it('prefers the field reason over a wire-key `Validation failed for` message', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: {
+        error: 'Validation failed for invitee_email',
+        code: 'VALIDATION_ERROR',
+        errors: [{ field: 'invitee_email', message: 'Email address is required' }],
+      },
+    });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('Email address is required');
+  });
+
+  // The other half of that rule: a top-level message written for a person (what `fromFieldErrors` is
+  // given on the public-registration guards) wins over the wire-keyed field array.
+  it('keeps a human top-level message over the field array', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { error: 'Email address is required.', code: 'VALIDATION_ERROR', errors: [{ field: 'email', message: 'Email address is required' }] },
+    });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('Email address is required.');
+  });
+
+  // The match is the two shapes `ServiceValidationError` mints — the bare prefix and `prefix + ' for '`
+  // — rather than any `startsWith`, so a human message that opens with the same words keeps its place.
+  it('does not demote a human message that merely starts with the prefix', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: {
+        error: 'Validation failed. Please check the highlighted fields.',
+        code: 'VALIDATION_ERROR',
+        errors: [{ field: 'email', message: 'Email address is required' }],
+      },
+    });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('Validation failed. Please check the highlighted fields.');
+  });
+
+  // A body with no top-level message at all can't come from this server's envelope — `toResponse()`
+  // always sets `error` — but an upstream service is free to send one, and the field array is then
+  // the only thing to read.
+  it('reads the field array when a foreign body carries no top-level message', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { code: 'VALIDATION_ERROR', errors: [{ field: 'email', message: 'Email address is required' }] },
+    });
+
+    expect(getHttpErrorDetail(error, 'fallback')).toBe('Email address is required');
+  });
+
+  // A 5xx body says "Internal server error", or repeats an upstream Go service's message verbatim.
+  // Neither is something to show a user, and both would displace the fallback that at least names
+  // the action that failed.
+  it('ignores a 5xx body in favour of the caller fallback', () => {
+    const error = new HttpErrorResponse({ status: 500, error: { error: 'Internal server error', code: 'INTERNAL_ERROR' } });
+
+    expect(getHttpErrorDetail(error, 'Could not save your changes.')).toBe('Could not save your changes.');
+  });
+
+  // `withFetch()` is on (`app.config.ts`), and Angular's fetch backend puts the raw thrown value in
+  // `HttpErrorResponse.error` — an `Error` reads as an object with a `message` key, which is exactly the
+  // shape this reader looks for. The 5xx skip does not cover it either: the status is 0.
+  it('ignores a thrown Error in the body on a network drop', () => {
+    const error = new HttpErrorResponse({ status: 0, error: new TypeError('Failed to fetch') });
+
+    expect(getHttpErrorDetail(error, 'Could not reach the server. Please try again.')).toBe('Could not reach the server. Please try again.');
+  });
+
+  // `MicroserviceError.toResponse()` forwards `errors` verbatim from upstream, so its shape is an
+  // upstream Go service's choice. Reading it unguarded threw from inside a `catchError` — costing the
+  // user the toast entirely rather than degrading it to a status hint. The fallback is the hint and
+  // NOT the top-level message: that one is already known to be a wire key here, so showing it would
+  // put "Validation failed for x" in the toast — the string this branch exists to suppress.
+  it('falls back to the status hint when `errors` is not an array of objects', () => {
+    const asString = new HttpErrorResponse({ status: 404, error: { error: 'Validation failed for x', code: 'VALIDATION_ERROR', errors: 'nope' } });
+    const asObject = new HttpErrorResponse({ status: 404, error: { error: 'Validation failed for x', code: 'VALIDATION_ERROR', errors: { x: 'nope' } } });
+    const ofStrings = new HttpErrorResponse({ status: 404, error: { error: 'Validation failed for x', code: 'VALIDATION_ERROR', errors: ['nope'] } });
+    const missing = new HttpErrorResponse({ status: 400, error: { error: 'Validation failed for x', code: 'VALIDATION_ERROR' } });
+
+    expect(getHttpErrorDetail(asString, 'fallback')).toBe('The resource was not found.');
+    expect(getHttpErrorDetail(asObject, 'fallback')).toBe('The resource was not found.');
+    expect(getHttpErrorDetail(ofStrings, 'fallback')).toBe('The resource was not found.');
+    expect(getHttpErrorDetail(missing, 'Could not add that member.')).toBe('Could not add that member.');
+  });
+
   // A plain-text body (an upstream 502 HTML page, say) is not a reason to show, so the status hint
   // still wins — unlike `extractErrorMessage`, whose callers have no hint layer to fall back to.
   it('ignores a plain-string body', () => {
     const error = new HttpErrorResponse({ status: 404, error: 'Not Found' });
 
     expect(getHttpErrorDetail(error, 'fallback')).toBe('The resource was not found.');
+  });
+});
+
+describe('extractErrorMessage', () => {
+  // `error` and not `message` is the key that matters: `BaseApiError.toResponse()` emits
+  // `{ error, code }`, so a reader that only knows `message` shows the fallback on every server
+  // validation failure — which is what it did before this was the util in use.
+  it('reads the `error` key this server actually sends', () => {
+    const error = new HttpErrorResponse({ status: 400, error: { error: 'Email address is required.', code: 'VALIDATION_ERROR' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Email address is required.');
+  });
+
+  it('still reads a `message` key, for upstream bodies that use it', () => {
+    const error = new HttpErrorResponse({ status: 400, error: { message: 'Upstream said no' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Upstream said no');
+  });
+
+  // Angular populates `HttpErrorResponse.message` for every failure with a string built for a
+  // console — "Http failure response for /api/thing: 0 Unknown Error". Preferring it would put a URL
+  // and a status code in front of a user on exactly the failures with no body to read.
+  it('prefers the caller fallback over Angular internal message text', () => {
+    const detail = extractErrorMessage(httpError(0), 'Could not reach the server. Please try again.');
+
+    expect(detail).toBe('Could not reach the server. Please try again.');
+    expect(detail).not.toContain('Http failure');
+  });
+
+  // 4xx, not 5xx: at 5xx this passes through the status skip and stops testing the branch it names.
+  it('falls back when the body is an object with no usable string', () => {
+    const error = new HttpErrorResponse({ status: 400, error: { code: 'BOOM' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  // Unlike `getHttpErrorDetail`, this one has no status-hint layer to fall back to, so a plain-text
+  // 4xx body is the best thing it has.
+  it('uses a plain-string body as the message', () => {
+    const error = new HttpErrorResponse({ status: 400, error: 'Missing project' });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Missing project');
+  });
+
+  // Angular's `parseBody` returns the raw response TEXT for any non-2xx body that isn't JSON, so a
+  // proxy or WAF page — a 413 from an nginx body-size limit, say — arrives as a whole HTML document.
+  // Reading it verbatim put that document in a toast, and in the `stripeError` signal at
+  // `add-payment-card-dialog.component.ts:119`, which renders it as a persistent block.
+  // The same text branch also catches a JSON document sent under the wrong content type and a stack
+  // trace — both reach a toast as a plain string, and neither is one sentence about the request.
+  it('refuses a plain-string body that is not one sentence', () => {
+    const fallback = 'Your file is too large to upload.';
+    const html = new HttpErrorResponse({ status: 413, error: '<html><head><title>413 Request Entity Too Large</title></head><body>...</body></html>' });
+    const json = new HttpErrorResponse({ status: 400, error: '{"error":"upstream timeout"}' });
+    const trace = new HttpErrorResponse({ status: 400, error: 'Error: upstream timeout\n    at Object.<anonymous> (/srv/app.js:12:9)' });
+    const wall = new HttpErrorResponse({ status: 400, error: 'x'.repeat(MAX_PLAIN_TEXT_BODY_LENGTH + 1) });
+
+    expect(extractErrorMessage(html, fallback)).toBe(fallback);
+    expect(extractErrorMessage(json, fallback)).toBe(fallback);
+    expect(extractErrorMessage(trace, fallback)).toBe(fallback);
+    expect(extractErrorMessage(wall, fallback)).toBe(fallback);
+  });
+
+  // The length and newline halves apply to a string inside an object body too — `MicroserviceError`
+  // takes its message from the upstream body at any status, so what lands in `error` on a 4xx can be a
+  // multi-line or arbitrarily long Go-service string rather than anything this server wrote.
+  it('refuses an object-body message that is not one line', () => {
+    const fallback = 'Could not save your changes.';
+    const multiline = new HttpErrorResponse({ status: 400, error: { error: 'rpc error: code = InvalidArgument\n\tdesc = bad field' } });
+    const wall = new HttpErrorResponse({ status: 400, error: { message: 'y'.repeat(MAX_PLAIN_TEXT_BODY_LENGTH + 1) } });
+    const wireKeyedWall = new HttpErrorResponse({
+      status: 400,
+      error: { error: 'Validation failed for id', code: 'VALIDATION_ERROR', errors: [{ field: 'id', message: 'z'.repeat(MAX_PLAIN_TEXT_BODY_LENGTH + 1) }] },
+    });
+
+    expect(extractErrorMessage(multiline, fallback)).toBe(fallback);
+    expect(extractErrorMessage(wall, fallback)).toBe(fallback);
+    expect(getHttpErrorDetail(wireKeyedWall, fallback)).toBe(fallback);
+  });
+
+  // Same policy as `getHttpErrorDetail`: nothing in a 5xx body was written for a user, and both the
+  // envelope's "Internal server error" and a forwarded Go-service string would displace the caller's
+  // fallback, which at least names the action that failed.
+  it('ignores a 5xx body in favour of the caller fallback', () => {
+    const envelope = new HttpErrorResponse({ status: 500, error: { error: 'Internal server error', code: 'INTERNAL_ERROR' } });
+    const upstreamText = new HttpErrorResponse({ status: 502, error: 'Bad gateway' });
+
+    expect(extractErrorMessage(envelope, 'Could not save your changes.')).toBe('Could not save your changes.');
+    expect(extractErrorMessage(upstreamText, 'Could not save your changes.')).toBe('Could not save your changes.');
+  });
+
+  it('reads a field reason when the top-level message carries a wire key', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: {
+        error: 'Validation failed for occurrence_id',
+        code: 'VALIDATION_ERROR',
+        errors: [{ field: 'occurrence_id', message: 'Occurrence ID is required' }],
+      },
+    });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Occurrence ID is required');
+  });
+
+  // `errors` is unknown runtime data: a body that is not this server's validation envelope can shape
+  // it as anything. Reading it unguarded threw, which cost the caller its toast entirely; the
+  // top-level message is still readable here because nothing marks the body as wire-keyed.
+  it('does not throw when `errors` is present but not an array', () => {
+    const error = new HttpErrorResponse({ status: 400, error: { message: 'Bad request', errors: 'validation failed' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Bad request');
+  });
+
+  // Same unknown-data argument one level down: within a well-formed array, an individual entry can
+  // still be null or missing `message`. The first entry that carries one wins rather than the first
+  // entry full stop, so a malformed leading entry does not cost the reader the reason behind it.
+  it('tolerates malformed entries inside a well-formed errors array', () => {
+    const error = new HttpErrorResponse({
+      status: 400,
+      error: { error: 'Validation failed', code: 'VALIDATION_ERROR', errors: [null, { field: 'x' }, { message: 'The real detail' }] },
+    });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('The real detail');
+  });
+
+  // Same fetch-backend shapes as above. The parse failure is the one the 5xx skip cannot catch: the
+  // status is the real response status, so a malformed 200 would otherwise show "Unexpected token <".
+  it('ignores a thrown Error in the body, on a network drop and on a parse failure', () => {
+    const dropped = new HttpErrorResponse({ status: 0, error: new TypeError('Failed to fetch') });
+    const unparsable = new HttpErrorResponse({ status: 200, error: new SyntaxError('Unexpected token < in JSON at position 0') });
+
+    expect(extractErrorMessage(dropped, 'Could not reach the server.')).toBe('Could not reach the server.');
+    expect(extractErrorMessage(unparsable, 'Could not reach the server.')).toBe('Could not reach the server.');
+  });
+
+  // An `Error` the caller threw itself is still worth reading — it is the one place the message was
+  // written by this codebase rather than by a network stack.
+  it('reads a thrown Error message, and falls back for anything else', () => {
+    expect(extractErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+    expect(extractErrorMessage(null, 'fallback')).toBe('fallback');
   });
 });
 
@@ -122,77 +351,6 @@ describe('retryTransientHttpError', () => {
   });
 });
 
-describe('extractErrorMessage', () => {
-  it('prefers the field-level detail in a ServiceValidationError body over the generic top-level message', () => {
-    // Mirrors ServiceValidationError.forField's response shape: a generic top-level `error`
-    // wrapper plus the actionable detail buried in `errors[0].message`.
-    const error = httpErrorWithBody(400, {
-      error: 'Validation failed for registrants',
-      code: 'VALIDATION_ERROR',
-      errors: [{ field: 'registrants', message: 'This meeting has 62 registrants — imports are limited to 50 per meeting.', code: 'FIELD_VALIDATION_ERROR' }],
-    });
-
-    expect(extractErrorMessage(error, 'fallback')).toBe('This meeting has 62 registrants — imports are limited to 50 per meeting.');
-  });
-
-  it('falls back to the top-level message when errors is absent', () => {
-    const error = httpErrorWithBody(404, { message: 'Meeting not found' });
-
-    expect(extractErrorMessage(error, 'fallback')).toBe('Meeting not found');
-  });
-
-  // `error` and not `message` is the key that matters here: `BaseApiError.toResponse()` emits
-  // `{ error, code }`, so a reader that only knows `message` shows the fallback on every server
-  // validation failure.
-  it('falls back to the top-level error when message is absent', () => {
-    const error = httpErrorWithBody(403, { error: 'Not authorized' });
-
-    expect(extractErrorMessage(error, 'fallback')).toBe('Not authorized');
-  });
-
-  // Angular synthesizes `HttpErrorResponse.message` for every failure as a string written for a
-  // console — "Http failure response for /api/thing: 500 x". Preferring it would put a URL and a
-  // status code in front of a user on exactly the failures with no body to read, so the caller's
-  // fallback — which is written for a human — wins instead.
-  it('prefers the caller fallback over Angular synthesized message text', () => {
-    const detail = extractErrorMessage(httpErrorWithBody(500, {}), 'fallback');
-
-    expect(detail).toBe('fallback');
-    expect(detail).not.toContain('Http failure');
-  });
-
-  it('prefers the caller fallback for a network drop, which has no body at all', () => {
-    const detail = extractErrorMessage(httpError(0), 'Could not reach the server. Please try again.');
-
-    expect(detail).toBe('Could not reach the server. Please try again.');
-  });
-
-  it('does not throw when errors is present but not an array — falls back to the top-level message', () => {
-    // body.error is unknown runtime data; a non-ServiceValidationError upstream could shape
-    // `errors` as anything (e.g. a string), not just the expected array of field errors.
-    const error = httpErrorWithBody(400, { message: 'Bad request', errors: 'validation failed' });
-
-    expect(extractErrorMessage(error, 'fallback')).toBe('Bad request');
-  });
-
-  it('tolerates malformed entries inside a well-formed errors array', () => {
-    const error = httpErrorWithBody(400, { error: 'Validation failed', errors: [null, { field: 'x' }, { message: 'The real detail' }] });
-
-    expect(extractErrorMessage(error, 'fallback')).toBe('The real detail');
-  });
-
-  it('returns a plain string body directly', () => {
-    const error = httpErrorWithBody(500, 'upstream down');
-
-    expect(extractErrorMessage(error, 'fallback')).toBe('upstream down');
-  });
-
-  it('handles a plain Error and an unknown value', () => {
-    expect(extractErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
-    expect(extractErrorMessage('not an error', 'fallback')).toBe('fallback');
-  });
-});
-
 /**
  * The composition for anywhere the fallback is user-facing copy rather than a debugging default.
  * `extractErrorMessage` alone cannot serve that case: it ends with `error.message || fallback`,
@@ -210,14 +368,26 @@ describe('serverAuthoredMessage', () => {
     expect(serverAuthoredMessage(httpErrorWithBody(403, body), 'fallback')).toBe('This organization requires additional review');
   });
 
+  // Field-level detail wins on exactly the bodies `extractErrorMessage` gives it to: a
+  // `VALIDATION_ERROR` whose top-level text is the wire key the error class interpolated itself.
+  // A top-level message written for a person still beats the field array, so this composition
+  // cannot start preferring a field reason the other reader would not have shown.
   it('prefers a field-level detail, exactly as extractErrorMessage does', () => {
-    const error = httpErrorWithBody(400, { error: 'Validation failed', errors: [{ message: 'The real detail' }] });
+    const error = httpErrorWithBody(400, {
+      error: 'Validation failed for invitee_email',
+      code: 'VALIDATION_ERROR',
+      errors: [{ message: 'The real detail' }],
+    });
 
     expect(serverAuthoredMessage(error, 'fallback')).toBe('The real detail');
   });
 
-  it('returns a plain string body directly', () => {
-    expect(serverAuthoredMessage(httpErrorWithBody(502, 'upstream down'), 'fallback')).toBe('upstream down');
+  // Below 500 a plain-string body is a sentence about the request and is shown as-is. At 5xx it is
+  // not read at all — that range is where "Internal server error" and verbatim Go-service strings
+  // live — so the caller's fallback, which at least names the action, wins there.
+  it('returns a plain string body directly, and refuses one from a 5xx', () => {
+    expect(serverAuthoredMessage(httpErrorWithBody(409, 'That email is already invited'), 'fallback')).toBe('That email is already invited');
+    expect(serverAuthoredMessage(httpErrorWithBody(502, 'upstream down'), 'fallback')).toBe('fallback');
   });
 
   // The whole reason this exists, and the case `extractErrorMessage` gets wrong.

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -108,18 +108,30 @@ describe('extractErrorMessage', () => {
     expect(extractErrorMessage(error, 'fallback')).toBe('Meeting not found');
   });
 
+  // `error` and not `message` is the key that matters here: `BaseApiError.toResponse()` emits
+  // `{ error, code }`, so a reader that only knows `message` shows the fallback on every server
+  // validation failure.
   it('falls back to the top-level error when message is absent', () => {
     const error = httpErrorWithBody(403, { error: 'Not authorized' });
 
     expect(extractErrorMessage(error, 'fallback')).toBe('Not authorized');
   });
 
-  it('falls back to the synthesized HttpErrorResponse message when the body has no usable message', () => {
-    // HttpErrorResponse always synthesizes a `.message` ("Http failure response for ..."), so an
-    // empty/unusable body never reaches the caller-provided fallback string for a real HTTP error.
-    const error = httpErrorWithBody(500, {});
+  // Angular synthesizes `HttpErrorResponse.message` for every failure as a string written for a
+  // console — "Http failure response for /api/thing: 500 x". Preferring it would put a URL and a
+  // status code in front of a user on exactly the failures with no body to read, so the caller's
+  // fallback — which is written for a human — wins instead.
+  it('prefers the caller fallback over Angular synthesized message text', () => {
+    const detail = extractErrorMessage(httpErrorWithBody(500, {}), 'fallback');
 
-    expect(extractErrorMessage(error, 'fallback')).toContain('Http failure response');
+    expect(detail).toBe('fallback');
+    expect(detail).not.toContain('Http failure');
+  });
+
+  it('prefers the caller fallback for a network drop, which has no body at all', () => {
+    const detail = extractErrorMessage(httpError(0), 'Could not reach the server. Please try again.');
+
+    expect(detail).toBe('Could not reach the server. Please try again.');
   });
 
   it('does not throw when errors is present but not an array — falls back to the top-level message', () => {

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -7,11 +7,17 @@ import { MonoTypeOperatorFunction, retry, throwError, timer } from 'rxjs';
 
 /**
  * Extracts a user-friendly error message from an HttpErrorResponse.
- * Prefers the upstream service message when available; falls back to
+ * Prefers the server's own message when the body carries one; falls back to
  * status-code hints, then the provided fallback string.
+ *
+ * The body's `error` key is read as well as `message`, because `error` is the one this server
+ * actually sends — `BaseApiError.toResponse()` emits `{ error, code }` and no `message`. Reading only
+ * `message` left every branch below on its hard-coded string, so a server validation reason never
+ * reached the ~13 committee and profile call sites.
  */
 export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): string {
-  const upstream = err.error?.message as string | undefined;
+  const body = err.error as { message?: string; error?: string } | string | null;
+  const upstream = typeof body === 'string' ? undefined : [body?.message, body?.error].find((value) => typeof value === 'string' && value.trim().length > 0);
 
   switch (err.status) {
     case 409:
@@ -42,8 +48,8 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
  * Angular fills that property in for every failure with a string built for a developer reading a
  * console — "Http failure response for /public/api/...: 0 Unknown Error" — so preferring it would
  * put a URL and a status code in front of a user on exactly the failures where the body is empty:
- * a network drop, or a 500 with no envelope. Every call site passes a written-for-a-human fallback;
- * that is the one to show.
+ * a network drop, or a 500 with no envelope. Call sites are expected to pass a written-for-a-human
+ * fallback; that is the one to show.
  */
 export function extractErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpErrorResponse) {

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -34,6 +34,16 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
  * a thrown Error, or any other value. Used by components that catch errors
  * from `firstValueFrom(...)` or RxJS `catchError` and need to surface a
  * single string to the UI.
+ *
+ * `body.error` is read as well as `body.message` because that is the key this server's error
+ * envelope actually uses — `BaseApiError.toResponse()` emits `{ error, code }` and no `message`.
+ *
+ * When the body yields nothing, the caller's `fallback` wins over `HttpErrorResponse.message`.
+ * Angular fills that property in for every failure with a string built for a developer reading a
+ * console — "Http failure response for /public/api/...: 0 Unknown Error" — so preferring it would
+ * put a URL and a status code in front of a user on exactly the failures where the body is empty:
+ * a network drop, or a 500 with no envelope. Every call site passes a written-for-a-human fallback;
+ * that is the one to show.
  */
 export function extractErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpErrorResponse) {
@@ -52,7 +62,7 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
       const candidate = [body.message, body.error].find((value): value is string => typeof value === 'string' && value.trim().length > 0);
       if (candidate) return candidate;
     }
-    return error.message || fallback;
+    return fallback;
   }
 
   if (error instanceof Error && error.message) return error.message;

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -2,22 +2,145 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { TRANSIENT_RETRY_DELAY_MS } from '@lfx-one/shared/constants';
+import { ERROR_CODES, MAX_PLAIN_TEXT_BODY_LENGTH, TRANSIENT_RETRY_DELAY_MS, VALIDATION_FAILED_MESSAGE_PREFIX } from '@lfx-one/shared/constants';
 import { MonoTypeOperatorFunction, retry, throwError, timer } from 'rxjs';
+
+/**
+ * The message an error body offers for display, or `undefined` when it offers none. Every policy the
+ * two readers below share lives here rather than in each of them: which key wins, when a 5xx body is
+ * discarded (see `getHttpErrorDetail` for why), and what a plain-text body is worth. The only thing
+ * left to a caller is `plainString`, which is genuinely a per-caller call.
+ *
+ * `error` is read as well as `message` because `error` is the key the envelope actually sends —
+ * `BaseApiError.toResponse()` emits `{ error, code }` and no `message`. A handful of controllers do
+ * hand-write a `message` key (`crowdfunding.controller.ts`, `clas.controller.ts`,
+ * `email-verification.service.ts`), and upstream Goa bodies use it, so both are read.
+ *
+ * A field reason wins over a `VALIDATION_ERROR` whose top-level message is one `ServiceValidationError`
+ * built itself: exactly `VALIDATION_FAILED_MESSAGE_PREFIX` (the `fromFieldErrors` default) or that
+ * prefix plus " for " (what `forField` mints). The two ends share the constant so a server-side reword
+ * fails loudly. `forField` interpolates the *wire key* — "Validation failed for invitee_email" — and
+ * leaves the readable reason ("Member ID is required") in the field array. The match is those two
+ * shapes rather than any `startsWith`, so a human message that happens to open with the same words
+ * ("Validation failed. Please check the highlighted fields.") is not demoted. The branch is also
+ * reachable from upstream: `getCodeForStatus(422)` gives a `MicroserviceError` the same code, and
+ * `toResponse()` forwards both the Goa message and `errors`, so a Go service whose top-level message
+ * happens to be one of those two shapes gets its field reasons preferred too — the wanted outcome.
+ *
+ * The consequence for the server is that a `forField` *reason* is now what a user reads. Most are
+ * already written that way ("Committee ID is required"), but not all: the newsletter schedule and
+ * cancel-schedule handlers reach `extractErrorMessage` at `newsletter-manage.component.ts` and
+ * `newsletter-list.component.ts`, and their `parseIfMatch` / `validateScheduleOverride` guards read
+ * like assertions to a developer ("If-Match header is required", "scheduled_at must be an RFC3339
+ * timestamp string or null"). Those guards fire on requests this app shouldn't be making, so a user
+ * seeing one means something upstream of the message is already wrong — but the string is now what
+ * they see, and it should be written for them. Same for the `fromFieldErrors` reasons on the same
+ * routes, which the field-array preference also promotes (those calls pass exactly the prefix).
+ *
+ * Any other top-level message under that code wins over the field array, on the grounds that a caller
+ * who wrote one wrote it for a person — as the public-registration guards do. That is a property of
+ * today's call sites, not a rule the type system enforces: several `fromFieldErrors` callers pass a
+ * developer string instead (`weekly-brief.controller.ts`, `'Upload request validation failed'` in
+ * `project.controller.ts` and `committee.controller.ts`). None of them reaches either reader today, and
+ * routing one here means rewording its message first.
+ *
+ * `errors` is shape-checked rather than trusted: `MicroserviceError.toResponse()` forwards it verbatim
+ * from an upstream Go service, so it can arrive as a string or an object. Throwing here would mean a
+ * caller's `catchError` shows no toast at all. Only the first usable reason is taken, deliberately: the
+ * destination is a one-line toast, and a server that wants to name several fields at once already has
+ * `joinAsSentenceList` to write one message that does — which is what `public-meeting.controller.ts`
+ * does for the registration form. When `errors` yields nothing usable the answer is `undefined`,
+ * not the top-level message: that message is already known to be a wire key at this point, so falling
+ * back to it would put "Validation failed for invitee_email" in front of a user — the string this
+ * whole branch exists to suppress. `undefined` gets the caller its status hint or its own fallback.
+ *
+ * A thrown `Error` is not an error body at all. The app runs `provideHttpClient(withFetch())`, and
+ * Angular's fetch backend puts the raw thrown value in `HttpErrorResponse.error` — so a dropped
+ * connection, an abort, a request timeout, or a body that failed to parse arrives here as an `Error`
+ * whose `message` is "Failed to fetch", "signal timed out", or "Unexpected token … in JSON". Those read
+ * as an object with a `message` key, which is exactly the shape this function is looking for, and the
+ * status is 0 (or a 2xx on a parse failure) so the 5xx skip doesn't cover them either. The check is
+ * `instanceof`, so an `Error` minted in another realm (an SSR worker, an iframe) would slip past it and
+ * have its `message` read; nothing in this app produces one, and the fallback for a missed case is a
+ * developer string in a toast rather than a crash.
+ *
+ * `plainString: 'read'` lets a caller take a plain-text body as the message — `getHttpErrorDetail` has
+ * a per-status hint that is better, `extractErrorMessage` does not. Either way the body has to read like
+ * one sentence about the request. Angular's `parseBody` hands back the raw response *text* for any
+ * non-2xx body that isn't JSON, so what arrives can be a proxy's whole HTML page, a JSON document the
+ * server sent under the wrong content type, or a stack trace — putting any of those in a toast is the
+ * failure this function exists to prevent. Hence the markup, structure, newline, and length checks; the
+ * length cap is generous enough for a real sentence and short enough that a document can't pass. The
+ * length and newline halves apply to a string found *inside* an object body too, because that string
+ * isn't necessarily this server's: `MicroserviceError.fromMicroserviceResponse` takes its message from
+ * the upstream body at any status, so an arbitrarily long or multi-line Go-service string reaches the
+ * `error` key on a 4xx. Only the leading-`<{[` check is specific to the raw-text path, where the payload
+ * is whatever the proxy in front of us decided to return rather than a key someone chose to fill.
+ */
+function readErrorBodyMessage(body: unknown, status: number, plainString: 'read' | 'ignore'): string | undefined {
+  if (status >= 500) {
+    return undefined;
+  }
+
+  const withinOneLine = (text: string): string | undefined =>
+    text.length > 0 && text.length <= MAX_PLAIN_TEXT_BODY_LENGTH && !text.includes('\n') ? text : undefined;
+
+  if (typeof body === 'string') {
+    if (plainString === 'ignore') {
+      return undefined;
+    }
+
+    const text = body.trim();
+    return /^[<{[]/.test(text) ? undefined : withinOneLine(text);
+  }
+
+  if (!body || typeof body !== 'object' || body instanceof Error) {
+    return undefined;
+  }
+
+  const nonBlank = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
+  const { message, error, code, errors } = body as { message?: string; error?: string; code?: string; errors?: unknown };
+  const top = [message, error].find(nonBlank)?.trim();
+  const isSelfBuilt = top === undefined || top === VALIDATION_FAILED_MESSAGE_PREFIX || top.startsWith(`${VALIDATION_FAILED_MESSAGE_PREFIX} for `);
+  const isWireKeyed = code === ERROR_CODES.VALIDATION_ERROR && isSelfBuilt;
+
+  if (isWireKeyed) {
+    const entries = Array.isArray(errors) ? errors : [];
+    const reason = entries
+      .map((entry) => (entry && typeof entry === 'object' ? (entry as { message?: unknown }).message : undefined))
+      .find(nonBlank)
+      ?.trim();
+    return reason === undefined ? undefined : withinOneLine(reason);
+  }
+
+  return top === undefined ? undefined : withinOneLine(top);
+}
 
 /**
  * Extracts a user-friendly error message from an HttpErrorResponse.
  * Prefers the server's own message when the body carries one; falls back to
  * status-code hints, then the provided fallback string.
  *
- * The body's `error` key is read as well as `message`, because `error` is the one this server
- * actually sends — `BaseApiError.toResponse()` emits `{ error, code }` and no `message`. Reading only
- * `message` left every branch below on its hard-coded string, so a server validation reason never
- * reached the ~13 committee and profile call sites.
+ * Reading only `message` — a key the envelope does not send — left every branch below on its hard-coded
+ * string, so a server reason never reached the committee call sites. See `readErrorBodyMessage`.
+ *
+ * A 5xx body is deliberately not read. Every 5xx body traced to these call sites is either the
+ * envelope's own "Internal server error" or an upstream Go service message that `MicroserviceError`
+ * passes through verbatim — neither tells the user anything, and both would displace the caller's
+ * fallback, which at least names the action that failed ("Failed to remove member. Please try again.").
+ * The skip is by status, not by provenance, so it also discards the hand-written 5xx messages this
+ * server mints — including ones written for a person (`ACCESS_CHECK_UNAVAILABLE`,
+ * `FORWARD_SET_FAILED`, and `ROLE_GRANTS_UNAVAILABLE` in `org-lens-access.service.ts`). None of those
+ * reaches a call site of either reader today, but routing one here would silently trade it for the
+ * fallback; a `code` allowlist would be the way to let a chosen few through.
+ *
+ * Below 500 the body is usually a validation or permission reason written about the request, which is
+ * worth showing. Not always: `MicroserviceError` forwards an upstream Go message verbatim at any
+ * status, so a Goa-shaped string can still reach a 4xx toast. Showing it beats a status hint that says
+ * nothing about which field or permission was at fault.
  */
 export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): string {
-  const body = err.error as { message?: string; error?: string } | string | null;
-  const upstream = typeof body === 'string' ? undefined : [body?.message, body?.error].find((value) => typeof value === 'string' && value.trim().length > 0);
+  const upstream = readErrorBodyMessage(err.error, err.status, 'ignore');
 
   switch (err.status) {
     case 409:
@@ -28,8 +151,6 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
       return upstream ?? 'You do not have permission to perform this action.';
     case 422:
       return upstream ?? 'The request contained invalid data. Please check your input.';
-    case 400:
-      return upstream ?? fallback;
     default:
       return upstream ?? fallback;
   }
@@ -41,34 +162,24 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
  * from `firstValueFrom(...)` or RxJS `catchError` and need to surface a
  * single string to the UI.
  *
- * `body.error` is read as well as `body.message` because that is the key this server's error
- * envelope actually uses — `BaseApiError.toResponse()` emits `{ error, code }` and no `message`.
+ * See `readErrorBodyMessage` for which key in the body is read, and why, and for the 5xx skip these two
+ * share — "Internal server error" and a forwarded Go-service string tell a user nothing, and the
+ * caller's fallback at least names the action that failed.
+ *
+ * Unlike `getHttpErrorDetail` this one does read a plain-text body: it has no per-status hint layer, so
+ * a 4xx sentence written about the request is the best thing on offer. `readErrorBodyMessage` still
+ * refuses one that reads like a proxy's HTML page.
  *
  * When the body yields nothing, the caller's `fallback` wins over `HttpErrorResponse.message`.
  * Angular fills that property in for every failure with a string built for a developer reading a
  * console — "Http failure response for /public/api/...: 0 Unknown Error" — so preferring it would
- * put a URL and a status code in front of a user on exactly the failures where the body is empty:
- * a network drop, or a 500 with no envelope. Call sites are expected to pass a written-for-a-human
- * fallback; that is the one to show.
+ * put a URL and a status code in front of a user on exactly the failures the body has nothing to say
+ * about: a network drop, or a 500 with no envelope. Call sites are expected to pass a
+ * written-for-a-human fallback; that is the one to show.
  */
 export function extractErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpErrorResponse) {
-    const body = error.error as { message?: string; error?: string; errors?: { message?: string }[] } | string | null;
-    if (typeof body === 'string' && body.trim().length > 0) return body;
-    if (body && typeof body === 'object') {
-      // ServiceValidationError's `errors[].message` (server) carries the specific, actionable
-      // detail for the failing field — the top-level message/error is often a generic
-      // "Validation failed for <field>" wrapper, so prefer the field-level detail when present.
-      // `body` is unknown runtime data cast through a type assertion, not a runtime guarantee —
-      // `errors` could be any shape (e.g. a string), so Array.isArray guards before searching it.
-      const fieldDetail = Array.isArray(body.errors)
-        ? body.errors.find((e): e is { message: string } => !!e && typeof e.message === 'string' && e.message.trim().length > 0)
-        : undefined;
-      if (fieldDetail) return fieldDetail.message;
-      const candidate = [body.message, body.error].find((value): value is string => typeof value === 'string' && value.trim().length > 0);
-      if (candidate) return candidate;
-    }
-    return fallback;
+    return readErrorBodyMessage(error.error, error.status, 'read') ?? fallback;
   }
 
   if (error instanceof Error && error.message) return error.message;

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -17,6 +17,7 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = v
   meetingSvc: {
     getMeetingById: vi.fn(),
     getMeetingRegistrants: vi.fn(),
+    getMeetingRegistrantsByEmail: vi.fn(),
     addMeetingRegistrant: vi.fn(),
   },
   aiSvc: { generateMeetingAgenda: vi.fn() },
@@ -50,7 +51,7 @@ vi.mock('../helpers/committee-v1-mapping.helper', () => ({
   resolveCommitteeV2UidsToV1Ids: resolveCommitteeV2UidsToV1IdsMock,
 }));
 vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(() => 'user@example.com') }));
-vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn().mockResolvedValue('m2m-bearer-token') }));
 
 vi.mock('../services/meeting.service', () => ({ MeetingService: vi.fn(() => meetingSvc) }));
 vi.mock('../services/ai.service', () => ({ AiService: vi.fn(() => aiSvc) }));
@@ -291,6 +292,40 @@ describe('MeetingController', () => {
       const res = buildRes();
 
       await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith([registrant]);
+    });
+  });
+
+  describe('getMyMeetingRegistrants', () => {
+    const registrant = { uid: 'reg-1', email: 'a@example.com', committee_uid: V1_COMMITTEE_SFID };
+
+    beforeEach(() => {
+      meetingSvc.getMeetingById.mockResolvedValue({ uid: MEETING_ID, organizer: true, committees: [{ uid: V2_COMMITTEE_UID }] });
+      meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([{ uid: 'reg-self', email: 'user@example.com' }]);
+      meetingSvc.getMeetingRegistrants.mockResolvedValue([{ ...registrant }]);
+      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]));
+      committeeSvc.getCommitteeById.mockResolvedValue({ uid: V2_COMMITTEE_UID, name: 'TAC', category: 'Technical' });
+      committeeSvc.getCommitteeMembers.mockResolvedValue([{ email: 'a@example.com', role: { name: 'Chair' }, voting: { status: 'Voting Rep' } }]);
+    });
+
+    it('enriches committee metadata for a registrant of the meeting', async () => {
+      const res = buildRes();
+
+      await controller.getMyMeetingRegistrants(buildReq(), res, next);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ committee_name: 'TAC', committee_uid: V2_COMMITTEE_UID })]);
+    });
+
+    // Group attribution is decoration; the guest list is not. The v2 → v1 mapping goes over NATS, so a
+    // transient committee-service problem must not turn this listing into a 500 — and this is the
+    // degradation `MeetingRegistrant.committee_uid`'s docstring promises on both read paths.
+    it('degrades to unenriched rows when the committee mapping lookup fails', async () => {
+      resolveCommitteeV2UidsToV1IdsMock.mockRejectedValue(new Error('nats timeout'));
+      const res = buildRes();
+
+      await controller.getMyMeetingRegistrants(buildReq(), res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith([registrant]);

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -936,7 +936,8 @@ export class ProjectController {
     }
 
     try {
-      // Public route has no session — obtain M2M token so meeting service calls succeed.
+      // `/public/api` is optional-auth, so a session may or may not exist. Fall back to an M2M token
+      // when there's no user bearer token, so meeting service calls succeed either way.
       if (!req.bearerToken) {
         req.bearerToken = await generateM2MToken(req);
       }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -892,7 +892,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2]).toMatchObject({ email: 'a@example.com', first_name: 'Alice', org_name: 'Acme' });
   });
 
-  it.each(['first_name', 'last_name', 'job_title', 'org_name', 'occurrence_id'])('caps %s so nothing unbounded reaches upstream', async (field) => {
+  it.each(['first_name', 'last_name', 'job_title', 'org_name'])('caps %s so nothing unbounded reaches upstream', async (field) => {
     const { req, res, next } = buildRegisterReq(true, { [field]: 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH * 2) });
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -901,13 +901,17 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2][field]).toHaveLength(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
   });
 
-  // The two identity keys are rejected rather than capped: truncating one would turn an unusable value
-  // into a different, valid-looking one — an invite to the wrong address, or a lookup against the wrong
-  // meeting. The error has to name the field, or a caller that did send an email is told it was
-  // missing.
+  // The three identifiers are rejected rather than capped: truncating one would turn an unusable value
+  // into a different, valid-looking one — a lookup against the wrong meeting, an invite to the wrong
+  // address, or a registration scoped to the wrong occurrence.
+  //
+  // Both the field array and the top-level message are asserted. The array alone isn't enough: the
+  // modal renders `error.message` and discards `errors[]`, so a generic message there would leave the
+  // registrant with nothing to act on — which is exactly what the old "Email is required" path did.
   it.each([
     ['email', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
     ['meeting_id', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+    ['occurrence_id', { occurrence_id: '1'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
   ])('rejects an over-length %s by name rather than truncating it', async (field, overrides) => {
     const { req, res, next } = buildRegisterReq(true, overrides);
 
@@ -919,6 +923,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     const error = next.mock.calls[0][0] as ServiceValidationError;
 
     expect(error.validationErrors).toEqual([expect.objectContaining({ field, message: expect.stringContaining(`${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH}`) })]);
+    expect(error.message).toBe(`${field} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`);
   });
 
   // Which occurrences the registration covers is part of what a registrant states about their own

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
 import { MeetingVisibility } from '@lfx-one/shared/enums';
 import type { Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -94,11 +95,19 @@ vi.mock('../services/logger.service', () => ({
     info: vi.fn(),
   },
 }));
-vi.mock('../utils/auth-helper', () => ({
-  getEffectiveEmail: getEffectiveEmailMock,
-  getEffectiveUsername: getEffectiveUsernameMock,
-  getUsernameFromAuth: vi.fn(),
-}));
+// `stripAuthPrefix` is kept real rather than stubbed: the controller's prefix stripping only matters
+// because it has to agree with what the read paths do, and a stand-in here would assert agreement with
+// the stand-in instead.
+vi.mock('../utils/auth-helper', async () => {
+  const actual = await vi.importActual<typeof import('../utils/auth-helper')>('../utils/auth-helper');
+
+  return {
+    getEffectiveEmail: getEffectiveEmailMock,
+    getEffectiveUsername: getEffectiveUsernameMock,
+    getUsernameFromAuth: vi.fn(),
+    stripAuthPrefix: actual.stripAuthPrefix,
+  };
+});
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 vi.mock('../utils/security.util', () => ({ validatePassword: validatePasswordMock }));
 
@@ -694,6 +703,11 @@ describe('PublicMeetingController.getMeetingOccurrences', () => {
   });
 });
 
+/**
+ * The route requires a session and registers the caller through the meeting service's `self`
+ * endpoint, so identity comes off the JWT — but the request body still supplies every descriptive
+ * field, and the caller controls all of it.
+ */
 describe('PublicMeetingController.registerForPublicMeeting', () => {
   let controller: PublicMeetingController;
 
@@ -876,19 +890,43 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2]).toMatchObject({ email: 'a@example.com', first_name: 'Alice', org_name: 'Acme' });
   });
 
-  it('caps each free-text field so nothing unbounded reaches upstream', async () => {
-    const { req, res, next } = buildRegisterReq(true, { org_name: 'x'.repeat(400) });
+  it.each(['first_name', 'last_name', 'job_title', 'org_name'])('caps %s so nothing unbounded reaches upstream', async (field) => {
+    const { req, res, next } = buildRegisterReq(true, { [field]: 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH * 2) });
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].org_name).toHaveLength(255);
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2][field]).toHaveLength(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
   });
 
-  // Derived from the session, never from the body: a registrant keeps their own LFID attribution and
-  // a forged `username` still can't get in.
-  it('takes username from the session and ignores the one in the body', async () => {
-    getEffectiveUsernameMock.mockReturnValue('realuser');
+  // Truncating the record's identity key would turn a too-long address into a different,
+  // valid-looking one — so it's dropped instead of capped.
+  it('drops an over-length email rather than truncating it', async () => {
+    const local = 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
+    const { req, res, next } = buildRegisterReq(true, { email: `${local}@example.com` });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].email).toBe('');
+  });
+
+  // Which occurrences the registration covers is part of what a registrant states about their own
+  // attendance. No in-app caller sends it yet, so only this test keeps it from falling out again.
+  it('still forwards a single-occurrence scope', async () => {
+    const { req, res, next } = buildRegisterReq(true, { occurrence_id: '1666848600' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].occurrence_id).toBe('1666848600');
+  });
+
+  // Derived from the session, never from the body. The provider prefix is stripped because a
+  // registrant record stores the plain LFID — every read path strips before matching, so a prefixed
+  // row would be invisible to the join-URL lookup.
+  it('takes username from the session, strips its provider prefix, and ignores the body', async () => {
+    getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
     const { req, res, next } = buildRegisterReq(true, { username: 'someone-else' });
 
     await controller.registerForPublicMeeting(req, res, next);

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -724,7 +724,11 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(meetingSvc.addMeetingRegistrantSelf).toHaveBeenCalledWith(req, MEETING_ID, req.body);
+    expect(meetingSvc.addMeetingRegistrantSelf).toHaveBeenCalledWith(
+      req,
+      MEETING_ID,
+      expect.objectContaining({ meeting_id: MEETING_ID, first_name: 'Alice', last_name: 'Liddell', host: false })
+    );
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({ uid: 'reg-1' });
   });
@@ -807,5 +811,31 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
     expect(req.bearerToken).toBe('user-token');
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // `host` grants "access to host key for the meeting" upstream, and `committee_uid` claims committee
+  // membership. Neither is the caller's to assert about themselves, so `toSelfRegistration` drops both
+  // before the body reaches the meeting service.
+  it('does not let a caller grant itself host access or claim a committee', async () => {
+    const { req, res, next } = buildRegisterReq(true, { host: true, committee_uid: 'committee-1' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const forwarded = meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2];
+    expect(forwarded.host).toBe(false);
+    expect(forwarded).not.toHaveProperty('committee_uid');
+  });
+
+  it('drops any other field the caller invents', async () => {
+    const { req, res, next } = buildRegisterReq(true, { username: 'someone-else', uid: 'reg-hijack', type: 'committee' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const forwarded = meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2];
+    for (const key of ['username', 'uid', 'type']) {
+      expect(forwarded).not.toHaveProperty(key);
+    }
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -63,6 +63,13 @@ vi.mock('@lfx-one/shared/constants', () => ({
   HOST_KEY_LATE_MINUTES: 40,
   MEETING_PASSWORD_HEADER: 'x-meeting-password',
   PUBLIC_REGISTRATION_FIELD_MAX_LENGTH: 255,
+  PUBLIC_REGISTRATION_FIELD_LABELS: {
+    meeting_id: 'Meeting ID',
+    occurrence_id: 'Occurrence ID',
+    email: 'Email address',
+    first_name: 'First name',
+    last_name: 'Last name',
+  },
   ROOT_PROJECT_SLUG: 'ROOT',
 }));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: validateUidParameterMock }));
@@ -906,13 +913,14 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
   // address, or a registration scoped to the wrong occurrence.
   //
   // Both the field array and the top-level message are asserted. The array alone isn't enough: the
-  // modal renders `error.message` and discards `errors[]`, so a generic message there would leave the
-  // registrant with nothing to act on — which is exactly what the old "Email is required" path did.
+  // modal shows the top-level message — serialized as the body's `error` key — and discards
+  // `errors[]`, so a generic message there would leave the registrant with nothing to act on, which is
+  // exactly what the old "Registration data validation failed" path did.
   it.each([
-    ['email', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
-    ['meeting_id', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
-    ['occurrence_id', { occurrence_id: '1'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
-  ])('rejects an over-length %s by name rather than truncating it', async (field, overrides) => {
+    ['email', 'Email address', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
+    ['meeting_id', 'Meeting ID', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+    ['occurrence_id', 'Occurrence ID', { occurrence_id: '1'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+  ])('rejects an over-length %s by name rather than truncating it', async (field, label, overrides) => {
     const { req, res, next } = buildRegisterReq(true, overrides);
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -922,8 +930,59 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
     const error = next.mock.calls[0][0] as ServiceValidationError;
 
+    // `errors[]` keeps the wire key; the message a person reads gets the label.
     expect(error.validationErrors).toEqual([expect.objectContaining({ field, message: expect.stringContaining(`${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH}`) })]);
-    expect(error.message).toBe(`${field} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`);
+    expect(error.message).toBe(`${label} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`);
+  });
+
+  // Two at once, because the join is what a single-field case can't catch: an `and`-joined message has
+  // to still read as one sentence, and both fields have to survive into `errors[]`.
+  it('names every over-length identifier in one message', async () => {
+    const { req, res, next } = buildRegisterReq(true, {
+      meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1),
+      email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com`,
+    });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors.map((entry) => entry.field)).toEqual(['meeting_id', 'email']);
+    expect(error.message).toBe(`Meeting ID and Email address must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`);
+  });
+
+  // The required-field path had the same defect the length path was fixed for: its top-level message
+  // was a generic "Registration data validation failed", so the registrant saw nothing actionable.
+  //
+  // Only the name fields are covered because they are the only ones this route requires:
+  // `meeting_id` is rejected earlier by `validateMeetingId`, and `email` never reaches upstream —
+  // `/registrants/self` takes identity off the caller's JWT.
+  it.each([
+    ['first_name', { first_name: '  ' }, 'First name is required.'],
+    ['last_name', { last_name: '' }, 'Last name is required.'],
+  ])('names a missing %s in the message the registrant sees', async (field, overrides, expected) => {
+    const { req, res, next } = buildRegisterReq(true, overrides);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors.map((entry) => entry.field)).toEqual([field]);
+    expect(error.message).toBe(expected);
+  });
+
+  // The plural join, on the path a registrant is most likely to hit: an empty form.
+  it('names both missing names in one sentence', async () => {
+    const { req, res, next } = buildRegisterReq(true, { first_name: '', last_name: '' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors.map((entry) => entry.field)).toEqual(['first_name', 'last_name']);
+    expect(error.message).toBe('First name and Last name are required.');
   });
 
   // Which occurrences the registration covers is part of what a registrant states about their own

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -59,6 +59,7 @@ vi.mock('@lfx-one/shared/constants', () => ({
   HOST_KEY_EARLY_MINUTES: 70,
   HOST_KEY_LATE_MINUTES: 40,
   MEETING_PASSWORD_HEADER: 'x-meeting-password',
+  PUBLIC_REGISTRATION_FIELD_MAX_LENGTH: 255,
   ROOT_PROJECT_SLUG: 'ROOT',
 }));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: validateUidParameterMock }));
@@ -716,6 +717,9 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     generateM2MTokenMock.mockResolvedValue('m2m-token');
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.addMeetingRegistrantSelf.mockResolvedValue({ uid: 'reg-1' });
+    // `clearAllMocks` leaves return values from earlier suites in place, so pin the session username
+    // rather than inherit one.
+    getEffectiveUsernameMock.mockReturnValue(null);
   });
 
   it('calls addMeetingRegistrantSelf with user token and returns 201', async () => {
@@ -837,5 +841,59 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     for (const key of ['username', 'uid', 'type']) {
       expect(forwarded).not.toHaveProperty(key);
     }
+  });
+
+  // The route mounts the handler with no express-validator, so a non-string is what actually gets to
+  // choose whether it clears the required-field gate. Narrowing to a string is the only thing that
+  // stops an object or array being forwarded upstream.
+  it.each([[{ nested: 'x' }], [['Alice']], [42], [null]])('rejects a non-string first_name (%j) instead of forwarding it', async (firstName) => {
+    const { req, res, next } = buildRegisterReq(true, { first_name: firstName });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw on a missing body', async () => {
+    const { req, res, next } = buildRegisterReq(true);
+    req.body = undefined;
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // Query-service tag matching is case-sensitive and every read path lowercases, so a mixed-case
+  // registration would be indexed under a tag no later invited-status lookup matches.
+  it('lowercases and trims the fields it forwards', async () => {
+    const { req, res, next } = buildRegisterReq(true, { email: '  A@Example.COM ', first_name: ' Alice ', org_name: ' Acme ' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2]).toMatchObject({ email: 'a@example.com', first_name: 'Alice', org_name: 'Acme' });
+  });
+
+  it('caps each free-text field so nothing unbounded reaches upstream', async () => {
+    const { req, res, next } = buildRegisterReq(true, { org_name: 'x'.repeat(400) });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].org_name).toHaveLength(255);
+  });
+
+  // Derived from the session, never from the body: a registrant keeps their own LFID attribution and
+  // a forged `username` still can't get in.
+  it('takes username from the session and ignores the one in the body', async () => {
+    getEffectiveUsernameMock.mockReturnValue('realuser');
+    const { req, res, next } = buildRegisterReq(true, { username: 'someone-else' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].username).toBe('realuser');
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -55,7 +55,14 @@ vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public',
 // resolveMeetingOwner from shared/utils; stub them so the real barrel (and its MeetingType enum
 // dependency) isn't pulled into the mock graph. Both null => the enrichment gate always opens,
 // but the default empty resolveCreatedByForMeetings map keeps enrichment a pass-through.
-vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null), resolveMeetingOwner: vi.fn(() => null) }));
+vi.mock('@lfx-one/shared/utils', () => ({
+  resolveMeetingOrganizer: vi.fn(() => null),
+  resolveMeetingOwner: vi.fn(() => null),
+  // Real implementation, not a stub: the rejection messages this suite asserts on are built by it, so a
+  // stub would make those assertions test the mock's wording rather than the controller's.
+  joinAsSentenceList: (labels: readonly string[]) =>
+    labels.length < 2 ? (labels[0] ?? '') : `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`,
+}));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
 vi.mock('@lfx-one/shared/constants', () => ({

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -6,6 +6,8 @@ import { MeetingVisibility } from '@lfx-one/shared/enums';
 import type { Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ServiceValidationError } from '../errors/service-validation.error';
+
 const MEETING_ID = 'meeting-1111';
 const PROJECT_UID = 'project-2222';
 
@@ -890,7 +892,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2]).toMatchObject({ email: 'a@example.com', first_name: 'Alice', org_name: 'Acme' });
   });
 
-  it.each(['first_name', 'last_name', 'job_title', 'org_name'])('caps %s so nothing unbounded reaches upstream', async (field) => {
+  it.each(['first_name', 'last_name', 'job_title', 'org_name', 'occurrence_id'])('caps %s so nothing unbounded reaches upstream', async (field) => {
     const { req, res, next } = buildRegisterReq(true, { [field]: 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH * 2) });
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -899,16 +901,24 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2][field]).toHaveLength(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
   });
 
-  // Truncating the record's identity key would turn a too-long address into a different,
-  // valid-looking one — so it's dropped instead of capped.
-  it('drops an over-length email rather than truncating it', async () => {
-    const local = 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
-    const { req, res, next } = buildRegisterReq(true, { email: `${local}@example.com` });
+  // The two identity keys are rejected rather than capped: truncating one would turn an unusable value
+  // into a different, valid-looking one — an invite to the wrong address, or a lookup against the wrong
+  // meeting. The error has to name the field, or a caller that did send an email is told it was
+  // missing.
+  it.each([
+    ['email', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
+    ['meeting_id', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+  ])('rejects an over-length %s by name rather than truncating it', async (field, overrides) => {
+    const { req, res, next } = buildRegisterReq(true, overrides);
 
     await controller.registerForPublicMeeting(req, res, next);
 
-    expect(next).not.toHaveBeenCalled();
-    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].email).toBe('');
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors).toEqual([expect.objectContaining({ field, message: expect.stringContaining(`${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH}`) })]);
   });
 
   // Which occurrences the registration covers is part of what a registrant states about their own

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -55,13 +55,14 @@ vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public',
 // resolveMeetingOwner from shared/utils; stub them so the real barrel (and its MeetingType enum
 // dependency) isn't pulled into the mock graph. Both null => the enrichment gate always opens,
 // but the default empty resolveCreatedByForMeetings map keeps enrichment a pass-through.
-vi.mock('@lfx-one/shared/utils', () => ({
+vi.mock('@lfx-one/shared/utils', async () => ({
   resolveMeetingOrganizer: vi.fn(() => null),
   resolveMeetingOwner: vi.fn(() => null),
-  // Real implementation, not a stub: the rejection messages this suite asserts on are built by it, so a
-  // stub would make those assertions test the mock's wording rather than the controller's.
-  joinAsSentenceList: (labels: readonly string[]) =>
-    labels.length < 2 ? (labels[0] ?? '') : `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`,
+  // The real function rather than a hand-copy, so a change to its wording fails these assertions
+  // instead of leaving them green against a stale duplicate. Imported by relative path (the idiom
+  // `meeting.controller.spec.ts` already uses for `truncateToUtf16Units`): `string.utils.ts` has no
+  // imports of its own, so this pulls in none of the aliased barrel graph the mock exists to avoid.
+  joinAsSentenceList: (await import('../../../../../packages/shared/src/utils/string.utils')).joinAsSentenceList,
 }));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -513,8 +513,10 @@ export class PublicMeetingController {
           Object.fromEntries(overLength.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
           // The cause goes in the top-level message, not only in `errors[]`: the one consumer of this
           // endpoint shows the top-level message — serialized as the body's `error` key, since
-          // `BaseApiError.toResponse` emits no `message` — and discards the field array. A generic
-          // "validation failed" here would leave the registrant with no idea which field to shorten.
+          // `BaseApiError.toResponse` emits no `message`. It prefers the field array only when that
+          // message is one `ServiceValidationError` built itself around a wire key, which this one is
+          // not. A generic "validation failed" here would leave the registrant with no idea which
+          // field to shorten.
           //
           // Labels rather than wire keys, because this string is read by someone looking at a form.
           `${joinAsSentenceList(overLength.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]))} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`,

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
-import { MEETING_PASSWORD_HEADER, ROOT_PROJECT_SLUG, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
+import { MEETING_PASSWORD_HEADER, PUBLIC_REGISTRATION_FIELD_LABELS, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   CreateMeetingRegistrantRequest,
@@ -497,22 +497,26 @@ export class PublicMeetingController {
     // Length is measured on the stored form rather than the submitted one — `email` is already
     // lowercased here, and lowercasing can lengthen a value for a handful of Unicode code points. The
     // stored form is what has to fit, so that's what's checked.
-    const overLength = Object.entries({
+    const identifiers = {
       meeting_id: meetingId,
       email: registrantData.email,
       occurrence_id: registrantData.occurrence_id ?? '',
-    }).filter(([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
+    };
+    const overLength = (Object.keys(identifiers) as (keyof typeof identifiers)[]).filter(
+      (field) => identifiers[field].length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH
+    );
 
     if (overLength.length > 0) {
-      const fields = overLength.map(([field]) => field);
-
       return next(
         ServiceValidationError.fromFieldErrors(
-          Object.fromEntries(fields.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
+          Object.fromEntries(overLength.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
           // The cause goes in the top-level message, not only in `errors[]`: the one consumer of this
-          // endpoint renders `error.message` and discards the field array, so a generic "validation
-          // failed" here would leave the registrant with no idea which field to shorten.
-          `${fields.join(', ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`,
+          // endpoint shows the top-level message — serialized as the body's `error` key, since
+          // `BaseApiError.toResponse` emits no `message` — and discards the field array. A generic
+          // "validation failed" here would leave the registrant with no idea which field to shorten.
+          //
+          // Labels rather than wire keys, because this string is read by someone looking at a form.
+          `${overLength.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]).join(' and ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`,
           {
             operation: 'register_for_public_meeting',
             service: 'public_meeting_controller',
@@ -543,14 +547,24 @@ export class PublicMeetingController {
 
       const userToken = req.bearerToken;
 
-      if (!registrantData.first_name || !registrantData.last_name) {
+      // The missing fields are named individually in the top-level message for the same reason as the
+      // length rejection above: that message is the only part of this error the registration modal
+      // shows, so a generic "validation failed" here is what turns a fixable empty field into an
+      // unexplained failure.
+      //
+      // Only the two name fields are required. `meeting_id` is already covered by
+      // `validateMeetingId` above, and `email` never reaches upstream on this route —
+      // `addMeetingRegistrantSelf` posts to `/registrants/self`, where the meeting service takes
+      // identity off the caller's JWT — so requiring it would reject correct requests.
+      const missing = (['first_name', 'last_name'] as const).filter((field) => !registrantData[field]);
+
+      if (missing.length > 0) {
+        const labels = missing.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]);
+
         return next(
           ServiceValidationError.fromFieldErrors(
-            {
-              first_name: !registrantData.first_name ? 'First name is required' : [],
-              last_name: !registrantData.last_name ? 'Last name is required' : [],
-            },
-            'Registration data validation failed',
+            Object.fromEntries(missing.map((field, index) => [field, `${labels[index]} is required`])),
+            `${labels.join(' and ')} ${missing.length > 1 ? 'are' : 'is'} required.`,
             {
               operation: 'register_for_public_meeting',
               service: 'public_meeting_controller',

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
-import { MEETING_PASSWORD_HEADER, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import { MEETING_PASSWORD_HEADER, ROOT_PROJECT_SLUG, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   CreateMeetingRegistrantRequest,
@@ -481,7 +481,7 @@ export class PublicMeetingController {
    * requests receive 401.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const registrantData = this.toSelfRegistration(req.body);
+    const registrantData = this.toSelfRegistration(req, req.body);
     const meetingId = registrantData.meeting_id;
 
     const startTime = logger.startOperation(req, 'register_for_public_meeting', {
@@ -607,17 +607,38 @@ export class PublicMeetingController {
    *
    * An allowlist rather than a denylist: a field added to `CreateMeetingRegistrantRequest` later
    * should have to be opted in to the public path deliberately, not inherit it.
+   *
+   * Values are narrowed, not just keys. The route mounts the handler bare — no express-validator — so
+   * the parameter is `unknown` rather than the request interface, which would be an assertion about a
+   * shape nothing produced. Anything that isn't a string is dropped, which is what stops an object or
+   * array from clearing the caller's `if (!registrantData.email …)` gate and reaching upstream.
+   *
+   * `username` is taken from the session when there is one and never from the body — a signed-in
+   * registrant keeps their LFID attribution on a record written with application credentials, and a
+   * forged one still can't get in. `email` is lowercased because query-service tag matching is
+   * case-sensitive and every read path lowercases; a mixed-case registration would otherwise be
+   * indexed under a tag no later lookup matches.
+   *
+   * One thing this doesn't close: `email` is the one field here that can't be self-asserted on a
+   * session-less route, so anyone can register a third party's address for a public meeting and
+   * trigger an invite to it. `publicApiRateLimiter` caps the volume, not the primitive.
    */
-  private toSelfRegistration(body: CreateMeetingRegistrantRequest): CreateMeetingRegistrantRequest {
+  private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
+    const raw = (body ?? {}) as Record<string, unknown>;
+    const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
+    const username = getEffectiveUsername(req);
+    const jobTitle = text('job_title');
+    const orgName = text('org_name');
+
     return {
-      meeting_id: body?.meeting_id,
-      email: body?.email,
-      first_name: body?.first_name,
-      last_name: body?.last_name,
+      meeting_id: text('meeting_id'),
+      email: text('email').toLowerCase(),
+      first_name: text('first_name'),
+      last_name: text('last_name'),
       host: false,
-      ...(body?.job_title ? { job_title: body.job_title } : {}),
-      ...(body?.org_name ? { org_name: body.org_name } : {}),
-      ...(body?.occurrence_id ? { occurrence_id: body.occurrence_id } : {}),
+      ...(jobTitle ? { job_title: jobTitle } : {}),
+      ...(orgName ? { org_name: orgName } : {}),
+      ...(username ? { username } : {}),
     };
   }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -28,7 +28,7 @@ import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
-import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveUsername, stripAuthPrefix } from '../utils/auth-helper';
 import { ProjectService } from '../services/project.service';
 import { generateM2MToken } from '../utils/m2m-token.util';
 import { validatePassword } from '../utils/security.util';
@@ -596,14 +596,14 @@ export class PublicMeetingController {
   }
 
   /**
-   * Narrows an anonymous request body to the fields a person may set about themselves.
+   * Narrows a self-registration request body to the fields a person may state about themselves.
    *
-   * This endpoint takes no session and forwards upstream under an M2M token, so whatever survives
-   * this function is written with application-level credentials and no user to attribute it to. The
-   * body used to be assigned wholesale, which let an anonymous caller set `host: true` — upstream
-   * documents that as "access to host key for the meeting" — or claim membership of a committee by
-   * passing `committee_uid`. Neither is the caller's to decide, so both are dropped here rather than
-   * left to upstream's discretion.
+   * `/public/api` is `auth: 'optional'`, so this runs both with and without a session — but it always
+   * forwards upstream under an M2M token, so whatever survives this function is written with
+   * application-level credentials. The body used to be assigned wholesale, which let a caller set
+   * `host: true` — upstream documents that as "access to host key for the meeting" — or claim
+   * membership of a committee by passing `committee_uid`. Neither is the caller's to decide, so both
+   * are dropped here rather than left to upstream's discretion.
    *
    * An allowlist rather than a denylist: a field added to `CreateMeetingRegistrantRequest` later
    * should have to be opted in to the public path deliberately, not inherit it.
@@ -615,29 +615,43 @@ export class PublicMeetingController {
    *
    * `username` is taken from the session when there is one and never from the body — a signed-in
    * registrant keeps their LFID attribution on a record written with application credentials, and a
-   * forged one still can't get in. `email` is lowercased because query-service tag matching is
-   * case-sensitive and every read path lowercases; a mixed-case registration would otherwise be
-   * indexed under a tag no later lookup matches.
+   * forged one still can't get in. It's stripped of any provider prefix because a registrant record
+   * stores the plain LFID: every read path strips before matching (`getMeetingRegistrantsByUsername`),
+   * so an `auth0|`-prefixed row would be invisible to the join-URL lookup that the username is stamped
+   * for in the first place. `email` is lowercased for the same reason, since query-service matching is
+   * case-sensitive and every read path lowercases.
    *
-   * One thing this doesn't close: `email` is the one field here that can't be self-asserted on a
-   * session-less route, so anyone can register a third party's address for a public meeting and
-   * trigger an invite to it. `publicApiRateLimiter` caps the volume, not the primitive.
+   * An over-length `email` is dropped rather than truncated, unlike the free-text fields — truncating
+   * the record's identity key would turn a too-long address into a different, valid-looking one and
+   * send an invite there.
+   *
+   * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
+   * register a third party's address for a public meeting and trigger an invite to it — and when the
+   * caller is signed in, the resulting row also carries their LFID against an address they don't own,
+   * which `getMeetingRegistrantsForUser`'s email-OR-username query matches for both parties.
+   * `publicApiRateLimiter` caps the volume, not the primitive.
    */
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
-    const username = getEffectiveUsername(req);
+    const rawEmail = typeof raw['email'] === 'string' ? raw['email'].trim() : '';
+    const sessionUsername = getEffectiveUsername(req);
+    const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
     const orgName = text('org_name');
+    const occurrenceId = text('occurrence_id');
 
     return {
       meeting_id: text('meeting_id'),
-      email: text('email').toLowerCase(),
+      email: rawEmail.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH ? '' : rawEmail.toLowerCase(),
       first_name: text('first_name'),
       last_name: text('last_name'),
       host: false,
       ...(jobTitle ? { job_title: jobTitle } : {}),
       ...(orgName ? { org_name: orgName } : {}),
+      // Which occurrences the registration covers is part of what a registrant states about their own
+      // attendance, so it stays allowlisted even though no in-app caller sends it yet.
+      ...(occurrenceId ? { occurrence_id: occurrenceId } : {}),
       ...(username ? { username } : {}),
     };
   }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -12,6 +12,7 @@ import {
   PublicMeetingOccurrencesResponse,
   PublicMeetingProject,
 } from '@lfx-one/shared/interfaces';
+import { joinAsSentenceList } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -516,7 +517,7 @@ export class PublicMeetingController {
           // "validation failed" here would leave the registrant with no idea which field to shorten.
           //
           // Labels rather than wire keys, because this string is read by someone looking at a form.
-          `${overLength.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]).join(' and ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`,
+          `${joinAsSentenceList(overLength.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]))} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`,
           {
             operation: 'register_for_public_meeting',
             service: 'public_meeting_controller',
@@ -564,7 +565,7 @@ export class PublicMeetingController {
         return next(
           ServiceValidationError.fromFieldErrors(
             Object.fromEntries(missing.map((field, index) => [field, `${labels[index]} is required`])),
-            `${labels.join(' and ')} ${missing.length > 1 ? 'are' : 'is'} required.`,
+            `${joinAsSentenceList(labels)} ${missing.length > 1 ? 'are' : 'is'} required.`,
             {
               operation: 'register_for_public_meeting',
               service: 'public_meeting_controller',

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -481,7 +481,7 @@ export class PublicMeetingController {
    * requests receive 401.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const registrantData: CreateMeetingRegistrantRequest = req.body;
+    const registrantData = this.toSelfRegistration(req.body);
     const meetingId = registrantData.meeting_id;
 
     const startTime = logger.startOperation(req, 'register_for_public_meeting', {
@@ -592,6 +592,32 @@ export class PublicMeetingController {
       uid: project.uid,
       parent_uid: project.parent_uid,
       parent: parent ? { uid: parent.uid, name: parent.name, slug: parent.slug } : null,
+    };
+  }
+
+  /**
+   * Narrows an anonymous request body to the fields a person may set about themselves.
+   *
+   * This endpoint takes no session and forwards upstream under an M2M token, so whatever survives
+   * this function is written with application-level credentials and no user to attribute it to. The
+   * body used to be assigned wholesale, which let an anonymous caller set `host: true` — upstream
+   * documents that as "access to host key for the meeting" — or claim membership of a committee by
+   * passing `committee_uid`. Neither is the caller's to decide, so both are dropped here rather than
+   * left to upstream's discretion.
+   *
+   * An allowlist rather than a denylist: a field added to `CreateMeetingRegistrantRequest` later
+   * should have to be opted in to the public path deliberately, not inherit it.
+   */
+  private toSelfRegistration(body: CreateMeetingRegistrantRequest): CreateMeetingRegistrantRequest {
+    return {
+      meeting_id: body?.meeting_id,
+      email: body?.email,
+      first_name: body?.first_name,
+      last_name: body?.last_name,
+      host: false,
+      ...(body?.job_title ? { job_title: body.job_title } : {}),
+      ...(body?.org_name ? { org_name: body.org_name } : {}),
+      ...(body?.occurrence_id ? { occurrence_id: body.occurrence_id } : {}),
     };
   }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -484,6 +484,33 @@ export class PublicMeetingController {
     const registrantData = this.toSelfRegistration(req, req.body);
     const meetingId = registrantData.meeting_id;
 
+    // Reject an over-length identity key rather than truncating it. `toSelfRegistration` caps the
+    // free-text fields, but truncating a meeting UID or an email address would turn an unusable value
+    // into a different, valid-looking one — a lookup against the wrong meeting, or an invite sent to an
+    // address nobody asked for. Rejected by name so the caller isn't told a field it did send was
+    // missing.
+    //
+    // Ahead of `startOperation`, because these two are the only fields that reach it untruncated and it
+    // logs `meeting_id` verbatim — checking after would put an unbounded value in the logs, which is
+    // exactly what the cap exists to prevent. `apiErrorHandler` logs the rejection centrally.
+    const overLength = Object.entries({ meeting_id: meetingId, email: registrantData.email }).filter(
+      ([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH
+    );
+
+    if (overLength.length > 0) {
+      return next(
+        ServiceValidationError.fromFieldErrors(
+          Object.fromEntries(overLength.map(([field]) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
+          'Registration data validation failed',
+          {
+            operation: 'register_for_public_meeting',
+            service: 'public_meeting_controller',
+            path: req.path,
+          }
+        )
+      );
+    }
+
     const startTime = logger.startOperation(req, 'register_for_public_meeting', {
       meeting_id: meetingId,
     });
@@ -621,9 +648,9 @@ export class PublicMeetingController {
    * for in the first place. `email` is lowercased for the same reason, since query-service matching is
    * case-sensitive and every read path lowercases.
    *
-   * An over-length `email` is dropped rather than truncated, unlike the free-text fields — truncating
-   * the record's identity key would turn a too-long address into a different, valid-looking one and
-   * send an invite there.
+   * `email` and `meeting_id` are trimmed but not truncated, unlike the free-text fields — truncating
+   * an identity key would turn an unusable value into a different, valid-looking one. The caller
+   * rejects an over-length one by name instead, so the response says what was actually wrong.
    *
    * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
    * register a third party's address for a public meeting and trigger an invite to it — and when the
@@ -634,7 +661,9 @@ export class PublicMeetingController {
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
-    const rawEmail = typeof raw['email'] === 'string' ? raw['email'].trim() : '';
+    // Identity keys are narrowed and trimmed but never truncated — see the length branch in
+    // `registerForPublicMeeting`, which rejects them by name instead.
+    const identity = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim() : '');
     const sessionUsername = getEffectiveUsername(req);
     const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
@@ -642,8 +671,8 @@ export class PublicMeetingController {
     const occurrenceId = text('occurrence_id');
 
     return {
-      meeting_id: text('meeting_id'),
-      email: rawEmail.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH ? '' : rawEmail.toLowerCase(),
+      meeting_id: identity('meeting_id'),
+      email: identity('email').toLowerCase(),
       first_name: text('first_name'),
       last_name: text('last_name'),
       host: false,

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -484,24 +484,35 @@ export class PublicMeetingController {
     const registrantData = this.toSelfRegistration(req, req.body);
     const meetingId = registrantData.meeting_id;
 
-    // Reject an over-length identity key rather than truncating it. `toSelfRegistration` caps the
-    // free-text fields, but truncating a meeting UID or an email address would turn an unusable value
-    // into a different, valid-looking one — a lookup against the wrong meeting, or an invite sent to an
-    // address nobody asked for. Rejected by name so the caller isn't told a field it did send was
-    // missing.
+    // Reject an over-length identifier rather than truncating it. `toSelfRegistration` caps the
+    // free-text fields, but truncating one of these three would turn an unusable value into a
+    // different, valid-looking one: a lookup against the wrong meeting, an invite sent to an address
+    // nobody asked for, or a registration scoped to the wrong occurrence. Rejected by name so the
+    // caller isn't told a field it did send was missing.
     //
-    // Ahead of `startOperation`, because these two are the only fields that reach it untruncated and it
+    // Ahead of `startOperation`, because these are the only fields that reach it untruncated and it
     // logs `meeting_id` verbatim — checking after would put an unbounded value in the logs, which is
     // exactly what the cap exists to prevent. `apiErrorHandler` logs the rejection centrally.
-    const overLength = Object.entries({ meeting_id: meetingId, email: registrantData.email }).filter(
-      ([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH
-    );
+    //
+    // Length is measured on the stored form rather than the submitted one — `email` is already
+    // lowercased here, and lowercasing can lengthen a value for a handful of Unicode code points. The
+    // stored form is what has to fit, so that's what's checked.
+    const overLength = Object.entries({
+      meeting_id: meetingId,
+      email: registrantData.email,
+      occurrence_id: registrantData.occurrence_id ?? '',
+    }).filter(([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
 
     if (overLength.length > 0) {
+      const fields = overLength.map(([field]) => field);
+
       return next(
         ServiceValidationError.fromFieldErrors(
-          Object.fromEntries(overLength.map(([field]) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
-          'Registration data validation failed',
+          Object.fromEntries(fields.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
+          // The cause goes in the top-level message, not only in `errors[]`: the one consumer of this
+          // endpoint renders `error.message` and discards the field array, so a generic "validation
+          // failed" here would leave the registrant with no idea which field to shorten.
+          `${fields.join(', ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`,
           {
             operation: 'register_for_public_meeting',
             service: 'public_meeting_controller',
@@ -648,9 +659,10 @@ export class PublicMeetingController {
    * for in the first place. `email` is lowercased for the same reason, since query-service matching is
    * case-sensitive and every read path lowercases.
    *
-   * `email` and `meeting_id` are trimmed but not truncated, unlike the free-text fields — truncating
-   * an identity key would turn an unusable value into a different, valid-looking one. The caller
-   * rejects an over-length one by name instead, so the response says what was actually wrong.
+   * The three identifiers — `meeting_id`, `email` and `occurrence_id` — are trimmed but not truncated,
+   * unlike the free-text fields, because truncating one would turn an unusable value into a different,
+   * valid-looking one. The caller rejects an over-length one by name instead, so the response says
+   * what was actually wrong.
    *
    * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
    * register a third party's address for a public meeting and trigger an invite to it — and when the
@@ -661,14 +673,14 @@ export class PublicMeetingController {
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
-    // Identity keys are narrowed and trimmed but never truncated — see the length branch in
+    // Identifiers are narrowed and trimmed but never truncated — see the length branch in
     // `registerForPublicMeeting`, which rejects them by name instead.
     const identity = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim() : '');
     const sessionUsername = getEffectiveUsername(req);
     const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
     const orgName = text('org_name');
-    const occurrenceId = text('occurrence_id');
+    const occurrenceId = identity('occurrence_id');
 
     return {
       meeting_id: identity('meeting_id'),

--- a/apps/lfx-one/src/server/errors/service-validation.error.spec.ts
+++ b/apps/lfx-one/src/server/errors/service-validation.error.spec.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+// Relative rather than `@lfx-one/shared/constants` for the reason `meeting.controller.spec.ts:40`
+// gives: the barrel pulls in the enums module graph, and this file needs one string.
+import { VALIDATION_FAILED_MESSAGE_PREFIX } from '../../../../../packages/shared/src/constants/validation.constants';
+import { ServiceValidationError } from './service-validation.error';
+
+describe('ServiceValidationError — the `Validation failed` wire contract', () => {
+  // `getHttpErrorDetail` sniffs this prefix to decide the top-level message names a wire key and the
+  // readable reason lives in `errors[]`. Reword either side without the other and every affected toast
+  // silently starts showing "Validation failed for invitee_email" — these two assertions are what makes
+  // that fail loudly instead.
+  it('prefixes a self-built message with the string the frontend matches on', () => {
+    expect(new ServiceValidationError([]).message).toBe(VALIDATION_FAILED_MESSAGE_PREFIX);
+    expect(ServiceValidationError.forField('invitee_email', 'Email address is required').message).toBe(`${VALIDATION_FAILED_MESSAGE_PREFIX} for invitee_email`);
+  });
+
+  // The other half of the rule: a caller-supplied message is written for a person, carries no prefix,
+  // and so wins over the field array on the client.
+  it('leaves a caller-supplied message unprefixed', () => {
+    const error = ServiceValidationError.fromFieldErrors({ email: 'Email address is required' }, 'Email address is required.');
+
+    expect(error.message).toBe('Email address is required.');
+    expect(error.toResponse()['errors']).toEqual([{ field: 'email', message: 'Email address is required', code: 'FIELD_VALIDATION_ERROR' }]);
+  });
+});

--- a/apps/lfx-one/src/server/errors/service-validation.error.ts
+++ b/apps/lfx-one/src/server/errors/service-validation.error.ts
@@ -8,6 +8,13 @@ import { BaseApiError } from './base.error';
 /**
  * Error class for service-level validation failures
  * Matches the format that microservices would return for validation errors
+ *
+ * The `Validation failed` messages below are a wire contract, not just copy: the frontend reads the
+ * prefix to know the top-level message names a wire key and the readable reason is in `errors[]`
+ * (`readErrorBodyMessage`, shared by both frontend readers). They are written out rather than interpolated from
+ * `VALIDATION_FAILED_MESSAGE_PREFIX` because most server specs stub `@lfx-one/shared/constants`
+ * wholesale; `service-validation.error.spec.ts` pins them against that constant instead, so a reword
+ * on either side fails loudly.
  */
 export class ServiceValidationError extends BaseApiError {
   public readonly validationErrors: ValidationError[];

--- a/apps/lfx-one/src/server/routes/public-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/public-meetings.route.ts
@@ -8,7 +8,8 @@ import { PublicMeetingController } from '../controllers/public-meeting.controlle
 const router = Router();
 const publicMeetingController = new PublicMeetingController();
 
-// POST /public/api/meetings/register - register for a public, non-restricted meeting (public access, no authentication required)
+// POST /public/api/meetings/register - register for a public, non-restricted meeting (optional auth:
+// no session required, but the handler reads the registrant's username off one when it exists)
 router.post('/register', (req, res, next) => publicMeetingController.registerForPublicMeeting(req, res, next));
 
 // GET /public/api/meetings/past/:id - get a past meeting with tiered access (public access, no authentication required)

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -299,6 +299,23 @@ describe('AiService.generateMeetingAgenda', () => {
       expect(prompt).toContain('must not exceed 1200 characters');
       expect(body.response_format.json_schema.schema.properties.agenda.maxLength).toBe(1200);
     });
+
+    // The prompt used to read the raw request while the schema and the outbound clamp read the resolved
+    // cap, so the three could disagree — the model was told "-5 characters" while the schema advertised
+    // something else. Both non-positive and absent caps resolve to the default, matching the policy
+    // `resolveAgendaMaxCharacters` states at the HTTP boundary.
+    it.each([
+      ['no cap', undefined],
+      ['a zero cap', 0],
+      ['a negative cap', -5],
+    ])('resolves %s to the default in both the prompt and the schema', async (_label, maxCharacters) => {
+      const { MEETING_AGENDA_MAX_LENGTH } = await import('@lfx-one/shared/constants');
+      const prompt = await promptFor({ title: 'TAC Monthly', maxCharacters });
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+      expect(prompt).toContain(`must not exceed ${MEETING_AGENDA_MAX_LENGTH} characters`);
+      expect(body.response_format.json_schema.schema.properties.agenda.maxLength).toBe(MEETING_AGENDA_MAX_LENGTH);
+    });
   });
 
   // The schema's `maxLength` and the prompt's cap are both hints the model can ignore. The composer

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -65,13 +65,14 @@ export class AiService {
     });
 
     try {
-      // Resolved once: the same cap is asked of the model (in the schema and the prompt) and enforced
-      // on the way back out, so the three can't disagree. Floored at 1 because `maxCharacters` is a
-      // plain optional number on the request — the app's only caller pre-validates it, but nothing in
-      // this service's contract says so, and a negative would make the clamp's `slice` chop the tail
-      // off the agenda instead of capping it.
-      const agendaMaxCharacters = Math.max(1, request.maxCharacters || MEETING_AGENDA_MAX_LENGTH);
-      const prompt = this.buildPrompt(request);
+      // Resolved once and then used everywhere: the same cap is asked of the model (in the schema and
+      // in the prompt) and enforced on the way back out, so the three can't disagree. A non-positive
+      // `maxCharacters` falls back to the default rather than being floored at 1, matching the policy
+      // `resolveAgendaMaxCharacters` already states at the HTTP boundary — a cap of 1 is honoured
+      // nonsense that guarantees a useless completion. `maxCharacters` is a plain optional number on
+      // the request, so this service defends itself rather than trusting its callers to pre-validate.
+      const agendaMaxCharacters = request.maxCharacters && request.maxCharacters > 0 ? request.maxCharacters : MEETING_AGENDA_MAX_LENGTH;
+      const prompt = this.buildPrompt({ ...request, maxCharacters: agendaMaxCharacters });
       const chatRequest: OpenAIChatRequest = {
         model: this.model,
         messages: [

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1032,9 +1032,26 @@ describe('MeetingService registrant write payloads', () => {
     expect(bodyOf()).toEqual({ email: 'a@example.com', first_name: 'A', last_name: 'B', host: true });
   });
 
-  // The update body uses `null` to erase a stored value, so the rename has to preserve it rather than
-  // treat it like an omission.
-  it('renames on update and preserves an explicit null', async () => {
+  it('renames on update too, since the PUT reuses the same body schema', async () => {
+    await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: 'Acme',
+      avatar_url: 'https://example.com/a.png',
+      occurrence_id: '1666848600',
+    });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
+    expect(bodyOf()).toMatchObject({ org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+  });
+
+  // `getChangedFields` nulls all three whenever they're blank — always, for the two with no form
+  // control. All three targets are declared non-nullable, and before the rename Goa dropped the
+  // undeclared key outright; omitting keeps that outcome instead of planting a null on a declared
+  // field on every ordinary registrant edit.
+  it('omits an explicit null rather than renaming it onto a non-nullable field', async () => {
     await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
       meeting_id: 'meeting-1',
       email: 'a@example.com',
@@ -1045,7 +1062,45 @@ describe('MeetingService registrant write payloads', () => {
       occurrence_id: null,
     });
 
-    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
-    expect(bodyOf()).toMatchObject({ org: null, profile_picture: null, occurrence: null });
+    for (const key of ['org', 'profile_picture', 'occurrence', 'org_name', 'avatar_url', 'occurrence_id']) {
+      expect(bodyOf()).not.toHaveProperty(key);
+    }
+  });
+
+  // Self-registration builds its own payload against a different endpoint, and it's the one path
+  // where a registrant types their own organization — so it has to rename too.
+  it('renames on the self-registration path', async () => {
+    await service.addMeetingRegistrantSelf(req, 'meeting-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: 'Acme',
+    });
+
+    expect(bodyOf()).toMatchObject({ org: 'Acme' });
+    expect(bodyOf()).not.toHaveProperty('org_name');
+    expect(bodyOf()).not.toHaveProperty('meeting_id');
+  });
+
+  // ITX answers a write with `ITXZoomMeetingRegistrant`, which uses the upstream spelling. Without
+  // the inverse rename the returned object satisfies `MeetingRegistrant` only nominally, and the
+  // modal renders a just-saved registrant with no organization.
+  it.each([
+    ['create', (s: MeetingService) => s.addMeetingRegistrant(req, { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' })],
+    ['update', (s: MeetingService) => s.updateMeetingRegistrant(req, 'm', 'r', { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' })],
+    [
+      'self-registration',
+      (s: MeetingService) => s.addMeetingRegistrantSelf(req, 'm', { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' }),
+    ],
+  ])('maps the %s response back to the app spelling', async (_label, call) => {
+    proxyRequest.mockResolvedValue({ uid: 'reg-1', org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+
+    const result = await call(service);
+
+    expect(result).toMatchObject({ uid: 'reg-1', org_name: 'Acme', avatar_url: 'https://example.com/a.png', occurrence_id: '1666848600' });
+    expect(result).not.toHaveProperty('org');
+    expect(result).not.toHaveProperty('profile_picture');
+    expect(result).not.toHaveProperty('occurrence');
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1094,13 +1094,25 @@ describe('MeetingService registrant write payloads', () => {
       (s: MeetingService) => s.addMeetingRegistrantSelf(req, 'm', { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' }),
     ],
   ])('maps the %s response back to the app spelling', async (_label, call) => {
-    proxyRequest.mockResolvedValue({ uid: 'reg-1', org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+    proxyRequest.mockResolvedValue({
+      uid: 'reg-1',
+      org: 'Acme',
+      profile_picture: 'https://example.com/a.png',
+      occurrence: '1666848600',
+      modified_at: '2026-08-17T00:00:00Z',
+    });
 
     const result = await call(service);
 
-    expect(result).toMatchObject({ uid: 'reg-1', org_name: 'Acme', avatar_url: 'https://example.com/a.png', occurrence_id: '1666848600' });
-    expect(result).not.toHaveProperty('org');
-    expect(result).not.toHaveProperty('profile_picture');
-    expect(result).not.toHaveProperty('occurrence');
+    expect(result).toMatchObject({
+      uid: 'reg-1',
+      org_name: 'Acme',
+      avatar_url: 'https://example.com/a.png',
+      occurrence_id: '1666848600',
+      updated_at: '2026-08-17T00:00:00Z',
+    });
+    for (const upstreamKey of ['org', 'profile_picture', 'occurrence', 'modified_at']) {
+      expect(result).not.toHaveProperty(upstreamKey);
+    }
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -984,3 +984,68 @@ describe('MeetingService participant write methods', () => {
     expect(path).toBe('/itx/past_meetings/pm%201/participants/p%2F1');
   });
 });
+
+/**
+ * The ITX registrant contract (`CreateItxRegistrantRequestBody`, reused verbatim for the PUT) declares
+ * `org`, `profile_picture` and `occurrence`; the app's read model — sourced from the v1 query-service
+ * index — spells them `org_name`, `avatar_url` and `occurrence_id`. Goa ignores undeclared body keys,
+ * so without the rename these three were dropped upstream behind a 200.
+ */
+describe('MeetingService registrant write payloads', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    proxyRequest.mockResolvedValue({});
+    service = new MeetingService();
+  });
+
+  const bodyOf = (): Record<string, unknown> => proxyRequest.mock.calls[0][5] as Record<string, unknown>;
+
+  it('renames org_name, avatar_url and occurrence_id on create', async () => {
+    await service.addMeetingRegistrant(req, {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: 'Acme',
+      avatar_url: 'https://example.com/a.png',
+      occurrence_id: '1666848600',
+    });
+
+    expect(bodyOf()).toMatchObject({ org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+    expect(bodyOf()).not.toHaveProperty('org_name');
+    expect(bodyOf()).not.toHaveProperty('avatar_url');
+    expect(bodyOf()).not.toHaveProperty('occurrence_id');
+  });
+
+  it('drops meeting_id from the create body, since it is the path parameter', async () => {
+    await service.addMeetingRegistrant(req, { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants');
+    expect(bodyOf()).not.toHaveProperty('meeting_id');
+  });
+
+  it('omits the renamed keys entirely when the caller omitted them', async () => {
+    await service.addMeetingRegistrant(req, { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B', host: true });
+
+    expect(bodyOf()).toEqual({ email: 'a@example.com', first_name: 'A', last_name: 'B', host: true });
+  });
+
+  // The update body uses `null` to erase a stored value, so the rename has to preserve it rather than
+  // treat it like an omission.
+  it('renames on update and preserves an explicit null', async () => {
+    await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: null,
+      avatar_url: null,
+      occurrence_id: null,
+    });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
+    expect(bodyOf()).toMatchObject({ org: null, profile_picture: null, occurrence: null });
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -906,7 +906,7 @@ export class MeetingService {
       `/itx/meetings/${registrantData.meeting_id}/registrants`,
       'POST',
       undefined,
-      registrantData
+      this.toUpstreamRegistrantBody(registrantData)
     );
 
     return newRegistrant;
@@ -930,7 +930,7 @@ export class MeetingService {
       `/itx/meetings/${meetingUid}/registrants/${registrantUid}`,
       'PUT',
       undefined,
-      updateData
+      this.toUpstreamRegistrantBody(updateData)
     );
 
     return updatedRegistrant;
@@ -2188,5 +2188,35 @@ export class MeetingService {
       return invitedEmail;
     }
     return group.find((participant) => participant.email?.trim())?.email;
+  }
+
+  /**
+   * Renames the three registrant fields whose app-side names differ from the upstream ITX contract.
+   *
+   * `CreateItxRegistrantRequestBody` (reused verbatim for the PUT) declares `org`, `profile_picture`
+   * and `occurrence`; the app's read model — which comes from the v1 query-service index, not from
+   * ITX — spells them `org_name`, `avatar_url` and `occurrence_id`. Goa silently ignores body keys it
+   * doesn't declare, so without this rename the organization an organizer types, the avatar, and a
+   * single-occurrence invite were all dropped on the way upstream, behind a 201.
+   *
+   * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
+   * caller has already used it to build the URL.
+   *
+   * Values pass through untouched, including the `null`s the update body uses to erase a stored value.
+   */
+  private toUpstreamRegistrantBody(body: CreateMeetingRegistrantRequest | UpdateMeetingRegistrantRequest): Record<string, unknown> {
+    const { org_name, avatar_url, occurrence_id } = body as UpdateMeetingRegistrantRequest;
+    const upstream: Record<string, unknown> = { ...body };
+
+    for (const appOnlyKey of ['meeting_id', 'org_name', 'avatar_url', 'occurrence_id']) {
+      delete upstream[appOnlyKey];
+    }
+
+    return {
+      ...upstream,
+      ...(org_name === undefined ? {} : { org: org_name }),
+      ...(avatar_url === undefined ? {} : { profile_picture: avatar_url }),
+      ...(occurrence_id === undefined ? {} : { occurrence: occurrence_id }),
+    };
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -900,7 +900,7 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ registrantData });
     logger.debug(req, 'add_meeting_registrant', 'Creating meeting registrant', sanitizedPayload);
 
-    const newRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+    const newRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${registrantData.meeting_id}/registrants`,
@@ -909,7 +909,7 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(registrantData)
     );
 
-    return newRegistrant;
+    return this.fromUpstreamRegistrant(newRegistrant);
   }
 
   /**
@@ -924,7 +924,7 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ updateData });
     logger.debug(req, 'update_meeting_registrant', 'Updating meeting registrant payload', sanitizedPayload);
 
-    const updatedRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+    const updatedRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${meetingUid}/registrants/${registrantUid}`,
@@ -933,7 +933,7 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(updateData)
     );
 
-    return updatedRegistrant;
+    return this.fromUpstreamRegistrant(updatedRegistrant);
   }
 
   /**
@@ -1939,7 +1939,7 @@ export class MeetingService {
       ...(registrantData.occurrence_id && { occurrence: registrantData.occurrence_id }),
     };
 
-    const newRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+    const upstreamRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${meetingId}/registrants/self`,
@@ -1948,6 +1948,7 @@ export class MeetingService {
       payload,
       { 'X-Sync': 'true' }
     );
+    const newRegistrant = this.fromUpstreamRegistrant(upstreamRegistrant);
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {
       meeting_id: meetingId,
@@ -2202,21 +2203,64 @@ export class MeetingService {
    * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
    * caller has already used it to build the URL.
    *
-   * Values pass through untouched, including the `null`s the update body uses to erase a stored value.
+   * A `null` is omitted rather than renamed. `UpdateMeetingRegistrantRequest` uses `null` to erase a
+   * stored value, but all three targets are declared as non-nullable `type: string`, and
+   * `getChangedFields` sends `null` for every one of them whenever the value is blank — which is
+   * always, for the two that have no form control. Renaming those nulls would newly plant an
+   * off-contract value on a declared field on ordinary registrant edits, where before this rename Goa
+   * discarded the whole key as undeclared. Omitting keeps that outcome exactly.
+   *
+   * Cost: clearing an organization on an edit leaves the stored value in place. It did before this
+   * rename too, so nothing regresses — but it stays unfixed until upstream states how these fields are
+   * erased. Don't guess between `null` and `''` here; `occurrence` already gives blank its own meaning
+   * ("blank = all occurrences"), so a wrong guess silently rescopes an invite.
    */
   private toUpstreamRegistrantBody(body: CreateMeetingRegistrantRequest | UpdateMeetingRegistrantRequest): Record<string, unknown> {
-    const { org_name, avatar_url, occurrence_id } = body as UpdateMeetingRegistrantRequest;
+    const { org_name, avatar_url, occurrence_id } = body;
     const upstream: Record<string, unknown> = { ...body };
 
-    for (const appOnlyKey of ['meeting_id', 'org_name', 'avatar_url', 'occurrence_id']) {
+    // Typed so a rename on either request interface fails the build here rather than silently
+    // re-introducing the drop this method exists to prevent.
+    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest | keyof UpdateMeetingRegistrantRequest)[] = [
+      'meeting_id',
+      'org_name',
+      'avatar_url',
+      'occurrence_id',
+    ];
+
+    for (const appOnlyKey of appOnlyKeys) {
       delete upstream[appOnlyKey];
     }
 
     return {
       ...upstream,
-      ...(org_name === undefined ? {} : { org: org_name }),
-      ...(avatar_url === undefined ? {} : { profile_picture: avatar_url }),
-      ...(occurrence_id === undefined ? {} : { occurrence: occurrence_id }),
+      ...(org_name == null ? {} : { org: org_name }),
+      ...(avatar_url == null ? {} : { profile_picture: avatar_url }),
+      ...(occurrence_id == null ? {} : { occurrence: occurrence_id }),
     };
+  }
+
+  /**
+   * Inverse of {@link toUpstreamRegistrantBody}, for the body ITX returns from a registrant write.
+   *
+   * The POST and PUT both respond with `ITXZoomMeetingRegistrant`, which spells the three fields the
+   * same way the request body does — `org`, `profile_picture`, `occurrence`. Both write methods used
+   * to declare the response as `MeetingRegistrant` and hand it straight back, so the object the
+   * registrant modal renders after a successful save had `org_name` and `avatar_url` undefined no
+   * matter what was stored. Renaming on the way out is what makes that declared type true.
+   *
+   * Only these three are remapped: every other field the app reads off a write response already
+   * shares its upstream name. The read paths need no equivalent, because they come from the v1
+   * query-service index, which already uses the app's spelling.
+   */
+  private fromUpstreamRegistrant(upstream: Record<string, unknown>): MeetingRegistrant {
+    const { org, profile_picture, occurrence, ...rest } = upstream;
+
+    return {
+      ...rest,
+      ...(org === undefined ? {} : { org_name: org }),
+      ...(profile_picture === undefined ? {} : { avatar_url: profile_picture }),
+      ...(occurrence === undefined ? {} : { occurrence_id: occurrence }),
+    } as MeetingRegistrant;
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -2203,12 +2203,18 @@ export class MeetingService {
    * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
    * caller has already used it to build the URL.
    *
-   * A `null` is omitted rather than renamed. `UpdateMeetingRegistrantRequest` uses `null` to erase a
-   * stored value, but all three targets are declared as non-nullable `type: string`, and
-   * `getChangedFields` sends `null` for every one of them whenever the value is blank — which is
-   * always, for the two that have no form control. Renaming those nulls would newly plant an
-   * off-contract value on a declared field on ordinary registrant edits, where before this rename Goa
-   * discarded the whole key as undeclared. Omitting keeps that outcome exactly.
+   * A `null` on one of the three renamed fields is omitted rather than renamed.
+   * `UpdateMeetingRegistrantRequest` uses `null` to erase a stored value, but all three targets are
+   * declared as non-nullable `type: string`, and `getChangedFields` sends `null` for every one of them
+   * whenever the value is blank — which is always, for the two that have no form control. Renaming
+   * those nulls would newly plant an off-contract value on a declared field on ordinary registrant
+   * edits, where before this rename Goa discarded the whole key as undeclared. Omitting keeps that
+   * outcome exactly.
+   *
+   * That omission is scoped to the renamed fields only. `getChangedFields` also nulls `job_title`,
+   * `username` and `linkedin_profile`; those keep whatever they had before, because their upstream
+   * handling is untouched by this rename (`job_title` and `username` are declared — non-nullable, so a
+   * `null` is off-contract there too, and unfixed — and `linkedin_profile` isn't declared at all).
    *
    * Cost: clearing an organization on an edit leaves the stored value in place. It did before this
    * rename too, so nothing regresses — but it stays unfixed until upstream states how these fields are
@@ -2219,9 +2225,10 @@ export class MeetingService {
     const { org_name, avatar_url, occurrence_id } = body;
     const upstream: Record<string, unknown> = { ...body };
 
-    // Typed so a rename on either request interface fails the build here rather than silently
-    // re-introducing the drop this method exists to prevent.
-    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest | keyof UpdateMeetingRegistrantRequest)[] = [
+    // Intersection, not union: a union only rejects a key once it's gone from *both* interfaces, so a
+    // rename on one of them would still compile while the `delete` quietly stopped matching. All four
+    // keys exist on both, so the intersection compiles as-is and does fail the build on either rename.
+    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[] = [
       'meeting_id',
       'org_name',
       'avatar_url',
@@ -2243,24 +2250,33 @@ export class MeetingService {
   /**
    * Inverse of {@link toUpstreamRegistrantBody}, for the body ITX returns from a registrant write.
    *
-   * The POST and PUT both respond with `ITXZoomMeetingRegistrant`, which spells the three fields the
-   * same way the request body does — `org`, `profile_picture`, `occurrence`. Both write methods used
-   * to declare the response as `MeetingRegistrant` and hand it straight back, so the object the
-   * registrant modal renders after a successful save had `org_name` and `avatar_url` undefined no
-   * matter what was stored. Renaming on the way out is what makes that declared type true.
+   * The POST and PUT both respond with `ITXZoomMeetingRegistrant`, which spells the three request
+   * fields the same way the request body does — `org`, `profile_picture`, `occurrence` — and spells the
+   * modification timestamp `modified_at` rather than `updated_at`. Both write methods used to declare
+   * the response as `MeetingRegistrant` and hand it straight back, so the object the registrant modal
+   * renders after a successful save had `org_name` and `avatar_url` undefined no matter what was
+   * stored. Renaming on the way out is what makes those four fields true.
    *
-   * Only these three are remapped: every other field the app reads off a write response already
-   * shares its upstream name. The read paths need no equivalent, because they come from the v1
-   * query-service index, which already uses the app's spelling.
+   * The declared type is still wider than the response: `ITXZoomMeetingRegistrant` carries no
+   * `meeting_id`, `org_is_member`, `org_is_project_member`, `invite_accepted` or `linkedin_profile`,
+   * all of which `MeetingRegistrant` declares as required. They're absent under any spelling, so
+   * there's nothing to rename — the `as` cast is what covers the gap, and a consumer that needs them
+   * has to read the registrant back rather than trust a write response. The read paths need no mapper
+   * at all, because they come from the v1 query-service index, which already uses the app's spelling.
+   *
+   * Absent stays absent rather than becoming `null` — the app's spelling is only introduced for a
+   * value upstream actually returned, so a missing field reads as "the write response didn't say"
+   * instead of "upstream stored nothing".
    */
   private fromUpstreamRegistrant(upstream: Record<string, unknown>): MeetingRegistrant {
-    const { org, profile_picture, occurrence, ...rest } = upstream;
+    const { org, profile_picture, occurrence, modified_at, ...rest } = upstream;
 
     return {
       ...rest,
       ...(org === undefined ? {} : { org_name: org }),
       ...(profile_picture === undefined ? {} : { avatar_url: profile_picture }),
       ...(occurrence === undefined ? {} : { occurrence_id: occurrence }),
+      ...(modified_at === undefined ? {} : { updated_at: modified_at }),
     } as MeetingRegistrant;
   }
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -708,11 +708,13 @@ export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
  * and it always forwards upstream under an M2M token. Without a ceiling here the only bound on a name
  * or organization is `express.json`'s body limit —
  * megabytes, applied to the whole body rather than per field. 255 is generous for every field it
- * covers — the meeting UID, email, first/last name, job title, organization and occurrence ID — and
- * small enough that nothing unbounded reaches upstream or the logs.
+ * bounds and small enough that nothing unbounded reaches upstream or the logs.
  *
- * Free-text fields are truncated at the cap; `email` is dropped instead, since truncating the record's
- * identity key would produce a different, valid-looking address to invite.
+ * Two rules, both keyed off this one number. The free-text fields — first/last name, job title,
+ * organization, occurrence ID — are truncated at the cap. The identity keys, `email` and `meeting_id`,
+ * are rejected with a validation error instead, since truncating one would turn an unusable value into
+ * a different, valid-looking one: an invite sent to the wrong address, or a lookup against the wrong
+ * meeting.
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -701,14 +701,18 @@ export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
 export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
 
 /**
- * Character ceiling for each free-text field an anonymous caller may set on itself when registering
- * for a public meeting (`POST /public/api/meetings/register`).
+ * Character ceiling for each free-text field a caller may set on itself when registering for a public
+ * meeting (`POST /public/api/meetings/register`).
  *
- * That route has no express-validator and no session, and forwards upstream under an M2M token, so
- * without a ceiling here the only bound on a name or organization is `express.json`'s body limit —
+ * That route has no express-validator and is optional-auth — so it runs with or without a session —
+ * and it always forwards upstream under an M2M token. Without a ceiling here the only bound on a name
+ * or organization is `express.json`'s body limit —
  * megabytes, applied to the whole body rather than per field. 255 is generous for every field it
- * covers (email, first/last name, job title, organization) and small enough that nothing unbounded
- * reaches upstream or the logs.
+ * covers — the meeting UID, email, first/last name, job title, organization and occurrence ID — and
+ * small enough that nothing unbounded reaches upstream or the logs.
+ *
+ * Free-text fields are truncated at the cap; `email` is dropped instead, since truncating the record's
+ * identity key would produce a different, valid-looking address to invite.
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -700,6 +700,18 @@ export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
 /** Prompt length at which the character counter turns amber — same 90% of cap as the agenda's */
 export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
 
+/**
+ * Character ceiling for each free-text field an anonymous caller may set on itself when registering
+ * for a public meeting (`POST /public/api/meetings/register`).
+ *
+ * That route has no express-validator and no session, and forwards upstream under an M2M token, so
+ * without a ceiling here the only bound on a name or organization is `express.json`'s body limit —
+ * megabytes, applied to the whole body rather than per field. 255 is generous for every field it
+ * covers (email, first/last name, job title, organization) and small enough that nothing unbounded
+ * reaches upstream or the logs.
+ */
+export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
+
 /** Lower bound for the custom meeting duration, in minutes */
 export const MIN_CUSTOM_DURATION = 5;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -711,10 +711,10 @@ export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
  * bounds and small enough that nothing unbounded reaches upstream or the logs.
  *
  * Two rules, both keyed off this one number. The free-text fields — first/last name, job title,
- * organization, occurrence ID — are truncated at the cap. The identity keys, `email` and `meeting_id`,
+ * organization — are truncated at the cap. The identifiers, `meeting_id`, `email` and `occurrence_id`,
  * are rejected with a validation error instead, since truncating one would turn an unusable value into
- * a different, valid-looking one: an invite sent to the wrong address, or a lookup against the wrong
- * meeting.
+ * a different, valid-looking one: a lookup against the wrong meeting, an invite sent to the wrong
+ * address, or a registration scoped to the wrong occurrence.
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -718,6 +718,26 @@ export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 
+/**
+ * Human labels for the public-registration fields the route rejects by name.
+ *
+ * The rejection's top-level message is the one string the registration modal shows, so it is read by
+ * someone filling in a form, not by someone reading a request body — `email` there says "Email
+ * address", not the wire key. `errors[]` stays keyed by the wire name for anything reading the
+ * fields programmatically.
+ *
+ * `meeting_id` and `occurrence_id` are in the map even though no form field corresponds to them:
+ * they can only be wrong if a caller built the request itself, and that caller is still better served
+ * by a name it can recognize than by silence.
+ */
+export const PUBLIC_REGISTRATION_FIELD_LABELS = {
+  meeting_id: 'Meeting ID',
+  occurrence_id: 'Occurrence ID',
+  email: 'Email address',
+  first_name: 'First name',
+  last_name: 'Last name',
+} as const;
+
 /** Lower bound for the custom meeting duration, in minutes */
 export const MIN_CUSTOM_DURATION = 5;
 

--- a/packages/shared/src/constants/validation.constants.ts
+++ b/packages/shared/src/constants/validation.constants.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Validation constants for form field validation
- * @description Regular expression patterns and validation rules used across the application
+ * Validation constants
+ * @description Regular expression patterns and validation rules used across the application, plus the
+ * two values that form the contract between the server's validation error envelope and the frontend
+ * readers that decide what of it a user is shown.
  */
 
 /**
@@ -33,3 +35,22 @@ export const WHOLE_NUMBER_PATTERN = /^\d+$/;
 
 /** Validates YYYY-MM month format with valid month ranges (01-12). Used for server-side month query parameter validation. */
 export const MONTH_FORMAT_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+/**
+ * The prefix `ServiceValidationError` puts on a validation message it built itself, rather than one a
+ * caller wrote for a person to read. `forField` appends the *wire key* to it ("Validation failed for
+ * invitee_email"), so the frontend uses this prefix to know the readable reason lives in `errors[]`
+ * instead — see `readErrorBodyMessage`, which both frontend error readers share.
+ *
+ * It lives here because both ends of that contract depend on the exact string: reword it on the server
+ * without this constant and every affected toast silently falls back to showing a wire key.
+ */
+export const VALIDATION_FAILED_MESSAGE_PREFIX = 'Validation failed';
+
+/**
+ * Longest plain-text error body `readErrorBodyMessage` will put in front of a user. Angular returns the
+ * raw response text for any non-2xx body that isn't JSON, so what arrives can be a proxy's HTML page or
+ * a stack trace rather than a message; this is the length half of the check that keeps a document out
+ * of a toast. Generous for a real sentence, well short of any document.
+ */
+export const MAX_PLAIN_TEXT_BODY_LENGTH = 200;

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -646,12 +646,16 @@ export interface MeetingRegistrant {
 export interface CreateMeetingRegistrantRequest {
   /*
    * Every optional field is typed without `| null`: upstream declares them all as non-nullable
-   * optional `string`s in `CreateItxRegistrantRequestBody`, and nothing between here and there
-   * launders a `null` — the BFF's one such drop is `committee_uid`-specific — so a `null` would reach
-   * upstream verbatim. Keeping it out of the type is what makes omission enforceable at compile time
-   * rather than a convention each caller has to remember. A create has nothing to clear, so omission
-   * loses no meaning — unlike `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a
-   * stored value.
+   * optional `string`s in `CreateItxRegistrantRequestBody`. Keeping `null` out of the type is what
+   * makes omission enforceable at compile time rather than a convention each caller has to remember. A
+   * create has nothing to clear, so omission loses no meaning — unlike
+   * `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a stored value.
+   *
+   * The BFF does drop a nullish `org_name`, `avatar_url` or `occurrence_id` on the way out
+   * (`MeetingService.toUpstreamRegistrantBody`), and drops a blank one again on the public
+   * self-registration path (`PublicMeetingController.toSelfRegistration`) — but both exist to serve
+   * the rename and the public trust boundary, not to launder this type, and neither covers
+   * `job_title`, `username` or `committee_uid`. Treat the type as the guard.
    *
    * Note that three of these names differ from the wire: the BFF renames `org_name` → `org`,
    * `avatar_url` → `profile_picture` and `occurrence_id` → `occurrence` before proxying, so this

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -644,6 +644,19 @@ export interface MeetingRegistrant {
  * @description Data required to add a new registrant to a meeting
  */
 export interface CreateMeetingRegistrantRequest {
+  /*
+   * Every optional field is typed without `| null`: upstream declares them all as non-nullable
+   * optional `string`s in `CreateItxRegistrantRequestBody`, and nothing between here and there
+   * launders a `null` — the BFF's one such drop is `committee_uid`-specific — so a `null` would reach
+   * upstream verbatim. Keeping it out of the type is what makes omission enforceable at compile time
+   * rather than a convention each caller has to remember. A create has nothing to clear, so omission
+   * loses no meaning — unlike `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a
+   * stored value.
+   *
+   * Note that three of these names differ from the wire: the BFF renames `org_name` → `org`,
+   * `avatar_url` → `profile_picture` and `occurrence_id` → `occurrence` before proxying, so this
+   * interface follows the app's read model (the v1 query-service index) rather than the ITX body.
+   */
   /** UUID of the meeting */
   meeting_id: string;
   /** User's email address */
@@ -655,22 +668,20 @@ export interface CreateMeetingRegistrantRequest {
   /** Whether user should have host access */
   host?: boolean;
   /** User's job title */
-  job_title?: string | null;
+  job_title?: string;
   /** User's organization */
-  org_name?: string | null;
+  org_name?: string;
   /** Specific occurrence ID to invite to (blank = all occurrences) */
-  occurrence_id?: string | null;
+  occurrence_id?: string;
   /** User's avatar URL */
-  avatar_url?: string | null;
+  avatar_url?: string;
   /** User's LFID */
-  username?: string | null;
+  username?: string;
   /**
    * Committee this registrant was added from, as a **v2** committee UID.
    * Upstream stores a v1 committee SFID and derives `type: 'committee'` from it, so the BFF
-   * resolves v2 → v1 before proxying. Omit for a directly-added guest: upstream declares the field a
-   * non-nullable optional `string`, so `null` is off-contract and the BFF drops the key rather than
-   * forwarding it. Typed without `| null` so that's enforceable at compile time for internal callers —
-   * the BFF's runtime drop stays as a guard for bodies it doesn't build itself.
+   * resolves v2 → v1 before proxying. Omit for a directly-added guest, as for every other optional
+   * field on this body.
    */
   committee_uid?: string;
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -651,11 +651,11 @@ export interface CreateMeetingRegistrantRequest {
    * create has nothing to clear, so omission loses no meaning — unlike
    * `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a stored value.
    *
-   * The BFF does drop a nullish `org_name`, `avatar_url` or `occurrence_id` on the way out
-   * (`MeetingService.toUpstreamRegistrantBody`), and drops a blank one again on the public
-   * self-registration path (`PublicMeetingController.toSelfRegistration`) — but both exist to serve
-   * the rename and the public trust boundary, not to launder this type, and neither covers
-   * `job_title`, `username` or `committee_uid`. Treat the type as the guard.
+   * `MeetingService.toUpstreamRegistrantBody` does drop a nullish `org_name`, `avatar_url` or
+   * `occurrence_id` on the way out — but it exists to serve the rename, not to launder this type, and
+   * it doesn't cover `job_title`, `username` or `committee_uid`. (The public self-registration path
+   * narrows harder still, but only because it's a trust boundary; nothing else shares that treatment.)
+   * Treat the type as the guard.
    *
    * Note that three of these names differ from the wire: the BFF renames `org_name` → `org`,
    * `avatar_url` → `profile_picture` and `occurrence_id` → `occurrence` before proxying, so this

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -691,6 +691,20 @@ export interface CreateMeetingRegistrantRequest {
  * @description Data required for PUT request to update an existing registrant
  */
 export interface UpdateMeetingRegistrantRequest {
+  /*
+   * The PUT reuses `CreateItxRegistrantRequestBody`, so the BFF renames `org_name`, `avatar_url` and
+   * `occurrence_id` on the way out (see `MeetingService.toUpstreamRegistrantBody`).
+   *
+   * Two known gaps, both pre-dating that rename:
+   *
+   * - `null` does not erase. Every target is declared non-nullable, and `MeetingService.getChangedFields`
+   *   nulls each of these whenever it's blank, so the BFF omits a `null` rather than sending one.
+   *   Clearing a stored organization therefore doesn't take effect. Fixing it needs upstream to say how
+   *   these fields are erased — don't guess between `null` and `''`; `occurrence` already gives blank
+   *   its own meaning ("blank = all occurrences").
+   * - `linkedin_profile` is not declared upstream at all, under this or any other name, so Goa discards
+   *   it. The registrant form still validates it and still reports success. Tracked separately.
+   */
   /** UUID of the meeting (required) */
   meeting_id: string;
   /** User's email address (required) */

--- a/packages/shared/src/utils/string.utils.spec.ts
+++ b/packages/shared/src/utils/string.utils.spec.ts
@@ -3,7 +3,16 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { capCodePointEdit, codePointLength, slugify, splitIntoParagraphs, sanitizePlainText, stripMarkdown, truncateToUtf16Units } from './string.utils';
+import {
+  capCodePointEdit,
+  codePointLength,
+  joinAsSentenceList,
+  sanitizePlainText,
+  slugify,
+  splitIntoParagraphs,
+  stripMarkdown,
+  truncateToUtf16Units,
+} from './string.utils';
 
 describe('codePointLength', () => {
   it('counts ASCII the same as String.length', () => {
@@ -199,5 +208,24 @@ describe('truncateToUtf16Units', () => {
   it('returns an empty string for a non-positive cap', () => {
     expect(truncateToUtf16Units('agenda', 0)).toBe('');
     expect(truncateToUtf16Units('agenda', -5)).toBe('');
+  });
+});
+
+describe('joinAsSentenceList', () => {
+  it('returns a single label unchanged', () => {
+    expect(joinAsSentenceList(['Email address'])).toBe('Email address');
+  });
+
+  it('joins two labels with a bare and', () => {
+    expect(joinAsSentenceList(['Meeting ID', 'Email address'])).toBe('Meeting ID and Email address');
+  });
+
+  // The case a plain join(' and ') gets wrong — three items chant instead of reading as a list.
+  it('commas all but the last label for three or more', () => {
+    expect(joinAsSentenceList(['Meeting ID', 'Email address', 'First name'])).toBe('Meeting ID, Email address and First name');
+  });
+
+  it('returns an empty string for no labels', () => {
+    expect(joinAsSentenceList([])).toBe('');
   });
 });

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -190,18 +190,28 @@ export function capCodePointEdit(previous: string, next: string, max: number): s
  * Truncate to at most `max` UTF-16 code units without leaving a lone surrogate behind.
  * @param value - The string to truncate
  * @param max - The maximum number of UTF-16 code units
- * @returns `value` unchanged when within the cap, otherwise clipped to `max` units (or `max - 1` when
- * the cut would land inside a surrogate pair)
+ * @returns `value` unchanged when within the cap, `''` when `max` is not a positive number, otherwise
+ * clipped to `max` units (or `max - 1` when the cut would land inside a surrogate pair)
  *
  * Deliberately measured in UTF-16 units rather than code points, unlike {@link codePointLength} and
- * {@link capCodePointEdit}: these caps guard values that are handed to `Validators.maxLength` or a
- * native `maxlength` attribute, both of which count UTF-16 units. Truncating by code point would let a
- * string full of emoji pass a code-point cap and still fail the validator on the other side — which,
- * for the meeting composer's agenda, means an invalid form and a Save button that does nothing.
+ * {@link capCodePointEdit}. That matters where the truncated value is handed to `Validators.maxLength`
+ * or a native `maxlength` attribute, both of which count UTF-16 units: truncating by code point would
+ * let a string full of emoji pass a code-point cap and still fail the validator on the other side —
+ * which, for the meeting composer's agenda, means an invalid form and a Save button that does nothing.
+ * Callers whose value never reaches a form control (the AI prompt descriptors) get only the
+ * lone-surrogate guarantee above, which is reason enough on its own.
+ *
+ * Surrogate pairs are the only unit kept whole — a cut can still split a ZWJ sequence or orphan a
+ * combining mark. Honouring grapheme clusters would break parity with the UTF-16 counts these caps
+ * exist to satisfy.
  */
 export function truncateToUtf16Units(value: string, max: number): string {
-  if (value.length <= max || max <= 0) {
-    return value.length <= max ? value : '';
+  if (!(max > 0)) {
+    return '';
+  }
+
+  if (value.length <= max) {
+    return value;
   }
 
   // A high surrogate at the last kept position means the cut splits a pair; drop it rather than emit

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -222,6 +222,22 @@ export function truncateToUtf16Units(value: string, max: number): string {
   return value.slice(0, splitsPair ? max - 1 : max);
 }
 
+/**
+ * Joins labels the way a sentence does — `"A"`, `"A and B"`, `"A, B and C"` — for user-facing copy
+ * that names a variable number of fields. A plain `join(' and ')` reads as a chant past two items
+ * ("Meeting ID and Email address and First name"), and a plain `join(', ')` drops the conjunction the
+ * last item needs.
+ *
+ * No Oxford comma, matching the rest of the app's copy.
+ */
+export function joinAsSentenceList(labels: readonly string[]): string {
+  if (labels.length < 2) {
+    return labels[0] ?? '';
+  }
+
+  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`;
+}
+
 /** Best-effort split of a display name into [firstName, lastName]; `null` parts when nothing usable (e.g. an email used as the name). */
 export function splitDisplayName(name: string | null): [string | null, string | null] {
   const trimmed = (name ?? '').trim();


### PR DESCRIPTION
> **Stack 10 of 20.** Based on PR 9 (`feat/issue-1464-agenda-ai-attribution`). Followed by PR 11 (`style/issue-1460-create-dropdown`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Sends registrant fields upstream under the names the ITX API actually expects, and surfaces the real failure reason instead of a generic error.

## How

- Renames the registrant fields on every ITX path so the upstream service receives `first_name` / `last_name` rather than the internal camelCase shape.
- Narrows the public registrant request body at the trust boundary — only the expected fields are forwarded, and each is type-checked.
- Restores the occurrence scope on the registrant paths and strips the LFID prefix from the identity key.
- Rejects an over-length identity key by name and makes that rejection reach the caller.
- Puts a readable cause in registration failures and stops rendering developer strings in error toasts.

## Notes for reviewers

- `addMeetingRegistrantWithM2M` no longer exists on `main` — the public self-registration path was rewritten upstream and the route is now session-required. This PR is written against that current shape.

## Protected files

This PR touches files flagged by `.claude/hooks/guard-protected-files.sh`. Requesting code-owner review from @linuxfoundation/lfx-platform.

| File | Why it is protected | What this PR changes |
| --- | --- | --- |
| `apps/lfx-one/src/server/services/ai.service.ts` | AI integration service. Changes affect AI-powered features. | Aligns the generation error path with the new readable-cause handling so a proxy failure reaches the caller as a real reason rather than a generic string. |

## Commits

9 commit(s), 23 files changed, 1288 insertions(+), 151 deletions(-).

- `fix(meetings): send registrant fields upstream by their real names`
- `fix(meetings): rename registrant fields on every ITX path`
- `fix(review): narrow the public registrant body at the trust boundary`
- `fix(review): restore the occurrence scope and strip the LFID prefix`
- `fix(review): reject an over-length identity key by name`
- `fix(review): make the length rejection reach the registrant`
- `fix(review): put a readable cause in registration failures`
- `fix(committees): read the error key the server actually sends`
- `fix(review): stop showing developer strings in error toasts`

## Related

- Refs #1463
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
