### PR TITLE
fix(meetings): validate registrant identity and correct composer gating

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -3,7 +3,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
-import type { Meeting, MeetingRegistrant, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
+import type { Meeting, MeetingComposerSection, MeetingComposerSectionId, MeetingRegistrant, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -328,5 +328,116 @@ describe('MeetingComposerFormService — load retry', () => {
     service.retryLoadMeeting();
 
     expect(getMeeting).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Covers the save gate the composer footer and the rail both read. Save is gated on whole-form
+ * validity, so every control that carries a validator has to be reachable from some section's
+ * `isSectionValid` — otherwise the organizer gets a dead Save button and nothing pointing at the
+ * cause. These assert the sections that own the easy-to-miss controls.
+ */
+describe('MeetingComposerFormService — save gate', () => {
+  let service: MeetingComposerFormService;
+  // Read through a closure rather than baked into the provider: `effectiveProjectUid` reads
+  // `activeContextUid()` as a plain call, and `initialize()` writes `contextProjectUid`, which is what
+  // actually invalidates the computed — so changing this and reopening is enough.
+  let ambientProjectUid: string | null = null;
+
+  beforeEach(() => {
+    ambientProjectUid = null;
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => ambientProjectUid } },
+        { provide: MeetingService, useValue: {} },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.form().patchValue({ title: 'Composer meeting', meeting_type: 'Technical' });
+  });
+
+  // The API, PCC and Zoom all accept early-join values outside [10, 60], and edit mode patches
+  // whatever is stored verbatim — so this is a real state, not a typing-only one.
+  it('flags date-schedule when the early-join value falls outside the allowed range', () => {
+    service.form().get('early_join_time_minutes')?.setValue(90);
+
+    expect(service.form().valid).toBe(false);
+    expect(service.isSectionValid('date-schedule')).toBe(false);
+  });
+
+  it('flags agenda-resources when the agenda exceeds the cap', () => {
+    service.form().get('description')?.setValue('x'.repeat(2001));
+
+    expect(service.form().valid).toBe(false);
+    expect(service.isSectionValid('agenda-resources')).toBe(false);
+  });
+
+  it('never flags guests, the one section that owns no validated control', () => {
+    expect(service.isSectionValid('guests')).toBe(true);
+  });
+
+  // `platform-features` is not a required section, but its reminder controls carry validators and are
+  // enabled in edit mode. Skipping optional sections is what previously left Save disabled silently.
+  it('flags an optional section whose control is invalid', () => {
+    service.form().get('reminderHours')?.enable();
+    service.form().get('reminderHours')?.setValue(999);
+
+    expect(service.form().valid).toBe(false);
+    expect(service.isSectionValid('platform-features')).toBe(false);
+    expect(
+      service.sectionNeedsAttention(
+        { id: 'platform-features', label: 'Platform & Features', required: false } as MeetingComposerSection,
+        new Set(['platform-features'])
+      )
+    ).toBe(true);
+  });
+
+  it('does not flag an unvisited section in create mode', () => {
+    service.form().get('description')?.setValue('x'.repeat(2001));
+
+    expect(
+      service.sectionNeedsAttention(
+        { id: 'agenda-resources', label: 'Agenda & Resources', required: false } as MeetingComposerSection,
+        new Set<MeetingComposerSectionId>()
+      )
+    ).toBe(false);
+  });
+
+  it('routes an off-scale stored duration to Custom rather than leaving the chips unselected', () => {
+    service.setDuration(37);
+
+    expect(service.form().get('duration')?.value).toBe('custom');
+    expect(service.form().get('customDuration')?.value).toBe(37);
+    // Marked so the range error shows, instead of silently deadening submit.
+    expect(service.form().get('customDuration')?.touched).toBe(true);
+  });
+
+  it('clears the custom control when the duration is back on the chip scale', () => {
+    service.setDuration(37);
+
+    service.setDuration(30);
+
+    expect(service.form().get('duration')?.value).toBe(30);
+    expect(service.form().get('customDuration')?.value).toBeNull();
+  });
+
+  it('resolves the effective project from the open context before the ambient one', () => {
+    ambientProjectUid = 'ambient-project';
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    expect(service.effectiveProjectUid()).toBe('project-1');
+  });
+
+  it('falls back to the ambient context when the open carried no project', () => {
+    ambientProjectUid = 'ambient-project';
+    service.initialize({ mode: 'create' });
+
+    expect(service.effectiveProjectUid()).toBe('ambient-project');
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { computed, DestroyRef, inject, Injectable, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
 import {
@@ -133,6 +133,16 @@ export class MeetingComposerFormService {
    * to the ambient context.
    */
   private readonly contextProjectUid = signal<string | null>(null);
+
+  /**
+   * Project uid the submit payload will actually be written against.
+   * @description Mirrors the `project_uid` resolution in `prepareMeetingData()` exactly, so callers
+   * that need to describe "the meeting's project" — the AI agenda prompt, for one — cannot describe a
+   * different project from the one the save writes to. Empty when nothing has resolved yet.
+   */
+  public readonly effectiveProjectUid: Signal<string> = computed(
+    () => this.meeting()?.project_uid || this.contextProjectUid() || this.projectContextService.activeContextUid()
+  );
 
   /**
    * Bumped on every form value/status change, and explicitly by `validateForSubmit()`.
@@ -291,12 +301,15 @@ export class MeetingComposerFormService {
    * to find out why Save is disabled. An edit whose meeting hasn't arrived is excluded — that form is
    * empty because of the fetch, not because of anything the organizer did. Callers must read `revision`
    * themselves: this is a plain method, so it carries no reactive dependency of its own.
+   *
+   * `section.required` is deliberately not consulted. Save is gated on whole-form validity, and an
+   * optional section can still hold an invalid control — `platform-features` is the live case, since
+   * its reminder inputs carry validators and are enabled in edit mode. Skipping optional sections here
+   * is what previously left a disabled Save button with nothing on screen explaining it. A section with
+   * no validators of its own (`guests`, `agenda-resources`) reports valid unconditionally, so widening
+   * this cannot make them nag.
    */
   public sectionNeedsAttention(section: MeetingComposerSection, visitedSections: ReadonlySet<MeetingComposerSectionId>): boolean {
-    if (!section.required) {
-      return false;
-    }
-
     const isEditMode = this.isEditMode();
 
     if (isEditMode && !this.meeting()) {
@@ -961,7 +974,6 @@ export class MeetingComposerFormService {
       meeting_type: meeting.meeting_type === MeetingType.NONE ? '' : meeting.meeting_type,
       startDate: startDate,
       startTime: startTime,
-      duration: meeting.duration || DEFAULT_DURATION,
       timezone: meeting.timezone || getUserTimezone(),
       early_join_time_minutes: meeting.early_join_time_minutes || DEFAULT_EARLY_JOIN_TIME,
       isRecurring: Boolean(meeting.recurrence && finalRecurrenceValue !== 'none'),
@@ -980,6 +992,11 @@ export class MeetingComposerFormService {
       recurrenceType: finalRecurrenceValue,
       committees: meeting.committees || [],
     });
+
+    // Duration is set through `setDuration()` rather than patched, because it lives in two controls.
+    // Patching `duration` alone left an off-chip stored value (20 or 75 minutes) selecting no chip at
+    // all while the form still read as valid, so the UI silently disagreed with what was saved.
+    this.setDuration(meeting.duration || DEFAULT_DURATION);
 
     if (meeting.recurrence) {
       this.populateRecurrenceGroup(meeting, isCustomRecurrence);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -136,9 +136,10 @@ export class MeetingComposerFormService {
 
   /**
    * Project uid the submit payload will actually be written against.
-   * @description Mirrors the `project_uid` resolution in `prepareMeetingData()` exactly, so callers
-   * that need to describe "the meeting's project" — the AI agenda prompt, for one — cannot describe a
-   * different project from the one the save writes to. Empty when nothing has resolved yet.
+   * @description The single source for that resolution — `prepareMeetingData()` reads this rather than
+   * repeating the expression, so callers that need to describe "the meeting's project" (the AI agenda
+   * prompt, for one) cannot describe a different project from the one the save writes to. Empty when
+   * nothing has resolved yet.
    */
   public readonly effectiveProjectUid: Signal<string> = computed(
     () => this.meeting()?.project_uid || this.contextProjectUid() || this.projectContextService.activeContextUid()
@@ -274,6 +275,11 @@ export class MeetingComposerFormService {
           form.get('startTime')?.valid &&
           form.get('duration')?.valid &&
           form.get('customDuration')?.valid &&
+          // Same `invalid ?? true` shape as the reminder controls below: an out-of-range stored value
+          // (min 10 / max 60) fails whole-form validity, so this section has to be the one that says so.
+          // Edit mode reaches it — the API, PCC and Zoom all accept early-join values outside our range,
+          // and `populateFormWithMeetingData` patches whatever is stored verbatim.
+          !(form.get('early_join_time_minutes')?.invalid ?? true) &&
           !form.errors?.['futureDateTime']
         );
 
@@ -283,8 +289,15 @@ export class MeetingComposerFormService {
         // the ?? true fallback still fails closed if the controls are ever missing from the form.
         return (form.get('platform')?.valid ?? false) && !(form.get('reminderHours')?.invalid ?? true) && !(form.get('reminderMinutes')?.invalid ?? true);
 
-      case 'guests':
       case 'agenda-resources':
+        // `description` carries `maxLength(MEETING_AGENDA_MAX_LENGTH)`. The template's `maxlength`
+        // attribute only constrains typing, so an over-cap agenda still arrives two ways: a stored one
+        // in edit mode, and an AI generation that came back long. Either kills whole-form validity, so
+        // without this the organizer gets a dead Save button and nothing pointing at the cause.
+        return !(form.get('description')?.invalid ?? true);
+
+      case 'guests':
+        // The only section that owns no validated control: guests are a list, not a form.
         return true;
 
       default:
@@ -305,9 +318,9 @@ export class MeetingComposerFormService {
    * `section.required` is deliberately not consulted. Save is gated on whole-form validity, and an
    * optional section can still hold an invalid control — `platform-features` is the live case, since
    * its reminder inputs carry validators and are enabled in edit mode. Skipping optional sections here
-   * is what previously left a disabled Save button with nothing on screen explaining it. A section with
-   * no validators of its own (`guests`, `agenda-resources`) reports valid unconditionally, so widening
-   * this cannot make them nag.
+   * is what previously left a disabled Save button with nothing on screen explaining it. `isSectionValid`
+   * covers every control that carries a validator, so `form.valid === false` always flags some section;
+   * `guests` is the one section that owns none and so can never nag.
    */
   public sectionNeedsAttention(section: MeetingComposerSection, visitedSections: ReadonlySet<MeetingComposerSectionId>): boolean {
     const isEditMode = this.isEditMode();
@@ -857,7 +870,7 @@ export class MeetingComposerFormService {
     const recurrenceObject = this.buildRecurrencePayload(formValue);
 
     return {
-      project_uid: this.meeting()?.project_uid || this.contextProjectUid() || this.projectContextService.activeContextUid(),
+      project_uid: this.effectiveProjectUid(),
       title: formValue.title,
       description: formValue.description || '',
       start_time: startDateTime,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -6,7 +6,7 @@
 }
 
 <!-- Post-create toast (GH-1461): creating no longer navigates, so this is the way back to the meeting -->
-<p-toast [key]="toastKey" position="top-right">
+<p-toast [key]="toastKey" [position]="toastPosition">
   <ng-template let-message pTemplate="message">
     <div class="flex w-full items-start gap-3" data-testid="meeting-composer-toast">
       <i class="fa-light fa-circle-check mt-0.5 shrink-0 text-xl text-emerald-500" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_LIFE } from '@lfx-one/shared/constants';
+import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_POSITION } from '@lfx-one/shared/constants';
 import type { Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -62,6 +62,7 @@ export class MeetingComposerHostComponent {
 
   protected readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
   protected readonly toastKey = MEETING_COMPOSER_TOAST_KEY;
+  protected readonly toastPosition = MEETING_COMPOSER_TOAST_POSITION;
 
   /**
    * Single mode source for the chrome, matching what the rail reads.
@@ -84,9 +85,18 @@ export class MeetingComposerHostComponent {
     this.formService.revision();
     return this.formService.isSectionValid(this.composer.activeSection());
   });
+  /**
+   * Gated on whole-form validity, which is the same rule `validateForSubmit()` applies.
+   * @description It used to check only the sections flagged `required`, which let the button and the
+   * submit path disagree: `platform-features` is not a required section, but its reminder controls
+   * carry validators and are enabled in edit mode, so a bad reminder value left Save clickable and
+   * `onSubmit()` returned silently. Anything that makes the form invalid now disables the button, and
+   * `sectionNeedsAttention()` no longer skips optional sections, so the reason is still findable.
+   */
   protected readonly canSubmit: Signal<boolean> = computed(() => {
+    // `revision` makes this recompute on every form value/status change — FormGroup validity is not a signal.
     this.formService.revision();
-    return this.sections.filter((section) => section.required).every((section) => this.formService.isSectionValid(section.id));
+    return this.formService.form().valid;
   });
   protected readonly activeSectionLabel: Signal<string> = computed(() => this.sections[this.activeIndex()]?.label ?? '');
   /** Whether any required section is flagged as blocking save, on the same rule as the rail's dots. */
@@ -195,7 +205,10 @@ export class MeetingComposerHostComponent {
         return 'Close the open composer first';
       }
 
-      return this.projectContextService.canWrite() ? null : 'You no longer have write access';
+      // Meeting-authoring permission, not writer-only: a meeting coordinator creates meetings without
+      // being a project writer, and `canWrite()` would deny them the edit action on the meeting this
+      // toast is announcing. Same signal the dashboard gates the create action on.
+      return this.projectContextService.canWriteMeetings() ? null : 'You no longer have write access';
     });
   }
 
@@ -225,7 +238,10 @@ export class MeetingComposerHostComponent {
       severity: 'success',
       summary: 'Meeting created',
       detail: data.meetingTitle,
-      life: MEETING_COMPOSER_TOAST_LIFE,
+      // Sticky, not timed. The toast carries the only two routes back to the meeting now that creating
+      // doesn't navigate, and a fixed lifetime put them out of reach of anyone who needs longer than a
+      // few seconds to read and target them. It has an explicit dismiss control instead.
+      sticky: true,
       data,
     });
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -12,6 +12,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { ToastModule } from 'primeng/toast';
+import type { ToastPositionType } from 'primeng/types/toast';
 import { filter, pairwise } from 'rxjs';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
@@ -62,7 +63,13 @@ export class MeetingComposerHostComponent {
 
   protected readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
   protected readonly toastKey = MEETING_COMPOSER_TOAST_KEY;
-  protected readonly toastPosition = MEETING_COMPOSER_TOAST_POSITION;
+  /**
+   * Annotated rather than inferred, so the shared literal is checked against PrimeNG's own union.
+   * @description The constant lives in `@lfx-one/shared`, which carries no PrimeNG dependency — not
+   * even a peer one — so the type has to be applied here, at the only place that feeds it to `<p-toast>`.
+   * A typo in the constant would otherwise reach the DOM as a silently ignored `position`.
+   */
+  protected readonly toastPosition: ToastPositionType = MEETING_COMPOSER_TOAST_POSITION;
 
   /**
    * Single mode source for the chrome, matching what the rail reads.
@@ -233,6 +240,11 @@ export class MeetingComposerHostComponent {
       meetingQueryParams: meeting.password ? { password: meeting.password } : {},
     };
 
+    // Only the newest sticky toast survives. Without a lifetime nothing retires these on its own, so
+    // creating several meetings in a row stacked permanent multi-line toasts up over the content the
+    // organizer is still working in. Scoped to this key, so unrelated toasts are untouched.
+    this.messageService.clear(this.toastKey);
+
     this.messageService.add({
       key: this.toastKey,
       severity: 'success',
@@ -240,8 +252,12 @@ export class MeetingComposerHostComponent {
       detail: data.meetingTitle,
       // Sticky, not timed. The toast carries the only two routes back to the meeting now that creating
       // doesn't navigate, and a fixed lifetime put them out of reach of anyone who needs longer than a
-      // few seconds to read and target them. It has an explicit dismiss control instead.
+      // few seconds to read and target them.
       sticky: true,
+      // Explicit rather than relying on the PrimeNG default: with `sticky`, the close button is the only
+      // way out, and it renders outside the custom-template branch — so a template refactor upstream
+      // could strand an undismissable toast. Stating it keeps the intent checkable.
+      closable: true,
       data,
     });
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -136,7 +136,13 @@ export class ComposerAgendaResourcesComponent {
     const context = (form.get('aiPrompt')?.value as string | null)?.trim() || null;
     const title = (form.get('title')?.value as string | null)?.trim() || null;
     const meetingType = this.meetingType();
+    // Only name the project when the ambient context is the same project the save will write to.
+    // `prepareMeetingData()` prefers the captured open-context uid over the ambient one, so a composer
+    // opened from a group/deep link while the sidebar still points elsewhere would otherwise ask the
+    // model for an agenda about the wrong project. The server omits an absent descriptor, so dropping
+    // it is strictly better than sending a mismatched one.
     const project = this.projectContextService.activeContext();
+    const projectName = project && project.uid === this.formService.effectiveProjectUid() ? project.name : null;
 
     // A title or a goal — whichever the organizer has — is enough. Edit mode drops the rail's
     // section locking entirely, so the organizer can be standing here having just cleared the title;
@@ -156,7 +162,7 @@ export class ComposerAgendaResourcesComponent {
     const request: GenerateAgendaRequest = {
       ...(meetingType ? { meetingType } : {}),
       ...(title ? { title } : {}),
-      ...(project ? { projectName: project.name } : {}),
+      ...(projectName ? { projectName } : {}),
       ...(context ? { context } : {}),
       maxCharacters: MEETING_AGENDA_MAX_LENGTH,
     };

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -136,13 +136,17 @@ export class ComposerAgendaResourcesComponent {
     const context = (form.get('aiPrompt')?.value as string | null)?.trim() || null;
     const title = (form.get('title')?.value as string | null)?.trim() || null;
     const meetingType = this.meetingType();
-    // Only name the project when the ambient context is the same project the save will write to.
+    // The saved meeting's own project name first: in edit mode the composer is frequently open over a
+    // different context (the Me lens, another project), and `project_name` is a required field on the
+    // meeting the form already holds — so this is the authoritative name, not a fallback.
+    // Otherwise, only name the ambient project when it is the same one the save will write to.
     // `prepareMeetingData()` prefers the captured open-context uid over the ambient one, so a composer
     // opened from a group/deep link while the sidebar still points elsewhere would otherwise ask the
     // model for an agenda about the wrong project. The server omits an absent descriptor, so dropping
     // it is strictly better than sending a mismatched one.
     const project = this.projectContextService.activeContext();
-    const projectName = project && project.uid === this.formService.effectiveProjectUid() ? project.name : null;
+    const ambientProjectName = project && project.uid === this.formService.effectiveProjectUid() ? project.name : null;
+    const projectName = this.formService.meeting()?.project_name || ambientProjectName;
 
     // A title or a goal — whichever the organizer has — is enough. Edit mode drops the rail's
     // section locking entirely, so the organizer can be standing here having just cleared the title;

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -45,7 +45,6 @@ import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
 import { MenuItem } from 'primeng/api';
@@ -97,7 +96,6 @@ import { MeetingsTopBarComponent } from './components/meetings-top-bar/meetings-
 export class MeetingsDashboardComponent {
   private readonly meetingService = inject(MeetingService);
   private readonly projectContextService = inject(ProjectContextService);
-  private readonly projectService = inject(ProjectService);
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
   private readonly userService = inject(UserService);

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -48,7 +48,6 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
-import { hasMeetingWriteAccess } from '@shared/utils/write-access.util';
 import { MenuItem } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -164,7 +163,7 @@ export class MeetingsDashboardComponent {
   public projectOptions: Signal<{ label: string; value: string | null }[]>;
   public project: Signal<ProjectContext | null>;
   protected readonly canWrite = this.projectContextService.canWrite;
-  protected readonly canWriteMeetings: Signal<boolean> = this.initCanWriteMeetings();
+  protected readonly canWriteMeetings: Signal<boolean> = this.projectContextService.canWriteMeetings;
   protected readonly publicCalendarUrl: Signal<string | null> = this.initPublicCalendarUrl();
   protected readonly isFiltered = this.initIsFiltered();
   public loadingMore = signal(false);
@@ -483,21 +482,6 @@ export class MeetingsDashboardComponent {
       // "Quick start" heading and a divider above Advanced.
       return [{ label: 'Quick start', items: [...typeRows, { separator: true }, advancedRow] }];
     });
-  }
-
-  private initCanWriteMeetings(): Signal<boolean> {
-    return toSignal(
-      toObservable(this.projectContextService.activeContext).pipe(
-        switchMap((ctx) => {
-          if (!ctx?.slug) return of(false);
-          return this.projectService.getProject(ctx.slug, false, { meetingCoordinator: true }).pipe(
-            map((project) => hasMeetingWriteAccess(project)),
-            catchError(() => of(false))
-          );
-        })
-      ),
-      { initialValue: false }
-    );
   }
 
   private initializeUpcomingMeetings(): Signal<Meeting[]> {

--- a/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
 import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { of, Subject, throwError } from 'rxjs';
+import { of, Subject, throwError, type Observable } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CookieRegistryService } from './cookie-registry.service';
@@ -188,5 +188,107 @@ describe('ProjectContextService — Formation signals (GH-1955)', () => {
     pending.next({ ...project('Active'), writer: false });
     TestBed.inject(ApplicationRef).tick();
     expect(service.canWrite()).toBe(false);
+  });
+});
+
+/**
+ * Covers the meeting-authoring gate every meeting surface reads. It is derived on the root singleton,
+ * so it resolves on the SSR critical path of *every* page — which makes the number of requests it
+ * costs part of the behavior, not just the answer it returns.
+ */
+describe('ProjectContextService — canWriteMeetings', () => {
+  /** Cache keys the stub actually went out for — one entry per HTTP round trip. */
+  let fetchedKeys: string[];
+
+  const setup = (responses: { plain: Partial<Project> | null; coordinator?: Partial<Project> | null }): ProjectContextService => {
+    fetchedKeys = [];
+    // Memoized per cache key, the way `ProjectService.getProject` is (`shareReplay` behind a
+    // `${slug}:${current}[:mc]` map). Without that, two gates reading the same key would look like two
+    // requests here and the round-trip assertions below would measure nothing real.
+    const cache = new Map<string, Observable<Partial<Project> | null>>();
+    const getProject = vi.fn((slug: string, current: boolean, options?: { meetingCoordinator?: boolean }) => {
+      const key = `${slug}:${current}${options?.meetingCoordinator ? ':mc' : ''}`;
+      if (!cache.has(key)) {
+        fetchedKeys.push(key);
+        cache.set(key, of(options?.meetingCoordinator ? (responses.coordinator ?? null) : responses.plain));
+      }
+      return cache.get(key)!;
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ProjectService, useValue: { getProject, getProjectSfid: vi.fn().mockReturnValue(of(null)) } },
+        { provide: SsrCookieService, useValue: { get: vi.fn(), set: vi.fn(), delete: vi.fn() } },
+        { provide: CookieRegistryService, useValue: { registerCookie: vi.fn(), unregisterCookie: vi.fn() } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: () => signal(false) } },
+        { provide: LensService, useValue: { activeLens: signal('project') } },
+        {
+          provide: PersonaService,
+          useValue: { isMarketingAuditor: signal(false), isCampaignManager: signal(false), marketingGrantSlug: signal(null), currentPersona: signal(null) },
+        },
+        { provide: Router, useValue: { getCurrentNavigation: () => null, parseUrl: vi.fn(), serializeUrl: vi.fn(), url: '/' } },
+        { provide: Location, useValue: { replaceState: vi.fn() } },
+        { provide: HttpClient, useValue: { get: vi.fn().mockReturnValue(of({})), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+
+    // The gate hangs off `activeContext`, which the auth gate holds closed until the session
+    // resolves — so an unauthenticated fixture would measure the gate's `null` branch, not its answer.
+    TestBed.inject(UserService).authenticated.set(true);
+
+    const service = TestBed.inject(ProjectContextService);
+    service.setRouteLensKind('project');
+    // `syncUrl: false` — the URL sync is the Router's business and not what these assert.
+    service.setProject(CONTEXT, false);
+    TestBed.inject(ApplicationRef).tick();
+
+    return service;
+  };
+
+  it('grants a project writer without asking for the coordinator role', () => {
+    const service = setup({ plain: { writer: true } });
+
+    expect(service.canWriteMeetings()).toBe(true);
+    // The upstream skips the `meeting_coordinator` FGA check for writers anyway, so the `:mc` request
+    // could only echo what this one already said — and it would land on every page.
+    expect(fetchedKeys).toEqual([`${CONTEXT.slug}:false`]);
+  });
+
+  it('grants a non-writer who holds the coordinator role', () => {
+    const service = setup({ plain: { writer: false }, coordinator: { writer: false, meetingCoordinator: true } });
+
+    expect(service.canWriteMeetings()).toBe(true);
+    expect(fetchedKeys).toEqual([`${CONTEXT.slug}:false`, `${CONTEXT.slug}:false:mc`]);
+  });
+
+  it('refuses a non-writer who holds neither role', () => {
+    const service = setup({ plain: { writer: false }, coordinator: { writer: false, meetingCoordinator: false } });
+
+    expect(service.canWriteMeetings()).toBe(false);
+  });
+
+  // The coordinator check returns `undefined` rather than `false` when the FGA call itself failed, so
+  // "unknown" must not read as a grant.
+  it('refuses when the coordinator check could not be resolved', () => {
+    const service = setup({ plain: { writer: false }, coordinator: { writer: false } });
+
+    expect(service.canWriteMeetings()).toBe(false);
+  });
+
+  it('refuses when the project could not be fetched at all', () => {
+    const service = setup({ plain: null, coordinator: null });
+
+    expect(service.canWriteMeetings()).toBe(false);
+  });
+
+  it('shares the plain fetch with the writer-only gate', () => {
+    const service = setup({ plain: { writer: true } });
+
+    expect(service.canWrite()).toBe(true);
+    expect(service.canWriteMeetings()).toBe(true);
+    // Both gates read the same cache key, which `projectQueryParamGuard` has already populated on
+    // every navigation — so between them they add nothing.
+    expect(fetchedKeys).toEqual([`${CONTEXT.slug}:false`]);
   });
 });

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -138,6 +138,15 @@ export class ProjectContextService {
    */
   public readonly activeProjectStage: Signal<string | null> = this.initActiveProjectStage();
 
+  /**
+   * Meeting-authoring permission for the current active context: writer *or* meeting coordinator.
+   * @description Distinct from {@link canWrite}, which is writer-only. A meeting coordinator can create
+   * and edit meetings without being a project writer, so gating a meeting action on `canWrite` locks out
+   * a legitimate coordinator — including from the meeting they just created. Lives here rather than in
+   * one dashboard so every meeting surface asks the same question.
+   */
+  public readonly canWriteMeetings: Signal<boolean> = this.initCanWriteMeetings();
+
   /** Salesforce 18-char ID for the active foundation — resolves PCC deep-link targets. `null` while resolving or unavailable. */
   public readonly selectedFoundationSfid: Signal<string | null> = this.initSelectedFoundationSfid();
 
@@ -368,6 +377,23 @@ export class ProjectContextService {
         })
       ),
       { initialValue: null }
+    );
+  }
+
+  private initCanWriteMeetings(): Signal<boolean> {
+    return toSignal(
+      toObservable(this.activeContext).pipe(
+        switchMap((ctx) => {
+          if (!ctx?.slug) {
+            return of(false);
+          }
+          return this.projectService.getProject(ctx.slug, false, { meetingCoordinator: true }).pipe(
+            map((project) => project?.writer === true || project?.meetingCoordinator === true),
+            catchError(() => of(false))
+          );
+        })
+      ),
+      { initialValue: false }
     );
   }
 

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -387,8 +387,22 @@ export class ProjectContextService {
           if (!ctx?.slug) {
             return of(false);
           }
-          return this.projectService.getProject(ctx.slug, false, { meetingCoordinator: true }).pipe(
-            map((project) => project?.writer === true || project?.meetingCoordinator === true),
+          // Two requests rather than one `?meeting_coordinator=true` fetch, and cheaper than it
+          // looks: the plain `getProject(slug, false)` response is already in ProjectService's
+          // cache on every navigation — `projectQueryParamGuard` fetches that exact key — while
+          // `:mc` is a separate cache entry and so a genuine extra round trip on the SSR critical
+          // path of every page. Upstream skips the `meeting_coordinator` FGA check outright for
+          // writers (`project.service.ts:344`), so for a writer that second request could only
+          // echo back what the first already said. Only a non-writer actually needs it.
+          return this.projectService.getProject(ctx.slug, false).pipe(
+            switchMap((project) => {
+              if (project?.writer === true) {
+                return of(true);
+              }
+              return this.projectService
+                .getProject(ctx.slug, false, { meetingCoordinator: true })
+                .pipe(map((coordinatorProject) => coordinatorProject?.writer === true || coordinatorProject?.meetingCoordinator === true));
+            }),
             catchError(() => of(false))
           );
         })

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -19,6 +19,7 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = v
     getMeetingRegistrants: vi.fn(),
     getMeetingRegistrantsByEmail: vi.fn(),
     addMeetingRegistrant: vi.fn(),
+    updateMeetingRegistrant: vi.fn(),
   },
   aiSvc: { generateMeetingAgenda: vi.fn() },
   committeeSvc: { getCommitteeById: vi.fn(), getCommitteeMembers: vi.fn() },
@@ -203,6 +204,9 @@ describe('MeetingController', () => {
   describe('addMeetingRegistrants', () => {
     beforeEach(() => {
       meetingSvc.addMeetingRegistrant.mockImplementation((_req: Request, registrant: Record<string, unknown>) => Promise.resolve(registrant));
+      // Committee attribution is allowlisted against the meeting's own committees, so the meeting has
+      // to actually carry the group the request attributes a guest to.
+      meetingSvc.getMeetingById.mockResolvedValue({ committees: [{ uid: V2_COMMITTEE_UID }] });
     });
 
     // GH-1463: upstream stores a v1 SFID and derives type: 'committee' from it. Forwarding the v2
@@ -214,6 +218,32 @@ describe('MeetingController', () => {
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
       expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ committee_uid: V1_COMMITTEE_SFID }));
+    });
+
+    // A caller can attribute a guest to any committee UID it likes; only the ones the meeting is
+    // actually scoped to may be resolved, or the v1 lookup becomes an unauthorized cross-project read.
+    it('strips a committee_uid the meeting is not scoped to without looking it up', async () => {
+      const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: 'cmte-v2-someone-elses' }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(resolveCommitteeV2UidsToV1IdsMock).not.toHaveBeenCalled();
+      const [, forwarded] = meetingSvc.addMeetingRegistrant.mock.calls[0];
+      expect(forwarded).not.toHaveProperty('committee_uid');
+    });
+
+    // An unknown allowlist fails the batch rather than downgrading it: nothing has been written yet,
+    // and a 201 that silently dropped every group attribution has no recovery path (the update
+    // contract carries no `committee_uid`).
+    it('fails the batch when the meeting committees cannot be loaded', async () => {
+      const upstreamError = new Error('upstream down');
+      meetingSvc.getMeetingById.mockRejectedValue(upstreamError);
+      const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(upstreamError);
+      expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
     });
 
     // The key is deleted, not nulled: upstream declares `committee_uid` a non-nullable optional
@@ -244,6 +274,24 @@ describe('MeetingController', () => {
 
       expect(resolveCommitteeV2UidsToV1IdsMock).not.toHaveBeenCalled();
       expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ email: 'a@example.com' }));
+    });
+  });
+
+  describe('updateMeetingRegistrants', () => {
+    // The edit endpoint is the one path that isn't allowlisted against the meeting's committees —
+    // `UpdateMeetingRegistrantRequest` declares no `committee_uid`, but that's a compile-time
+    // guarantee and `req.body` is untyped JSON that the service forwards key-for-key.
+    it('strips a runtime committee_uid instead of forwarding it upstream', async () => {
+      meetingSvc.updateMeetingRegistrant.mockImplementation((_req: Request, _uid: string, _regUid: string, changes: Record<string, unknown>) =>
+        Promise.resolve(changes)
+      );
+      const req = buildReq({ body: [{ uid: 'reg-1', changes: { email: 'a@example.com', committee_uid: V1_COMMITTEE_SFID } }] });
+
+      await controller.updateMeetingRegistrants(req, buildRes(), next);
+
+      const [, , , forwarded] = meetingSvc.updateMeetingRegistrant.mock.calls[0];
+      expect(forwarded).not.toHaveProperty('committee_uid');
+      expect(forwarded).toMatchObject({ email: 'a@example.com', meeting_id: MEETING_ID });
     });
   });
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -12,8 +12,10 @@ const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
 const MEETING_ID = 'meeting-1111';
 const V2_COMMITTEE_UID = 'cmte-v2-aaaa';
 const V1_COMMITTEE_SFID = 'a09v1SFIDaaaa';
+const USER_TOKEN = 'user-bearer-token';
+const M2M_TOKEN = 'm2m-bearer-token';
 
-const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = vi.hoisted(() => ({
+const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock, generateM2MTokenMock } = vi.hoisted(() => ({
   meetingSvc: {
     getMeetingById: vi.fn(),
     getMeetingRegistrants: vi.fn(),
@@ -24,12 +26,25 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = v
   aiSvc: { generateMeetingAgenda: vi.fn() },
   committeeSvc: { getCommitteeById: vi.fn(), getCommitteeMembers: vi.fn() },
   resolveCommitteeV2UidsToV1IdsMock: vi.fn(),
+  generateM2MTokenMock: vi.fn(),
 }));
 
 // The `@lfx-one/shared/*` path alias isn't wired into vitest, and the controller only uses those
 // imports as types — stub the barrels so their runtime module graphs never load.
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
-vi.mock('@lfx-one/shared/enums', () => ({}));
+// `MeetingType` is imported as a value (the controller narrows client input against
+// `Object.values(MeetingType)`), so the stub has to carry the real members rather than being empty.
+vi.mock('@lfx-one/shared/enums', () => ({
+  MeetingType: {
+    BOARD: 'Board',
+    MAINTAINERS: 'Maintainers',
+    MARKETING: 'Marketing',
+    TECHNICAL: 'Technical',
+    LEGAL: 'Legal',
+    OTHER: 'Other',
+    NONE: 'None',
+  },
+}));
 // Literals rather than the consts above: `vi.mock` factories are hoisted, so they can't close over
 // module-level bindings. Kept in sync with `MEETING_AGENDA_*` in the shared constants barrel.
 vi.mock('@lfx-one/shared/constants', () => ({ MEETING_AGENDA_MAX_LENGTH: 2000, MEETING_AGENDA_PROMPT_MAX_LENGTH: 1000 }));
@@ -52,7 +67,7 @@ vi.mock('../helpers/committee-v1-mapping.helper', () => ({
   resolveCommitteeV2UidsToV1Ids: resolveCommitteeV2UidsToV1IdsMock,
 }));
 vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(() => 'user@example.com') }));
-vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn().mockResolvedValue('m2m-bearer-token') }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 
 vi.mock('../services/meeting.service', () => ({ MeetingService: vi.fn(() => meetingSvc) }));
 vi.mock('../services/ai.service', () => ({ AiService: vi.fn(() => aiSvc) }));
@@ -85,6 +100,9 @@ vi.mock('../errors', () => ({
 }));
 
 const { MeetingController } = await import('./meeting.controller');
+// The stubbed logger, imported after the mock is registered, so the metadata assertions read the same
+// object the controller writes to.
+const { logger } = await import('../services/logger.service');
 
 function buildRes(): Response {
   const res = { status: vi.fn(() => res), json: vi.fn(() => res), send: vi.fn(() => res) } as unknown as Response;
@@ -199,6 +217,32 @@ describe('MeetingController', () => {
 
       expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ maxCharacters: expected }));
     });
+
+    // `meetingType` is the one prompt input with a closed value set, and it lands in two log lines
+    // (this route's start line and `AiService`'s own) plus the prompt. Narrowing to the enum bounds all
+    // three at once — a 15mb string on a route behind `express.json({ limit: '15mb' })` would otherwise
+    // reach CloudWatch verbatim, and `getMeetingTypeDescription` falls back to a generic descriptor for
+    // anything off the enum anyway, so an unrecognized value carries no signal worth keeping.
+    it('forwards a recognized meeting type verbatim', async () => {
+      await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly', meetingType: 'Technical' } }), buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ meetingType: 'Technical' }));
+    });
+
+    it.each([
+      ['an unrecognized string', 'Definitely Not A Meeting Type'],
+      ['an oversized string', 'z'.repeat(50_000)],
+      ['a non-string value', { toString: (): string => 'Technical' }],
+    ])('drops %s rather than logging or prompting on it', async (_label, supplied) => {
+      const req = buildReq({ body: { title: 'TAC Monthly', meetingType: supplied } });
+
+      await controller.generateAgenda(req, buildRes(), next);
+
+      const [, request] = aiSvc.generateMeetingAgenda.mock.calls[0];
+      expect(request.meetingType).toBeUndefined();
+      // Dropped, not truncated: a prefix of an invalid type is still an invalid type.
+      expect(logger.startOperation).toHaveBeenCalledWith(req, 'generate_agenda', expect.objectContaining({ meeting_type: null }));
+    });
   });
 
   describe('addMeetingRegistrants', () => {
@@ -275,6 +319,16 @@ describe('MeetingController', () => {
       expect(resolveCommitteeV2UidsToV1IdsMock).not.toHaveBeenCalled();
       expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ email: 'a@example.com' }));
     });
+
+    // Same unprotected position as the update endpoint's body map — see the note there.
+    it('rejects a non-array body as a validation error rather than throwing', async () => {
+      const req = buildReq({ body: { email: 'a@example.com' } });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateMeetingRegistrants', () => {
@@ -292,6 +346,32 @@ describe('MeetingController', () => {
       const [, , , forwarded] = meetingSvc.updateMeetingRegistrant.mock.calls[0];
       expect(forwarded).not.toHaveProperty('committee_uid');
       expect(forwarded).toMatchObject({ email: 'a@example.com', meeting_id: MEETING_ID });
+    });
+
+    // The body map runs before `startOperation` and outside the `try`, and `routes/meetings.route.ts`
+    // registers a bare async arrow that Express 4 does not catch — so a throw here is an unhandled
+    // rejection that kills the SSR worker with no log line at all. `changes` and the array-ness of the
+    // body are compile-time guarantees only; both of these bodies are reachable over HTTP.
+    it('handles an entry that omits changes instead of throwing', async () => {
+      meetingSvc.updateMeetingRegistrant.mockImplementation((_req: Request, _uid: string, _regUid: string, changes: Record<string, unknown>) =>
+        Promise.resolve(changes)
+      );
+      const req = buildReq({ body: [{ uid: 'reg-1' }] });
+
+      await controller.updateMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
+      const [, , , forwarded] = meetingSvc.updateMeetingRegistrant.mock.calls[0];
+      expect(forwarded).toEqual({ meeting_id: MEETING_ID });
+    });
+
+    it('rejects a non-array body as a validation error rather than throwing', async () => {
+      const req = buildReq({ body: { uid: 'reg-1' } });
+
+      await controller.updateMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(meetingSvc.updateMeetingRegistrant).not.toHaveBeenCalled();
     });
   });
 
@@ -356,6 +436,7 @@ describe('MeetingController', () => {
       resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]));
       committeeSvc.getCommitteeById.mockResolvedValue({ uid: V2_COMMITTEE_UID, name: 'TAC', category: 'Technical' });
       committeeSvc.getCommitteeMembers.mockResolvedValue([{ email: 'a@example.com', role: { name: 'Chair' }, voting: { status: 'Voting Rep' } }]);
+      generateM2MTokenMock.mockResolvedValue(M2M_TOKEN);
     });
 
     it('enriches committee metadata for a registrant of the meeting', async () => {
@@ -377,6 +458,55 @@ describe('MeetingController', () => {
 
       expect(next).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith([registrant]);
+    });
+
+    // The M2M token is swapped onto `req` for the privileged registrant reads and must come back off
+    // before the request continues its lifetime. `req` outlives this handler — SSR rendering and any
+    // later middleware read `req.bearerToken` — so a leaked M2M token means subsequent upstream calls
+    // are made with application credentials instead of the user's, silently bypassing per-user
+    // authorization. The restore lives in a `finally`, and these cover each way out of that block.
+    describe('bearer token restore', () => {
+      it('restores the user bearer token after the privileged reads succeed', async () => {
+        const req = buildReq({ bearerToken: USER_TOKEN } as Partial<Request>);
+
+        await controller.getMyMeetingRegistrants(req, buildRes(), next);
+
+        // Proof the swap actually happened, so the restore assertion isn't vacuous.
+        expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalled();
+        expect(req.bearerToken).toBe(USER_TOKEN);
+      });
+
+      it('restores the user bearer token on the non-registrant, non-organizer early return', async () => {
+        meetingSvc.getMeetingById.mockResolvedValue({ uid: MEETING_ID, organizer: false, committees: [] });
+        meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
+        const req = buildReq({ bearerToken: USER_TOKEN } as Partial<Request>);
+        const res = buildRes();
+
+        await controller.getMyMeetingRegistrants(req, res, next);
+
+        expect(res.json).toHaveBeenCalledWith([]);
+        expect(req.bearerToken).toBe(USER_TOKEN);
+      });
+
+      it('restores the user bearer token when a privileged read throws', async () => {
+        meetingSvc.getMeetingRegistrants.mockRejectedValue(new Error('upstream 503'));
+        const req = buildReq({ bearerToken: USER_TOKEN } as Partial<Request>);
+
+        await controller.getMyMeetingRegistrants(req, buildRes(), next);
+
+        expect(next).toHaveBeenCalledWith(expect.any(Error));
+        expect(req.bearerToken).toBe(USER_TOKEN);
+      });
+
+      it('deletes the token rather than leaving the M2M one when the request had none', async () => {
+        // Anonymous-ish callers reach here with no bearer token at all. Assigning `undefined` back
+        // would leave the key present, so the restore deletes it — assert the key itself is gone.
+        const req = buildReq();
+
+        await controller.getMyMeetingRegistrants(req, buildRes(), next);
+
+        expect('bearerToken' in req).toBe(false);
+      });
     });
   });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -661,8 +661,12 @@ export class MeetingController {
       }
 
       // Group-added guests arrive carrying the v2 committee UID the picker works in; upstream
