### PR TITLE
style(meetings): add a descriptive create dropdown and align the drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/agenda-template-selector/agenda-template-selector.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/agenda-template-selector/agenda-template-selector.component.html
@@ -1,47 +1,34 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-@if (visible()) {
-  <lfx-message severity="secondary" icon="fa-light fa-list" styleClass="mb-4" data-testid="template-selector-panel">
-    <ng-template #content>
-      <div>
-        <h3 class="text-base font-semibold mb-1">Agenda Templates</h3>
-        <p class="text-sm">Choose from common agenda templates for {{ meetingType().toLowerCase() }} meetings.</p>
-      </div>
-    </ng-template>
-  </lfx-message>
-  <div>
-    @if (displayTemplates().length > 0) {
-      <div class="flex flex-col gap-3 mb-4" data-testid="template-list">
-        @for (template of displayTemplates(); track template.id) {
-          <div
-            class="bg-white border border-gray-200 rounded-lg p-4 hover:border-blue-500 hover:bg-blue-50 cursor-pointer transition-all duration-200"
-            (click)="selectTemplate(template)"
-            [attr.data-testid]="'template-item-' + template.id">
-            <div class="flex items-start justify-between">
-              <h4 class="text-sm font-semibold text-gray-900">{{ template.title }}</h4>
-              <lfx-tag [value]="template.formattedDuration" severity="secondary"></lfx-tag>
-            </div>
-            <p class="text-xs text-gray-600 leading-relaxed">{{ template.preview }}</p>
-          </div>
-        }
-      </div>
-    } @else {
-      <div class="text-center py-6" data-testid="no-templates-message">
-        <i class="fa-light fa-book-open text-gray-400 text-2xl mb-2"></i>
-        <p class="text-sm text-gray-500">No templates available for {{ meetingType() }} meetings</p>
-      </div>
-    }
-
-    <div class="pt-3 border-t border-gray-200">
-      <lfx-button
-        (onClick)="close()"
-        label="Cancel"
-        size="small"
-        [text]="true"
-        styleClass="text-gray-500 hover:text-gray-700 text-sm"
-        data-testid="template-selector-close">
-      </lfx-button>
-    </div>
+<!-- Rendered as popover content: the popover owns visibility and dismissal, so there is no
+     visibility gate and no cancel button here. -->
+<div class="flex flex-col gap-3" data-testid="template-selector-panel">
+  <div class="flex flex-col gap-0.5">
+    <h3 class="text-sm font-semibold text-gray-900">Agenda templates</h3>
+    <p class="text-xs text-gray-500">Choose from common agenda templates for {{ meetingType().toLowerCase() }} meetings.</p>
   </div>
-}
+
+  @if (displayTemplates().length > 0) {
+    <div class="flex flex-col gap-2" data-testid="template-list">
+      @for (template of displayTemplates(); track template.id) {
+        <button
+          type="button"
+          class="flex cursor-pointer flex-col gap-1 rounded-lg border border-gray-200 bg-white p-3 text-left transition-colors duration-200 hover:border-blue-500 hover:bg-blue-50"
+          (click)="selectTemplate(template)"
+          [attr.data-testid]="'template-item-' + template.id">
+          <span class="flex w-full items-start justify-between gap-2">
+            <span class="text-sm font-semibold text-gray-900">{{ template.title }}</span>
+            <span class="shrink-0 rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">{{ template.formattedDuration }}</span>
+          </span>
+          <span class="text-xs leading-relaxed text-gray-500">{{ template.preview }}</span>
+        </button>
+      }
+    </div>
+  } @else {
+    <div class="flex flex-col items-center gap-2 py-6" data-testid="no-templates-message">
+      <i class="fa-light fa-book-open text-2xl text-gray-400" aria-hidden="true"></i>
+      <p class="text-sm text-gray-500">No templates available for {{ meetingType() }} meetings</p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/meetings/components/agenda-template-selector/agenda-template-selector.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/agenda-template-selector/agenda-template-selector.component.ts
@@ -1,26 +1,20 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, OnInit, output } from '@angular/core';
-import { ButtonComponent } from '@components/button/button.component';
-import { MessageComponent } from '@components/message/message.component';
-import { TagComponent } from '@components/tag/tag.component';
+import { Component, computed, input, output } from '@angular/core';
 import { MeetingTemplate, MeetingType } from '@lfx-one/shared';
 import { MEETING_TEMPLATES } from '@lfx-one/shared/constants';
 
 @Component({
   selector: 'lfx-agenda-template-selector',
-  imports: [ButtonComponent, MessageComponent, TagComponent],
   templateUrl: './agenda-template-selector.component.html',
 })
-export class AgendaTemplateSelectorComponent implements OnInit {
+export class AgendaTemplateSelectorComponent {
   // Inputs
   public readonly meetingType = input.required<MeetingType>();
-  public readonly visible = input.required<boolean>();
 
   // Outputs
   public readonly templateSelected = output<MeetingTemplate>();
-  public readonly closeSelector = output<void>();
 
   // Computed properties
   public readonly availableTemplates = computed(() => {
@@ -36,16 +30,8 @@ export class AgendaTemplateSelectorComponent implements OnInit {
     }));
   });
 
-  public ngOnInit(): void {
-    // Component initialization if needed
-  }
-
   public selectTemplate(template: MeetingTemplate): void {
     this.templateSelected.emit(template);
-  }
-
-  public close(): void {
-    this.closeSelector.emit();
   }
 
   private getPreview(content: string): string {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
@@ -21,8 +21,8 @@
     <!-- Committee Selection -->
     @if (committeeContext(); as ctx) {
       <!-- Read-only locked group display (from group context) -->
-      <div class="flex flex-col gap-1">
-        <label class="block text-neutral-950 mb-2">{{ committeeLabel.singular }}</label>
+      <div class="flex flex-col gap-1.5">
+        <label class="text-sm font-medium text-gray-900">{{ committeeLabel.singular }}</label>
         <div class="flex items-center gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg" data-testid="meeting-committee-locked">
           <div class="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center flex-shrink-0">
             <i class="fa-light fa-users text-sm text-blue-600" aria-hidden="true"></i>
@@ -35,8 +35,8 @@
         </div>
       </div>
     } @else {
-      <div class="flex flex-col gap-1">
-        <label class="block text-neutral-950 mb-2">Select {{ committeeLabel.plural }}</label>
+      <div class="flex flex-col gap-1.5">
+        <label class="text-sm font-medium text-gray-900">{{ committeeLabel.plural }}</label>
         <lfx-multi-select
           [form]="committeeForm"
           control="committees"
@@ -50,20 +50,21 @@
           class="w-full"
           appendTo="body"
           data-testid="meeting-committee-multi-select"></lfx-multi-select>
+        <!-- Inside the field stack so the hint sits on the field's own gap, not the section's -->
+        @if (selectedCommitteeIds().length === 0) {
+          <p class="text-xs text-gray-500">
+            Select {{ committeeLabel.plural.toLowerCase() }} to associate with this meeting. {{ committeeLabel.singular }} members will automatically be added
+            as guests.
+          </p>
+        }
       </div>
-      @if (selectedCommitteeIds().length === 0) {
-        <p class="text-sm text-gray-500">
-          Select {{ committeeLabel.plural.toLowerCase() }} to associate with this meeting. {{ committeeLabel.singular }} members will automatically be added as
-          guests.
-        </p>
-      }
     }
 
     <!-- Voting Status Selection -->
     @if (hasVotingEnabledCommittee()) {
-      <div class="flex flex-col gap-1">
-        <div class="flex items-center gap-1 mb-2">
-          <label class="block text-neutral-950">Voting Status Selection</label>
+      <div class="flex flex-col gap-1.5">
+        <div class="flex items-center gap-1">
+          <label class="text-sm font-medium text-gray-900">Voting Status Selection</label>
           <i
             class="fa-light fa-info-circle text-sm text-gray-500"
             pTooltip="Select which voting statuses committee members must have to participate in this meeting. Only members with the selected voting status(es) will be invited to the meeting."></i>
@@ -84,7 +85,7 @@
     }
 
     @if (selectedCommitteeIds().length > 0) {
-      <p class="text-sm text-gray-500">
+      <p class="text-xs text-gray-500">
         <strong>{{ selectedCommitteeIds().length }}</strong> {{ committeeLabel.plural.toLowerCase() }} selected.
         @if (filteredCommitteeMembers().length > 0) {
           <strong>{{ filteredCommitteeMembers().length }}</strong> unique member(s) will be added to the invitation list.

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.html
@@ -1,144 +1,116 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="border border-gray-200 rounded-lg p-4">
-  <!-- Header -->
-  <div class="mb-4">
-    <p class="text-neutral-950 mb-1">Custom Recurrence Pattern</p>
-    <p class="text-sm text-gray-600">Configure a custom recurring pattern for this meeting</p>
+<!-- No nested card or heading: this panel only ever renders under the "Custom" cadence chip, inside the
+     recurring card that already frames and titles it. A rule stands in for the border it used to draw. -->
+<div class="flex flex-col gap-4 border-t border-gray-200 pt-3" [formGroup]="recurrenceForm()">
+  <!-- Interval -->
+  <div class="flex flex-col gap-1.5">
+    <span class="text-sm font-medium text-gray-900">Repeat every <span class="text-red-500">*</span></span>
+
+    <div class="flex flex-wrap items-center gap-2">
+      <lfx-input-number [form]="recurrenceForm()" control="repeat_interval" placeholder="1" styleClass="w-20" data-testid="recurrence-interval-input" />
+      <lfx-select [form]="form()" control="patternTypeUI" [options]="patternTypeOptions" styleClass="min-w-24" data-testid="recurrence-pattern-type-select" />
+    </div>
   </div>
 
-  <!-- Form Content -->
-  <div class="flex flex-col gap-4" [formGroup]="recurrenceForm()">
-    <!-- Section 1: Pattern Selection -->
-    <div class="border-b border-gray-100 pb-4">
-      <label class="block text-neutral-950 mb-2">Repeat Pattern</label>
-
-      <div class="flex items-center gap-3 flex-wrap">
-        <span class="text-sm text-gray-600">Repeat every</span>
-
-        <lfx-input-number [form]="recurrenceForm()" control="repeat_interval" placeholder="1" styleClass="w-20" data-testid="recurrence-interval-input">
-        </lfx-input-number>
-
-        <lfx-select [form]="form()" control="patternTypeUI" [options]="patternTypeOptions" styleClass="min-w-24" data-testid="recurrence-pattern-type-select">
-        </lfx-select>
+  <!-- Weekly Pattern Details -->
+  @if (patternType() === 'weekly') {
+    <div class="flex flex-col gap-1.5">
+      <span id="recurrence-weekly-label" class="text-sm font-medium text-gray-900">Repeat on</span>
+      <!-- Wrapping pills rather than a 7-column grid: the same chip shape as the duration and cadence
+           rows above, and the days stay legible in the quick dialog's narrow schedule column. -->
+      <div role="group" aria-labelledby="recurrence-weekly-label" class="flex flex-wrap gap-2">
+        @for (day of daysOfWeek; track day.value; let i = $index) {
+          <label [class]="isWeeklyDaySelected(i) ? chipSelectedClass : chipUnselectedClass" [attr.data-testid]="'recurrence-day-' + day.label.toLowerCase()">
+            <input type="checkbox" [checked]="isWeeklyDaySelected(i)" (change)="onWeeklyDayChange(i, $event)" class="sr-only" />
+            <span>{{ day.label }}</span>
+          </label>
+        }
       </div>
     </div>
+  }
 
-    <!-- Section 2: Pattern Details -->
-    <div class="border-b border-gray-100 pb-4">
-      <label class="block text-neutral-950 mb-2">Pattern Details</label>
-
-      <!-- Weekly Pattern Details -->
-      @if (patternType() === 'weekly') {
-        <div class="flex flex-col gap-3">
-          <p class="text-sm text-gray-600 mb-2">Repeat on:</p>
-          <div class="grid grid-cols-7 gap-2">
-            @for (day of daysOfWeek; track day.value; let i = $index) {
-              <label
-                class="flex flex-col items-center p-2 border border-gray-200 rounded-md cursor-pointer transition-colors hover:bg-gray-50"
-                [class.bg-blue-50]="isWeeklyDaySelected(i)"
-                [class.border-blue-300]="isWeeklyDaySelected(i)"
-                [attr.data-testid]="'recurrence-day-' + day.label.toLowerCase()">
-                <input type="checkbox" [checked]="isWeeklyDaySelected(i)" (change)="onWeeklyDayChange(i, $event)" class="sr-only" />
-                <span class="text-xs font-medium text-gray-700">{{ day.label }}</span>
-              </label>
-            }
-          </div>
-        </div>
-      }
-
-      <!-- Monthly Pattern Details -->
-      @if (patternType() === 'monthly') {
-        <div class="flex flex-col gap-4">
-          <div class="flex flex-col gap-2">
-            @for (option of monthlyTypeOptions; track option.value) {
-              <label class="flex items-center gap-2 cursor-pointer" [attr.data-testid]="'recurrence-monthly-' + option.value">
-                <lfx-radio-button [form]="recurrenceForm()" control="monthlyTypeUI" [value]="option.value" name="monthlyTypeUI"> </lfx-radio-button>
-                <span class="text-sm text-gray-600">{{ option.label }}</span>
-              </label>
-            }
-          </div>
-
-          <!-- Day of Month Option -->
-          @if (monthlyType() === 'dayOfMonth') {
-            <div class="flex items-center gap-2 flex-wrap pl-6">
-              <span class="text-sm text-gray-600">On day</span>
-              <lfx-input-number [form]="recurrenceForm()" control="monthly_day" placeholder="1" styleClass="w-16" data-testid="recurrence-monthly-day">
-              </lfx-input-number>
-              <span class="text-sm text-gray-600">of the month</span>
-            </div>
-          }
-
-          <!-- Day of Week Option -->
-          @if (monthlyType() === 'dayOfWeek') {
-            <div class="flex items-center gap-2 flex-wrap pl-6">
-              <span class="text-sm text-gray-600">On the</span>
-              <lfx-select
-                [form]="recurrenceForm()"
-                control="monthly_week"
-                [options]="weeklyOrdinals"
-                styleClass="min-w-16"
-                data-testid="recurrence-monthly-week">
-              </lfx-select>
-              <lfx-select
-                [form]="recurrenceForm()"
-                control="monthly_week_day"
-                [options]="daysOfWeek"
-                [optionLabel]="'fullLabel'"
-                [optionValue]="'value'"
-                styleClass="min-w-24"
-                data-testid="recurrence-monthly-weekday">
-              </lfx-select>
-            </div>
-          }
-        </div>
-      }
-
-      <!-- Daily Pattern (no additional details needed) -->
-      @if (patternType() === 'daily') {
-        <div>
-          <p class="text-sm text-gray-600 italic">Meeting will repeat every {{ recurrenceForm().get('repeat_interval')?.value || 1 }} day(s)</p>
-        </div>
-      }
-    </div>
-
-    <!-- Section 3: End Condition -->
-    <div>
-      <label class="block text-neutral-950 mb-2">End Condition</label>
-
-      <div class="flex flex-col gap-2 mb-4">
-        @for (option of endTypeOptions; track option.value) {
-          <label class="flex items-center gap-2 cursor-pointer" [attr.data-testid]="'recurrence-end-' + option.value">
-            <lfx-radio-button [form]="recurrenceForm()" control="endTypeUI" [value]="option.value" name="endTypeUI"> </lfx-radio-button>
-            <span class="text-sm text-gray-600">{{ option.label }}</span>
+  <!-- Monthly Pattern Details -->
+  @if (patternType() === 'monthly') {
+    <div class="flex flex-col gap-1.5">
+      <span id="recurrence-monthly-label" class="text-sm font-medium text-gray-900">Repeat on</span>
+      <div role="radiogroup" aria-labelledby="recurrence-monthly-label" class="flex flex-wrap gap-2">
+        @for (option of monthlyTypeOptions; track option.value) {
+          <label [class]="monthlyType() === option.value ? chipSelectedClass : chipUnselectedClass" [attr.data-testid]="'recurrence-monthly-' + option.value">
+            <input
+              type="radio"
+              name="recurrence-monthly-type"
+              class="sr-only"
+              [checked]="monthlyType() === option.value"
+              (change)="selectMonthlyType(option.value)" />
+            <span>{{ option.label }}</span>
           </label>
         }
       </div>
 
-      <!-- End Date Option -->
-      @if (endType() === 'date') {
-        <div class="pl-6">
-          <lfx-calendar
-            [form]="recurrenceForm()"
-            control="end_date_time"
-            placeholder="Select end date"
-            [minDate]="minEndDate()"
-            styleClass="max-w-xs"
-            data-testid="recurrence-end-date">
-          </lfx-calendar>
+      <!-- Day of Month Option -->
+      @if (monthlyType() === 'dayOfMonth') {
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-sm text-gray-600">On day</span>
+          <lfx-input-number [form]="recurrenceForm()" control="monthly_day" placeholder="1" styleClass="w-16" data-testid="recurrence-monthly-day" />
+          <span class="text-sm text-gray-600">of the month</span>
         </div>
       }
 
-      <!-- End Occurrences Option -->
-      @if (endType() === 'occurrences') {
-        <div class="flex items-center gap-2 flex-wrap pl-6">
-          <span class="text-sm text-gray-600">After</span>
-          <lfx-input-number [form]="recurrenceForm()" control="end_times" placeholder="10" styleClass="w-20" data-testid="recurrence-end-occurrences">
-          </lfx-input-number>
-          <span class="text-sm text-gray-600">occurrence(s)</span>
+      <!-- Day of Week Option -->
+      @if (monthlyType() === 'dayOfWeek') {
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-sm text-gray-600">On the</span>
+          <lfx-select [form]="recurrenceForm()" control="monthly_week" [options]="weeklyOrdinals" styleClass="min-w-16" data-testid="recurrence-monthly-week" />
+          <lfx-select
+            [form]="recurrenceForm()"
+            control="monthly_week_day"
+            [options]="daysOfWeek"
+            [optionLabel]="'fullLabel'"
+            [optionValue]="'value'"
+            styleClass="min-w-24"
+            data-testid="recurrence-monthly-weekday" />
         </div>
       }
     </div>
+  }
+
+  <!-- Daily Pattern (no additional details needed) -->
+  @if (patternType() === 'daily') {
+    <p class="text-sm italic text-gray-600">Meeting will repeat every {{ recurrenceForm().get('repeat_interval')?.value || 1 }} day(s)</p>
+  }
+
+  <!-- End Condition -->
+  <div class="flex flex-col gap-1.5">
+    <span id="recurrence-end-label" class="text-sm font-medium text-gray-900">End condition</span>
+    <div role="radiogroup" aria-labelledby="recurrence-end-label" class="flex flex-wrap gap-2">
+      @for (option of endTypeOptions; track option.value) {
+        <label [class]="endType() === option.value ? chipSelectedClass : chipUnselectedClass" [attr.data-testid]="'recurrence-end-' + option.value">
+          <input type="radio" name="recurrence-end-type" class="sr-only" [checked]="endType() === option.value" (change)="selectEndType(option.value)" />
+          <span>{{ option.label }}</span>
+        </label>
+      }
+    </div>
+
+    <!-- End Date Option -->
+    @if (endType() === 'date') {
+      <lfx-calendar
+        [form]="recurrenceForm()"
+        control="end_date_time"
+        placeholder="Select end date"
+        [minDate]="minEndDate()"
+        styleClass="max-w-xs"
+        data-testid="recurrence-end-date" />
+    }
+
+    <!-- End Occurrences Option -->
+    @if (endType() === 'occurrences') {
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-sm text-gray-600">After</span>
+        <lfx-input-number [form]="recurrenceForm()" control="end_times" placeholder="10" styleClass="w-20" data-testid="recurrence-end-occurrences" />
+        <span class="text-sm text-gray-600">occurrence(s)</span>
+      </div>
+    }
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts
@@ -6,7 +6,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CalendarComponent } from '@components/calendar/calendar.component';
 import { InputNumberComponent } from '@components/input-number/input-number.component';
-import { RadioButtonComponent } from '@components/radio-button/radio-button.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
   RECURRENCE_DAYS_OF_WEEK,
@@ -19,7 +18,7 @@ import { getWeekOfMonth } from '@lfx-one/shared/utils';
 
 @Component({
   selector: 'lfx-meeting-recurrence-pattern',
-  imports: [ReactiveFormsModule, CalendarComponent, InputNumberComponent, RadioButtonComponent, SelectComponent],
+  imports: [ReactiveFormsModule, CalendarComponent, InputNumberComponent, SelectComponent],
   templateUrl: './meeting-recurrence-pattern.component.html',
 })
 export class MeetingRecurrencePatternComponent implements OnInit {
@@ -37,6 +36,17 @@ export class MeetingRecurrencePatternComponent implements OnInit {
   public readonly monthlyTypeOptions = RECURRENCE_MONTHLY_TYPE_OPTIONS;
   public readonly daysOfWeek = RECURRENCE_DAYS_OF_WEEK;
   public readonly weeklyOrdinals = RECURRENCE_WEEKLY_ORDINALS;
+
+  /**
+   * Outlined-pill styling for every choice in this panel.
+   * @description Same shape as the meeting-type, duration and cadence chips the panel sits under, so the
+   * whole schedule column reads as one control language. Whole class strings rather than a toggled
+   * fragment because Tailwind only emits what it can see literally.
+   */
+  protected readonly chipSelectedClass =
+    'cursor-pointer rounded-full border border-blue-500 bg-blue-50 px-2.5 py-1 text-sm font-medium text-blue-700 transition-colors';
+  protected readonly chipUnselectedClass =
+    'cursor-pointer rounded-full border border-gray-200 px-2.5 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50';
 
   // Get the recurrence FormGroup from parent
   public readonly recurrenceForm = computed(() => this.form().get('recurrence') as FormGroup);
@@ -81,6 +91,20 @@ export class MeetingRecurrencePatternComponent implements OnInit {
 
   public isWeeklyDaySelected(dayIndex: number): boolean {
     return this.weeklyDaysArray().includes(dayIndex);
+  }
+
+  /**
+   * Selects a monthly pattern from the chip row.
+   * @description Writes through `monthlyTypeUI` rather than calling `onMonthlyTypeChange` directly, so the
+   * control's subscription stays the one place a change reseeds the monthly fields.
+   */
+  public selectMonthlyType(monthlyType: string): void {
+    this.recurrenceForm()?.get('monthlyTypeUI')?.setValue(monthlyType);
+  }
+
+  /** Selects an end condition from the chip row; `endTypeUI`'s subscription applies the side effects. */
+  public selectEndType(endType: string): void {
+    this.recurrenceForm()?.get('endTypeUI')?.setValue(endType);
   }
 
   // Monthly handlers

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -198,7 +198,7 @@ export class MeetingComposerFormService {
     this.loading.set(false);
     this.form.set(this.createMeetingFormGroup());
     this.revision.set(0);
-    this.wireFormSubscriptions();
+    this.wireFormSubscriptions(context.variant === 'quick');
 
     // Create only: the group context pre-fills and locks the committees field. In edit mode the saved
     // meeting owns that field, and locking it to a single committee would drop the others on save.
@@ -211,7 +211,7 @@ export class MeetingComposerFormService {
       this.loadGuests(context.meetingUid);
     }
 
-    // Set after the subscriptions are wired so the type's visibility/restriction defaults still apply.
+    // Set after the subscriptions are wired so quick create's visibility/restriction defaults still apply.
     if (context.mode === 'create' && context.meetingType) {
       this.form().get('meeting_type')?.setValue(context.meetingType);
     }
@@ -676,7 +676,7 @@ export class MeetingComposerFormService {
     );
   }
 
-  private wireFormSubscriptions(): void {
+  private wireFormSubscriptions(appliesTypeDefaults: boolean): void {
     const form = this.form();
 
     this.formSubscriptions.add(form.valueChanges.subscribe(() => this.revision.update((value) => value + 1)));
@@ -715,7 +715,10 @@ export class MeetingComposerFormService {
     // When switching away from Board, reset to public + unrestricted defaults so the
     // user isn't left with Board-level settings silently applied to a non-Board meeting.
     // The user can freely override visibility and restriction after the default is applied.
-    const meetingTypeControl = form.get('meeting_type');
+    //
+    // Quick create only: prefilling from the meeting type is that dialog's whole premise, whereas the
+    // drawer walks every field explicitly and must not move one the organizer hasn't reached yet.
+    const meetingTypeControl = appliesTypeDefaults ? form.get('meeting_type') : null;
     if (meetingTypeControl) {
       let previousType = meetingTypeControl.value as string;
       this.formSubscriptions.add(

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -58,10 +58,10 @@
   position="right"
   [modal]="true"
   [showCloseIcon]="true"
-  styleClass="xl:w-[45%] lg:w-[55%] w-full">
+  styleClass="w-[1200px] max-w-full [&_.p-drawer-content]:py-0 [&_.p-drawer-header]:items-center [&_.p-drawer-header]:border-b [&_.p-drawer-header]:border-gray-200 [&_.p-drawer-footer]:border-t [&_.p-drawer-footer]:border-gray-200 [&_.p-drawer-footer]:pt-3">
   <ng-template #header>
-    <div class="flex min-w-0 flex-col" data-testid="meeting-composer-header">
-      <span class="truncate text-lg font-semibold text-gray-900">
+    <div class="flex min-w-0 flex-col justify-center" data-testid="meeting-composer-header">
+      <span class="truncate text-xl font-semibold text-gray-900">
         {{ isEditMode() ? 'Edit meeting' : 'Create meeting' }}
       </span>
       @if (isEditMode() && formService.meeting(); as meeting) {
@@ -70,25 +70,30 @@
     </div>
   </ng-template>
 
+  <!-- The drawer content pane is flush top and bottom (`p-drawer-content:py-0`) and each column carries its
+       own vertical padding instead, so the rule between them runs the full height rather than stopping short
+       of the header and footer. -->
   <div class="flex h-full min-h-0 gap-6">
     <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (GH-1462).
          The column is hidden when the edit-mode fetch failed: there is no form behind the rail, so every row
          would report empty and clicking one would swap a section the organizer can't see. -->
     @if (!formService.meetingLoadFailed()) {
-      <div class="hidden w-[262px] shrink-0 flex-col gap-4 overflow-y-auto lg:flex">
+      <div class="hidden w-[286px] shrink-0 flex-col gap-4 overflow-y-auto py-5 lg:flex lg:border-r lg:border-gray-200 lg:pr-6">
         <lfx-meeting-composer-rail />
 
         @if (!isEditMode()) {
-          <lfx-meeting-composer-preview />
+          <!-- Pushed to the bottom of the column so the preview reads as a summary of the whole form,
+               not as a sixth rail row hanging off the last step -->
+          <lfx-meeting-composer-preview class="mt-auto" />
         }
       </div>
     }
 
     @if (formService.loading()) {
-      <p class="text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
+      <p class="py-5 text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
     } @else if (formService.meetingLoadFailed()) {
       <!-- Without this the failed fetch leaves an empty form and a disabled Save with nothing saying why -->
-      <div class="flex min-w-0 flex-1 flex-col items-start gap-3" data-testid="meeting-composer-load-error">
+      <div class="flex min-w-0 flex-1 flex-col items-start gap-3 py-5" data-testid="meeting-composer-load-error">
         <div class="flex flex-col gap-1">
           <span class="text-sm font-semibold text-gray-900">Couldn't load this meeting</span>
           <span class="text-sm text-gray-600">It may have been deleted, or you may not have permission to edit it.</span>
@@ -103,10 +108,14 @@
           (onClick)="formService.retryLoadMeeting()" />
       </div>
     } @else {
-      <div class="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto">
+      <div class="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto py-5">
         <!-- Stands in for the hidden rail: where you are, what's done, and what still needs fixing.
              Sticky because it is the only section navigation at this width. -->
-        <div class="sticky top-0 z-10 flex flex-col gap-2 border-b border-gray-200 bg-white pb-3 lg:hidden" data-testid="meeting-composer-compact-progress">
+        <!-- Negative top/margin cancel the column's own `py-5`: the bar covers that band whether it is
+             stuck or not, so content never scrolls through a gap above it. -->
+        <div
+          class="sticky -top-5 z-10 -mt-5 flex flex-col gap-2 border-b border-gray-200 bg-white pb-3 pt-5 lg:hidden"
+          data-testid="meeting-composer-compact-progress">
           <div class="flex items-center gap-2">
             @if (!isEditMode()) {
               <span class="text-xs font-medium text-gray-500">Step {{ activeIndex() + 1 }} of {{ sections.length }}</span>
@@ -146,18 +155,17 @@
   </div>
 
   <ng-template #footer>
-    <div class="flex items-center justify-between gap-2 border-t border-gray-200 pt-3" data-testid="meeting-composer-footer">
-      <lfx-button label="Cancel" severity="secondary" [text]="true" size="small" data-testid="meeting-composer-cancel" (onClick)="composer.close()" />
+    <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-footer">
+      <lfx-button label="Cancel" severity="secondary" [text]="true" data-testid="meeting-composer-cancel" (onClick)="composer.close()" />
 
       <div class="flex items-center gap-2">
         @if (!isEditMode() && activeIndex() > 0) {
-          <lfx-button label="Back" severity="secondary" [outlined]="true" size="small" data-testid="meeting-composer-back" (onClick)="onBack()" />
+          <lfx-button label="Back" severity="secondary" [outlined]="true" data-testid="meeting-composer-back" (onClick)="onBack()" />
         }
 
         @if (isEditMode()) {
           <lfx-button
             label="Save changes"
-            size="small"
             [loading]="formService.submitting()"
             [disabled]="!canSubmit()"
             data-testid="meeting-composer-save"
@@ -165,13 +173,12 @@
         } @else if (isLastSection()) {
           <lfx-button
             label="Create meeting"
-            size="small"
             [loading]="formService.submitting()"
             [disabled]="!canSubmit()"
             data-testid="meeting-composer-create"
             (onClick)="onSubmit()" />
         } @else {
-          <lfx-button label="Next" size="small" [disabled]="!canProceed()" data-testid="meeting-composer-next" (onClick)="onNext()" />
+          <lfx-button label="Next" [disabled]="!canProceed()" data-testid="meeting-composer-next" (onClick)="onNext()" />
         }
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.html
@@ -1,90 +1,89 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="meeting-composer-preview">
-  <span class="text-[10px] font-semibold uppercase tracking-wider text-gray-400">Preview</span>
+<section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-3.5" data-testid="meeting-composer-preview">
+  <span class="text-[9px] font-semibold uppercase tracking-wider text-gray-400">Preview</span>
 
-  <div class="flex items-start gap-3">
-    <div class="flex w-10 flex-col overflow-hidden rounded-md border border-gray-200 text-center">
-      <span class="bg-blue-600 py-0.5 text-[10px] font-semibold uppercase leading-tight text-white">{{ dateChip().month }}</span>
-      <span class="py-0.5 text-base font-semibold leading-tight text-gray-900">{{ dateChip().day }}</span>
+  <div class="flex items-start gap-2.5">
+    <div class="flex w-[26px] shrink-0 flex-col overflow-hidden rounded border border-gray-200 text-center">
+      <span class="bg-blue-600 text-[8px] font-bold uppercase leading-[13px] text-white" aria-hidden="true">{{ dateChip().month }}</span>
+      <span class="text-[11px] font-bold leading-[15px] text-gray-900" aria-hidden="true">{{ dateChip().day }}</span>
     </div>
 
-    <div class="flex min-w-0 flex-col gap-1">
-      <span class="truncate text-sm font-semibold text-gray-900" [title]="title()" data-testid="meeting-composer-preview-title">{{ title() }}</span>
+    <div class="flex min-w-0 flex-1 flex-col gap-1">
+      <span class="truncate text-sm font-semibold text-gray-900" data-testid="meeting-composer-preview-title">{{ title() }}</span>
       @if (whenSummary(); as when) {
         <span class="text-xs text-gray-500" data-testid="meeting-composer-preview-when">{{ when }}</span>
       } @else {
-        <span class="w-28"><span class="sr-only">Date and time not set</span><p-skeleton height="0.75rem" /></span>
+        <span class="flex h-4 items-center">
+          <span class="sr-only">Date and time not set</span>
+          <span class="h-[7px] w-2/3 rounded-full bg-gray-100" aria-hidden="true"></span>
+        </span>
       }
     </div>
   </div>
 
   <div class="h-px bg-gray-100"></div>
 
-  <dl class="flex flex-col gap-2 text-xs">
-    <div class="flex items-center justify-between gap-2">
-      <dt class="text-gray-500">Type</dt>
-      @if (typeLabel()) {
-        <dd class="truncate font-medium text-gray-900" data-testid="meeting-composer-preview-type">{{ typeLabel() }}</dd>
+  <!-- Flat icon + value rows: the design carries no field labels here, so an unset row reads as a bar -->
+  <ul class="flex flex-col gap-2">
+    <li class="flex items-center gap-2">
+      <i class="w-3.5 shrink-0 text-center text-[11px] font-light text-gray-400 fa-light fa-hexagon" aria-hidden="true"></i>
+      @if (typeLabel(); as type) {
+        <span class="truncate text-[11px] text-gray-700" data-testid="meeting-composer-preview-type">{{ type }}</span>
       } @else {
-        <dd class="w-24"><span class="sr-only">Not set</span><p-skeleton height="0.75rem" /></dd>
+        <span class="sr-only">Meeting type not set</span>
+        <span class="h-[7px] w-[65%] rounded-full bg-gray-100" aria-hidden="true"></span>
       }
-    </div>
+    </li>
 
     @if (visibility(); as visibilityRow) {
-      <div class="flex items-center justify-between gap-2">
-        <dt class="text-gray-500">Visibility</dt>
-        <dd class="flex items-center gap-1.5 font-medium text-gray-900" data-testid="meeting-composer-preview-visibility">
-          <i [ngClass]="visibilityRow.icon" class="text-gray-400" aria-hidden="true"></i>
-          <span class="truncate">{{ visibilityRow.label }}</span>
-        </dd>
-      </div>
+      <li class="flex items-center gap-2">
+        <span
+          class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full text-[7px] text-white"
+          [style.background-color]="visibilityRow.color"
+          aria-hidden="true">
+          <i [ngClass]="visibilityRow.icon"></i>
+        </span>
+        <span class="truncate text-[11px] text-gray-700" data-testid="meeting-composer-preview-visibility">{{ visibilityRow.label }}</span>
+      </li>
     }
 
-    @if (restricted()) {
-      <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-restricted">
-        <dt class="text-gray-500">Access</dt>
-        <dd class="font-medium text-gray-900">Restricted</dd>
-      </div>
-    }
-
-    @if (recurrenceSummary(); as recurrence) {
-      <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-recurrence">
-        <dt class="text-gray-500">Repeats</dt>
-        <dd class="truncate font-medium text-gray-900">{{ recurrence }}</dd>
-      </div>
-    }
-
-    <div class="flex items-center justify-between gap-2">
-      <dt class="text-gray-500">Platform</dt>
-      @if (platformLabel(); as platform) {
-        <dd class="truncate font-medium text-gray-900" data-testid="meeting-composer-preview-platform">{{ platform }}</dd>
+    <li class="flex items-center gap-2">
+      <i class="w-3.5 shrink-0 text-center text-[11px] font-light text-gray-400 fa-light fa-arrows-repeat" aria-hidden="true"></i>
+      @if (recurrenceLabel(); as recurrence) {
+        <span class="truncate text-[11px] text-gray-700" data-testid="meeting-composer-preview-recurrence">{{ recurrence }}</span>
       } @else {
-        <dd class="w-24"><span class="sr-only">Not set</span><p-skeleton height="0.75rem" /></dd>
+        <span class="sr-only">Schedule not set</span>
+        <span class="h-[7px] w-1/2 rounded-full bg-gray-100" aria-hidden="true"></span>
       }
-    </div>
+    </li>
+
+    <li class="flex items-center gap-2">
+      <i class="w-3.5 shrink-0 text-center text-[11px] font-light text-gray-400 fa-light fa-video" aria-hidden="true"></i>
+      @if (platformLabel(); as platform) {
+        <span class="truncate text-[11px] text-gray-700" data-testid="meeting-composer-preview-platform">{{ platform }}</span>
+      } @else {
+        <span class="sr-only">Platform not set</span>
+        <span class="h-[7px] w-[45%] rounded-full bg-gray-100" aria-hidden="true"></span>
+      }
+    </li>
 
     @for (feature of features(); track feature.label) {
-      <div class="flex items-center justify-between gap-2" data-testid="meeting-composer-preview-feature">
-        <dt class="flex items-center gap-1.5 text-gray-500">
-          <i [ngClass]="feature.icon" class="text-gray-400" aria-hidden="true"></i>
-          <span class="truncate">{{ feature.label }}</span>
-        </dt>
-        <dd class="font-medium text-emerald-600">On</dd>
-      </div>
+      <li class="flex items-center gap-2" data-testid="meeting-composer-preview-feature">
+        <i class="w-3.5 shrink-0 text-center text-[11px] font-light text-gray-400" [ngClass]="feature.icon" aria-hidden="true"></i>
+        <span class="truncate text-[11px] text-gray-700">{{ feature.label }}</span>
+      </li>
     }
 
-    <div class="flex items-center justify-between gap-2">
-      <dt class="text-gray-500">Guests</dt>
-      <dd class="font-medium text-gray-900" data-testid="meeting-composer-preview-guests">{{ guestCount() }} invited</dd>
-    </div>
-
-    @if (resourceCount() > 0) {
-      <div class="flex items-center justify-between gap-2">
-        <dt class="text-gray-500">Resources</dt>
-        <dd class="font-medium text-gray-900" data-testid="meeting-composer-preview-resources">{{ resourceCount() }}</dd>
-      </div>
-    }
-  </dl>
+    <li class="flex items-center gap-2">
+      <i class="w-3.5 shrink-0 text-center text-[11px] font-light text-gray-400 fa-light fa-user" aria-hidden="true"></i>
+      @if (guestLabel(); as guests) {
+        <span class="truncate text-[11px] text-gray-700" data-testid="meeting-composer-preview-guests">{{ guests }}</span>
+      } @else {
+        <span class="sr-only">No guests invited yet</span>
+        <span class="h-[7px] w-[55%] rounded-full bg-gray-100" aria-hidden="true"></span>
+      }
+    </li>
+  </ul>
 </section>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
@@ -3,12 +3,10 @@
 
 import { NgClass } from '@angular/common';
 import { Component, computed, inject, type Signal } from '@angular/core';
-import type { FormArray } from '@angular/forms';
 import { MEETING_COMPOSER_PREVIEW_FEATURES, MEETING_PLATFORMS, MEETING_TYPE_OPTIONS, MEETING_VISIBILITY_OPTIONS } from '@lfx-one/shared/constants';
 import type { MeetingVisibility } from '@lfx-one/shared/enums';
-import type { ImportantLinkFormValue, MeetingComposerPreviewDateChip, MeetingComposerPreviewRow } from '@lfx-one/shared/interfaces';
+import type { MeetingComposerPreviewDateChip, MeetingComposerPreviewRow } from '@lfx-one/shared/interfaces';
 import { buildRecurrenceSummary, convertRecurrenceToPattern } from '@lfx-one/shared/utils';
-import { SkeletonModule } from 'primeng/skeleton';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerService } from './meeting-composer.service';
@@ -16,14 +14,15 @@ import { MeetingComposerService } from './meeting-composer.service';
 /**
  * Live preview of the meeting being created (GH-1459).
  * @description Create mode only — in edit mode the meeting already exists and the sections themselves
- * show its saved state. Several controls are pre-filled with defaults, so a row only resolves once its
- * owning section has been visited; until then it renders as a skeleton bar rather than presenting a
- * default as a choice the organizer made. Details & Access is where the composer opens, so its rows
- * resolve as soon as they have a value.
+ * show its saved state. Rows carry no field labels: an icon plus the chosen value, or a bar while the
+ * value is still unknown. Several controls are pre-filled with defaults, so a row only resolves once
+ * its owning section has been visited (or, for recurrence, is complete) — until then it shows the bar
+ * rather than presenting a default as a choice the organizer made. Details & Access is where the
+ * composer opens, so its rows resolve as soon as they have a value.
  */
 @Component({
   selector: 'lfx-meeting-composer-preview',
-  imports: [NgClass, SkeletonModule],
+  imports: [NgClass],
   templateUrl: './meeting-composer-preview.component.html',
 })
 export class MeetingComposerPreviewComponent {
@@ -35,12 +34,10 @@ export class MeetingComposerPreviewComponent {
   protected readonly whenSummary: Signal<string | null> = this.initWhenSummary();
   protected readonly typeLabel: Signal<string | null> = this.initTypeLabel();
   protected readonly visibility: Signal<MeetingComposerPreviewRow | null> = this.initVisibility();
-  protected readonly restricted: Signal<boolean> = this.initRestricted();
-  protected readonly recurrenceSummary: Signal<string | null> = this.initRecurrenceSummary();
+  protected readonly recurrenceLabel: Signal<string | null> = this.initRecurrenceLabel();
   protected readonly platformLabel: Signal<string | null> = this.initPlatformLabel();
   protected readonly features: Signal<MeetingComposerPreviewRow[]> = this.initFeatures();
-  protected readonly guestCount: Signal<number> = this.initGuestCount();
-  protected readonly resourceCount: Signal<number> = this.initResourceCount();
+  protected readonly guestLabel: Signal<string | null> = this.initGuestLabel();
 
   private initDateChip(): Signal<MeetingComposerPreviewDateChip> {
     return computed(() => {
@@ -65,13 +62,19 @@ export class MeetingComposerPreviewComponent {
     });
   }
 
+  /** Date alone once it is picked, then `date · time` — duration and timezone stay out of this line. */
   private initWhenSummary(): Signal<string | null> {
     return computed(() => {
       const startDate = this.startDate();
-      const startTime = startDate ? ((this.controlValue('startTime') as string | null) ?? '') : '';
-      const date = startDate ? startDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }) : '';
 
-      return [date, startTime].filter(Boolean).join(' · ') || null;
+      if (!startDate) {
+        return null;
+      }
+
+      const date = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      const startTime = (this.controlValue('startTime') as string | null) ?? '';
+
+      return [date, startTime].filter(Boolean).join(' · ');
     });
   }
 
@@ -93,18 +96,25 @@ export class MeetingComposerPreviewComponent {
         return null;
       }
 
-      return { label: option.label, icon: option.info.icon };
+      return { label: option.label, icon: option.info.icon, color: option.info.color };
     });
   }
 
-  private initRestricted(): Signal<boolean> {
-    return computed(() => this.controlValue('restricted') === true);
-  }
-
-  private initRecurrenceSummary(): Signal<string | null> {
+  /**
+   * Recurrence row, or `null` while Date & Schedule is still incomplete.
+   * @description "Does not repeat" is a real answer, but only once the organizer has actually settled
+   * the schedule — showing it against an empty section would be stating the default back at them.
+   */
+  private initRecurrenceLabel(): Signal<string | null> {
     return computed(() => {
-      if (this.controlValue('isRecurring') !== true) {
+      this.formService.revision();
+
+      if (!this.formService.isSectionValid('date-schedule')) {
         return null;
+      }
+
+      if (this.controlValue('isRecurring') !== true) {
+        return 'Does not repeat';
       }
 
       const recurrence = this.formService.recurrencePayload();
@@ -143,19 +153,16 @@ export class MeetingComposerPreviewComponent {
     );
   }
 
-  private initGuestCount(): Signal<number> {
-    return computed(() => this.formService.guests().filter((guest) => guest.state !== 'deleted').length);
-  }
-
-  /** Documents and links staged for upload. Saved attachments are ignored — nothing is saved yet in create mode. */
-  private initResourceCount(): Signal<number> {
+  /** `null` at zero guests — the design shows a bar there rather than "0 invited". */
+  private initGuestLabel(): Signal<string | null> {
     return computed(() => {
-      this.formService.revision();
+      const count = this.formService.guests().filter((guest) => guest.state !== 'deleted').length;
 
-      const pendingAttachments = (this.formService.form().get('attachments')?.value as unknown[] | null) ?? [];
-      const links = ((this.formService.form().get('important_links') as FormArray | null)?.value ?? []) as ImportantLinkFormValue[];
+      if (count === 0) {
+        return null;
+      }
 
-      return pendingAttachments.length + links.filter((link) => !!link.url?.trim()).length;
+      return `${count} ${count === 1 ? 'guest' : 'guests'} invited`;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.html
@@ -8,33 +8,25 @@
   [attr.data-testid]="testIdPrefix()">
   @for (row of rows(); track row.section.id) {
     @if (compact()) {
-      <!-- Locked chips are greyed by surface rather than opacity: they stay keyboard-reachable, so the label has to stay legible -->
       <button
         type="button"
         class="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
         [ngClass]="{
-          'border-blue-700 bg-blue-700 text-white': row.active,
-          'border-blue-200 bg-white text-blue-700': row.complete,
-          'border-gray-200 bg-white text-gray-600': !row.active && !row.complete && !row.locked,
-          'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-600': row.locked,
+          'border-blue-700 bg-blue-700 text-white cursor-pointer': row.active,
+          'border-blue-200 bg-white text-blue-700 cursor-pointer': row.complete,
+          'border-gray-200 bg-white text-gray-600 cursor-pointer': !row.active && !row.complete && row.reachable,
+          'border-gray-200 bg-white text-gray-400 cursor-default': !row.active && !row.complete && !row.reachable,
         }"
-        [attr.aria-disabled]="row.locked ? 'true' : null"
         [attr.aria-current]="row.active ? activeChipAriaCurrent() : null"
+        [attr.aria-disabled]="row.reachable ? null : 'true'"
         [attr.data-active-chip]="row.active ? 'true' : null"
         [attr.data-testid]="testIdPrefix() + '-' + row.section.id"
         (click)="onSelect(row)">
-        @if (row.complete) {
-          <i class="fa-light fa-check" aria-hidden="true"></i>
-        } @else {
-          <i [ngClass]="row.section.icon" aria-hidden="true"></i>
-        }
+        <i [ngClass]="row.section.icon" aria-hidden="true"></i>
         <span class="whitespace-nowrap">{{ row.section.label }}</span>
         @if (row.needsAttention) {
           <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="testIdPrefix() + '-attention-' + row.section.id"></span>
           <span class="sr-only">Required fields still missing</span>
-        }
-        @if (row.locked) {
-          <span class="sr-only">Complete earlier sections first</span>
         }
       </button>
     } @else if (isEditMode()) {
@@ -53,52 +45,43 @@
         }
       </button>
     } @else {
-      <!-- Locked rows are greyed by surface rather than opacity: they stay keyboard-reachable, so their text
-           has to stay legible, and the tint is what separates them from a row that just isn't done yet -->
+      <!-- Create-mode stepper: the section's own icon throughout — blue once done, filled while active,
+           gray while still ahead. Sections past the frontier are inert, matching the footer's ordering -->
       <button
         type="button"
-        class="group relative flex items-start gap-3 rounded-md py-2 pl-1 pr-3 text-left"
-        [ngClass]="row.locked ? 'cursor-not-allowed bg-gray-50' : 'cursor-pointer'"
-        [attr.aria-disabled]="row.locked ? 'true' : null"
+        class="group relative flex items-center gap-3 rounded-md py-2 pl-1 pr-2 text-left"
+        [ngClass]="row.reachable ? 'cursor-pointer' : 'cursor-default'"
         [attr.aria-current]="row.active ? 'step' : null"
+        [attr.aria-disabled]="row.reachable ? null : 'true'"
         [attr.data-testid]="'meeting-composer-rail-' + row.section.id"
         (click)="onSelect(row)">
         <span class="relative flex w-8 shrink-0 justify-center self-stretch">
           @if (!row.isLast) {
-            <span
-              class="absolute left-1/2 top-8 h-full w-0.5 -translate-x-1/2"
-              [ngClass]="row.lineBelowComplete ? 'bg-blue-600' : 'bg-gray-200'"
-              aria-hidden="true"></span>
+            <span class="absolute left-1/2 top-8 h-full w-px -translate-x-1/2 bg-gray-200" aria-hidden="true"></span>
           }
           <span
-            class="relative z-10 flex h-8 w-8 items-center justify-center rounded-full border text-xs"
+            class="relative z-10 flex h-7 w-7 items-center justify-center rounded-full border-[1.5px] text-xs"
             [ngClass]="{
               'border-blue-600 bg-blue-600 text-white ring-4 ring-blue-50': row.active,
               'border-blue-600 bg-white text-blue-600': row.complete,
-              'border-gray-200 bg-white text-gray-400': !row.active && !row.complete && !row.locked,
-              'border-gray-200 bg-gray-100 text-gray-600': row.locked,
+              'border-gray-200 bg-white text-gray-400': !row.active && !row.complete,
             }">
-            @if (row.complete) {
-              <i class="fa-light fa-check" aria-hidden="true"></i>
-            } @else {
-              <i [ngClass]="row.section.icon" aria-hidden="true"></i>
-            }
+            <i [ngClass]="row.section.icon" aria-hidden="true"></i>
           </span>
         </span>
 
-        <span class="flex min-w-0 flex-col gap-0.5 pt-1.5">
-          <span class="flex items-center gap-1.5 text-sm font-medium" [ngClass]="row.active ? 'text-gray-900' : 'text-gray-600'">
-            <span class="truncate">{{ row.section.label }}</span>
-            @if (row.needsAttention) {
-              <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="'meeting-composer-rail-attention-' + row.section.id"></span>
-              <span class="sr-only">Required fields still missing</span>
-            }
-          </span>
-          @if (row.locked) {
-            <!-- The only text saying why the row won't respond, and the row stays keyboard-reachable, so it
-                 carries no opacity and sits at `gray-600` on the row's `gray-50` surface (7.2:1) rather than
-                 the decorative `gray-400` it used to use -->
-            <span class="text-xs text-gray-600">Complete earlier sections first</span>
+        <span
+          class="flex min-w-0 flex-1 items-center gap-1.5 text-sm font-medium"
+          [ngClass]="{
+            'text-blue-600': row.active,
+            'text-gray-900': !row.active && row.complete,
+            'text-gray-600': !row.active && !row.complete && row.reachable,
+            'text-gray-400': !row.active && !row.complete && !row.reachable,
+          }">
+          <span class="truncate">{{ row.section.label }}</span>
+          @if (row.needsAttention) {
+            <span class="ml-auto h-1.5 w-1.5 shrink-0 rounded-full bg-red-500" [attr.data-testid]="'meeting-composer-rail-attention-' + row.section.id"></span>
+            <span class="sr-only">Required fields still missing</span>
           }
         </span>
       </button>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -11,11 +11,11 @@ import { MeetingComposerService } from './meeting-composer.service';
 
 /**
  * Section navigation for the meeting composer (GH-1459).
- * @description Create mode is a progress stepper: later sections stay locked until every earlier
- * required section is valid, so the organizer can't skip past a section that would block submit.
- * Edit mode is a flat menu — the meeting already exists, so every section is reachable. `compact`
- * renders either mode as a horizontal chip row, which is what the composer shows below `lg` where the
- * rail column is hidden (GH-1462).
+ * @description Create mode is a progress stepper: a completed section shows its own icon in blue, the
+ * current one is filled, and a visited-but-invalid required section carries an attention dot. Rows the
+ * organizer hasn't reached yet are inert — reachable means visited, or the one section past the furthest
+ * they've been, and never past a required section that still has holes in it. Edit mode is free navigation. `compact` renders either mode as a horizontal chip row,
+ * which is what the composer shows below `lg` where the rail column is hidden (GH-1462).
  */
 @Component({
   selector: 'lfx-meeting-composer-rail',
@@ -29,19 +29,19 @@ export class MeetingComposerRailComponent {
 
   /**
    * Renders as a horizontal chip row instead of a vertical stepper.
-   * @description What the composer shows below `lg`, where the rail column is hidden: the same rows and
-   * the same locking, laid out to fit above the section content.
+   * @description What the composer shows below `lg`, where the rail column is hidden: the same rows,
+   * laid out to fit above the section content.
    */
   public readonly compact = input(false);
 
   private readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
 
   /**
-   * Single mode source for layout, locking and the active marker.
+   * Single mode source for layout and the active marker.
    * @description Read from the form service because that is what `sectionNeedsAttention` reads — the other
    * mode-dependent input to a row — and because `composer.context()` is written before `initialize()` runs,
    * so a context-derived reader would lead this one by a flush. Taking mode from both would render the flat
-   * edit rows while locking them like create-mode rows, leaving rows that look interactive and do nothing.
+   * edit rows while numbering them like create-mode steps.
    */
   protected readonly isEditMode: Signal<boolean> = this.formService.isEditMode;
 
@@ -69,7 +69,7 @@ export class MeetingComposerRailComponent {
   }
 
   protected onSelect(row: MeetingComposerRailRow): void {
-    if (row.locked || row.active) {
+    if (row.active || !row.reachable) {
       return;
     }
 
@@ -84,29 +84,31 @@ export class MeetingComposerRailComponent {
       const sections = this.sections;
       const activeSection = this.composer.activeSection();
       const visited = this.composer.visitedSections();
-      const isEditMode = this.isEditMode();
       const validById = new Map<MeetingComposerSectionId, boolean>(sections.map((section) => [section.id, this.formService.isSectionValid(section.id)]));
-      const isComplete = (section: MeetingComposerSection): boolean => (section.required ? (validById.get(section.id) ?? false) : visited.has(section.id));
+      // A section only reads as done once the organizer has actually been there: Date & Schedule validates
+      // straight out of the box from its defaults, and a check mark on a section nobody has opened yet
+      // claims work that didn't happen.
+      const isComplete = (section: MeetingComposerSection): boolean =>
+        visited.has(section.id) && (section.required ? (validById.get(section.id) ?? false) : true);
+      // Create mode advances one section at a time, so the frontier is the section right after the
+      // furthest one visited. Edit mode has no order to respect.
+      const frontier = sections.reduce((furthest, section, index) => (visited.has(section.id) ? index : furthest), 0) + 1;
+      // Nothing past the first required section that still has holes in it: the rail can't be a way
+      // around the footer's disabled Next.
+      const firstBlocking = sections.findIndex((section) => section.required && !validById.get(section.id));
+      const blockedAt = firstBlocking === -1 ? sections.length : firstBlocking;
+      const isEditMode = this.isEditMode();
 
       return sections.map((section, index) => {
         const active = section.id === activeSection;
-        const blockedByEarlier = sections.slice(0, index).some((earlier) => earlier.required && !validById.get(earlier.id));
-        // The organizer can be standing on a section an out-of-section validator has just invalidated
-        // (enabling YouTube upload tightens the title's max length), so never lock the row they're on.
-        const locked = !isEditMode && blockedByEarlier && !active;
 
         return {
           section,
           active,
-          // A locked row can't claim to be done even when its own controls validate — a check inside the
-          // greyed circle would contradict the "Complete earlier sections first" text right beside it.
-          complete: isComplete(section) && !active && !locked,
-          locked,
+          complete: isComplete(section) && !active,
           // Shared with the compact badge in the host, so the two can't disagree about what needs fixing.
           needsAttention: this.formService.sectionNeedsAttention(section, visited),
-          // A locked row is behind an invalid earlier section, so its connector can't claim the chain is done
-          // even when this section itself validates.
-          lineBelowComplete: isComplete(section) && !locked,
+          reachable: isEditMode || (index <= blockedAt && (visited.has(section.id) || index <= frontier)),
           isLast: index === sections.length - 1,
         };
       });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-route.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-route.component.ts
@@ -25,10 +25,14 @@ export class MeetingComposerRouteComponent {
     const snapshot = this.route.snapshot;
     const meetingUid = snapshot.paramMap.get('id');
 
+    // Create lands on the quick dialog — the same surface the dashboard's "Create meeting" dropdown
+    // opens — with no `meetingType`, so nothing is pre-selected and no template prefill runs. Edit
+    // still opens the full drawer, which is the only surface that renders every section.
     this.composer.open({
       mode: meetingUid ? 'edit' : 'create',
       meetingUid: meetingUid ?? undefined,
       committeeUid: snapshot.queryParamMap.get('committee_uid') ?? undefined,
+      variant: meetingUid ? 'drawer' : 'quick',
     });
 
     // Redirect within the same lens prefix and keep the query params. A bare `/meetings` would drop

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -8,26 +8,60 @@
   [modal]="true"
   [draggable]="false"
   [dismissableMask]="true"
-  header="Create meeting"
-  styleClass="w-[min(1024px,94vw)]">
-  <div class="grid grid-cols-1 gap-6 lg:grid-cols-2" data-testid="quick-create-body">
-    <div class="flex min-w-0 flex-col gap-6">
+  styleClass="w-[min(1200px,94vw)] [&_.p-dialog-content]:pt-5 [&_.p-dialog-header]:py-3 [&_.p-dialog-header]:border-b [&_.p-dialog-header]:border-gray-200 [&_.p-dialog-footer]:pt-5 [&_.p-dialog-footer]:border-t [&_.p-dialog-footer]:border-gray-200">
+  <ng-template #header>
+    <div class="flex flex-col gap-0.5">
+      <span class="text-xl font-semibold text-gray-900">Create meeting</span>
+      <span class="text-xs font-medium text-gray-500">Instant meeting creation with minimal setup</span>
+    </div>
+  </ng-template>
+
+  <!-- 3/5 + 2/5 rather than an even split: the left column carries the long-form fields (title, agenda,
+       access) while the right one only holds the schedule controls. -->
+  <div class="grid grid-cols-1 gap-5 lg:grid-cols-5 lg:gap-x-8" data-testid="quick-create-body">
+    <div class="flex min-w-0 flex-col gap-4 lg:col-span-3">
+      <!-- Type leads the form here rather than sitting inside the section: picking it is what seeds the
+           rest of the dialog, so it reads as chips above the fields it fills in. -->
+      <div class="flex flex-col gap-1.5">
+        <span id="quick-create-type-label" class="text-sm font-medium text-gray-900">
+          Meeting type <span class="text-red-500" aria-hidden="true">*</span>
+        </span>
+        <div role="group" aria-labelledby="quick-create-type-label" class="flex flex-wrap gap-2" data-testid="quick-create-type-chips">
+          @for (option of meetingTypeOptions(); track option.value) {
+            <button
+              type="button"
+              class="flex items-center gap-2 rounded-full border px-2.5 py-1 text-sm transition-colors"
+              [ngClass]="{
+                'border-blue-500 bg-blue-50 font-medium text-blue-700': option.value === selectedMeetingType(),
+                'border-gray-200 text-gray-700 hover:bg-gray-50': option.value !== selectedMeetingType(),
+              }"
+              [attr.aria-pressed]="option.value === selectedMeetingType()"
+              [attr.data-testid]="'quick-create-type-' + option.value"
+              (click)="onSelectMeetingType(option.value)">
+              <i [class]="option.info.icon" aria-hidden="true"></i>
+              <span>{{ option.label }}</span>
+            </button>
+          }
+        </div>
+      </div>
+
       <!-- The hints are passed down rather than rendered here so each one sits under the field it
            describes and can be wired to it with `aria-describedby` -->
       <lfx-composer-details-access
         [form]="formService.form()"
         [showHeading]="false"
+        [showTypeSelect]="false"
         [titleHint]="prefilledTitle() ? 'Pre-filled for this meeting type — edit freely.' : null" />
 
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-1.5">
         <label for="quick-create-agenda" class="text-sm font-medium text-gray-900">Agenda</label>
         <lfx-textarea
           [form]="formService.form()"
           control="description"
           id="quick-create-agenda"
           placeholder="Enter meeting agenda and key discussion points"
-          styleClass="w-full"
-          [rows]="6"
+          styleClass="w-full min-h-[80px] max-h-[200px]"
+          [rows]="4"
           [maxlength]="agendaMaxLength"
           data-testid="quick-create-agenda-textarea" />
         <div class="flex items-center justify-between gap-2">
@@ -45,20 +79,25 @@
         (committeeMembersChange)="onCommitteeMembersChange($event)" />
     </div>
 
-    <div class="flex min-w-0 flex-col gap-6">
+    <!-- The rule only exists once the two columns sit side by side; stacked, the row gap separates them. -->
+    <div class="flex min-w-0 flex-col gap-4 lg:col-span-2 lg:border-l lg:border-gray-200 lg:pl-8">
       <!-- Its own hint rather than sharing the title's: only a template whose estimate lands on the chip
            scale seeds duration at all, so the two go quiet independently -->
       <lfx-composer-date-schedule
         [form]="formService.form()"
         [showHeading]="false"
         [showEarlyJoin]="false"
+        [compact]="true"
         [durationHint]="prefilledDuration() ? 'Pre-filled for this meeting type — edit freely.' : null" />
     </div>
   </div>
 
   <ng-template #footer>
     <div class="flex w-full items-center justify-between gap-2" data-testid="quick-create-footer">
-      <p class="text-xs text-gray-500">You can configure advanced settings later.</p>
+      <p class="flex items-center gap-1.5 text-xs text-gray-500">
+        <i class="fa-light fa-circle-info" aria-hidden="true"></i>
+        <span>You can configure advanced settings later.</span>
+      </p>
 
       <div class="flex items-center gap-2">
         <lfx-button label="Cancel" severity="secondary" [text]="true" size="small" data-testid="quick-create-cancel" (onClick)="composer.close()" />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -8,7 +8,9 @@ import { ButtonComponent } from '@components/button/button.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
 import { MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_WARNING_LENGTH, MEETING_DURATION_CHIP_OPTIONS, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
-import type { CommitteeMember, MeetingTemplate } from '@lfx-one/shared/interfaces';
+import type { CardSelectorOption, CommitteeMember, MeetingTemplate } from '@lfx-one/shared/interfaces';
+import { getSelectableMeetingTypeOptions } from '@lfx-one/shared/utils';
+import { PersonaService } from '@services/persona.service';
 import { DialogModule } from 'primeng/dialog';
 import { startWith, switchMap } from 'rxjs';
 
@@ -40,6 +42,7 @@ import { ComposerDetailsAccessComponent } from './sections/composer-details-acce
   templateUrl: './quick-create-dialog.component.html',
 })
 export class QuickCreateDialogComponent {
+  private readonly personaService = inject(PersonaService);
   protected readonly composer = inject(MeetingComposerService);
   protected readonly formService = inject(MeetingComposerFormService);
 
@@ -61,6 +64,17 @@ export class QuickCreateDialogComponent {
   protected readonly prefilledTitle: Signal<boolean> = this.initPrefilledTitle();
   protected readonly prefilledDuration: Signal<boolean> = this.initPrefilledDuration();
   protected readonly prefilledAgenda: Signal<boolean> = this.initPrefilledAgenda();
+
+  // Same persona filter the drawer's type select uses, so the two surfaces can't offer different types.
+  // Quick create is create-only, so there is no stored type to retain in the list.
+  protected readonly meetingTypeOptions: Signal<CardSelectorOption<MeetingType>[]> = computed(() =>
+    getSelectableMeetingTypeOptions(this.personaService.currentPersona())
+  );
+  protected readonly selectedMeetingType: Signal<MeetingType | null> = computed(() => {
+    // FormGroup values are not reactive; `revision` is what makes the chip selection repaint.
+    this.formService.revision();
+    return (this.formService.form().get('meeting_type')?.value as MeetingType | null) ?? null;
+  });
 
   protected readonly agendaLength: Signal<number> = computed(() => {
     this.formService.revision();
@@ -99,6 +113,22 @@ export class QuickCreateDialogComponent {
     if (!visible) {
       this.composer.close();
     }
+  }
+
+  /**
+   * Switches the meeting type from the chip row.
+   * @description Writes through the control rather than calling `applyTypeTemplate` directly, so the
+   * constructor's subscription stays the single place a type change reseeds the form.
+   */
+  protected onSelectMeetingType(meetingType: MeetingType): void {
+    const control = this.formService.form().get('meeting_type');
+
+    if (!control || control.value === meetingType) {
+      return;
+    }
+
+    control.setValue(meetingType);
+    control.markAsDirty();
   }
 
   protected onCommitteeMembersChange(members: CommitteeMember[]): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
@@ -1,13 +1,13 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6" data-testid="composer-agenda-resources">
+<div class="flex flex-col gap-4" data-testid="composer-agenda-resources">
   <div class="flex flex-col gap-1">
     <h2 class="text-base font-semibold text-gray-900">Agenda &amp; resources</h2>
     <p class="text-sm text-gray-500">Share agenda, documents, and reference materials so participants come prepared.</p>
   </div>
 
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-1.5">
     <div class="flex items-center justify-between gap-3">
       <label for="composer-agenda" class="text-sm font-medium text-gray-900">Agenda</label>
       <div class="flex items-center gap-2">
@@ -17,7 +17,7 @@
           size="small"
           [text]="true"
           [ariaPressed]="showTemplates()"
-          (onClick)="onToggleTemplates()"
+          (onClick)="onToggleTemplates($event, templatesPopover)"
           data-testid="composer-agenda-templates-toggle" />
         <lfx-button
           label="Help me write"
@@ -25,24 +25,34 @@
           size="small"
           [text]="true"
           [ariaPressed]="showAiHelper()"
-          (onClick)="onToggleAiHelper()"
+          (onClick)="aiPopover.toggle($event)"
           data-testid="composer-agenda-ai-toggle" />
       </div>
     </div>
 
-    @if (meetingType()) {
-      <lfx-agenda-template-selector
-        [meetingType]="meetingType()!"
-        [visible]="showTemplates()"
-        (templateSelected)="onApplyTemplate($event)"
-        (closeSelector)="onCloseTemplates()" />
-    }
+    <!-- Both header actions open popovers anchored to their button, per the design. `p-popover` is used
+         raw because the design system has no wrapper for it yet. -->
+    <p-popover
+      #templatesPopover
+      appendTo="body"
+      styleClass="w-[26rem] max-w-[calc(100vw-2rem)]"
+      (onShow)="showTemplates.set(true)"
+      (onHide)="showTemplates.set(false)">
+      @if (meetingType(); as type) {
+        <lfx-agenda-template-selector [meetingType]="type" (templateSelected)="onApplyTemplate($event, templatesPopover)" />
+      }
+    </p-popover>
 
-    @if (showAiHelper()) {
-      <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4" data-testid="composer-agenda-ai-panel">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">AI agenda generator</h3>
-          <p class="text-xs text-gray-500">Tell me the goal and I'll draft a structured agenda.</p>
+    <p-popover #aiPopover appendTo="body" styleClass="w-[26rem] max-w-[calc(100vw-2rem)]" (onShow)="showAiHelper.set(true)" (onHide)="onAiHelperHide()">
+      <div class="flex flex-col gap-3" data-testid="composer-agenda-ai-panel">
+        <div class="flex items-start gap-2.5">
+          <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600 text-xs text-white" aria-hidden="true">
+            <i class="fa-light fa-lightbulb"></i>
+          </span>
+          <div class="flex flex-col gap-0.5">
+            <h3 class="text-sm font-semibold text-gray-900">AI agenda generator</h3>
+            <p class="text-xs text-gray-500">Tell me the goal and I'll draft a structured agenda.</p>
+          </div>
         </div>
 
         <lfx-textarea
@@ -58,25 +68,19 @@
           {{ aiPromptLength() }}/{{ promptMaxLength }}
         </p>
 
-        <div class="flex justify-end gap-2">
-          <lfx-button
-            label="Cancel"
-            size="small"
-            severity="secondary"
-            [outlined]="true"
-            (onClick)="onCancelAiHelper()"
-            data-testid="composer-agenda-ai-cancel" />
+        <div class="flex items-center justify-end gap-2">
+          <lfx-button label="Cancel" size="small" severity="secondary" [text]="true" (onClick)="aiPopover.hide()" data-testid="composer-agenda-ai-cancel" />
           <lfx-button
             [label]="isGeneratingAgenda() ? 'Generating…' : 'Generate agenda'"
             size="small"
             severity="info"
             [loading]="isGeneratingAgenda()"
             [disabled]="isGeneratingAgenda()"
-            (onClick)="onGenerateAgenda()"
+            (onClick)="onGenerateAgenda(aiPopover)"
             data-testid="composer-agenda-ai-generate" />
         </div>
       </div>
-    }
+    </p-popover>
 
     <lfx-textarea
       [form]="form()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.spec.ts
@@ -9,6 +9,7 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
+import { Popover } from 'primeng/popover';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -32,7 +33,9 @@ describe('ComposerAgendaResourcesComponent — AI helper guard', () => {
   let generateAgenda: ReturnType<typeof vi.fn>;
   let messageAdd: ReturnType<typeof vi.fn>;
 
-  const generate = (): void => component['onGenerateAgenda']();
+  // The popover is only asked to close itself on success, so a hide-only stub is enough here.
+  const popoverStub = { hide: vi.fn() } as unknown as Popover;
+  const generate = (): void => component['onGenerateAgenda'](popoverStub);
 
   beforeEach(async () => {
     generateAgenda = vi.fn(() => of({ agenda: 'Roll call', estimatedDuration: 30 }));

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -27,6 +27,7 @@ import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Popover, PopoverModule } from 'primeng/popover';
 import { catchError, EMPTY, finalize, take, tap } from 'rxjs';
 
 import { AgendaTemplateSelectorComponent } from '../../components/agenda-template-selector/agenda-template-selector.component';
@@ -41,7 +42,7 @@ import { MeetingComposerFormService } from '../meeting-composer-form.service';
  */
 @Component({
   selector: 'lfx-composer-agenda-resources',
-  imports: [NgClass, ButtonComponent, FileUploadComponent, TextareaComponent, FileSizePipe, AgendaTemplateSelectorComponent],
+  imports: [NgClass, PopoverModule, ButtonComponent, FileUploadComponent, TextareaComponent, FileSizePipe, AgendaTemplateSelectorComponent],
   templateUrl: './composer-agenda-resources.component.html',
 })
 export class ComposerAgendaResourcesComponent {
@@ -104,7 +105,8 @@ export class ComposerAgendaResourcesComponent {
     return [...this.linksArray().controls] as FormGroup[];
   });
 
-  protected onToggleTemplates(): void {
+  /** Templates are grouped by meeting type, so the popover has nothing to show until one is picked. */
+  protected onToggleTemplates(event: MouseEvent, popover: Popover): void {
     if (!this.meetingType()) {
       this.messageService.add({
         severity: 'warn',
@@ -114,31 +116,22 @@ export class ComposerAgendaResourcesComponent {
       return;
     }
 
-    this.showAiHelper.set(false);
-    this.showTemplates.update((visible) => !visible);
+    popover.toggle(event);
   }
 
-  protected onToggleAiHelper(): void {
-    this.showTemplates.set(false);
-    this.showAiHelper.update((visible) => !visible);
-  }
-
-  protected onCloseTemplates(): void {
-    this.showTemplates.set(false);
-  }
-
-  protected onCancelAiHelper(): void {
+  /** The prompt is scratch state: it resets whenever the popover closes, however it was closed. */
+  protected onAiHelperHide(): void {
     this.showAiHelper.set(false);
     this.form().get('aiPrompt')?.setValue('');
   }
 
-  protected onApplyTemplate(template: MeetingTemplate): void {
+  protected onApplyTemplate(template: MeetingTemplate, popover: Popover): void {
     this.form().get('description')?.setValue(template.content);
     this.applyEstimatedDuration(template.estimatedDuration);
-    this.showTemplates.set(false);
+    popover.hide();
   }
 
-  protected onGenerateAgenda(): void {
+  protected onGenerateAgenda(popover: Popover): void {
     const form = this.form();
     const context = (form.get('aiPrompt')?.value as string | null)?.trim() || null;
     const title = (form.get('title')?.value as string | null)?.trim() || null;
@@ -177,7 +170,7 @@ export class ComposerAgendaResourcesComponent {
           next: (response) => {
             this.form().get('description')?.setValue(response.agenda);
             this.applyEstimatedDuration(response.estimatedDuration);
-            this.onCancelAiHelper();
+            popover.hide();
             this.messageService.add({ severity: 'success', summary: 'Agenda generated', detail: 'Review the draft and edit it as needed.' });
           },
           // `MeetingService.generateAgenda` already logs the failure before re-throwing.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -1,18 +1,20 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6" data-testid="composer-date-schedule">
+<div class="flex flex-col gap-4" data-testid="composer-date-schedule">
   @if (showHeading()) {
     <div class="flex flex-col gap-1">
-      <h2>Date &amp; Schedule</h2>
+      <h2 class="text-base font-semibold text-gray-900">Date &amp; Schedule</h2>
       <p class="text-sm text-gray-500">When it happens and how often it repeats.</p>
     </div>
   }
 
   <!-- Start date + start time -->
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-    <div class="flex flex-col gap-2">
-      <label for="composer-start-date" class="text-sm font-medium text-gray-900"> Start date <span class="text-red-500">*</span> </label>
+  <div [class]="dateTimeGridClass()">
+    <div class="flex flex-col gap-1.5">
+      <label for="composer-start-date" class="text-sm font-medium text-gray-900">
+        {{ compact() ? 'Date' : 'Start date' }} <span class="text-red-500">*</span>
+      </label>
       <lfx-calendar
         [form]="form()"
         control="startDate"
@@ -28,8 +30,10 @@
       }
     </div>
 
-    <div class="flex flex-col gap-2">
-      <label for="composer-start-time" class="text-sm font-medium text-gray-900"> Start time <span class="text-red-500">*</span> </label>
+    <div class="flex flex-col gap-1.5">
+      <label for="composer-start-time" class="text-sm font-medium text-gray-900">
+        {{ compact() ? 'Time' : 'Start time' }} <span class="text-red-500">*</span>
+      </label>
       <lfx-time-picker
         [form]="form()"
         control="startTime"
@@ -48,14 +52,21 @@
   }
 
   <!-- Duration -->
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-1.5">
     <span id="composer-duration-label" class="text-sm font-medium text-gray-900"> Duration <span class="text-red-500">*</span> </span>
     <div
       role="group"
       aria-labelledby="composer-duration-label"
       [attr.aria-describedby]="durationHint() ? 'composer-duration-hint' : null"
       data-testid="composer-duration-chips">
-      <lfx-select-button [form]="form()" control="duration" [options]="durationOptions" [unselectable]="false" [required]="true" />
+      <lfx-select-button
+        [form]="form()"
+        control="duration"
+        [options]="durationOptions"
+        [unselectable]="false"
+        [required]="true"
+        [class]="chipGroupClass"
+        [styleClass]="chipButtonClass" />
     </div>
 
     @if (durationHint(); as hint) {
@@ -66,7 +77,7 @@
     }
 
     @if (form().get('duration')?.value === 'custom') {
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-1.5">
         <div class="flex items-center gap-2">
           <lfx-input-number
             [form]="form()"
@@ -92,7 +103,7 @@
   </div>
 
   <!-- Timezone -->
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-1.5">
     <!-- p-select's inputId lands on a span[role=combobox], so this associates via aria-labelledby, not `for` -->
     <label id="composer-timezone-label" class="text-sm font-medium text-gray-900"> Timezone <span class="text-red-500">*</span> </label>
     <lfx-select
@@ -114,7 +125,7 @@
 
   <!-- Early join -->
   @if (showEarlyJoin()) {
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-1.5">
       <span id="composer-early-join-label" class="flex items-center gap-2 text-sm font-medium text-gray-900">
         Early join
         <i
@@ -128,7 +139,13 @@
           tooltipStyleClass="text-xs max-w-xs"></i>
       </span>
       <div role="group" aria-labelledby="composer-early-join-label" data-testid="composer-early-join-chips">
-        <lfx-select-button [form]="form()" control="early_join_time_minutes" [options]="earlyJoinOptions" [unselectable]="false" />
+        <lfx-select-button
+          [form]="form()"
+          control="early_join_time_minutes"
+          [options]="earlyJoinOptions"
+          [unselectable]="false"
+          [class]="chipGroupClass"
+          [styleClass]="chipButtonClass" />
       </div>
       @if (form().get('early_join_time_minutes')?.errors?.['min'] && form().get('early_join_time_minutes')?.touched) {
         <p class="text-sm text-red-600" data-testid="composer-early-join-min-error">Early join time must be at least {{ minEarlyJoinTime }} minutes</p>
@@ -139,18 +156,27 @@
     </div>
   }
 
-  <hr class="border-gray-200" />
+  @if (!compact()) {
+    <hr class="border-gray-200" />
+  }
 
   <!-- Recurring -->
   <lfx-feature-toggle [feature]="recurringFeature" [form]="form()">
     @if (form().get('isRecurring')?.value) {
-      <div class="mt-4 flex flex-col gap-2 border-t border-gray-200 pt-4">
+      <div class="mt-3 flex flex-col gap-1.5 border-t border-gray-200 pt-3">
         <span id="composer-cadence-label" class="text-sm font-medium text-gray-900"> Cadence <span class="text-red-500">*</span> </span>
         @if (cadenceOptions().length === 0) {
           <p class="text-sm text-gray-500" data-testid="composer-cadence-needs-date">Pick a start date to choose how often this meeting repeats.</p>
         } @else {
           <div role="group" aria-labelledby="composer-cadence-label" data-testid="composer-cadence-chips">
-            <lfx-select-button [form]="form()" control="recurrenceType" [options]="cadenceOptions()" [unselectable]="false" [required]="true" />
+            <lfx-select-button
+              [form]="form()"
+              control="recurrenceType"
+              [options]="cadenceOptions()"
+              [unselectable]="false"
+              [required]="true"
+              [class]="chipGroupClass"
+              [styleClass]="chipButtonClass" />
           </div>
         }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -59,6 +59,14 @@ export class ComposerDateScheduleComponent implements OnInit {
   /** Early join is an advanced setting the quick create dialog leaves at its default. */
   public readonly showEarlyJoin = input(true);
   /**
+   * Narrow-column layout for the quick create dialog's right-hand rail.
+   * @description Not a media query: the section is the same width on a phone and in the dialog's 2/5
+   * column, so the breakpoint that would drive this doesn't describe the space it actually has. Stacks
+   * date over time, shortens their labels (the surrounding column is already "when it happens"), and
+   * drops the rule above the recurring card, which the column's own divider already stands in for.
+   */
+  public readonly compact = input(false);
+  /**
    * Hint text for a duration that was written by something other than the organizer.
    * @description Passed in rather than derived here because only quick create prefills from the meeting
    * type. It renders directly under the chips and is wired through `aria-describedby` on their group, so
@@ -67,6 +75,24 @@ export class ComposerDateScheduleComponent implements OnInit {
    * `lfx-select-button` exposes no `ariaDescribedBy` input to pass it through.
    */
   public readonly durationHint = input<string | null>(null);
+
+  /**
+   * Outlined-pill styling for every chip group in this section.
+   * @description The theme renders a select button as one joined segmented control that can't wrap, so
+   * in the quick dialog's 2/5 column the seven duration chips overflow and clip "Custom". Detaching the
+   * buttons into individually rounded pills lets the group wrap onto a second row, and matches how the
+   * chips read next to the meeting-type row above them. Split in two because the wrapper forwards
+   * `class` to the group and `styleClass` to each button; kept here so the three groups can't drift.
+   */
+  protected readonly chipGroupClass = 'flex flex-wrap gap-2 bg-transparent p-0';
+  protected readonly chipButtonClass = [
+    // `p-0` because the theme pads the button *and* its content; only the inner padding is wanted, or
+    // these sit taller than the meeting-type chips they're meant to match.
+    'rounded-full border border-gray-200 bg-white p-0 text-sm text-gray-700 transition-colors hover:bg-gray-50',
+    '[&_.p-togglebutton-content]:bg-transparent [&_.p-togglebutton-content]:px-2.5 [&_.p-togglebutton-content]:py-1 [&_.p-togglebutton-content]:shadow-none',
+    '[&.p-togglebutton-checked]:border-blue-500 [&.p-togglebutton-checked]:bg-blue-50 [&.p-togglebutton-checked]:hover:bg-blue-50',
+    '[&.p-togglebutton-checked_.p-togglebutton-label]:font-medium [&.p-togglebutton-checked_.p-togglebutton-label]:text-blue-700',
+  ].join(' ');
 
   protected readonly durationOptions = MEETING_DURATION_CHIP_OPTIONS;
   protected readonly earlyJoinOptions = EARLY_JOIN_CHIP_OPTIONS;
@@ -82,6 +108,9 @@ export class ComposerDateScheduleComponent implements OnInit {
   protected readonly cadenceOptions = signal<{ label: string; value: string }[]>([]);
   // Rebuilt whenever the meeting date changes so the listed DST offsets match that date.
   protected readonly timezoneOptions = signal<{ label: string; value: string }[]>(this.buildTimezoneOptions(new Date()));
+
+  // Both literals live here rather than in a class binding so Tailwind's `content` scan still sees them.
+  protected readonly dateTimeGridClass = computed(() => (this.compact() ? 'grid grid-cols-1 gap-3' : 'grid grid-cols-1 gap-3 sm:grid-cols-2'));
 
   protected readonly minDate = computed(() => {
     const yesterday = new Date();

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -1,16 +1,16 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6" data-testid="composer-details-access">
+<div class="flex flex-col gap-4" data-testid="composer-details-access">
   @if (showHeading()) {
     <div class="flex flex-col gap-1">
-      <h2>Details &amp; Access</h2>
+      <h2 class="text-base font-semibold text-gray-900">Details &amp; Access</h2>
       <p class="text-sm text-gray-500">Name the meeting and set who it's for.</p>
     </div>
   }
 
   <!-- Meeting title -->
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-1.5">
     <label for="composer-meeting-title" class="text-sm font-medium text-gray-900"> Meeting title <span class="text-red-500">*</span> </label>
     <lfx-input-text
       [form]="form()"
@@ -58,51 +58,66 @@
   </div>
 
   <!-- Meeting type -->
-  <div class="flex flex-col gap-2">
-    <!-- p-select's inputId lands on a span[role=combobox], so this associates via aria-labelledby, not `for` -->
-    <label id="composer-meeting-type-label" class="text-sm font-medium text-gray-900"> Meeting type <span class="text-red-500">*</span> </label>
-    <lfx-select
-      [form]="form()"
-      control="meeting_type"
-      [options]="meetingTypeOptions()"
-      inputId="composer-meeting-type"
-      ariaLabelledBy="composer-meeting-type-label"
-      [required]="true"
-      placeholder="Select meeting type…"
-      styleClass="w-full"
-      [checkmark]="true"
-      dataTest="composer-meeting-type-select">
-      <ng-template #item let-option>
-        <div class="flex items-start gap-3 py-1">
-          <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-50" [style.color]="option.info.color">
-            <i [class]="option.info.icon" aria-hidden="true"></i>
+  @if (showTypeSelect()) {
+    <div class="flex flex-col gap-1.5">
+      <!-- p-select's inputId lands on a span[role=combobox], so this associates via aria-labelledby, not `for` -->
+      <label id="composer-meeting-type-label" class="text-sm font-medium text-gray-900"> Meeting type <span class="text-red-500">*</span> </label>
+      <lfx-select
+        [form]="form()"
+        control="meeting_type"
+        [options]="meetingTypeOptions()"
+        inputId="composer-meeting-type"
+        ariaLabelledBy="composer-meeting-type-label"
+        [required]="true"
+        placeholder="Select meeting type…"
+        styleClass="w-full"
+        scrollHeight="330px"
+        dataTest="composer-meeting-type-select">
+        <!-- `checkmark` is off: PrimeNG puts its own tick on the left, and the design marks the
+             selected row on the right, past the description -->
+        <ng-template #item let-option>
+          <div class="flex w-full items-start gap-2.5">
+            <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gray-50 text-xs" [style.color]="option.info.color">
+              <i [class]="option.info.icon" aria-hidden="true"></i>
+            </span>
+            <span class="flex min-w-0 flex-col">
+              <span class="text-sm font-semibold leading-tight text-gray-900">{{ option.label }}</span>
+              <span class="whitespace-normal text-xs leading-snug text-gray-500">{{ option.info.description }}</span>
+            </span>
+            @if (option.value === selectedMeetingType()) {
+              <i class="fa-light fa-check ml-auto mt-0.5 shrink-0 text-xs text-blue-600" aria-hidden="true"></i>
+            }
+          </div>
+        </ng-template>
+        <ng-template #selectedItem let-option>
+          <span class="flex items-center gap-2">
+            <i [class]="option.info.icon" [style.color]="option.info.color" aria-hidden="true"></i>
+            <span class="text-sm text-gray-900">{{ option.label }}</span>
           </span>
-          <span class="flex min-w-0 flex-col gap-0.5">
-            <span class="text-sm font-semibold text-gray-900">{{ option.label }}</span>
-            <span class="whitespace-normal text-xs leading-relaxed text-gray-500">{{ option.info.description }}</span>
-          </span>
-        </div>
-      </ng-template>
-      <ng-template #selectedItem let-option>
-        <span class="flex items-center gap-2">
-          <i [class]="option.info.icon" [style.color]="option.info.color" aria-hidden="true"></i>
-          <span class="text-sm text-gray-900">{{ option.label }}</span>
-        </span>
-      </ng-template>
-    </lfx-select>
+        </ng-template>
+      </lfx-select>
 
-    @if (form().get('meeting_type')?.errors?.['required'] && form().get('meeting_type')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-meeting-type-required-error">Meeting type is required</p>
-    }
-  </div>
+      @if (form().get('meeting_type')?.errors?.['required'] && form().get('meeting_type')?.touched) {
+        <p class="text-sm text-red-600" data-testid="composer-meeting-type-required-error">Meeting type is required</p>
+      }
+    </div>
+  }
 
-  <!-- Visibility + join restriction: two independent API fields, one card -->
-  <div class="overflow-hidden rounded-xl border border-gray-200">
-    <fieldset class="flex flex-col border-b border-gray-200 px-4 py-3">
-      <legend class="text-sm font-medium text-gray-900">Visibility</legend>
-      @for (option of visibilityOptions; track option.value) {
-        <label [for]="'composer-visibility-' + option.value" class="flex cursor-pointer items-center gap-3 py-2">
-          <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-50" [style.color]="option.info.color">
+  <!-- Visibility + join restriction: two independent API fields, so two labelled cards rather than one
+       card with internal legends — the heading reads as the question and the card as its answers. -->
+  <fieldset>
+    <legend class="mb-1.5 text-sm font-medium text-gray-900">Visibility</legend>
+    <div class="overflow-hidden rounded-xl border border-gray-200">
+      @for (option of visibilityOptions; track option.value; let last = $last) {
+        <label
+          [for]="'composer-visibility-' + option.value"
+          class="flex cursor-pointer items-center gap-3 px-3 py-2.5"
+          [class.border-b]="!last"
+          [class.border-gray-200]="!last">
+          <span
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs"
+            [class]="option.value === selectedVisibility() ? iconChipSelectedClass : iconChipClass"
+            [style.background-color]="option.value === selectedVisibility() ? option.info.color : null">
             <i [class]="option.info.icon" aria-hidden="true"></i>
           </span>
           <span class="flex min-w-0 flex-1 flex-col">
@@ -118,13 +133,22 @@
             [attr.data-testid]="'composer-visibility-' + option.value + '-radio'" />
         </label>
       }
-    </fieldset>
+    </div>
+  </fieldset>
 
-    <fieldset class="flex flex-col px-4 py-3">
-      <legend class="text-sm font-medium text-gray-900">Join restriction</legend>
-      @for (option of joinRestrictionOptions; track option.value) {
-        <label [for]="'composer-restricted-' + option.value" class="flex cursor-pointer items-center gap-3 py-2">
-          <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-50" [style.color]="option.info.color">
+  <fieldset>
+    <legend class="mb-1.5 text-sm font-medium text-gray-900">Join Restriction</legend>
+    <div class="overflow-hidden rounded-xl border border-gray-200">
+      @for (option of joinRestrictionOptions; track option.value; let last = $last) {
+        <label
+          [for]="'composer-restricted-' + option.value"
+          class="flex cursor-pointer items-center gap-3 px-3 py-2.5"
+          [class.border-b]="!last"
+          [class.border-gray-200]="!last">
+          <span
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs"
+            [class]="option.value === selectedRestricted() ? iconChipSelectedClass : iconChipClass"
+            [style.background-color]="option.value === selectedRestricted() ? option.info.color : null">
             <i [class]="option.info.icon" aria-hidden="true"></i>
           </span>
           <span class="flex min-w-0 flex-1 flex-col">
@@ -140,6 +164,6 @@
             [attr.data-testid]="'composer-restricted-' + option.value + '-radio'" />
         </label>
       }
-    </fieldset>
-  </div>
+    </div>
+  </fieldset>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -41,6 +41,8 @@ export class ComposerDetailsAccessComponent {
   public readonly form = input.required<FormGroup>();
   /** Quick create renders these fields under its own dialog header, where a section heading only repeats it. */
   public readonly showHeading = input(true);
+  /** Quick create renders the type as its own chip row above these fields, so the select would duplicate it. */
+  public readonly showTypeSelect = input(true);
   /**
    * Hint text for a title that was written by something other than the organizer.
    * @description Passed in rather than derived here because only quick create prefills from the meeting
@@ -54,6 +56,21 @@ export class ComposerDetailsAccessComponent {
   protected readonly youtubeTitleLimit = YOUTUBE_MAX_MEETING_TITLE_LENGTH;
   protected readonly youtubeAmberThreshold = YOUTUBE_MEETING_TITLE_WARNING_LENGTH;
 
+  /**
+   * Icon chip styling for the visibility / join-restriction rows.
+   * @description Unselected reads as a muted affordance; the selected row fills the chip with the option's
+   * own colour (set inline, since the palette is per-option) and flips the glyph to white, so the answer is
+   * legible without reading the radio. Whole class strings — Tailwind only emits what it can see literally.
+   */
+  protected readonly iconChipClass = 'bg-gray-100 text-gray-400';
+  protected readonly iconChipSelectedClass = 'text-white';
+
+  // FormGroup state isn't reactive, so both read `revision()` before touching the control.
+  protected readonly selectedVisibility: Signal<string | null> = this.initSelectedVisibility();
+  protected readonly selectedRestricted: Signal<boolean | null> = this.initSelectedRestricted();
+  /** Drives the option rows' own check mark, which sits on the right rather than PrimeNG's left tick. */
+  protected readonly selectedMeetingType: Signal<MeetingType | null> = this.initSelectedMeetingType();
+
   protected readonly titleLength: Signal<number> = this.initTitleLength();
   /**
    * Ids the title input points at through `aria-describedby`.
@@ -64,6 +81,27 @@ export class ComposerDetailsAccessComponent {
   protected readonly titleDescribedBy: Signal<string | null> = this.initTitleDescribedBy();
   private readonly hydratedMeetingType: Signal<MeetingType | null> = this.initHydratedMeetingType();
   protected readonly meetingTypeOptions: Signal<CardSelectorOption<MeetingType>[]> = this.initMeetingTypeOptions();
+
+  private initSelectedVisibility(): Signal<string | null> {
+    return computed(() => {
+      this.formService.revision();
+      return (this.form().get('visibility')?.value as string | null) ?? null;
+    });
+  }
+
+  private initSelectedMeetingType(): Signal<MeetingType | null> {
+    return computed(() => {
+      this.formService.revision();
+      return (this.form().get('meeting_type')?.value as MeetingType | null) ?? null;
+    });
+  }
+
+  private initSelectedRestricted(): Signal<boolean | null> {
+    return computed(() => {
+      this.formService.revision();
+      return (this.form().get('restricted')?.value as boolean | null) ?? null;
+    });
+  }
 
   private initTitleLength(): Signal<number> {
     return toSignal(

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
@@ -1,14 +1,14 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6" data-testid="composer-guests">
+<div class="flex flex-col gap-4" data-testid="composer-guests">
   <div class="flex flex-col gap-1">
-    <h2>Invite guests</h2>
+    <h2 class="text-base font-semibold text-gray-900">Invite guests</h2>
     <p class="text-sm text-gray-500">Add key stakeholders and contributors who should participate in this discussion.</p>
   </div>
 
   <!-- Search and add -->
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-1.5">
     <span class="text-sm font-medium text-gray-900">Search and add guests</span>
     <lfx-user-search
       [form]="quickAddForm"
@@ -64,7 +64,7 @@
         <p class="text-sm text-gray-500">Search for people or add a group to invite everyone at once.</p>
       </div>
     } @else {
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-1.5">
         <div class="flex flex-wrap items-baseline justify-between gap-2">
           <span class="text-sm font-medium text-gray-900">Invited · {{ guestCount() }}</span>
           <span class="text-xs text-gray-500" data-testid="composer-guests-stats">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.html
@@ -1,14 +1,14 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-6" data-testid="composer-platform-features">
+<div class="flex flex-col gap-4" data-testid="composer-platform-features">
   <div class="flex flex-col gap-1">
-    <h2>Platform &amp; features</h2>
+    <h2 class="text-base font-semibold text-gray-900">Platform &amp; features</h2>
     <p class="text-sm text-gray-500">Select your video platform and enable transparency features like recording and transcripts.</p>
   </div>
 
   <!-- Platform -->
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-1.5">
     <span id="composer-platform-label" class="text-sm font-medium text-gray-900"> Platform <span class="text-red-500" aria-hidden="true">*</span> </span>
     <div
       role="group"
@@ -51,11 +51,14 @@
 
     <lfx-feature-toggle [feature]="transcriptFeature" [form]="form()" />
 
-    <lfx-feature-toggle [feature]="youtubeFeature" [form]="form()" />
-
-    @if (!form().get('recording_enabled')?.value) {
-      <p class="text-xs text-gray-500" data-testid="composer-recording-dependency-hint">Transcripts and YouTube upload need recording enabled.</p>
-    }
+    <!-- The dependency note lives inside the YouTube card: it's the card whose toggle the requirement gates -->
+    <lfx-feature-toggle [feature]="youtubeFeature" [form]="form()">
+      @if (!form().get('recording_enabled')?.value) {
+        <p class="mt-3 border-t border-gray-200 pt-3 text-xs text-gray-500" data-testid="composer-recording-dependency-hint">
+          Transcripts and YouTube upload need recording enabled.
+        </p>
+      }
+    </lfx-feature-toggle>
 
     @if (form().get('youtube_upload_enabled')?.value && form().get('title')?.errors?.['maxlength']) {
       <div class="flex gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4" data-testid="composer-youtube-title-warning">
@@ -76,11 +79,78 @@
         </div>
       </div>
     }
+
+    <!-- Email reminder -->
+    <lfx-feature-toggle [feature]="emailReminderFeature" [form]="form()">
+      @if (form().get('auto_email_reminder_enabled')?.value) {
+        <div class="mt-4 flex flex-col gap-2 border-t border-gray-200 pt-4">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1" role="group" aria-label="Send reminder before the meeting starts">
+            <div class="flex items-center gap-2">
+              <lfx-input-number
+                class="w-20 flex-none"
+                [form]="form()"
+                control="reminderHours"
+                size="small"
+                id="composer-reminder-hours"
+                data-testid="composer-reminder-hours" />
+              <label for="composer-reminder-hours" class="text-sm text-gray-900">hours</label>
+            </div>
+            <div class="flex items-center gap-2">
+              <lfx-input-number
+                class="w-20 flex-none"
+                [form]="form()"
+                control="reminderMinutes"
+                size="small"
+                id="composer-reminder-minutes"
+                data-testid="composer-reminder-minutes" />
+              <label for="composer-reminder-minutes" class="text-sm text-gray-900">minutes</label>
+            </div>
+            <span class="text-sm text-gray-900">before the meeting starts</span>
+            <button
+              type="button"
+              class="cursor-help text-gray-400"
+              [attr.aria-label]="emailReminderTooltip"
+              [pTooltip]="emailReminderTooltip"
+              tooltipEvent="both"
+              tooltipPosition="right"
+              tooltipStyleClass="text-xs max-w-xs"
+              data-testid="composer-reminder-tooltip">
+              <i class="fa-light fa-info-circle" aria-hidden="true"></i>
+            </button>
+          </div>
+          @if (form().get('reminderHours')?.errors?.['required'] && form().get('reminderHours')?.touched) {
+            <p class="text-sm text-red-600" data-testid="composer-reminder-hours-required-error">Reminder hours is required</p>
+          }
+          @if (form().get('reminderHours')?.errors?.['pattern'] && form().get('reminderHours')?.touched) {
+            <p class="text-sm text-red-600" data-testid="composer-reminder-hours-pattern-error">Reminder hours must be a whole number</p>
+          }
+          @if (form().get('reminderHours')?.errors?.['min'] && form().get('reminderHours')?.touched) {
+            <p class="text-sm text-red-600" data-testid="composer-reminder-hours-min-error">
+              Reminder must be at least {{ minReminderHours }} hours before the meeting starts
+            </p>
+          }
+          @if (form().get('reminderHours')?.errors?.['max'] && form().get('reminderHours')?.touched) {
+            <p class="text-sm text-red-600" data-testid="composer-reminder-hours-max-error">
+              Reminder cannot be more than {{ maxReminderHours }} hours before the meeting starts
+            </p>
+          }
+          @if (
+            (form().get('reminderMinutes')?.errors?.['required'] ||
+              form().get('reminderMinutes')?.errors?.['pattern'] ||
+              form().get('reminderMinutes')?.errors?.['min'] ||
+              form().get('reminderMinutes')?.errors?.['max']) &&
+            form().get('reminderMinutes')?.touched
+          ) {
+            <p class="text-sm text-red-600" data-testid="composer-reminder-minutes-error">Minutes must be a whole number between 0 and 59</p>
+          }
+        </div>
+      }
+    </lfx-feature-toggle>
   </div>
 
   <!-- Artifact access -->
   @if (form().get('recording_enabled')?.value || form().get('zoom_ai_enabled')?.value) {
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-1.5">
       <!-- p-select's inputId lands on a span[role=combobox], so this associates via aria-labelledby, not `for` -->
       <label id="composer-artifact-visibility-label" class="text-sm font-medium text-gray-900">
         @if (form().get('recording_enabled')?.value && form().get('zoom_ai_enabled')?.value) {
@@ -103,71 +173,4 @@
         dataTest="composer-artifact-visibility-select" />
     </div>
   }
-
-  <!-- Email reminder -->
-  <lfx-feature-toggle [feature]="emailReminderFeature" [form]="form()">
-    @if (form().get('auto_email_reminder_enabled')?.value) {
-      <div class="mt-4 flex flex-col gap-2 border-t border-gray-200 pt-4">
-        <div class="flex flex-wrap items-center gap-x-2 gap-y-1" role="group" aria-label="Send reminder before the meeting starts">
-          <div class="flex items-center gap-2">
-            <lfx-input-number
-              class="w-20 flex-none"
-              [form]="form()"
-              control="reminderHours"
-              size="small"
-              id="composer-reminder-hours"
-              data-testid="composer-reminder-hours" />
-            <label for="composer-reminder-hours" class="text-sm text-gray-900">hours</label>
-          </div>
-          <div class="flex items-center gap-2">
-            <lfx-input-number
-              class="w-20 flex-none"
-              [form]="form()"
-              control="reminderMinutes"
-              size="small"
-              id="composer-reminder-minutes"
-              data-testid="composer-reminder-minutes" />
-            <label for="composer-reminder-minutes" class="text-sm text-gray-900">minutes</label>
-          </div>
-          <span class="text-sm text-gray-900">before the meeting starts</span>
-          <button
-            type="button"
-            class="cursor-help text-gray-400"
-            [attr.aria-label]="emailReminderTooltip"
-            [pTooltip]="emailReminderTooltip"
-            tooltipEvent="both"
-            tooltipPosition="right"
-            tooltipStyleClass="text-xs max-w-xs"
-            data-testid="composer-reminder-tooltip">
-            <i class="fa-light fa-info-circle" aria-hidden="true"></i>
-          </button>
-        </div>
-        @if (form().get('reminderHours')?.errors?.['required'] && form().get('reminderHours')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-required-error">Reminder hours is required</p>
-        }
-        @if (form().get('reminderHours')?.errors?.['pattern'] && form().get('reminderHours')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-pattern-error">Reminder hours must be a whole number</p>
-        }
-        @if (form().get('reminderHours')?.errors?.['min'] && form().get('reminderHours')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-min-error">
-            Reminder must be at least {{ minReminderHours }} hours before the meeting starts
-          </p>
-        }
-        @if (form().get('reminderHours')?.errors?.['max'] && form().get('reminderHours')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-max-error">
-            Reminder cannot be more than {{ maxReminderHours }} hours before the meeting starts
-          </p>
-        }
-        @if (
-          (form().get('reminderMinutes')?.errors?.['required'] ||
-            form().get('reminderMinutes')?.errors?.['pattern'] ||
-            form().get('reminderMinutes')?.errors?.['min'] ||
-            form().get('reminderMinutes')?.errors?.['max']) &&
-          form().get('reminderMinutes')?.touched
-        ) {
-          <p class="text-sm text-red-600" data-testid="composer-reminder-minutes-error">Minutes must be a whole number between 0 and 59</p>
-        }
-      </div>
-    }
-  </lfx-feature-toggle>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -31,22 +31,16 @@
               </lfx-button>
             }
             @if (activeLens() !== 'me' && canWriteMeetings()) {
-              <div class="flex items-center gap-1">
+              <div class="flex items-center">
+                <!-- One button, not a split: every create path starts by picking a meeting type or Advanced,
+                     so there is no default action for a separate primary half to perform. -->
                 <lfx-button
-                  icon="fa-light fa-calendar"
+                  icon="fa-light fa-chevron-down"
+                  iconPos="right"
                   severity="info"
                   [attr.data-testid]="'meeting-create-button'"
                   label="Create Meeting"
                   size="small"
-                  (onClick)="onCreateMeeting()">
-                </lfx-button>
-                <lfx-button
-                  icon="fa-light fa-chevron-down"
-                  severity="info"
-                  [outlined]="true"
-                  size="small"
-                  ariaLabel="More create options"
-                  [attr.data-testid]="'meeting-create-options-button'"
                   (onClick)="createMenu.toggle($event)">
                 </lfx-button>
                 <lfx-menu #createMenu [model]="createMenuItems()" [popup]="true" appendTo="body" styleClass="w-[22rem] py-2">

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -49,7 +49,22 @@
                   [attr.data-testid]="'meeting-create-options-button'"
                   (onClick)="createMenu.toggle($event)">
                 </lfx-button>
-                <lfx-menu #createMenu [model]="createMenuItems()" [popup]="true" appendTo="body"></lfx-menu>
+                <lfx-menu #createMenu [model]="createMenuItems()" [popup]="true" appendTo="body" styleClass="w-[22rem] py-2">
+                  <ng-template #submenuheader let-item>
+                    <span class="text-[0.6875rem] font-semibold uppercase tracking-wide text-gray-500">{{ item.label }}</span>
+                  </ng-template>
+                  <ng-template #item let-item>
+                    <div class="flex w-full items-start gap-3 px-2 py-1.5" [attr.data-testid]="item.testId">
+                      <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg" [class]="item.tileClass">
+                        <i class="text-sm" [class]="item.icon"></i>
+                      </span>
+                      <span class="flex min-w-0 flex-col gap-0.5">
+                        <span class="text-sm font-semibold text-gray-900">{{ item.label }}</span>
+                        <span class="whitespace-normal text-xs leading-snug text-gray-500">{{ item.description }}</span>
+                      </span>
+                    </div>
+                  </ng-template>
+                </lfx-menu>
               </div>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -42,6 +42,11 @@
                   label="Create Meeting"
                   size="small"
                   (onClick)="createMenu.toggle($event)">
+                  <!-- The calendar sits here rather than in `icon` because `lfx-button` takes a single
+                       icon and the chevron needs it. PrimeNG renders projected content before its own
+                       icon and label, and `p-button-icon-right` reorders the chevron last, so this
+                       lands left of the label and inherits the button's own gap. -->
+                  <i class="fa-light fa-calendar" aria-hidden="true"></i>
                 </lfx-button>
                 <lfx-menu #createMenu [model]="createMenuItems()" [popup]="true" appendTo="body" styleClass="w-[22rem] py-2">
                   <ng-template #submenuheader let-item>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -48,7 +48,16 @@
                        lands left of the label and inherits the button's own gap. -->
                   <i class="fa-light fa-calendar" aria-hidden="true"></i>
                 </lfx-button>
-                <lfx-menu #createMenu [model]="createMenuItems()" [popup]="true" appendTo="body" styleClass="w-[22rem] py-2">
+                <!-- `mt-1.5` offsets the panel off the trigger: PrimeNG positions the popup with an inline
+                     `top`, and margin still shifts an absolutely positioned element. The submenu-label
+                     override trims the theme's own heading padding, which stacked with the panel's. -->
+                <lfx-menu
+                  #createMenu
+                  [model]="createMenuItems()"
+                  [popup]="true"
+                  appendTo="body"
+                  (onShow)="onCreateMenuShow()"
+                  styleClass="meeting-create-menu-overlay mt-1.5 w-[22rem] pt-1 pb-2 [&_.p-menu-submenu-label]:py-1.5">
                   <ng-template #submenuheader let-item>
                     <span class="text-[0.6875rem] font-semibold uppercase tracking-wide text-gray-500">{{ item.label }}</span>
                   </ng-template>
@@ -58,8 +67,8 @@
                         <i class="text-sm" [class]="item.icon"></i>
                       </span>
                       <span class="flex min-w-0 flex-col gap-0.5">
-                        <span class="text-sm font-semibold text-gray-900">{{ item.label }}</span>
-                        <span class="whitespace-normal text-xs leading-snug text-gray-500">{{ item.description }}</span>
+                        <span class="text-sm font-medium text-gray-900">{{ item.label }}</span>
+                        <span class="whitespace-normal text-xs leading-snug text-gray-400">{{ item.description }}</span>
                       </span>
                     </div>
                   </ng-template>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -110,7 +110,9 @@ export class MeetingsDashboardComponent {
 
   /**
    * Create Meeting dropdown: a quick start per meeting type, then the full drawer.
-   * @description A type row opens the quick dialog pre-selected, so its template prefill runs immediately.
+   * @description The button has no default action of its own — creating a meeting always starts by
+   * choosing one of these rows, so this model is the only entry point into either composer surface.
+   * A type row opens the quick dialog pre-selected, so its template prefill runs immediately.
    * Types come from the same persona filter the composer's type select uses — otherwise a maintainer
    * could seed a type here that the select then hides, leaving it set but uneditable.
    */
@@ -291,11 +293,6 @@ export class MeetingsDashboardComponent {
     toObservable(this.composer.saveCount)
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => this.refreshMeetings());
-  }
-
-  /** Main button: the quick create dialog. The dropdown covers per-type quick starts and the drawer. */
-  public onCreateMeeting(): void {
-    this.composer.open({ mode: 'create', variant: 'quick' });
   }
 
   public onQuickCreateMeeting(meetingType: MeetingType): void {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -118,6 +118,16 @@ export class MeetingsDashboardComponent {
    */
   public readonly createMenuItems: Signal<MenuItem[]> = this.initCreateMenuItems();
 
+  /**
+   * Marker class on the body-appended popup, so `onCreateMenuShow` can find it back.
+   * @description Not an id: `p-menu`'s `id` input lands on its inline root, not on the overlay it
+   * teleports to `body`.
+   */
+  private readonly createMenuOverlaySelector = '.meeting-create-menu-overlay';
+
+  /** Smallest gap left between the right-aligned popup and the viewport edge, in px. */
+  protected readonly createMenuViewportGutter = 8;
+
   public readonly activeLens: Signal<Lens> = this.lensService.activeLens;
   protected readonly personaLoaded = this.personaService.personaLoaded;
 
@@ -399,6 +409,33 @@ export class MeetingsDashboardComponent {
   }
 
   /**
+   * Right-aligns the create dropdown with its trigger.
+   * @description PrimeNG appends the popup to `body` and lines its *left* edge up with the trigger,
+   * which throws a 22rem panel out toward the page edge. `p-menu` has no alignment input, so nudge
+   * the inline `left` PrimeNG just wrote — on every show, since the trigger can move with the layout.
+   * Body-appended popups are positioned in page coordinates, hence the scroll offset.
+   */
+  protected onCreateMenuShow(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    // Next frame, not this one: PrimeNG emits `onShow` from the same handler that aligns the overlay,
+    // so writing `left` here races its own write (and the panel is still mid-animation, so it hasn't
+    // settled at its final width yet).
+    requestAnimationFrame(() => {
+      const trigger = document.querySelector(`[data-testid="meeting-create-button"]`);
+      const panel = document.querySelector<HTMLElement>(this.createMenuOverlaySelector);
+      if (!trigger || !panel) {
+        return;
+      }
+
+      const aligned = trigger.getBoundingClientRect().right + window.scrollX - panel.offsetWidth;
+      panel.style.left = `${Math.max(aligned, window.scrollX + this.createMenuViewportGutter)}px`;
+    });
+  }
+
+  /**
    * Anonymous, shareable view of this project's PUBLIC meetings — the link a maintainer hands to their
    * community. Null until the active project context resolves.
    *
@@ -425,7 +462,7 @@ export class MeetingsDashboardComponent {
         // Reuses the type's composer description so the dropdown and the Details & Access select
         // never explain the same meeting type two different ways.
         description: option.info.description,
-        tileClass: 'bg-gray-100 text-gray-500',
+        tileClass: 'bg-gray-50 text-gray-700',
         testId: `meeting-create-quick-${option.value.toLowerCase()}`,
         command: () => this.onQuickCreateMeeting(option.value),
       }));
@@ -435,7 +472,7 @@ export class MeetingsDashboardComponent {
         description: 'Configure every aspect of your meeting',
         // Tinted rather than neutral: this row leaves the quick path for the full composer, so it
         // shouldn't read as a seventh meeting type.
-        tileClass: 'bg-blue-50 text-blue-600',
+        tileClass: 'bg-blue-100 text-blue-600',
         testId: 'meeting-create-advanced',
         command: () => this.onAdvancedCreateMeeting(),
       };

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -17,7 +17,17 @@ import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
-import { Lens, MeLensMeetingFilters, Meeting, MeetingCalendarClickProps, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
+import {
+  Lens,
+  MeetingCalendarClickProps,
+  MeetingCreateMenuRow,
+  MeLensMeetingFilters,
+  Meeting,
+  PageResult,
+  PastMeeting,
+  ProjectContext,
+  ViewMode,
+} from '@lfx-one/shared/interfaces';
 import {
   getCurrentOrNextOccurrence,
   getLargestSessionShareUrl,
@@ -411,22 +421,34 @@ export class MeetingsDashboardComponent {
   }
 
   private initCreateMenuItems(): Signal<MenuItem[]> {
-    return computed(() => [
-      {
-        label: 'Quick start',
-        items: getSelectableMeetingTypeOptions(this.personaService.currentPersona()).map((option) => ({
-          label: option.label,
-          icon: option.info.icon,
-          command: () => this.onQuickCreateMeeting(option.value),
-        })),
-      },
-      { separator: true },
-      {
+    return computed(() => {
+      const typeRows: (MenuItem & MeetingCreateMenuRow)[] = getSelectableMeetingTypeOptions(this.personaService.currentPersona()).map((option) => ({
+        label: option.label,
+        icon: option.info.icon,
+        // Reuses the type's composer description so the dropdown and the Details & Access select
+        // never explain the same meeting type two different ways.
+        description: option.info.description,
+        tileClass: 'bg-gray-100 text-gray-500',
+        testId: `meeting-create-quick-${option.value.toLowerCase()}`,
+        command: () => this.onQuickCreateMeeting(option.value),
+      }));
+      const advancedRow: MenuItem & MeetingCreateMenuRow = {
         label: 'Advanced',
         icon: 'fa-light fa-sliders',
+        description: 'Configure every aspect of your meeting',
+        // Tinted rather than neutral: this row leaves the quick path for the full composer, so it
+        // shouldn't read as a seventh meeting type.
+        tileClass: 'bg-blue-50 text-blue-600',
+        testId: 'meeting-create-advanced',
         command: () => this.onAdvancedCreateMeeting(),
-      },
-    ]);
+      };
+
+      // One group, not two: PrimeNG renders every *top-level* entry as a submenu label once any entry
+      // has children, so a top-level Advanced would come out as a second section heading. Keeping it
+      // inside the group behind an item separator also matches the prototype, which shows a single
+      // "Quick start" heading and a divider above Advanced.
+      return [{ label: 'Quick start', items: [...typeRows, { separator: true }, advancedRow] }];
+    });
   }
 
   private initCanWriteMeetings(): Signal<boolean> {

--- a/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.html
+++ b/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.html
@@ -19,14 +19,14 @@
       </div>
       <div class="flex-1">
         <div class="flex items-center gap-2 mb-1">
-          <p [ngClass]="{ 'text-neutral-950': !comingSoon(), 'text-gray-400': comingSoon() }">{{ feature().title }}</p>
+          <p class="text-sm font-semibold" [ngClass]="{ 'text-gray-900': !comingSoon(), 'text-gray-400': comingSoon() }">{{ feature().title }}</p>
           @if (comingSoon()) {
             <span class="px-2 py-0.5 bg-gray-200 text-gray-500 text-xs rounded">Coming Soon</span>
           } @else if (feature().recommended) {
             <span class="px-2 py-0.5 bg-blue-100 text-blue-500 text-xs rounded">Recommended</span>
           }
         </div>
-        <p class="text-sm" [ngClass]="{ 'text-gray-600': !comingSoon(), 'text-gray-400': comingSoon() }">{{ feature().description }}</p>
+        <p class="text-xs font-medium" [ngClass]="{ 'text-gray-500': !comingSoon(), 'text-gray-400': comingSoon() }">{{ feature().description }}</p>
       </div>
     </div>
     @if (!comingSoon()) {

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -332,10 +332,10 @@ export const DEFAULT_MEETING_TYPE_CONFIG: MeetingTypeConfig = {
  */
 export const MEETING_COMPOSER_SECTIONS = [
   { id: 'details-access', label: 'Details & Access', icon: 'fa-light fa-circle-info', required: true },
-  { id: 'date-schedule', label: 'Date & Schedule', icon: 'fa-light fa-calendar-days', required: true },
-  { id: 'platform-features', label: 'Platform & Features', icon: 'fa-light fa-video', required: false },
-  { id: 'guests', label: 'Guests', icon: 'fa-light fa-users', required: false },
-  { id: 'agenda-resources', label: 'Agenda & Resources', icon: 'fa-light fa-list-check', required: false },
+  { id: 'date-schedule', label: 'Date & schedule', icon: 'fa-light fa-calendar-days', required: true },
+  { id: 'platform-features', label: 'Platform & features', icon: 'fa-light fa-video', required: false },
+  { id: 'guests', label: 'Invite guests', icon: 'fa-light fa-users', required: false },
+  { id: 'agenda-resources', label: 'Agenda & resources', icon: 'fa-light fa-list-check', required: false },
 ] as const;
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1974,3 +1974,20 @@ export interface MeetingLinkDialogResult {
   title: string;
   url: string;
 }
+
+/**
+ * Extra per-row fields the meetings dashboard's Create Meeting dropdown renders alongside the
+ * label and icon a PrimeNG `MenuItem` already carries.
+ * @description Deliberately free of any PrimeNG import so it can live here — the dashboard
+ * intersects it with `MenuItem` at the boundary and reads these fields from the menu's `item`
+ * template. The dropdown is a descriptive picker rather than a plain list, so each row needs
+ * supporting copy and its own icon tile, neither of which `MenuItem` can express.
+ */
+export interface MeetingCreateMenuRow {
+  /** Supporting copy shown under the row's title. */
+  description: string;
+  /** Tailwind classes for the row's icon tile — background plus icon colour. */
+  tileClass: string;
+  /** `data-testid` for the row, since the template replaces PrimeNG's own item markup. */
+  testId: string;
+}

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1878,20 +1878,21 @@ export interface MeetingComposerSection {
  * A rail row's derived display state for one composer section.
  * @description `complete` is validity for required sections and "has been visited" for optional ones —
  * an optional section can never be invalid, so visiting it is the only signal that it was considered.
- * It excludes the active row, which renders its own state; `lineBelowComplete` does not, so the
- * connector below a completed-but-active row still reads as done.
+ * It excludes the active row, which renders its own state.
  */
 export interface MeetingComposerRailRow {
   section: MeetingComposerSection;
   active: boolean;
-  /** Done and reachable — never set on the active row, and never on a locked one. */
+  /** Done and reachable — never set on the active row. */
   complete: boolean;
-  /** Blocked by an earlier invalid required section — never set on the active row. */
-  locked: boolean;
   /** Visited required section that isn't valid yet — drives the row's attention dot. */
   needsAttention: boolean;
-  /** Whether the connector drawn below this row should read as completed. */
-  lineBelowComplete: boolean;
+  /**
+   * Whether the row can be jumped to.
+   * @description Create mode only walks forward one section at a time: a section the organizer hasn't
+   * reached yet is inert. Always `true` in edit mode, where the rail is free navigation.
+   */
+  reachable: boolean;
   isLast: boolean;
 }
 
@@ -1915,6 +1916,8 @@ export interface MeetingComposerPreviewDateChip {
 export interface MeetingComposerPreviewRow {
   label: string;
   icon: string;
+  /** Set only where the icon renders as a filled chip (visibility), matching its card in the form. */
+  color?: string;
 }
 
 /**


### PR DESCRIPTION
> **Stack 11 of 20.** Based on PR 10 (`fix/issue-1463-registrant-fields`). Followed by PR 12 (`fix/issue-1463-registrant-identity`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Reworks the Create Meeting entry point into a single descriptive dropdown and aligns the drawer chrome with the design prototype.

## How

- Collapses the split Create Meeting button into one trigger that opens the dropdown; the user always chooses a path before the composer opens.
- Makes the dropdown a descriptive picker — icon, label and a short description per meeting type — and keeps the calendar icon on the trigger.
- Aligns the drawer header, footer and section dividers with the prototype's layout.

## Notes for reviewers

- The split button is gone, so the `meeting-create-options-button` test id no longer exists. E2E specs referencing it need updating.

## Commits

4 commit(s), 28 files changed, 886 insertions(+), 623 deletions(-).

- `style(meetings): make the create dropdown a descriptive picker`
- `style(meetings): make create meeting a single dropdown trigger`
- `style(meetings): keep the calendar icon on the create button`
- `style(meetings): align the composer with the design prototype`

## Related

- Refs #1460
- Refs #1452
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