-      // stores a v1 SFID and derives `type: 'committee'` from it.
-      const resolvedRegistrants = await this.resolveRegistrantCommitteeUids(req, registrantData);
+      // stores a v1 SFID and derives `type: 'committee'` from it. The meeting is loaded first so a
+      // UID that isn't one of this meeting's own committees can be stripped before it's resolved —
+      // the client is the only source of that field, and nothing downstream re-checks it.
+      const hasCommitteeAttribution = registrantData.some((registrant: CreateMeetingRegistrantRequest) => !!registrant.committee_uid);
+      const allowedCommitteeUids = hasCommitteeAttribution ? await this.getMeetingCommitteeUids(req, uid) : new Set<string>();
+      const resolvedRegistrants = await this.resolveRegistrantCommitteeUids(req, registrantData, allowedCommitteeUids);
 
       // Process registrants with fail-fast for 403 errors
       // This will stop the processing if a 403 error is encountered
@@ -1512,7 +1516,7 @@ export class MeetingController {
     });
 
     try {
-      const { meetingType, projectName, maxCharacters, title: rawTitle, context: rawContext } = req.body;
+      const { meetingType, projectName: rawProjectName, maxCharacters, title: rawTitle, context: rawContext } = req.body;
       // A title / type / project are not guaranteed to exist: edit mode drops the rail's section
       // locking, so the organizer can request an agenda having just cleared the title, and the
       // client's project context resolves asynchronously. Only require enough signal to write a
@@ -1521,6 +1525,10 @@ export class MeetingController {
       // prompt, which is also why both are capped at the prompt budget.
       const title = MeetingController.readPromptField(rawTitle);
       const context = MeetingController.readPromptField(rawContext);
+      // Normalized on the same footing as the other two: it is interpolated into the prompt by
+      // `AiService.buildAgendaPrompt` and recorded in the operation log, and the route accepts direct
+      // clients under a 15mb body limit, so an unbounded value reaches both.
+      const projectName = MeetingController.readPromptField(rawProjectName);
 
       // Truncation is invisible to the organizer — the request still succeeds and returns an agenda
       // written against a shortened descriptor — so log it. Derived by comparing what arrived against
@@ -1531,6 +1539,7 @@ export class MeetingController {
       const truncated = [
         { field: 'title', raw: rawTitle, kept: title },
         { field: 'context', raw: rawContext, kept: context },
+        { field: 'projectName', raw: rawProjectName, kept: projectName },
       ].flatMap(({ field, raw, kept }) => {
         if (typeof raw !== 'string' || kept === undefined) {
           return [];
@@ -1853,6 +1862,29 @@ export class MeetingController {
   }
 
   /**
+   * The v2 UIDs of the committees actually attached to a meeting — the allowlist that
+   * `resolveRegistrantCommitteeUids` checks a client-supplied `committee_uid` against.
+   *
+   * A read failure resolves to an empty set rather than propagating. That fails closed: every
+   * committee attribution in the batch is stripped and those guests land as `direct`, which is the
+   * same fallback the resolver already documents for an unresolvable UID. The alternative — letting
+   * the error out — would fail the entire registrant batch on a transient read, and attribution is
+   * recoverable by re-saving in a way a half-applied guest list isn't.
+   */
+  private async getMeetingCommitteeUids(req: Request, meetingUid: string): Promise<Set<string>> {
+    try {
+      const meeting = await this.meetingService.getMeetingById(req, meetingUid, 'v1_meeting');
+      return new Set((meeting.committees || []).map((committee) => committee.uid));
+    } catch (error) {
+      logger.warning(req, 'get_meeting_committee_uids', 'Could not load meeting committees; dropping all committee attribution', {
+        meeting_id: meetingUid,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return new Set<string>();
+    }
+  }
+
+  /**
    * Rewrites each registrant's `committee_uid` from the v2 UID the client works in to the v1 SFID
    * upstream stores. Upstream derives `type: 'committee'` from that field, so dropping it (as the
    * BFF used to) silently persists a group-added guest as `direct` and loses attribution.
@@ -1862,9 +1894,31 @@ export class MeetingController {
    * key is deleted, not nulled: upstream's `CreateItxRegistrantRequestBody` declares `committee_uid`
    * as a non-nullable optional `string`, so an explicit `null` is off-contract even though omission
    * is fine. A `null` arriving from the client is dropped for the same reason.
+   *
+   * `allowedV2Uids` is the meeting's own `committees[].uid` set, and a UID outside it is stripped
+   * before any lookup. Without that gate the resolver would happily resolve any committee UID the
+   * caller cared to send — `resolveCommitteeV2UidsToV1Ids` goes over NATS with the BFF's own
+   * credentials and applies no authorization of its own — and upstream derives `type: 'committee'`
+   * from whatever SFID it receives. That would let a meeting editor attribute a guest to a committee
+   * the meeting has nothing to do with, inflating `committee_members_count` against it. Such a row
+   * would also read back unenriched, since `enrichCommitteeRegistrants` only maps the meeting's own
+   * committees, leaking the raw v1 SFID to the client.
    */
-  private async resolveRegistrantCommitteeUids(req: Request, registrants: CreateMeetingRegistrantRequest[]): Promise<CreateMeetingRegistrantRequest[]> {
-    const v2Uids = [...new Set(registrants.map((registrant) => registrant.committee_uid).filter((value): value is string => !!value))];
+  private async resolveRegistrantCommitteeUids(
+    req: Request,
+    registrants: CreateMeetingRegistrantRequest[],
+    allowedV2Uids: Set<string>
+  ): Promise<CreateMeetingRegistrantRequest[]> {
+    const requestedUids = [...new Set(registrants.map((registrant) => registrant.committee_uid).filter((value): value is string => !!value))];
+    const v2Uids = requestedUids.filter((uid) => allowedV2Uids.has(uid));
+
+    if (v2Uids.length < requestedUids.length) {
+      logger.warning(req, 'resolve_registrant_committee_uids', 'Dropped committee UIDs not associated with this meeting', {
+        requested: requestedUids.length,
+        associated: v2Uids.length,
+        unassociated: requestedUids.filter((uid) => !allowedV2Uids.has(uid)),
+      });
+    }
 
     // Still fall through to the map when there's nothing to resolve — a client that sent an explicit
     // `committee_uid: null` needs the key dropped, and only the map below does that.
@@ -1878,7 +1932,7 @@ export class MeetingController {
     }
 
     return registrants.map((registrant) => {
-      const v1Sfid = registrant.committee_uid ? v2ToV1Map.get(registrant.committee_uid) : undefined;
+      const v1Sfid = registrant.committee_uid && allowedV2Uids.has(registrant.committee_uid) ? v2ToV1Map.get(registrant.committee_uid) : undefined;
 
       if (v1Sfid) {
         return { ...registrant, committee_uid: v1Sfid };

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -716,7 +716,7 @@ export class MeetingController {
       req.body?.map((update: { uid: string; changes: UpdateMeetingRegistrantRequest }) => ({
         ...update,
         changes: {
-          ...update.changes,
+          ...MeetingController.stripCommitteeUid(update.changes),
           meeting_id: uid,
         },
       })) || [];
@@ -1511,7 +1511,10 @@ export class MeetingController {
    */
   public async generateAgenda(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'generate_agenda', {
-      meeting_type: req.body['meetingType'],
+      // Bounded before it is logged: nothing validates `meetingType` at this point, and the request
+      // body is client content behind a 15mb limit. It reaches the prompt only through
+      // `getMeetingTypeDescription`'s exhaustive switch, so the log is the only exposure.
+      meeting_type: MeetingController.readPromptField(req.body['meetingType']) || null,
       has_context: !!req.body['context'],
     });
 
@@ -1862,26 +1865,40 @@ export class MeetingController {
   }
 
   /**
+   * Drops a runtime `committee_uid` from a registrant update body.
+   *
+   * `UpdateMeetingRegistrantRequest` declares no such field, but that is a compile-time guarantee
+   * only: `req.body` is untyped JSON and `toUpstreamRegistrantBody` forwards every key it doesn't
+   * recognize, so an extra one here would reach upstream — which derives `type: 'committee'` from
+   * whatever SFID it receives. That would route around the meeting-scoped allowlist the create path
+   * enforces, using the edit endpoint instead. Attribution is set when a guest is added and never
+   * edited, so stripping costs nothing.
+   */
+  private static stripCommitteeUid(changes: UpdateMeetingRegistrantRequest): UpdateMeetingRegistrantRequest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-to-strip: the key is deleted, not read
+    const { committee_uid: _dropped, ...rest } = changes as UpdateMeetingRegistrantRequest & { committee_uid?: unknown };
+
+    return rest;
+  }
+
+  /**
    * The v2 UIDs of the committees actually attached to a meeting — the allowlist that
    * `resolveRegistrantCommitteeUids` checks a client-supplied `committee_uid` against.
    *
-   * A read failure resolves to an empty set rather than propagating. That fails closed: every
-   * committee attribution in the batch is stripped and those guests land as `direct`, which is the
-   * same fallback the resolver already documents for an unresolvable UID. The alternative — letting
-   * the error out — would fail the entire registrant batch on a transient read, and attribution is
-   * recoverable by re-saving in a way a half-applied guest list isn't.
+   * A read failure propagates rather than resolving to an empty set. Swallowing it would answer 201
+   * "all registrants added" while every group guest silently landed as `direct`, and there is no way
+   * back: `UpdateMeetingRegistrantRequest` declares no `committee_uid`, and `updateMeetingRegistrants`
+   * resolves none — so a re-save cannot restore what a downgrade dropped. Nothing has been written at
+   * the point this runs, so letting the error out fails the whole batch cleanly and the organizer can
+   * retry. An empty set is reserved for the case it actually describes: a meeting with no committees.
+   *
+   * `access: false` because only `committees[].uid` is read here — the default would additionally pay
+   * a committee-name query fan-out and an FGA access check, both discarded.
    */
   private async getMeetingCommitteeUids(req: Request, meetingUid: string): Promise<Set<string>> {
-    try {
-      const meeting = await this.meetingService.getMeetingById(req, meetingUid, 'v1_meeting');
-      return new Set((meeting.committees || []).map((committee) => committee.uid));
-    } catch (error) {
-      logger.warning(req, 'get_meeting_committee_uids', 'Could not load meeting committees; dropping all committee attribution', {
-        meeting_id: meetingUid,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return new Set<string>();
-    }
+    const meeting = await this.meetingService.getMeetingById(req, meetingUid, 'v1_meeting', { access: false });
+
+    return new Set((meeting.committees || []).map((committee) => committee.uid));
   }
 
   /**
@@ -1916,7 +1933,10 @@ export class MeetingController {
       logger.warning(req, 'resolve_registrant_committee_uids', 'Dropped committee UIDs not associated with this meeting', {
         requested: requestedUids.length,
         associated: v2Uids.length,
-        unassociated: requestedUids.filter((uid) => !allowedV2Uids.has(uid)),
+        // Counts only. `committee_uid` is unvalidated client content on an unbounded batch behind a
+        // 15mb body limit, and `logger.warning` passes metadata through untruncated — logging the
+        // values would let one request push megabytes of attacker-chosen strings into CloudWatch.
+        unassociated: requestedUids.length - v2Uids.length,
       });
     }
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_PROMPT_MAX_LENGTH } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
 import {
   AttachmentCategory,
   BatchRegistrantOperationResponse,
@@ -621,11 +622,14 @@ export class MeetingController {
    */
   public async addMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const registrantData: CreateMeetingRegistrantRequest[] =
-      req.body?.map((registrant: CreateMeetingRegistrantRequest) => ({
-        ...registrant,
-        meeting_id: uid,
-      })) || [];
+    // Shape-guarded for the same reason as `updateMeetingRegistrants`: this runs outside the `try`,
+    // so a non-array body would throw before any log line exists to explain it.
+    const registrantData: CreateMeetingRegistrantRequest[] = Array.isArray(req.body)
+      ? req.body.map((registrant: CreateMeetingRegistrantRequest) => ({
+          ...registrant,
+          meeting_id: uid,
+        }))
+      : [];
 
     const startTime = logger.startOperation(req, 'add_meeting_registrants', {
       meeting_id: uid,
@@ -712,14 +716,20 @@ export class MeetingController {
    */
   public async updateMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const updateData: { uid: string; changes: UpdateMeetingRegistrantRequest }[] =
-      req.body?.map((update: { uid: string; changes: UpdateMeetingRegistrantRequest }) => ({
-        ...update,
-        changes: {
-          ...MeetingController.stripCommitteeUid(update.changes),
-          meeting_id: uid,
-        },
-      })) || [];
+    // `Array.isArray` rather than `req.body?.map`, and `update?.changes` rather than `update.changes`:
+    // this runs before `startOperation` and outside the `try`, so a throw here escapes the handler as
+    // an unhandled rejection with no log line at all. The declared types are a compile-time guarantee
+    // only — a client can PUT `{}` or `[{ "uid": "x" }]` past them. An empty list falls through to the
+    // "No registrants provided" validation below, which is the 400 those bodies deserve.
+    const updateData: { uid: string; changes: UpdateMeetingRegistrantRequest }[] = Array.isArray(req.body)
+      ? req.body.map((update: { uid: string; changes?: UpdateMeetingRegistrantRequest }) => ({
+          ...update,
+          changes: {
+            ...MeetingController.stripCommitteeUid(update?.changes),
+            meeting_id: uid,
+          },
+        }))
+      : [];
 
     const startTime = logger.startOperation(req, 'update_meeting_registrants', {
       meeting_id: uid,
@@ -1510,16 +1520,21 @@ export class MeetingController {
    * Generate meeting agenda using AI
    */
   public async generateAgenda(req: Request, res: Response, next: NextFunction): Promise<void> {
+    // Narrowed to the enum once, up front, and reused for every downstream consumer — the log lines
+    // here and in `AiService`, and the value forwarded into the prompt. `meetingType` has a closed value
+    // set, so unlike the free-text descriptors it needs no length budget: anything outside the set is
+    // not a meeting type and is dropped rather than truncated. Doing this once is the point — bounding
+    // only the start line left the INFO success line and `AiService`'s own log carrying the raw value,
+    // which is the higher-retention pair of the three.
+    const meetingType = MeetingController.readMeetingType(req.body?.['meetingType']);
+
     const startTime = logger.startOperation(req, 'generate_agenda', {
-      // Bounded before it is logged: nothing validates `meetingType` at this point, and the request
-      // body is client content behind a 15mb limit. It reaches the prompt only through
-      // `getMeetingTypeDescription`'s exhaustive switch, so the log is the only exposure.
-      meeting_type: MeetingController.readPromptField(req.body['meetingType']) || null,
-      has_context: !!req.body['context'],
+      meeting_type: meetingType ?? null,
+      has_context: !!req.body?.['context'],
     });
 
     try {
-      const { meetingType, projectName: rawProjectName, maxCharacters, title: rawTitle, context: rawContext } = req.body;
+      const { projectName: rawProjectName, maxCharacters, title: rawTitle, context: rawContext } = req.body;
       // A title / type / project are not guaranteed to exist: edit mode drops the rail's section
       // locking, so the organizer can request an agenda having just cleared the title, and the
       // client's project context resolves asynchronously. Only require enough signal to write a
@@ -1587,7 +1602,7 @@ export class MeetingController {
       // wizard, so track how it's actually being invoked (and how much it costs) per request.
       logger.success(req, 'generate_agenda', startTime, {
         estimated_duration: response.estimatedDuration,
-        meeting_type: meetingType || null,
+        meeting_type: meetingType ?? null,
         has_title: !!title,
         has_project_name: !!projectName,
         has_context: !!context,
@@ -1874,7 +1889,11 @@ export class MeetingController {
    * enforces, using the edit endpoint instead. Attribution is set when a guest is added and never
    * edited, so stripping costs nothing.
    */
-  private static stripCommitteeUid(changes: UpdateMeetingRegistrantRequest): UpdateMeetingRegistrantRequest {
+  private static stripCommitteeUid(changes: UpdateMeetingRegistrantRequest | undefined): UpdateMeetingRegistrantRequest {
+    if (!changes) {
+      return {} as UpdateMeetingRegistrantRequest;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-to-strip: the key is deleted, not read
     const { committee_uid: _dropped, ...rest } = changes as UpdateMeetingRegistrantRequest & { committee_uid?: unknown };
 
@@ -1892,8 +1911,9 @@ export class MeetingController {
    * the point this runs, so letting the error out fails the whole batch cleanly and the organizer can
    * retry. An empty set is reserved for the case it actually describes: a meeting with no committees.
    *
-   * `access: false` because only `committees[].uid` is read here — the default would additionally pay
-   * a committee-name query fan-out and an FGA access check, both discarded.
+   * `access: false` because only `committees[].uid` is read here, and the default would additionally
+   * pay an FGA access check that is discarded. It does *not* skip `getCommitteeNameMap` — that runs
+   * unconditionally inside `getMeetingById` — so this saves the access check, not the name query.
    */
   private async getMeetingCommitteeUids(req: Request, meetingUid: string): Promise<Set<string>> {
     const meeting = await this.meetingService.getMeetingById(req, meetingUid, 'v1_meeting', { access: false });
@@ -1936,7 +1956,7 @@ export class MeetingController {
         // Counts only. `committee_uid` is unvalidated client content on an unbounded batch behind a
         // 15mb body limit, and `logger.warning` passes metadata through untruncated — logging the
         // values would let one request push megabytes of attacker-chosen strings into CloudWatch.
-        unassociated: requestedUids.length - v2Uids.length,
+        unassociated_count: requestedUids.length - v2Uids.length,
       });
     }
 
@@ -1976,6 +1996,18 @@ export class MeetingController {
    * leading budget's worth of signal, so a descriptor the organizer typed is never silently discarded
    * in full and the client guard mirrors this one exactly.
    */
+  /**
+   * Narrows a client-supplied meeting type to the enum, or drops it.
+   * @description `meetingType` is the one prompt input with a closed value set, and
+   * `getMeetingTypeDescription` already falls back to a generic descriptor for anything it doesn't
+   * recognise — so a value outside the set carries no signal and only exists to be logged and
+   * interpolated. Dropping it is strictly better than truncating it, which is what the free-text
+   * descriptors get.
+   */
+  private static readMeetingType(value: unknown): MeetingType | undefined {
+    return typeof value === 'string' && (Object.values(MeetingType) as string[]).includes(value) ? (value as MeetingType) : undefined;
+  }
+
   private static readPromptField(value: unknown): string | undefined {
     if (typeof value !== 'string') {
       return undefined;

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -63,6 +63,9 @@ vi.mock('@lfx-one/shared/utils', async () => ({
   // `meeting.controller.spec.ts` already uses for `truncateToUtf16Units`): `string.utils.ts` has no
   // imports of its own, so this pulls in none of the aliased barrel graph the mock exists to avoid.
   joinAsSentenceList: (await import('../../../../../packages/shared/src/utils/string.utils')).joinAsSentenceList,
+  // Real too, for the same reason: the field-length assertions are about what the controller sends
+  // upstream, and a stub would make them assert nothing.
+  truncateToUtf16Units: (await import('../../../../../packages/shared/src/utils/string.utils')).truncateToUtf16Units,
 }));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
@@ -1009,11 +1012,43 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
   // row would be invisible to the join-URL lookup.
   it('takes username from the session, strips its provider prefix, and ignores the body', async () => {
     getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
-    const { req, res, next } = buildRegisterReq(true, { username: 'someone-else' });
+    getEffectiveEmailMock.mockReturnValue('a@example.com');
+    const { req, res, next } = buildRegisterReq(true, { email: 'a@example.com', username: 'someone-else' });
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].username).toBe('realuser');
+  });
+
+  // The LFID is what makes a row *this* person's, so it may only be stamped on a row that carries an
+  // address the session owns. Without this, one signed-in visitor could register a colleague's email
+  // and silently own the resulting RSVP.
+  it('omits the session username when the submitted email is not the session email', async () => {
+    getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
+    getEffectiveEmailMock.mockReturnValue('someone-else@example.com');
+    const { req, res, next } = buildRegisterReq(true, { email: 'a@example.com' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2]).not.toHaveProperty('username');
+  });
+
+  // Ownership is an address comparison, not a string comparison: the IdP hands back a lowercased
+  // address and the registrant types whatever they type.
+  it('treats a differently-cased and padded submitted email as the session email', async () => {
+    getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
+    getEffectiveEmailMock.mockReturnValue('a@example.com');
+    const { req, res, next } = buildRegisterReq(true, { email: '  A@Example.COM  ' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+
+    const forwarded = meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2];
+
+    expect(forwarded.username).toBe('realuser');
+    expect(forwarded.email).toBe('a@example.com');
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -689,6 +689,16 @@ export class PublicMeetingController {
    * still register a third party's address for a public meeting and trigger an invite to it.
    * `publicApiRateLimiter` caps the volume, not the primitive. Such a row is now unattributed, so it
    * no longer collides with that person's own registration — the invite is the whole of the abuse.
+   * Nothing here checks `email_verified` either, so an IdP that admits an unverified address would
+   * still let an attacker who set their own account email to the victim's earn the stamp.
+   *
+   * What it costs: the registration form prefills the session email but leaves it editable, and
+   * ownership is decided against the session's single primary address. A signed-in user who registers
+   * with a secondary address of theirs now gets an unattributed row, so `createMeetingRsvp` — which
+   * resolves on session-email-OR-username — won't find it, and the RSVP controls read as
+   * "not invited". Closing that means comparing against the user's *verified* address set rather than
+   * the primary, which is an Auth0 Management round trip on an anonymous-capable route; deliberately
+   * left for its own change rather than bolted onto the identity fix.
    */
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,11 +8,11 @@ import {
   CreateMeetingRegistrantRequest,
   MeetingOccurrenceSummary,
   MeetingRegistrant,
-  Project,
   PublicMeetingOccurrencesResponse,
+  Project,
   PublicMeetingProject,
 } from '@lfx-one/shared/interfaces';
-import { joinAsSentenceList } from '@lfx-one/shared/utils';
+import { joinAsSentenceList, truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -668,13 +668,17 @@ export class PublicMeetingController {
    * shape nothing produced. Anything that isn't a string is dropped, which is what stops an object or
    * array from clearing the caller's `if (!registrantData.email …)` gate and reaching upstream.
    *
-   * `username` is taken from the session when there is one and never from the body — a signed-in
-   * registrant keeps their LFID attribution on a record written with application credentials, and a
-   * forged one still can't get in. It's stripped of any provider prefix because a registrant record
-   * stores the plain LFID: every read path strips before matching (`getMeetingRegistrantsByUsername`),
-   * so an `auth0|`-prefixed row would be invisible to the join-URL lookup that the username is stamped
-   * for in the first place. `email` is lowercased for the same reason, since query-service matching is
-   * case-sensitive and every read path lowercases.
+   * `username` is taken from the session and never from the body, and only when the submitted email
+   * is the one that session belongs to. That second condition is what keeps LFID attribution honest:
+   * the row is written with application credentials, so upstream applies no ownership check of its
+   * own, and `getMeetingRegistrantsForUser` matches on email OR username. A row carrying one person's
+   * LFID against another person's address would therefore match both of them, and `createMeetingRsvp`
+   * takes `registrants[0]` from an unordered result — so either party's RSVP could land on it. Only
+   * stamping self-registrations removes that ambiguity at the source. It's stripped of any provider
+   * prefix because a registrant record stores the plain LFID: every read path strips before matching
+   * (`getMeetingRegistrantsByUsername`), so an `auth0|`-prefixed row would be invisible to the
+   * join-URL lookup that the username is stamped for in the first place. `email` is lowercased for the
+   * same reason, since query-service matching is case-sensitive and every read path lowercases.
    *
    * The three identifiers — `meeting_id`, `email` and `occurrence_id` — are trimmed but not truncated,
    * unlike the free-text fields, because truncating one would turn an unusable value into a different,
@@ -682,26 +686,32 @@ export class PublicMeetingController {
    * what was actually wrong.
    *
    * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
-   * register a third party's address for a public meeting and trigger an invite to it — and when the
-   * caller is signed in, the resulting row also carries their LFID against an address they don't own,
-   * which `getMeetingRegistrantsForUser`'s email-OR-username query matches for both parties.
-   * `publicApiRateLimiter` caps the volume, not the primitive.
+   * still register a third party's address for a public meeting and trigger an invite to it.
+   * `publicApiRateLimiter` caps the volume, not the primitive. Such a row is now unattributed, so it
+   * no longer collides with that person's own registration — the invite is the whole of the abuse.
    */
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
-    const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
+    const text = (key: string): string =>
+      typeof raw[key] === 'string' ? truncateToUtf16Units((raw[key] as string).trim(), PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '';
     // Identifiers are narrowed and trimmed but never truncated — see the length branch in
     // `registerForPublicMeeting`, which rejects them by name instead.
     const identity = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim() : '');
+    const submittedEmail = identity('email').toLowerCase();
+    // The LFID is only stamped when the caller is registering the address their own session is for.
+    // Registering a third party's address stays allowed, but it produces an unattributed row rather
+    // than one that a downstream email-OR-username lookup would match for two different people.
     const sessionUsername = getEffectiveUsername(req);
-    const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
+    const sessionEmail = getEffectiveEmail(req)?.trim().toLowerCase() || '';
+    const ownsSubmittedEmail = !!sessionEmail && sessionEmail === submittedEmail;
+    const username = sessionUsername && ownsSubmittedEmail ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
     const orgName = text('org_name');
     const occurrenceId = identity('occurrence_id');
 
     return {
       meeting_id: identity('meeting_id'),
-      email: identity('email').toLowerCase(),
+      email: submittedEmail,
       first_name: text('first_name'),
       last_name: text('last_name'),
       host: false,

--- a/apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts
@@ -1,0 +1,121 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { aiRateLimiter } from './rate-limit.middleware';
+
+// `aiRateLimiter` counts in the default in-process MemoryStore, so the counter is shared across
+// every test in this file. Each test therefore uses its own key (a distinct `sub` or IP) rather
+// than trying to reset the store, which express-rate-limit does not expose.
+const AI_LIMIT = 10;
+
+// Minimal Express stand-ins. express-rate-limit only reads `req.ip`, `req.oidc` (through our
+// keyGenerator) and `req.app.get('trust proxy')`, and only writes through `res.setHeader` plus
+// `res.status().send()` on the reject path.
+function buildReq(opts: { sub?: string; ip?: string }): Request {
+  return {
+    ip: opts.ip ?? '203.0.113.10',
+    app: { get: () => undefined },
+    ...(opts.sub ? { oidc: { user: { sub: opts.sub } } } : {}),
+  } as unknown as Request;
+}
+
+function buildRes(): Response & { statusCode?: number; headers: Record<string, string> } {
+  const headers: Record<string, string> = {};
+
+  const res = {
+    headersSent: false,
+    headers,
+    // Declared up front so `status()` writing to `this.statusCode` type-checks.
+    statusCode: undefined as number | undefined,
+    setHeader: (name: string, value: string) => {
+      headers[name] = String(value);
+    },
+    getHeader: (name: string) => headers[name],
+    status(code: number) {
+      this.statusCode = code;
+
+      return this;
+    },
+    send: vi.fn(),
+    json: vi.fn(),
+    end: vi.fn(),
+    on: vi.fn(),
+  };
+
+  return res as unknown as Response & { statusCode?: number; headers: Record<string, string> };
+}
+
+/** Drives the limiter once and reports whether the request was allowed through. */
+async function request(opts: { sub?: string; ip?: string }): Promise<{ allowed: boolean; statusCode?: number; headers: Record<string, string> }> {
+  const req = buildReq(opts);
+  const res = buildRes();
+  const next = vi.fn() as unknown as NextFunction;
+
+  await aiRateLimiter(req, res, next);
+
+  return { allowed: (next as unknown as ReturnType<typeof vi.fn>).mock.calls.length > 0, statusCode: res.statusCode, headers: res.headers };
+}
+
+describe('aiRateLimiter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows the first ten requests in the window and rejects the eleventh with 429', async () => {
+    const sub = 'auth0|budget-holder';
+
+    for (let attempt = 1; attempt <= AI_LIMIT; attempt++) {
+      const result = await request({ sub });
+
+      expect(result.allowed, `request ${attempt} should be allowed`).toBe(true);
+    }
+
+    const rejected = await request({ sub });
+
+    // A 429 rather than a pass-through: the LiteLLM fan-out behind this route is the thing being
+    // bounded, so exhausting the budget has to stop the request, not just annotate it.
+    expect(rejected.allowed).toBe(false);
+    expect(rejected.statusCode).toBe(429);
+    expect(rejected.headers['Retry-After']).toBe('60');
+  });
+
+  it('advertises the limit in the standard RateLimit headers, not the legacy X-RateLimit ones', async () => {
+    const result = await request({ sub: 'auth0|header-reader' });
+
+    expect(result.headers['RateLimit-Limit']).toBe(String(AI_LIMIT));
+    expect(result.headers['RateLimit-Policy']).toBe(`${AI_LIMIT};w=60`);
+    expect(result.headers['X-RateLimit-Limit']).toBeUndefined();
+  });
+
+  it('keys on the authenticated sub so one user cannot exhaust a shared egress IP', async () => {
+    const sharedIp = '198.51.100.7';
+
+    // Burn the whole budget for one user behind the shared IP.
+    for (let attempt = 1; attempt <= AI_LIMIT; attempt++) {
+      await request({ sub: 'auth0|noisy-neighbour', ip: sharedIp });
+    }
+
+    expect((await request({ sub: 'auth0|noisy-neighbour', ip: sharedIp })).allowed).toBe(false);
+
+    // A different user on the same IP still has their own budget — the whole point of keying on
+    // `sub` rather than letting the IP fallback bucket a corporate NAT together.
+    expect((await request({ sub: 'auth0|innocent-bystander', ip: sharedIp })).allowed).toBe(true);
+  });
+
+  it('falls back to a /56-masked IP key for anonymous callers', async () => {
+    // Two addresses inside the same IPv6 /56 must share a bucket: masking is what stops a caller
+    // with a routed prefix from minting a fresh budget per address.
+    for (let attempt = 1; attempt <= AI_LIMIT; attempt++) {
+      await request({ ip: '2001:db8:aaaa:0001:0:0:0:1' });
+    }
+
+    expect((await request({ ip: '2001:db8:aaaa:0001:0:0:0:1' })).allowed).toBe(false);
+    expect((await request({ ip: '2001:db8:aaaa:00ff:0:0:0:9' })).allowed).toBe(false);
+
+    // A different /56 is a different caller and keeps its own budget.
+    expect((await request({ ip: '2001:db8:bbbb:0001:0:0:0:1' })).allowed).toBe(true);
+  });
+});

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -57,11 +57,14 @@ export class AiService {
   public async generateMeetingAgenda(req: Request, request: GenerateAgendaRequest): Promise<GenerateAgendaResponse> {
     this.assertConfigured();
 
+    // Shapes, not values: the title, the goal and the project name are all organizer-authored content
+    // that ends up in the prompt, and the controller's own truncation telemetry logs lengths only for
+    // exactly that reason. The success log downstream already reports `has_project_name`.
     const startTime = logger.startOperation(req, 'generate_meeting_agenda', {
       meetingType: request.meetingType,
-      title: request.title,
+      titleLength: request.title?.length ?? 0,
       hasContext: !!request.context,
-      projectName: request.projectName,
+      hasProjectName: !!request.projectName,
     });
 
     try {

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -61,7 +61,11 @@ export class AiService {
     // that ends up in the prompt, and the controller's own truncation telemetry logs lengths only for
     // exactly that reason. The success log downstream already reports `has_project_name`.
     const startTime = logger.startOperation(req, 'generate_meeting_agenda', {
-      meetingType: request.meetingType,
+      // `meetingType` is typed as the enum but arrives from a request body, and a type is not a
+      // runtime guarantee — an unrecognized value would be logged verbatim. `getMeetingTypeDescription`
+      // already defaults anything off the enum to a generic descriptor, so it never reaches the
+      // prompt; this log line was the only place an arbitrary string still got through.
+      meetingType: AiService.knownMeetingType(request.meetingType),
       titleLength: request.title?.length ?? 0,
       hasContext: !!request.context,
       hasProjectName: !!request.projectName,
@@ -559,6 +563,11 @@ export class AiService {
   }
 
   /** `default` also covers an unset type — the helper is reachable before one is chosen. */
+  /** Returns the value only when it is an actual `MeetingType` member, else `null`. */
+  private static knownMeetingType(value: unknown): MeetingType | null {
+    return typeof value === 'string' && (Object.values(MeetingType) as string[]).includes(value) ? (value as MeetingType) : null;
+  }
+
   private getMeetingTypeDescription(meetingType?: MeetingType): string {
     switch (meetingType) {
       case MeetingType.BOARD:

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1067,6 +1067,39 @@ describe('MeetingService registrant write payloads', () => {
     }
   });
 
+  // `ApiClientService` turns an empty response body into `null`. Mapping that alone would return
+  // `{}`, and `processRegistrantOperations` hands the result straight back as the updated row — so a
+  // succeeded write would render as a registrant that lost every field.
+  it('falls back to the submitted payload when the update answers without a body', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+    });
+
+    expect(result).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
+  });
+
+  // Where upstream did answer, its body is the whole answer: merging the request underneath it would
+  // report an omitted `org_name: null` as cleared when upstream still holds the old organization.
+  it('does not merge the submitted payload under a body upstream did answer with', async () => {
+    proxyRequest.mockResolvedValue({ uid: 'reg-1', org: 'Acme' });
+
+    const result = await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: null,
+    });
+
+    expect(result).toMatchObject({ uid: 'reg-1', org_name: 'Acme' });
+    expect(result).not.toHaveProperty('email');
+  });
+
   // Self-registration builds its own payload against a different endpoint, and it's the one path
   // where a registrant types their own organization — so it has to rename too.
   it('renames on the self-registration path', async () => {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -933,9 +933,20 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(updateData)
     );
 
-    // The submitted payload underlies the response: on a body-less 2xx it is the only truthful
-    // description of what upstream now stores, and where upstream did answer, its values win.
-    return { ...updateData, ...this.fromUpstreamRegistrant(updatedRegistrant) } as MeetingRegistrant;
+    // Where upstream answered, its body is the whole answer — merging the submitted payload underneath
+    // it would report fields as persisted that upstream never stored: `toUpstreamRegistrantBody`
+    // deliberately omits nullish `org_name`/`avatar_url`/`occurrence_id` so upstream keeps the old
+    // value, and Goa discards `linkedin_profile` outright.
+    if (updatedRegistrant) {
+      return this.fromUpstreamRegistrant(updatedRegistrant);
+    }
+
+    // A body-less 2xx is the one case with nothing else to report: `ApiClientService` turns an empty
+    // body into `null`, so mapping it would return `{}` — and `processRegistrantOperations` hands the
+    // result back to the client as the updated row. The submitted payload is the closest available
+    // description of what upstream now stores. It inherits the two caveats above: a cleared
+    // organization and a `linkedin_profile` both echo back as if they had been written.
+    return { ...updateData } as MeetingRegistrant;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -924,7 +924,11 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ updateData });
     logger.debug(req, 'update_meeting_registrant', 'Updating meeting registrant payload', sanitizedPayload);
 
-    const updatedRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
+    // `| null` in the type parameter because that is what actually comes back: `ApiClientService`
+    // maps an empty response body to `null`. Declaring it non-nullable made the guard below read as
+    // always-true to TypeScript, so a future cleanup could have deleted the fallback without a
+    // compile error.
+    const updatedRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${meetingUid}/registrants/${registrantUid}`,
@@ -937,13 +941,15 @@ export class MeetingService {
     // it would report fields as persisted that upstream never stored: `toUpstreamRegistrantBody`
     // deliberately omits nullish `org_name`/`avatar_url`/`occurrence_id` so upstream keeps the old
     // value, and Goa discards `linkedin_profile` outright.
-    if (updatedRegistrant) {
+    // Keys, not truthiness: a 2xx carrying a literal `{}` is truthy, and mapping it would hand the
+    // client back a registrant that lost every field — the exact failure the fallback exists to avoid.
+    if (updatedRegistrant && Object.keys(updatedRegistrant).length > 0) {
       return this.fromUpstreamRegistrant(updatedRegistrant);
     }
 
-    // A body-less 2xx is the one case with nothing else to report: `ApiClientService` turns an empty
-    // body into `null`, so mapping it would return `{}` — and `processRegistrantOperations` hands the
-    // result back to the client as the updated row. The submitted payload is the closest available
+    // A 2xx with no usable body is the one case with nothing else to report: `ApiClientService` turns
+    // an empty body into `null`, so mapping it would return `{}` — and `processRegistrantOperations`
+    // hands the result back to the client as the updated row. The submitted payload is the closest available
     // description of what upstream now stores. It inherits the two caveats above: a cleared
     // organization and a `linkedin_profile` both echo back as if they had been written.
     return { ...updateData } as MeetingRegistrant;

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -933,7 +933,9 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(updateData)
     );
 
-    return this.fromUpstreamRegistrant(updatedRegistrant);
+    // The submitted payload underlies the response: on a body-less 2xx it is the only truthful
+    // description of what upstream now stores, and where upstream did answer, its values win.
+    return { ...updateData, ...this.fromUpstreamRegistrant(updatedRegistrant) } as MeetingRegistrant;
   }
 
   /**
@@ -2267,9 +2269,16 @@ export class MeetingService {
    * Absent stays absent rather than becoming `null` — the app's spelling is only introduced for a
    * value upstream actually returned, so a missing field reads as "the write response didn't say"
    * instead of "upstream stored nothing".
+   *
+   * A body-less 2xx maps to no fields rather than throwing. `ApiClientService` turns an empty
+   * response body into `null` (`data = text ? JSON.parse(text) : null`), and destructuring that
+   * would throw *after* the write had already succeeded — turning a successful registrant edit into
+   * a failed batch item under `processRegistrantOperations`' `Promise.allSettled`. The response
+   * documented above is a populated body, so this is defence rather than an expectation; callers
+   * that need a value here already have to treat every field as "the write response didn't say".
    */
-  private fromUpstreamRegistrant(upstream: Record<string, unknown>): MeetingRegistrant {
-    const { org, profile_picture, occurrence, modified_at, ...rest } = upstream;
+  private fromUpstreamRegistrant(upstream: Record<string, unknown> | null | undefined): MeetingRegistrant {
+    const { org, profile_picture, occurrence, modified_at, ...rest } = upstream ?? {};
 
     return {
       ...rest,

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -360,8 +360,15 @@ export const MEETING_COMPOSER_PREVIEW_FEATURES: MeetingComposerPreviewFeature[] 
  */
 export const MEETING_COMPOSER_TOAST_KEY = 'meeting-composer-toast';
 
-/** How long the post-create toast stays up, in ms — longer than a plain toast because it carries actions. */
-export const MEETING_COMPOSER_TOAST_LIFE = 10000;
+/**
+ * Where the composer's post-create toast renders.
+ * @description Not the app-wide top-right slot. Two independently positioned `p-toast` containers in the
+ * same corner overlap rather than stack, and the composer's own partial-save warning is emitted unkeyed
+ * — through the app-wide container — immediately before this success message, so the success toast could
+ * cover the warning that matters more. Bottom-right also suits a sticky, action-bearing toast, which is
+ * conventionally a snackbar slot.
+ */
+export const MEETING_COMPOSER_TOAST_POSITION = 'bottom-right';
 
 /**
  * Default meeting duration in minutes


### PR DESCRIPTION
> **Stack 12 of 20.** Based on PR 11 (`style/issue-1460-create-dropdown`). Followed by PR 13 (`fix/issue-1463-encode-path-segments`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Validates registrant identity and attribution server-side, and corrects the composer's validity, access and toast gating.

## How

- Validates registrant identity and attribution before the request is built, so a malformed body is rejected by name rather than throwing downstream.
- Hardens the update responses so a partial upstream failure is reported rather than swallowed.
- Corrects the composer's validity, access and toast gates, which could each fire on the wrong condition.
- Makes every validated control reachable from the rail — a section could previously be marked invalid with no way to scroll to the offending field.

## Protected files

This PR touches files flagged by `.claude/hooks/guard-protected-files.sh`. Requesting code-owner review from @linuxfoundation/lfx-platform.

| File | Why it is protected | What this PR changes |
| --- | --- | --- |
| `apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts` | Request middleware. Changes affect request processing for all routes. | Adds the missing spec coverage for `aiRateLimiter` — key selection, the anonymous IP fallback, and the window/limit configuration. Test-only. |
| `apps/lfx-one/src/server/services/ai.service.ts` | AI integration service. Changes affect AI-powered features. | Tightens request-body validation before the prompt is built. |

## Commits

5 commit(s), 17 files changed, 931 insertions(+), 86 deletions(-).

- `fix(meetings): validate registrant identity and attribution`
- `fix(meetings): harden registrant attribution and update responses`
- `fix(meetings): correct composer validity, access and toast gates`
- `fix(meetings): guard the registrant request bodies before they throw`
- `fix(meetings): reach every validated control from the composer rail`

## Related

- Refs #1463
- Refs #1452
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
