### PR TITLE
fix(meetings): encode upstream path segments and close the test gaps

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
@@ -1,56 +1,63 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-@if (canWrite()) {
-  @if (layout() === 'header') {
-    <div class="flex items-center gap-2 text-sm" data-testid="dashboard-quicklinks">
-      <span class="text-surface-400 font-medium">Quick links:</span>
-      @for (link of links; track link.testId; let last = $last) {
-        @if (link.command; as command) {
-          <button
-            type="button"
-            (click)="command()"
-            class="flex items-center gap-1.5 text-primary hover:underline"
-            [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-            <i [class]="link.icon" aria-hidden="true"></i>
-            {{ link.label }}
-          </button>
-        } @else {
-          <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-            <i [class]="link.icon" aria-hidden="true"></i>
-            {{ link.label }}
-          </a>
-        }
-        @if (!last) {
-          <span class="text-surface-300 select-none" aria-hidden="true">|</span>
-        }
-      }
-    </div>
-  } @else {
-    <div class="flex flex-col gap-3" data-testid="dashboard-quicklinks-sidebar">
-      <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Quick links</h2>
-      <div class="flex flex-row flex-wrap items-center gap-x-4 gap-y-2 xl:flex-col xl:items-start xl:gap-3">
-        @for (link of links; track link.testId) {
+<!-- One body for all four branches (button/anchor × header/sidebar) so the branches carry structure
+     only — the icon and label can't drift between them. -->
+<ng-template #linkBody let-link>
+  <i [class]="link.icon" aria-hidden="true"></i>
+  {{ link.label }}
+</ng-template>
+
+@if (visibleLinks(); as links) {
+  @if (links.length) {
+    @if (layout() === 'header') {
+      <div class="flex items-center gap-2 text-sm" data-testid="dashboard-quicklinks">
+        <span class="text-surface-400 font-medium">Quick links:</span>
+        @for (link of links; track link.testId; let last = $last) {
           @if (link.command; as command) {
             <button
               type="button"
               (click)="command()"
-              class="flex items-center gap-2 text-sm text-primary hover:underline"
+              aria-haspopup="dialog"
+              class="flex items-center gap-1.5 text-primary hover:underline"
               [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-              <i [class]="link.icon" aria-hidden="true"></i>
-              {{ link.label }}
+              <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
             </button>
           } @else {
-            <a
-              [routerLink]="link.route"
-              class="flex items-center gap-2 text-sm text-primary hover:underline"
-              [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-              <i [class]="link.icon" aria-hidden="true"></i>
-              {{ link.label }}
+            <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+              <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
             </a>
+          }
+          @if (!last) {
+            <span class="text-surface-300 select-none" aria-hidden="true">|</span>
           }
         }
       </div>
-    </div>
+    } @else {
+      <div class="flex flex-col gap-3" data-testid="dashboard-quicklinks-sidebar">
+        <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Quick links</h2>
+        <div class="flex flex-row flex-wrap items-center gap-x-4 gap-y-2 xl:flex-col xl:items-start xl:gap-3">
+          @for (link of links; track link.testId) {
+            @if (link.command; as command) {
+              <button
+                type="button"
+                (click)="command()"
+                aria-haspopup="dialog"
+                class="flex items-center gap-2 text-sm text-primary hover:underline"
+                [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+                <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
+              </button>
+            } @else {
+              <a
+                [routerLink]="link.route"
+                class="flex items-center gap-2 text-sm text-primary hover:underline"
+                [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+                <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
+              </a>
+            }
+          }
+        </div>
+      </div>
+    }
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
@@ -1,63 +1,36 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<!-- One body for all four branches (button/anchor × header/sidebar) so the branches carry structure
-     only — the icon and label can't drift between them. -->
-<ng-template #linkBody let-link>
-  <i [class]="link.icon" aria-hidden="true"></i>
-  {{ link.label }}
-</ng-template>
-
-@if (visibleLinks(); as links) {
-  @if (links.length) {
-    @if (layout() === 'header') {
-      <div class="flex items-center gap-2 text-sm" data-testid="dashboard-quicklinks">
-        <span class="text-surface-400 font-medium">Quick links:</span>
-        @for (link of links; track link.testId; let last = $last) {
-          @if (link.command; as command) {
-            <button
-              type="button"
-              (click)="command()"
-              aria-haspopup="dialog"
-              class="flex items-center gap-1.5 text-primary hover:underline"
-              [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-              <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
-            </button>
-          } @else {
-            <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-              <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
-            </a>
-          }
-          @if (!last) {
-            <span class="text-surface-300 select-none" aria-hidden="true">|</span>
-          }
+<!-- `.length`, not `visibleLinks(); as links`: an array is always truthy, so the `as` form rendered
+     the heading over an empty list. The host relies on this emitting nothing at all — it carries
+     `empty:hidden` so the sidebar's `gap-8` doesn't leave a hole where the section would be. -->
+@if (visibleLinks().length) {
+  <div class="flex flex-col gap-3" data-testid="dashboard-quicklinks-sidebar">
+    <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Quick links</h2>
+    <div class="flex flex-row flex-wrap items-center gap-x-4 gap-y-2 xl:flex-col xl:items-start xl:gap-3">
+      @for (link of visibleLinks(); track link.testId) {
+        <!-- A button for a link that opens something in place, an anchor for one that navigates, so
+             nothing about the element promises a destination it doesn't have. -->
+        @if (link.command; as command) {
+          <button
+            type="button"
+            (click)="command()"
+            [attr.aria-haspopup]="link.hasPopup ?? null"
+            class="flex items-center gap-2 text-sm text-primary hover:underline"
+            [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+            <i [class]="link.icon" aria-hidden="true"></i>
+            {{ link.label }}
+          </button>
+        } @else {
+          <a
+            [routerLink]="link.route"
+            class="flex items-center gap-2 text-sm text-primary hover:underline"
+            [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+            <i [class]="link.icon" aria-hidden="true"></i>
+            {{ link.label }}
+          </a>
         }
-      </div>
-    } @else {
-      <div class="flex flex-col gap-3" data-testid="dashboard-quicklinks-sidebar">
-        <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Quick links</h2>
-        <div class="flex flex-row flex-wrap items-center gap-x-4 gap-y-2 xl:flex-col xl:items-start xl:gap-3">
-          @for (link of links; track link.testId) {
-            @if (link.command; as command) {
-              <button
-                type="button"
-                (click)="command()"
-                aria-haspopup="dialog"
-                class="flex items-center gap-2 text-sm text-primary hover:underline"
-                [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-                <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
-              </button>
-            } @else {
-              <a
-                [routerLink]="link.route"
-                class="flex items-center gap-2 text-sm text-primary hover:underline"
-                [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-                <ng-container *ngTemplateOutlet="linkBody; context: { $implicit: link }" />
-              </a>
-            }
-          }
-        </div>
-      </div>
-    }
-  }
+      }
+    </div>
+  </div>
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
@@ -6,10 +6,21 @@
     <div class="flex items-center gap-2 text-sm" data-testid="dashboard-quicklinks">
       <span class="text-surface-400 font-medium">Quick links:</span>
       @for (link of links; track link.testId; let last = $last) {
-        <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-          <i [class]="link.icon" aria-hidden="true"></i>
-          {{ link.label }}
-        </a>
+        @if (link.command; as command) {
+          <button
+            type="button"
+            (click)="command()"
+            class="flex items-center gap-1.5 text-primary hover:underline"
+            [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+            <i [class]="link.icon" aria-hidden="true"></i>
+            {{ link.label }}
+          </button>
+        } @else {
+          <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+            <i [class]="link.icon" aria-hidden="true"></i>
+            {{ link.label }}
+          </a>
+        }
         @if (!last) {
           <span class="text-surface-300 select-none" aria-hidden="true">|</span>
         }
@@ -20,13 +31,24 @@
       <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Quick links</h2>
       <div class="flex flex-row flex-wrap items-center gap-x-4 gap-y-2 xl:flex-col xl:items-start xl:gap-3">
         @for (link of links; track link.testId) {
-          <a
-            [routerLink]="link.route"
-            class="flex items-center gap-2 text-sm text-primary hover:underline"
-            [attr.data-testid]="'dashboard-quicklink-' + link.testId">
-            <i [class]="link.icon" aria-hidden="true"></i>
-            {{ link.label }}
-          </a>
+          @if (link.command; as command) {
+            <button
+              type="button"
+              (click)="command()"
+              class="flex items-center gap-2 text-sm text-primary hover:underline"
+              [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+              <i [class]="link.icon" aria-hidden="true"></i>
+              {{ link.label }}
+            </button>
+          } @else {
+            <a
+              [routerLink]="link.route"
+              class="flex items-center gap-2 text-sm text-primary hover:underline"
+              [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+              <i [class]="link.icon" aria-hidden="true"></i>
+              {{ link.label }}
+            </a>
+          }
         }
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.spec.ts
@@ -22,7 +22,11 @@ describe('DashboardQuicklinksComponent', () => {
   let fixture: ComponentFixture<DashboardQuicklinksComponent>;
   const canWrite = signal(false);
   const canWriteMeetings = signal(false);
-  const activeContextUid = signal<string | null>(null);
+  // `signal<string>('')`, matching `ProjectContextService.activeContextUid`, which is a
+  // `Signal<string>` that reports `''` for "no context" rather than `null`. A double typed
+  // `string | null` would let this file assert against a shape the real service never produces —
+  // the same drift the `FakeValidationError` double in the server specs was fixed for.
+  const activeContextUid = signal('');
   const open = vi.fn();
 
   /** The `data-testid` slug of every link rendered, in order. */
@@ -36,7 +40,7 @@ describe('DashboardQuicklinksComponent', () => {
   beforeEach(async () => {
     canWrite.set(false);
     canWriteMeetings.set(false);
-    activeContextUid.set(null);
+    activeContextUid.set('');
     open.mockClear();
 
     TestBed.configureTestingModule({

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.spec.ts
@@ -1,0 +1,124 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { MeetingComposerService } from '@modules/meetings/meeting-composer/meeting-composer.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DashboardQuicklinksComponent } from './dashboard-quicklinks.component';
+
+/**
+ * Covers which quick links a given set of permissions actually renders, and as what element.
+ *
+ * The two permissions are deliberately driven apart in these tests. They used to be one `canWrite()`
+ * gate over the whole row, and the bug that split them — a meeting coordinator who is not a project
+ * writer seeing no quick links at all — only reproduces when they disagree, so every case here sets
+ * them independently.
+ */
+describe('DashboardQuicklinksComponent', () => {
+  let fixture: ComponentFixture<DashboardQuicklinksComponent>;
+  const canWrite = signal(false);
+  const canWriteMeetings = signal(false);
+  const activeContextUid = signal<string | null>(null);
+  const open = vi.fn();
+
+  /** The `data-testid` slug of every link rendered, in order. */
+  const renderedSlugs = (): string[] =>
+    Array.from(fixture.nativeElement.querySelectorAll('[data-testid^="dashboard-quicklink-"]')).map((element) =>
+      (element as HTMLElement).getAttribute('data-testid')!.replace('dashboard-quicklink-', '')
+    );
+
+  const link = (slug: string): HTMLElement | null => fixture.nativeElement.querySelector(`[data-testid="dashboard-quicklink-${slug}"]`);
+
+  beforeEach(async () => {
+    canWrite.set(false);
+    canWriteMeetings.set(false);
+    activeContextUid.set(null);
+    open.mockClear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: ProjectContextService, useValue: { canWrite, canWriteMeetings, activeContextUid } },
+        { provide: MeetingComposerService, useValue: { open } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(DashboardQuicklinksComponent);
+    await fixture.whenStable();
+  });
+
+  it('renders nothing at all when the user can use none of the links', async () => {
+    await fixture.whenStable();
+
+    expect(renderedSlugs()).toEqual([]);
+    // Not just the links: the heading has to go too, and the component has to leave the host element
+    // with no rendered children — the sidebar carries `empty:hidden` on it so the surrounding `gap-8`
+    // doesn't leave a hole, and that only fires while the host is `:empty`.
+    expect(fixture.nativeElement.querySelector('[data-testid="dashboard-quicklinks-sidebar"]')).toBeNull();
+    expect(fixture.nativeElement.children.length).toBe(0);
+  });
+
+  it('shows only the meeting link to someone who can author meetings but cannot write to the project', async () => {
+    canWriteMeetings.set(true);
+    await fixture.whenStable();
+
+    expect(renderedSlugs()).toEqual(['create-meeting']);
+  });
+
+  it('shows only the project links to a writer who cannot author meetings', async () => {
+    canWrite.set(true);
+    await fixture.whenStable();
+
+    expect(renderedSlugs()).toEqual(['create-group', 'create-mailing-list']);
+  });
+
+  it('renders the meeting link as a button that announces the dialog it opens', async () => {
+    canWriteMeetings.set(true);
+    await fixture.whenStable();
+
+    const trigger = link('create-meeting');
+
+    // A button rather than an anchor, because it opens the composer over the current page: an anchor
+    // would put a destination in the status bar that this link does not navigate to.
+    expect(trigger?.tagName).toBe('BUTTON');
+    expect(trigger?.getAttribute('aria-haspopup')).toBe('dialog');
+  });
+
+  it('renders a navigating link as an anchor with an href and no popup announcement', async () => {
+    canWrite.set(true);
+    await fixture.whenStable();
+
+    const trigger = link('create-group');
+
+    expect(trigger?.tagName).toBe('A');
+    expect(trigger?.getAttribute('href')).toBe('/groups/create');
+    // The attribute is bound to the link's own `hasPopup`, so a link that opens nothing announces
+    // nothing — the template hard-coded `dialog` on every non-anchor branch before.
+    expect(trigger?.getAttribute('aria-haspopup')).toBeNull();
+  });
+
+  it('opens the quick composer against the active project when the meeting link is clicked', async () => {
+    canWriteMeetings.set(true);
+    activeContextUid.set('project-1');
+    await fixture.whenStable();
+
+    link('create-meeting')?.click();
+
+    expect(open).toHaveBeenCalledWith({ mode: 'create', variant: 'quick', projectUid: 'project-1' });
+  });
+
+  it('leaves the project unset when there is no active context', async () => {
+    canWriteMeetings.set(true);
+    await fixture.whenStable();
+
+    link('create-meeting')?.click();
+
+    // `undefined`, not `null` or `''`: the composer treats an explicit `projectUid` as taking
+    // precedence over the ambient context, so passing a falsy one would pin it to nothing.
+    expect(open).toHaveBeenCalledWith({ mode: 'create', variant: 'quick', projectUid: undefined });
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
@@ -1,8 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NgTemplateOutlet } from '@angular/common';
-import { Component, computed, inject, input } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DashboardQuickLink } from '@lfx-one/shared/interfaces';
 import { MeetingComposerService } from '@modules/meetings/meeting-composer/meeting-composer.service';
@@ -10,14 +9,12 @@ import { ProjectContextService } from '@services/project-context.service';
 
 @Component({
   selector: 'lfx-dashboard-quicklinks',
-  imports: [NgTemplateOutlet, RouterLink],
+  imports: [RouterLink],
   templateUrl: './dashboard-quicklinks.component.html',
 })
 export class DashboardQuicklinksComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly composer = inject(MeetingComposerService);
-
-  public readonly layout = input<'header' | 'sidebar'>('header');
 
   protected readonly links: DashboardQuickLink[] = [
     {
@@ -38,6 +35,7 @@ export class DashboardQuicklinksComponent {
           variant: 'quick',
           projectUid: this.projectContextService.activeContextUid() || undefined,
         }),
+      hasPopup: 'dialog',
       // Meeting-authoring permission, not writer permission: a meeting coordinator who isn't a
       // project writer can create meetings, and gating this on `canWrite` hid the link from them.
       visible: () => this.projectContextService.canWriteMeetings(),

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject, input } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, computed, inject, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DashboardQuickLink } from '@lfx-one/shared/interfaces';
 import { MeetingComposerService } from '@modules/meetings/meeting-composer/meeting-composer.service';
@@ -9,7 +10,7 @@ import { ProjectContextService } from '@services/project-context.service';
 
 @Component({
   selector: 'lfx-dashboard-quicklinks',
-  imports: [RouterLink],
+  imports: [NgTemplateOutlet, RouterLink],
   templateUrl: './dashboard-quicklinks.component.html',
 })
 export class DashboardQuicklinksComponent {
@@ -27,12 +28,42 @@ export class DashboardQuicklinksComponent {
       // Going through it would push the dashboard the organizer is reading out from under them.
       // `variant: 'quick'` with no `meetingType`, matching the deep link and the dashboard's
       // "Create meeting" dropdown — a single link has nowhere to offer the drawer/type choice.
-      command: () => this.composer.open({ mode: 'create', variant: 'quick' }),
+      //
+      // `projectUid` is passed explicitly because the composer documents it as taking precedence
+      // over the ambient project context, which resolves asynchronously — without it a composer
+      // opened straight after a context switch can open against the previous project.
+      command: () =>
+        this.composer.open({
+          mode: 'create',
+          variant: 'quick',
+          projectUid: this.projectContextService.activeContextUid() || undefined,
+        }),
+      // Meeting-authoring permission, not writer permission: a meeting coordinator who isn't a
+      // project writer can create meetings, and gating this on `canWrite` hid the link from them.
+      visible: () => this.projectContextService.canWriteMeetings(),
       testId: 'create-meeting',
     },
-    { label: 'Create group', icon: 'fa-light fa-users', route: ['/groups', 'create'], testId: 'create-group' },
-    { label: 'Create mailing list', icon: 'fa-light fa-envelope', route: ['/mailing-lists', 'create'], testId: 'create-mailing-list' },
+    {
+      label: 'Create group',
+      icon: 'fa-light fa-users',
+      route: ['/groups', 'create'],
+      visible: () => this.projectContextService.canWrite(),
+      testId: 'create-group',
+    },
+    {
+      label: 'Create mailing list',
+      icon: 'fa-light fa-envelope',
+      route: ['/mailing-lists', 'create'],
+      visible: () => this.projectContextService.canWrite(),
+      testId: 'create-mailing-list',
+    },
   ];
 
-  protected readonly canWrite = this.projectContextService.canWrite;
+  /**
+   * The links the current user can actually use.
+   * @description Filtered per link rather than gated as a block, so a meeting coordinator who is not
+   * a project writer still sees "Create meeting" and nothing else. The whole section hides only when
+   * this is empty — an empty "Quick links" heading is worse than no heading.
+   */
+  protected readonly visibleLinks = computed(() => this.links.filter((link) => link.visible?.() ?? true));
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.ts
@@ -4,6 +4,7 @@
 import { Component, inject, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DashboardQuickLink } from '@lfx-one/shared/interfaces';
+import { MeetingComposerService } from '@modules/meetings/meeting-composer/meeting-composer.service';
 import { ProjectContextService } from '@services/project-context.service';
 
 @Component({
@@ -13,11 +14,22 @@ import { ProjectContextService } from '@services/project-context.service';
 })
 export class DashboardQuicklinksComponent {
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly composer = inject(MeetingComposerService);
 
   public readonly layout = input<'header' | 'sidebar'>('header');
 
   protected readonly links: DashboardQuickLink[] = [
-    { label: 'Create meeting', icon: 'fa-light fa-calendar', route: ['/meetings', 'create'], testId: 'create-meeting' },
+    {
+      label: 'Create meeting',
+      icon: 'fa-light fa-calendar',
+      // Opens the composer over the dashboard rather than routing to `/meetings/create`, which
+      // exists only to keep that URL deep-linkable and immediately redirects to the meetings list.
+      // Going through it would push the dashboard the organizer is reading out from under them.
+      // `variant: 'quick'` with no `meetingType`, matching the deep link and the dashboard's
+      // "Create meeting" dropdown — a single link has nowhere to offer the drawer/type choice.
+      command: () => this.composer.open({ mode: 'create', variant: 'quick' }),
+      testId: 'create-meeting',
+    },
     { label: 'Create group', icon: 'fa-light fa-users', route: ['/groups', 'create'], testId: 'create-group' },
     { label: 'Create mailing list', icon: 'fa-light fa-envelope', route: ['/mailing-lists', 'create'], testId: 'create-mailing-list' },
   ];

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-sidebar/dashboard-sidebar.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <aside class="flex flex-col gap-8 w-full" data-testid="dashboard-sidebar">
-  <lfx-dashboard-quicklinks layout="sidebar" class="empty:hidden" />
+  <lfx-dashboard-quicklinks class="empty:hidden" />
   <lfx-project-staff-card [projectUid]="projectUid()" [heading]="staffHeading()" class="empty:hidden" />
   @if (showFormationCard() && formationFlagEnabled() && isFormation()) {
     <lfx-formation-card class="empty:hidden" />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -151,6 +151,133 @@ describe('MeetingComposerFormService — submit generation guard', () => {
 
     expect(addMeetingRegistrants).toHaveBeenCalledWith('meeting-1', [expect.objectContaining({ meeting_id: 'meeting-1' })]);
   });
+
+  /**
+   * Closing without reopening deliberately leaves the generation alone, so the save runs to completion.
+   * @description Reviewer feedback asked for the token to be invalidated on every close as well, not just
+   * on reopen. Doing that would break the create path: `announceCreatedMeeting` in the host is the only
+   * route back to a meeting now that creating no longer navigates, and it only fires on an emission. A
+   * close that bumped the generation would swallow the emission for a meeting that genuinely was created,
+   * and — because the guests were in fact attached — would replace the "Meeting created" toast with the
+   * "guests and resources were not attached" warning. The state writes the guard exists to prevent
+   * (`meetingId.set`, `reportDependentResults`) are harmless here, because they are all reset by the next
+   * `initialize()`. These two cases pin that down so a future change to it has to be deliberate.
+   */
+  it('emits and attaches guests when the composer closed without reopening', () => {
+    const created = new Subject<Meeting>();
+    createMeeting.mockReturnValue(created);
+    service.registrantUpdates.set({ toAdd: [REGISTRANT], toUpdate: [], toDelete: [] });
+
+    const emissions: (Meeting | null)[] = [];
+    service.submit().subscribe((meeting) => emissions.push(meeting));
+
+    // No `initialize()` — a close on its own touches nothing the submit pipeline reads.
+    created.next({ id: 'meeting-1' } as Meeting);
+    created.complete();
+
+    expect(emissions).toEqual([{ id: 'meeting-1' }]);
+    expect(addMeetingRegistrants).toHaveBeenCalledWith('meeting-1', [expect.objectContaining({ meeting_id: 'meeting-1' })]);
+    expect(messageAdd).not.toHaveBeenCalledWith(expect.objectContaining({ summary: 'Partially saved' }));
+  });
+
+  it('clears the submitting flag when the composer closed without reopening', () => {
+    const created = new Subject<Meeting>();
+    createMeeting.mockReturnValue(created);
+
+    service.submit().subscribe();
+    expect(service.submitting()).toBe(true);
+
+    created.next({ id: 'meeting-1' } as Meeting);
+    created.complete();
+
+    // The reopen cases leave this to the next `initialize()`; a plain close has no next `initialize()`,
+    // so the flag has to be cleared here or the reopened composer would start with Save disabled.
+    expect(service.submitting()).toBe(false);
+  });
+});
+
+/**
+ * Covers the attachment-deletion queue across a save.
+ * @description `processAttachmentOperations` snapshots the queue up front, so what survives the pass is
+ * not simply "the queue, cleared": the ids that failed have to stay, and anything the organizer removed
+ * while the requests were in flight has to stay too — clearing wholesale would drop it with no trace,
+ * and clearing nothing would retry a delete upstream has already applied.
+ */
+describe('MeetingComposerFormService — attachment deletion queue', () => {
+  let service: MeetingComposerFormService;
+  let deleteMeetingAttachment: ReturnType<typeof vi.fn>;
+  let messageAdd: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    deleteMeetingAttachment = vi.fn().mockReturnValue(of(undefined));
+    messageAdd = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: messageAdd } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        {
+          provide: MeetingService,
+          useValue: {
+            createMeeting: vi.fn().mockReturnValue(of({ id: 'meeting-1' } as Meeting)),
+            updateMeeting: vi.fn(),
+            addMeetingRegistrants: vi.fn().mockReturnValue(of({ summary: { successful: 0, failed: 0 } })),
+            updateMeetingRegistrants: vi.fn().mockReturnValue(of({ summary: { successful: 0, failed: 0 } })),
+            deleteMeetingRegistrants: vi.fn().mockReturnValue(of({ summary: { successful: 0, failed: 0 } })),
+            createMeetingAttachment: vi.fn(),
+            deleteMeetingAttachment,
+            uploadMeetingFile: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.form().patchValue({ title: 'Composer meeting', meeting_type: 'Technical' });
+  });
+
+  it('keeps the ids whose delete failed and drops the ones that succeeded', () => {
+    deleteMeetingAttachment.mockImplementation((_meetingId: string, attachmentId: string) =>
+      attachmentId === 'doc-2' ? throwError(() => new Error('upstream refused')) : of(undefined)
+    );
+    service.deleteAttachment('doc-1');
+    service.deleteAttachment('doc-2');
+
+    service.submit().subscribe();
+
+    expect(service.pendingAttachmentDeletions()).toEqual(['doc-2']);
+    // Counted as a resource failure, so the organizer is told the meeting saved but the removal didn't.
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn', detail: expect.stringContaining('1 resource(s)') }));
+  });
+
+  it('keeps a deletion queued after the pass snapshotted the queue', () => {
+    const firstDelete = new Subject<void>();
+    deleteMeetingAttachment.mockReturnValue(firstDelete);
+    service.deleteAttachment('doc-1');
+
+    service.submit().subscribe();
+
+    // Queued while the request is in flight, so it is not in the snapshot the pass is working from.
+    service.deleteAttachment('doc-2');
+    firstDelete.next();
+    firstDelete.complete();
+
+    expect(service.pendingAttachmentDeletions()).toEqual(['doc-2']);
+    expect(deleteMeetingAttachment).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nothing when every queued deletion succeeded', () => {
+    service.deleteAttachment('doc-1');
+    service.deleteAttachment('doc-2');
+
+    service.submit().subscribe();
+
+    expect(service.pendingAttachmentDeletions()).toEqual([]);
+    expect(messageAdd).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -169,7 +169,15 @@ export class MeetingComposerFormService {
    */
   private readonly reset$ = new Subject<void>();
 
-  /** Incremented on every `initialize()` so callers can detect a submit that outlived its open. */
+  /**
+   * Incremented on every `initialize()` so callers can detect a submit that outlived its open.
+   * @description Deliberately not incremented on close. A close on its own leaves nothing for a
+   * resolving save to corrupt — every piece of state it writes is reset by the next `initialize()` —
+   * and cancelling there would swallow the emission the host turns into the "Meeting created" toast,
+   * which is the only route back to a meeting now that creating no longer navigates. What the guard
+   * is actually for is a close *followed by a reopen*, where the resolving save would write into a
+   * different meeting's form. Covered in `meeting-composer-form.service.spec.ts`.
+   */
   private generation = 0;
 
   public constructor() {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -18,8 +18,9 @@
           @let editBlockedReason = editFromToastBlockedReason();
 
           <div class="mt-1 flex items-center gap-3">
-            <!-- `aria-disabled` rather than `disabled`, matching the rail: the toast auto-dismisses, so an
-                 unreachable control here would leave a screen-reader user no way to hear why it did nothing.
+            <!-- `aria-disabled` rather than `disabled`, matching the rail: a focusable control that explains
+                 itself beats an unreachable one, which would leave a screen-reader user no way to hear why
+                 nothing happened.
                  The reason rides on `aria-label`/`title` rather than an sr-only child, because PrimeNG's
                  toast item is an `aria-atomic` live region — adding or removing a child re-announces the
                  whole toast. `onEditCreatedMeeting` is the real guard. -->

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.spec.ts
@@ -9,7 +9,7 @@ import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerRailComponent } from './meeting-composer-rail.component';
@@ -24,6 +24,9 @@ import { MeetingComposerService } from './meeting-composer.service';
  * ceiling and the "one past the furthest visited" frontier — are asserted, because either one alone
  * still passes the obvious cases: with only the ceiling, clearing the two required sections unlocks all
  * three optional ones at once; with only the frontier, a blank required section is walkable past.
+ *
+ * The last block covers the compact chip row's auto-scroll, which is the one behavior here that is not
+ * a pure function of the rows — it reads the rendered DOM.
  */
 describe('MeetingComposerRailComponent', () => {
   let fixture: ComponentFixture<MeetingComposerRailComponent>;
@@ -36,6 +39,29 @@ describe('MeetingComposerRailComponent', () => {
     rows()
       .filter((candidate) => candidate.reachable)
       .map((candidate) => candidate.section.id);
+
+  /**
+   * Drops the template for the blocks that only read `rows()`.
+   *
+   * Called per block rather than in the shared `beforeEach` because the compact block below needs the
+   * real markup — its subject is an `afterRenderEffect` that queries the rendered chip, so a stub would
+   * leave it asserting against an empty DOM while looking like it covered something.
+   */
+  const stubTemplate = (): void => {
+    TestBed.overrideComponent(MeetingComposerRailComponent, { set: { template: '', imports: [] } });
+  };
+
+  /**
+   * Resolves the two services under test.
+   *
+   * Separate from the shared `beforeEach` because the first `inject` instantiates the test module and
+   * `overrideComponent` throws after that — so a block that stubs its template has to stub before it
+   * reaches for a service.
+   */
+  const injectServices = (): void => {
+    composer = TestBed.inject(MeetingComposerService);
+    formService = TestBed.inject(MeetingComposerFormService);
+  };
 
   /** Fills what `details-access` validates, which is what unblocks everything after it. */
   const completeDetails = (): void => {
@@ -55,16 +81,12 @@ describe('MeetingComposerRailComponent', () => {
         { provide: PersonaService, useValue: { currentPersona: () => null } },
       ],
     });
-    // Rendered rows are covered by the section-state assertions below; the template only branches on
-    // them. Dropping it keeps the fixture free of the icon/class markup and of `NgClass`.
-    TestBed.overrideComponent(MeetingComposerRailComponent, { set: { template: '', imports: [] } });
-
-    composer = TestBed.inject(MeetingComposerService);
-    formService = TestBed.inject(MeetingComposerFormService);
   });
 
   describe('create mode', () => {
     beforeEach(() => {
+      stubTemplate();
+      injectServices();
       composer.open({ mode: 'create', projectUid: 'project-1' });
       formService.initialize({ mode: 'create', projectUid: 'project-1' });
 
@@ -150,6 +172,8 @@ describe('MeetingComposerRailComponent', () => {
 
   describe('edit mode', () => {
     beforeEach(() => {
+      stubTemplate();
+      injectServices();
       composer.open({ mode: 'edit', meetingUid: 'meeting-1' });
       // `initialize` is called without `meetingUid` on purpose: the fetch is what this test does not
       // want, and the rail reads mode, not the meeting.
@@ -168,6 +192,85 @@ describe('MeetingComposerRailComponent', () => {
       fixture.componentInstance['onSelect'](row('agenda-resources'));
 
       expect(composer.activeSection()).toBe('agenda-resources');
+    });
+  });
+
+  /**
+   * The compact chip row's `afterRenderEffect`, which scrolls the active chip into view.
+   *
+   * `lg:hidden` is a CSS breakpoint, so at desktop widths the chip row is still in the DOM and the
+   * component's query still finds the chip — the only thing separating "collapsed and visible" from
+   * "present but hidden" is whether the element has been laid out. Getting that wrong is invisible in
+   * the collapsed layout the feature was built for and yanks the desktop composer's scroll position
+   * sideways on every section change, so both branches are pinned here.
+   *
+   * This block renders the real template: the subject is a DOM read, and both `getClientRects` and
+   * `scrollIntoView` are patched on `Element.prototype` rather than on one node because the effect
+   * resolves its own element after the render this test can't reach into.
+   */
+  describe('compact chip row', () => {
+    const originalGetClientRects = Element.prototype.getClientRects;
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    let scrolled: { testId: string | null; options: unknown }[];
+
+    /** jsdom performs no layout, so both states are stated outright rather than left to the default. */
+    const setLaidOut = (laidOut: boolean): void => {
+      Element.prototype.getClientRects = () => (laidOut ? [new DOMRect(0, 0, 120, 32)] : []) as unknown as DOMRectList;
+    };
+
+    const renderRail = (compact: boolean): void => {
+      fixture = TestBed.createComponent(MeetingComposerRailComponent);
+      fixture.componentRef.setInput('compact', compact);
+      // `TestBed.tick()` rather than `fixture.detectChanges()`: the latter runs this view's change
+      // detection, and `afterRenderEffect` only flushes on an application tick.
+      TestBed.tick();
+    };
+
+    beforeEach(() => {
+      scrolled = [];
+      // jsdom leaves `scrollIntoView` unimplemented, so this is a stand-in as much as a spy. The
+      // element is recorded by test id because the assertion is about *which* chip moved.
+      Element.prototype.scrollIntoView = function (options?: boolean | ScrollIntoViewOptions) {
+        scrolled.push({ testId: (this as Element).getAttribute('data-testid'), options });
+      };
+
+      injectServices();
+      composer.open({ mode: 'create', projectUid: 'project-1' });
+      formService.initialize({ mode: 'create', projectUid: 'project-1' });
+    });
+
+    afterEach(() => {
+      Element.prototype.getClientRects = originalGetClientRects;
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    });
+
+    it('scrolls the active chip into view once the row is laid out', () => {
+      setLaidOut(true);
+
+      renderRail(true);
+
+      // `nearest`/`center` and not `smooth`: the row is scrolled sideways under an already-open
+      // composer, so this has to be the minimum movement that reveals the chip.
+      expect(scrolled).toEqual([{ testId: 'meeting-composer-rail-compact-details-access', options: { block: 'nearest', inline: 'center' } }]);
+    });
+
+    it('leaves the scroll position alone when the chip row is in the DOM but not laid out', () => {
+      // What `lg:hidden` produces: the query still finds the chip, and `getClientRects()` is empty for
+      // anything `display: none`. Scrolling here would move the page behind a row nobody can see.
+      setLaidOut(false);
+
+      renderRail(true);
+
+      expect(fixture.nativeElement.querySelector('[data-active-chip]')).not.toBeNull();
+      expect(scrolled).toEqual([]);
+    });
+
+    it('never scrolls in the vertical layout, however the rail is laid out', () => {
+      setLaidOut(true);
+
+      renderRail(false);
+
+      expect(scrolled).toEqual([]);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.spec.ts
@@ -1,0 +1,173 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
+import type { MeetingComposerRailRow, MeetingComposerSectionId } from '@lfx-one/shared/interfaces';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerRailComponent } from './meeting-composer-rail.component';
+import { MeetingComposerService } from './meeting-composer.service';
+
+/**
+ * Covers the rail's reachability state machine.
+ *
+ * It is the only surface that can put the organizer on a section out of order, so it has to agree with
+ * the footer's disabled Next in both directions: never open a section the footer wouldn't advance to,
+ * and never lock one the footer would. Both halves of that — the "first invalid required section"
+ * ceiling and the "one past the furthest visited" frontier — are asserted, because either one alone
+ * still passes the obvious cases: with only the ceiling, clearing the two required sections unlocks all
+ * three optional ones at once; with only the frontier, a blank required section is walkable past.
+ */
+describe('MeetingComposerRailComponent', () => {
+  let fixture: ComponentFixture<MeetingComposerRailComponent>;
+  let composer: MeetingComposerService;
+  let formService: MeetingComposerFormService;
+
+  const rows = (): MeetingComposerRailRow[] => fixture.componentInstance['rows']();
+  const row = (id: MeetingComposerSectionId): MeetingComposerRailRow => rows().find((candidate) => candidate.section.id === id)!;
+  const reachableIds = (): MeetingComposerSectionId[] =>
+    rows()
+      .filter((candidate) => candidate.reachable)
+      .map((candidate) => candidate.section.id);
+
+  /** Fills what `details-access` validates, which is what unblocks everything after it. */
+  const completeDetails = (): void => {
+    formService.form().get('title')?.setValue('Composer meeting');
+    formService.form().get('meeting_type')?.setValue('Board');
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        MeetingComposerService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        { provide: PersonaService, useValue: { currentPersona: () => null } },
+      ],
+    });
+    // Rendered rows are covered by the section-state assertions below; the template only branches on
+    // them. Dropping it keeps the fixture free of the icon/class markup and of `NgClass`.
+    TestBed.overrideComponent(MeetingComposerRailComponent, { set: { template: '', imports: [] } });
+
+    composer = TestBed.inject(MeetingComposerService);
+    formService = TestBed.inject(MeetingComposerFormService);
+  });
+
+  describe('create mode', () => {
+    beforeEach(() => {
+      composer.open({ mode: 'create', projectUid: 'project-1' });
+      formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+      fixture = TestBed.createComponent(MeetingComposerRailComponent);
+      fixture.detectChanges();
+    });
+
+    it('locks everything past the first required section while it is still empty', () => {
+      // `date-schedule` is valid from its own defaults, so a ceiling-only rule would already offer it.
+      expect(formService.isSectionValid('date-schedule')).toBe(true);
+      expect(reachableIds()).toEqual(['details-access']);
+    });
+
+    it('unlocks only the next section once the first one validates', () => {
+      completeDetails();
+
+      // Not `platform-features`: nothing is invalid any more, so this is the frontier doing the work.
+      expect(reachableIds()).toEqual(['details-access', 'date-schedule']);
+    });
+
+    it('advances the frontier one section per visit', () => {
+      completeDetails();
+      composer.setSection('date-schedule');
+
+      expect(reachableIds()).toEqual(['details-access', 'date-schedule', 'platform-features']);
+    });
+
+    it('re-locks the sections past a required one that was emptied again', () => {
+      completeDetails();
+      composer.setSection('date-schedule');
+      composer.setSection('platform-features');
+      formService.form().get('title')?.setValue('');
+
+      // Visited sections stay reachable up to the break, so the organizer can walk back to the field
+      // that broke — but nothing past it opens, even though `platform-features` was visited.
+      expect(reachableIds()).toEqual(['details-access']);
+    });
+
+    it('marks a section complete only after it has been visited', () => {
+      completeDetails();
+
+      // Valid out of the box, but a check mark on a section nobody has opened claims work that did not
+      // happen.
+      expect(row('date-schedule').complete).toBe(false);
+
+      composer.setSection('date-schedule');
+      composer.setSection('platform-features');
+
+      expect(row('date-schedule').complete).toBe(true);
+    });
+
+    it('never marks the section being edited complete', () => {
+      completeDetails();
+
+      expect(row('details-access').active).toBe(true);
+      expect(row('details-access').complete).toBe(false);
+    });
+
+    it('flags a visited required section that is still invalid, and nothing further ahead', () => {
+      completeDetails();
+      composer.setSection('date-schedule');
+      formService.form().get('title')?.setValue('');
+
+      expect(row('details-access').needsAttention).toBe(true);
+      // Unvisited: reporting it as broken would describe the form as failing before it was filled.
+      expect(row('agenda-resources').needsAttention).toBe(false);
+    });
+
+    it('ignores a click on an unreachable row and jumps on a reachable one', () => {
+      completeDetails();
+
+      fixture.componentInstance['onSelect'](row('agenda-resources'));
+      expect(composer.activeSection()).toBe('details-access');
+
+      fixture.componentInstance['onSelect'](row('date-schedule'));
+      expect(composer.activeSection()).toBe('date-schedule');
+    });
+
+    it('marks the last row so the connector line stops there', () => {
+      expect(rows().map((candidate) => candidate.isLast)).toEqual([false, false, false, false, true]);
+    });
+  });
+
+  describe('edit mode', () => {
+    beforeEach(() => {
+      composer.open({ mode: 'edit', meetingUid: 'meeting-1' });
+      // `initialize` is called without `meetingUid` on purpose: the fetch is what this test does not
+      // want, and the rail reads mode, not the meeting.
+      formService.initialize({ mode: 'edit' });
+
+      fixture = TestBed.createComponent(MeetingComposerRailComponent);
+      fixture.detectChanges();
+    });
+
+    it('leaves every section reachable however invalid the form is', () => {
+      expect(formService.isSectionValid('details-access')).toBe(false);
+      expect(reachableIds()).toEqual(MEETING_COMPOSER_SECTIONS.map((section) => section.id));
+    });
+
+    it('jumps to a section the create-mode rail would have locked', () => {
+      fixture.componentInstance['onSelect'](row('agenda-resources'));
+
+      expect(composer.activeSection()).toBe('agenda-resources');
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -60,7 +60,17 @@ export class MeetingComposerRailComponent {
       earlyRead: () => {
         this.composer.activeSection();
 
-        return this.compact() ? this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]') : null;
+        if (!this.compact()) {
+          return null;
+        }
+
+        const chip = this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]');
+
+        // `lg:hidden` is a CSS breakpoint, not an input, so this component has no signal that says
+        // whether its own chip row is on screen — at `lg` and up the row is still in the DOM and this
+        // query still finds the chip. `getClientRects()` is empty for anything `display: none`, which
+        // is the one reliable read of "laid out" available here.
+        return chip?.getClientRects().length ? chip : null;
       },
       // `scrollIntoView` reads layout before it scrolls, so it is a mixed read/write rather than the pure
       // write the `write` phase promises.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -2,6 +2,14 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!-- Quick create dialog (GH-1460) -->
+
+<!-- Declarative `<p-dialog>` rather than `DialogService.open()`, which `docs/reviews/frontend-checklist.md`
+     marks as the rule: this dialog is one of two surfaces the composer opens — the drawer is the other —
+     and both are driven off the same `MeetingComposerService` signals from a single always-mounted host,
+     so the open/close state has one owner and one lifecycle. `DialogService.open()` is imperative and
+     returns its own ref, which would split that ownership in two and leave the service's `isOpen()` and
+     the ref's lifetime to be kept in step by hand. Called out here so the deviation reads as a decision;
+     it is not the only one in the app (eight other templates mount `<p-dialog>` directly today). -->
 <p-dialog
   [visible]="composer.isOpen()"
   (visibleChange)="onVisibleChange($event)"
@@ -63,10 +71,13 @@
           styleClass="w-full min-h-[80px] max-h-[200px]"
           [rows]="4"
           [maxlength]="agendaMaxLength"
+          [ariaDescribedBy]="prefilledAgenda() ? 'quick-create-agenda-hint' : undefined"
           data-testid="quick-create-agenda-textarea" />
         <div class="flex items-center justify-between gap-2">
           @if (prefilledAgenda()) {
-            <p class="text-xs text-gray-500" data-testid="quick-create-agenda-hint">Suggested agenda template — adjust as needed.</p>
+            <p id="quick-create-agenda-hint" class="text-xs text-gray-500" data-testid="quick-create-agenda-hint">
+              Suggested agenda template — adjust as needed.
+            </p>
           }
           <p class="ml-auto text-xs" [ngClass]="agendaCounterClass()">{{ agendaLength() }}/{{ agendaMaxLength }}</p>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
@@ -146,7 +146,9 @@
                 [title]="attachment.name">
                 {{ attachment.name }}
               </span>
-              @if (attachment.file_size) {
+              <!-- Null check, not truthiness: `file_size` is optional, and a genuine 0-byte upload
+                   still has a size to show — `FileSizePipe` renders it as "0 B". -->
+              @if (attachment.file_size !== null && attachment.file_size !== undefined) {
                 <span class="flex-shrink-0 text-xs text-gray-400">{{ attachment.file_size | fileSize }}</span>
               }
             </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -79,6 +79,10 @@
     @if (form().get('duration')?.value === 'custom') {
       <div class="flex flex-col gap-1.5">
         <div class="flex items-center gap-2">
+          <!-- Visually hidden: the chip group's "Duration" label names the group, and the adjacent
+               "minutes" is a unit — neither gives this input an accessible name of its own. `id`
+               lands on the real <input> in `InputNumberComponent`, so `for` associates correctly. -->
+          <label class="sr-only" for="composer-custom-duration">Custom duration in minutes</label>
           <lfx-input-number
             [form]="form()"
             control="customDuration"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -72,7 +72,8 @@
         placeholder="Select meeting type…"
         styleClass="w-full"
         scrollHeight="330px"
-        dataTest="composer-meeting-type-select">
+        dataTest="composer-meeting-type-select"
+        data-testid="composer-meeting-type-select">
         <!-- `checkmark` is off: PrimeNG puts its own tick on the left, and the design marks the
              selected row on the right, past the description -->
         <ng-template #item let-option>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
@@ -81,33 +81,31 @@
         </div>
 
         <ul class="flex max-h-96 flex-col gap-2 overflow-y-auto rounded-lg border border-gray-200 p-3" data-testid="composer-guests-list">
-          @for (guest of visibleGuests(); track guest.uid || guest.tempId) {
+          @for (row of guestRows(); track row.trackId) {
             <li class="flex items-center gap-3 rounded-md border border-gray-200 p-3">
               <span class="flex h-8 w-8 flex-none items-center justify-center rounded-full bg-gray-100 text-xs font-semibold text-gray-600" aria-hidden="true">
-                {{ initials(guest) }}
+                {{ row.initials }}
               </span>
               <div class="flex min-w-0 flex-1 flex-col">
                 <div class="flex items-center gap-2">
-                  <span class="truncate text-sm font-medium text-gray-900" [title]="guest.first_name + ' ' + guest.last_name">
-                    {{ guest.first_name }} {{ guest.last_name }}
-                  </span>
-                  @if (guest.host) {
+                  <span class="truncate text-sm font-medium text-gray-900" [title]="row.displayName">{{ row.displayName }}</span>
+                  @if (row.guest.host) {
                     <span class="flex-none rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">Host</span>
                   }
                 </div>
-                <span class="truncate text-xs text-gray-500" [title]="secondaryLine(guest)">{{ secondaryLine(guest) }}</span>
+                <span class="truncate text-xs text-gray-500" [title]="row.secondaryLine">{{ row.secondaryLine }}</span>
               </div>
-              @if (guest.committee_name) {
-                <span class="max-w-[8rem] shrink truncate rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600" [title]="guest.committee_name">
-                  via {{ guest.committee_name }}
+              @if (row.guest.committee_name) {
+                <span class="max-w-[8rem] shrink truncate rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600" [title]="row.guest.committee_name">
+                  via {{ row.guest.committee_name }}
                 </span>
               }
               <button
                 type="button"
                 class="flex-none rounded-md p-2 text-gray-400 hover:bg-gray-50 hover:text-red-600"
-                [attr.aria-label]="'Remove ' + guest.first_name + ' ' + guest.last_name"
-                (click)="onRemoveGuest(guest)"
-                [attr.data-testid]="'composer-guest-remove-' + (guest.uid || guest.tempId)">
+                [attr.aria-label]="'Remove ' + row.displayName"
+                (click)="onRemoveGuest(row.guest)"
+                [attr.data-testid]="'composer-guest-remove-' + row.trackId">
                 <i class="fa-light fa-xmark" aria-hidden="true"></i>
               </button>
             </li>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -7,7 +7,7 @@ import { FormGroup } from '@angular/forms';
 import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggle.component';
 import { UserSearchComponent } from '@components/user-search/user-search.component';
 import { COMMITTEE_LABEL, SHOW_MEETING_ATTENDEES_FEATURE } from '@lfx-one/shared/constants';
-import type { CommitteeMember, ManualGuestDialogResult, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
+import type { ComposerGuestRow, CommitteeMember, ManualGuestDialogResult, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
 import { avatarInitials } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -48,16 +48,24 @@ export class ComposerGuestsComponent {
   protected readonly groupGuestCount = computed(() => this.visibleGuests().filter((guest) => guest.type === 'committee').length);
   protected readonly directGuestCount = computed(() => this.visibleGuests().filter((guest) => guest.type === 'direct').length);
 
+  /**
+   * The guest list, with every derived string resolved once per change.
+   * @description Rendered instead of `visibleGuests()` directly: these strings used to be method
+   * calls in the template, which Angular re-evaluates on every change-detection pass — the display
+   * name three times per row and the secondary line twice. Computing them here runs each once per
+   * guest, and only when the list itself changes.
+   */
+  protected readonly guestRows = computed<ComposerGuestRow[]>(() =>
+    this.visibleGuests().map((guest) => ({
+      guest,
+      trackId: guest.uid || guest.tempId || '',
+      initials: avatarInitials(guest.first_name, guest.last_name, guest.email),
+      displayName: `${guest.first_name} ${guest.last_name}`,
+      secondaryLine: [guest.email, guest.org_name].filter(Boolean).join(' · '),
+    }))
+  );
+
   private readonly invitedEmails: Signal<Set<string>> = computed(() => new Set(this.visibleGuests().map((guest) => guest.email?.toLowerCase() ?? '')));
-
-  protected initials(guest: MeetingRegistrantWithState): string {
-    return avatarInitials(guest.first_name, guest.last_name, guest.email);
-  }
-
-  /** `email · org` secondary line, collapsing to just the email when the org is unknown. */
-  protected secondaryLine(guest: MeetingRegistrantWithState): string {
-    return [guest.email, guest.org_name].filter(Boolean).join(' · ');
-  }
 
   /**
    * Adds the person picked from search, or falls back to the manual dialog.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -55,15 +55,7 @@ export class ComposerGuestsComponent {
    * name three times per row and the secondary line twice. Computing them here runs each once per
    * guest, and only when the list itself changes.
    */
-  protected readonly guestRows = computed<ComposerGuestRow[]>(() =>
-    this.visibleGuests().map((guest) => ({
-      guest,
-      trackId: guest.uid || guest.tempId || '',
-      initials: avatarInitials(guest.first_name, guest.last_name, guest.email),
-      displayName: `${guest.first_name} ${guest.last_name}`,
-      secondaryLine: [guest.email, guest.org_name].filter(Boolean).join(' · '),
-    }))
-  );
+  protected readonly guestRows: Signal<ComposerGuestRow[]> = this.initGuestRows();
 
   private readonly invitedEmails: Signal<Set<string>> = computed(() => new Set(this.visibleGuests().map((guest) => guest.email?.toLowerCase() ?? '')));
 
@@ -118,6 +110,29 @@ export class ComposerGuestsComponent {
 
   protected onCommitteeMembersChange(members: CommitteeMember[]): void {
     this.formService.syncCommitteeMembers(members);
+  }
+
+  private initGuestRows(): Signal<ComposerGuestRow[]> {
+    return computed(() =>
+      this.visibleGuests().map((guest, index) => ({
+        guest,
+        // The index is the last resort, not the preferred key: it is unstable across a reorder,
+        // which is exactly what `track` exists to survive. It is still better than the `''` it
+        // replaced — two uid-less, tempId-less guests would both key on the empty string, and a
+        // duplicate `track` key is a runtime error rather than a degraded animation. Nothing
+        // produces such a guest today (`newGuestDefaults` always stamps a `tempId`, and loaded
+        // registrants carry a `uid`), so this arm only fires if upstream returns one with neither.
+        trackId: guest.uid || guest.tempId || guest.email || `guest-${index}`,
+        initials: avatarInitials(guest.first_name, guest.last_name, guest.email),
+        // Filtered and joined rather than interpolated into a template literal. The template this
+        // replaced rendered the two names with `{{ }}`, which prints nothing for a nullish value; a
+        // literal prints the string `"undefined"`. Both names are typed as required, so this only
+        // matters for a registrant that arrives from upstream without one — but that is exactly the
+        // row where a visible `"undefined"` would be worst.
+        displayName: [guest.first_name, guest.last_name].filter(Boolean).join(' '),
+        secondaryLine: [guest.email, guest.org_name].filter(Boolean).join(' · '),
+      }))
+    );
   }
 
   private openManualDialog(prefill: Record<string, unknown> | null): void {

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
@@ -13,7 +13,7 @@
     [class]="styleClass()"
     [autoResize]="autoResize()"
     [attr.maxlength]="maxlength() || null"
-    [attr.aria-describedby]="describedBy() || null"
+    [attr.aria-describedby]="describedByIds()"
     [attr.aria-invalid]="invalid() ? true : null"
     [attr.aria-required]="required() ? true : null"
     [attr.data-test]="dataTest()"></textarea>

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input, Signal } from '@angular/core';
+import { Component, computed, input, Signal } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TextareaModule } from 'primeng/textarea';
 
@@ -36,6 +36,14 @@ export class TextareaComponent {
    * not for a value written programmatically with `setValue`.
    */
   public maxlength = input<number>();
+  /**
+   * Id of the element that describes this field, wired through as `aria-describedby`.
+   * @description A hint rendered next to the textarea is invisible to a screen reader unless the
+   * field points at it, and the hint lives in the caller's template — only the caller knows which
+   * one applies and when. Bound as an attribute so an unset value emits nothing rather than an
+   * `aria-describedby` pointing at `""`.
+   */
+  public ariaDescribedBy = input<string>();
   public dataTest = input<string>();
   /** id of the element describing a validation error (wired to aria-describedby). */
   public describedBy = input<string>();
@@ -43,4 +51,16 @@ export class TextareaComponent {
   public invalid = input<boolean>(false);
   /** Marks the control mandatory for assistive tech (wired to aria-required). */
   public required = input<boolean>(false);
+
+  /**
+   * The two description hooks joined, because they share one attribute.
+   * @description A field can carry a standing hint (`ariaDescribedBy`) and a transient validation
+   * error (`describedBy`) at the same time; letting either win would silently drop the other for a
+   * screen reader. Null rather than `''` so an unset pair emits no attribute at all.
+   */
+  protected readonly describedByIds: Signal<string | null> = this.initDescribedByIds();
+
+  private initDescribedByIds(): Signal<string | null> {
+    return computed(() => [this.ariaDescribedBy(), this.describedBy()].filter((id): id is string => !!id).join(' ') || null);
+  }
 }

--- a/apps/lfx-one/src/server/constants/index.ts
+++ b/apps/lfx-one/src/server/constants/index.ts
@@ -6,5 +6,6 @@ export * from './meta.constants';
 export * from './public-profile.constants';
 export * from './query-service.constants';
 export * from './reddit.constants';
+export * from './registrant.constants';
 export * from './rewards.constants';
 export * from './weekly-brief.constants';

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -4,34 +4,36 @@
 import { CreateMeetingRegistrantRequest, UpdateMeetingRegistrantRequest } from '@lfx-one/shared/interfaces';
 
 /**
- * Registrant fields the app carries but ITX does not accept under that name.
+ * Registrant fields the outbound mapper drops whatever their value is.
  *
- * `MeetingService.toUpstreamRegistrantBody` deletes all four from the outbound body: `meeting_id`
- * because the meeting is addressed by the path, and the other three because they are re-emitted
- * under ITX's spelling (`org`, `profile_picture`, `occurrence`).
- *
- * Typed as the *intersection* of the two request interfaces rather than a union: a union only
- * rejects a key once it is gone from both, so renaming it on one of them would still compile while
- * the delete quietly stopped matching. All four exist on both, so this fails the build on either
- * rename.
+ * Only `meeting_id` today: the meeting is addressed by the path, so ITX has no field to put it in.
+ * A key here can never reach upstream, which is why `MeetingController.hasRegistrantChanges` treats
+ * one as no change at all rather than as a change whose value happens to be nullish.
  */
-export const APP_ONLY_REGISTRANT_KEYS = [
-  'meeting_id',
-  'org_name',
-  'avatar_url',
-  'occurrence_id',
-] as const satisfies readonly (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[];
+export const UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS = ['meeting_id'] as const satisfies readonly (keyof CreateMeetingRegistrantRequest &
+  keyof UpdateMeetingRegistrantRequest)[];
 
 /**
- * The subset of {@link APP_ONLY_REGISTRANT_KEYS} that is re-emitted under ITX's spelling, and so
- * disappears from the outbound body entirely when the value is nullish.
+ * Registrant fields the app carries that ITX accepts only under a different name.
  *
- * `MeetingController.hasRegistrantChanges` reads this to decide whether an update actually asks for
- * anything: `{ "org_name": null }` maps to `{}` upstream, so counting it as a change would forward
- * the empty write the guard exists to reject. Both sites read the same list so they cannot drift.
+ * `MeetingService.toUpstreamRegistrantBody` re-emits these three as `org`, `profile_picture` and
+ * `occurrence`, but only when the value is non-nullish — so a nullish one disappears from the
+ * outbound body entirely. `MeetingController.hasRegistrantChanges` reads this to decide whether an
+ * update actually asks for anything: `{ "org_name": null }` maps to `{}` upstream, so counting it as
+ * a change would forward the empty write the guard exists to reject.
  */
-export const NULLISH_DROPPED_REGISTRANT_KEYS = [
-  'org_name',
-  'avatar_url',
-  'occurrence_id',
-] as const satisfies readonly (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[];
+export const NULLISH_DROPPED_REGISTRANT_KEYS = ['org_name', 'avatar_url', 'occurrence_id'] as const satisfies readonly (keyof CreateMeetingRegistrantRequest &
+  keyof UpdateMeetingRegistrantRequest)[];
+
+/**
+ * Every registrant field the app carries but ITX does not accept under that name.
+ *
+ * `MeetingService.toUpstreamRegistrantBody` deletes all of them from the outbound body. Composed
+ * from the two halves above rather than written out again, so the mapper and the
+ * `hasRegistrantChanges` guard cannot disagree about which keys exist: adding a key to either half
+ * updates the delete loop and the guard in the same edit. Both halves are typed as the
+ * *intersection* of the two request interfaces rather than a union — a union only rejects a key once
+ * it is gone from both, so renaming it on one of them would still compile while the delete quietly
+ * stopped matching.
+ */
+export const APP_ONLY_REGISTRANT_KEYS = [...UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS, ...NULLISH_DROPPED_REGISTRANT_KEYS] as const;

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -1,0 +1,37 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CreateMeetingRegistrantRequest, UpdateMeetingRegistrantRequest } from '@lfx-one/shared/interfaces';
+
+/**
+ * Registrant fields the app carries but ITX does not accept under that name.
+ *
+ * `MeetingService.toUpstreamRegistrantBody` deletes all four from the outbound body: `meeting_id`
+ * because the meeting is addressed by the path, and the other three because they are re-emitted
+ * under ITX's spelling (`org`, `profile_picture`, `occurrence`).
+ *
+ * Typed as the *intersection* of the two request interfaces rather than a union: a union only
+ * rejects a key once it is gone from both, so renaming it on one of them would still compile while
+ * the delete quietly stopped matching. All four exist on both, so this fails the build on either
+ * rename.
+ */
+export const APP_ONLY_REGISTRANT_KEYS = [
+  'meeting_id',
+  'org_name',
+  'avatar_url',
+  'occurrence_id',
+] as const satisfies readonly (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[];
+
+/**
+ * The subset of {@link APP_ONLY_REGISTRANT_KEYS} that is re-emitted under ITX's spelling, and so
+ * disappears from the outbound body entirely when the value is nullish.
+ *
+ * `MeetingController.hasRegistrantChanges` reads this to decide whether an update actually asks for
+ * anything: `{ "org_name": null }` maps to `{}` upstream, so counting it as a change would forward
+ * the empty write the guard exists to reject. Both sites read the same list so they cannot drift.
+ */
+export const NULLISH_DROPPED_REGISTRANT_KEYS = [
+  'org_name',
+  'avatar_url',
+  'occurrence_id',
+] as const satisfies readonly (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[];

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -14,16 +14,35 @@ export const UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS = ['meeting_id'] as const s
   keyof UpdateMeetingRegistrantRequest)[];
 
 /**
- * Registrant fields the app carries that ITX accepts only under a different name.
+ * Registrant fields the app carries that ITX accepts only under a different name, mapped to it.
  *
- * `MeetingService.toUpstreamRegistrantBody` re-emits these three as `org`, `profile_picture` and
- * `occurrence`, but only when the value is non-nullish — so a nullish one disappears from the
- * outbound body entirely. `MeetingController.hasRegistrantChanges` reads this to decide whether an
- * update actually asks for anything: `{ "org_name": null }` maps to `{}` upstream, so counting it as
- * a change would forward the empty write the guard exists to reject.
+ * The app's read model comes from the v1 query-service index, not from ITX, and spells these three
+ * `org_name`, `avatar_url` and `occurrence_id`; `CreateItxRegistrantRequestBody` declares them `org`,
+ * `profile_picture` and `occurrence`. Goa silently ignores body keys it doesn't declare, so an
+ * unrenamed key is dropped upstream behind a 201.
+ *
+ * A map rather than a list of names because `MeetingService.toUpstreamRegistrantBody` has to do two
+ * things with each of these — delete the app-side key and re-emit the value under the upstream one —
+ * and those were previously written out in two places. A fourth key added to a bare list would have
+ * been deleted from the outbound body and then never re-emitted: silent data loss, no type error.
+ * Here one entry drives both halves.
+ *
+ * `MeetingController.hasRegistrantChanges` reads the key side to decide whether an update actually
+ * asks for anything: a nullish value on one of these is omitted rather than renamed, so
+ * `{ "org_name": null }` maps to `{}` upstream and counting it as a change would forward the empty
+ * write the guard exists to reject.
  */
-export const NULLISH_DROPPED_REGISTRANT_KEYS = ['org_name', 'avatar_url', 'occurrence_id'] as const satisfies readonly (keyof CreateMeetingRegistrantRequest &
-  keyof UpdateMeetingRegistrantRequest)[];
+export const RENAMED_REGISTRANT_KEYS = {
+  org_name: 'org',
+  avatar_url: 'profile_picture',
+  occurrence_id: 'occurrence',
+} as const satisfies Partial<Record<keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest, string>>;
+
+/**
+ * The app-side names of {@link RENAMED_REGISTRANT_KEYS} — the keys dropped when, and only when, the
+ * value is nullish.
+ */
+export const NULLISH_DROPPED_REGISTRANT_KEYS = Object.keys(RENAMED_REGISTRANT_KEYS) as (keyof typeof RENAMED_REGISTRANT_KEYS)[];
 
 /**
  * Every registrant field the app carries but ITX does not accept under that name.
@@ -31,8 +50,8 @@ export const NULLISH_DROPPED_REGISTRANT_KEYS = ['org_name', 'avatar_url', 'occur
  * `MeetingService.toUpstreamRegistrantBody` deletes all of them from the outbound body. Composed
  * from the two halves above rather than written out again, so the mapper and the
  * `hasRegistrantChanges` guard cannot disagree about which keys exist: adding a key to either half
- * updates the delete loop and the guard in the same edit. Both halves are typed as the
- * *intersection* of the two request interfaces rather than a union — a union only rejects a key once
+ * updates the delete loop, the upstream re-emit, and the guard in the same edit. Both halves are
+ * keyed on the *intersection* of the two request interfaces rather than a union — a union only rejects a key once
  * it is gone from both, so renaming it on one of them would still compile while the delete quietly
  * stopped matching.
  */

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { ValidationError } from '@lfx-one/shared/interfaces';
 import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -91,15 +92,32 @@ vi.mock('../services/logger.service', () => ({
   },
 }));
 
+/**
+ * Stand-in for `ServiceValidationError`, mirroring the field the real class exposes.
+ *
+ * `../errors` is mocked so these tests don't drag in `BaseApiError` and the shared constants behind
+ * it, but the double carries `validationErrors: ValidationError[]` — the real class's own property,
+ * populated by its own factories' rules — rather than a convenient `fields` map. A double with a
+ * shape of its own lets an assertion pin a contract that exists nowhere but this file: it would keep
+ * passing after the production error changed, and it silently discarded the `message` that
+ * `forField` is called with, which is the part a caller actually reads.
+ */
 class FakeValidationError extends Error {
-  public constructor(public readonly fields: unknown) {
+  public constructor(public readonly validationErrors: ValidationError[]) {
     super('validation');
   }
 }
 vi.mock('../errors', () => ({
   ServiceValidationError: {
-    forField: (field: string) => new FakeValidationError({ [field]: 'required' }),
-    fromFieldErrors: (fields: unknown) => new FakeValidationError(fields),
+    forField: (field: string, message: string) => new FakeValidationError([{ field, message, code: 'FIELD_VALIDATION_ERROR' }]),
+    fromFieldErrors: (fieldErrors: Record<string, string | string[]>) =>
+      new FakeValidationError(
+        Object.entries(fieldErrors).map(([field, messages]) => ({
+          field,
+          message: Array.isArray(messages) ? messages.join(', ') : messages,
+          code: 'FIELD_VALIDATION_ERROR',
+        }))
+      ),
   },
 }));
 
@@ -115,7 +133,7 @@ function buildRes(): Response {
 
 function buildReq(overrides: Partial<Request> = {}, headers: Record<string, string> = {}): Request {
   // `get` is stubbed because the registrant batch endpoints read `content-length` off the request for
-  // their `content_length` log field. These reqs are built by hand rather than sent over HTTP, so no
+  // their `request_content_length` log field. These reqs are built by hand rather than sent over HTTP, so no
   // header exists unless a test asks for one — which is also the state a chunked request arrives in,
   // and what exercises `readContentLength`'s `null` fallback.
   return {
@@ -364,7 +382,7 @@ describe('MeetingController', () => {
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
       expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
-      expect(next).toHaveBeenCalledWith(expect.objectContaining({ fields: { 'registrants.email': 'required' } }));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ validationErrors: [expect.objectContaining({ field: 'registrants.email' })] }));
       expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
     });
 
@@ -373,17 +391,37 @@ describe('MeetingController', () => {
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
-      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ content_length: 2048 }));
+      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ request_content_length: 2048 }));
     });
 
-    it('records a null content length when the request declares none', async () => {
-      const req = buildReq({ body: [{ email: 'a@example.com' }] });
+    // `null`, not `0`: a chunked request omits the header, and logging it as `0` would make it
+    // indistinguishable from a declared empty body. The empty-string case is the one that regresses
+    // silently — `Number('')` is `0`, so a header that arrives blank lands on exactly the value the
+    // `null` exists to stay distinct from — and the malformed cases would otherwise log a byte count
+    // no real request can produce.
+    it.each([
+      ['declares none', undefined],
+      ['sends an empty header', ''],
+      ['sends a whitespace-only header', '   '],
+      ['sends a non-numeric header', 'abc'],
+      ['sends a negative header', '-1'],
+      ['sends a fractional header', '12.5'],
+    ])('records a null content length when the request %s', async (_label, header) => {
+      const req = buildReq({ body: [{ email: 'a@example.com' }] }, header === undefined ? {} : { 'content-length': header });
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
-      // `null`, not `0`: a chunked request omits the header, and logging it as `0` would make it
-      // indistinguishable from an empty body.
-      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ content_length: null }));
+      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ request_content_length: null }));
+    });
+
+    it('records a zero content length when the request explicitly declares one', async () => {
+      const req = buildReq({ body: [{ email: 'a@example.com' }] }, { 'content-length': '0' });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      // A declared `0` is a measurement, not a missing header, so it is kept as `0` — that is the
+      // distinction the `null` above is protecting.
+      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ request_content_length: 0 }));
     });
   });
 
@@ -438,19 +476,20 @@ describe('MeetingController', () => {
       await controller.updateMeetingRegistrants(req, buildRes(), next);
 
       expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
-      expect(next).toHaveBeenCalledWith(expect.objectContaining({ fields: { 'registrants.changes': 'required' } }));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ validationErrors: [expect.objectContaining({ field: 'registrants.changes' })] }));
       expect(meetingSvc.updateMeetingRegistrant).not.toHaveBeenCalled();
     });
 
-    // Spreading `null` is legal and yields `{}`, so the body map doesn't throw — the entry simply
-    // arrives with no UID, and the UID check is what turns it away.
+    // The body map reads the entry rather than spreading it — `update?.uid ?? ''` and
+    // `stripCommitteeUid(update?.changes)`, both null-safe — so a `null` entry doesn't throw. It
+    // simply arrives with an empty UID, and the UID check is what turns it away.
     it('rejects a null entry on the missing-UID check rather than throwing', async () => {
       const req = buildReq({ body: [null] });
 
       await controller.updateMeetingRegistrants(req, buildRes(), next);
 
       expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
-      expect(next).toHaveBeenCalledWith(expect.objectContaining({ fields: { 'registrants.uid': 'required' } }));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ validationErrors: [expect.objectContaining({ field: 'registrants.uid' })] }));
       expect(meetingSvc.updateMeetingRegistrant).not.toHaveBeenCalled();
     });
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -99,19 +99,29 @@ vi.mock('../services/logger.service', () => ({
  * it, but the double carries `validationErrors: ValidationError[]` — the real class's own property,
  * populated by its own factories' rules — rather than a convenient `fields` map. A double with a
  * shape of its own lets an assertion pin a contract that exists nowhere but this file: it would keep
- * passing after the production error changed, and it silently discarded the `message` that
- * `forField` is called with, which is the part a caller actually reads.
+ * passing after the production error changed.
+ *
+ * The two factories' `message` strings are mirrored too, including the detail that `forField`
+ * *discards* the message it is handed and reports `Validation failed for <field>` instead, putting
+ * the caller's message only inside `validationErrors`. An earlier version of this double passed the
+ * message straight to `super()`, which would have let a handler that reads `err.message` pass here
+ * and report something else in production.
  */
 class FakeValidationError extends Error {
-  public constructor(public readonly validationErrors: ValidationError[]) {
-    super('validation');
+  public constructor(
+    message: string,
+    public readonly validationErrors: ValidationError[]
+  ) {
+    super(message);
   }
 }
 vi.mock('../errors', () => ({
   ServiceValidationError: {
-    forField: (field: string, message: string) => new FakeValidationError([{ field, message, code: 'FIELD_VALIDATION_ERROR' }]),
+    forField: (field: string, message: string) =>
+      new FakeValidationError(`Validation failed for ${field}`, [{ field, message, code: 'FIELD_VALIDATION_ERROR' }]),
     fromFieldErrors: (fieldErrors: Record<string, string | string[]>) =>
       new FakeValidationError(
+        'Validation failed',
         Object.entries(fieldErrors).map(([field, messages]) => ({
           field,
           message: Array.isArray(messages) ? messages.join(', ') : messages,
@@ -406,6 +416,9 @@ describe('MeetingController', () => {
       ['sends a non-numeric header', 'abc'],
       ['sends a negative header', '-1'],
       ['sends a fractional header', '12.5'],
+      ['sends a hexadecimal header', '0x10'],
+      ['sends an exponent-notation header', '1e3'],
+      ['sends a signed header', '+8'],
     ])('records a null content length when the request %s', async (_label, header) => {
       const req = buildReq({ body: [{ email: 'a@example.com' }] }, header === undefined ? {} : { 'content-length': header });
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -34,6 +34,10 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock, gene
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 // `MeetingType` is imported as a value (the controller narrows client input against
 // `Object.values(MeetingType)`), so the stub has to carry the real members rather than being empty.
+// Kept in sync with `MeetingType` in `packages/shared/src/enums/meeting.enum.ts` by hand — `vi.mock`
+// factories are hoisted, so they can't import the real enum to derive from. A member added upstream
+// and missed here shows up as a narrowing test that rejects a type the controller actually accepts,
+// not as a false pass: every assertion below tests a value against the stub's own member list.
 vi.mock('@lfx-one/shared/enums', () => ({
   MeetingType: {
     BOARD: 'Board',
@@ -110,7 +114,19 @@ function buildRes(): Response {
 }
 
 function buildReq(overrides: Partial<Request> = {}): Request {
-  return { params: { uid: MEETING_ID }, query: {}, body: {}, path: '/api/meetings', ...overrides } as unknown as Request;
+  // `get` is stubbed because the registrant batch endpoints read `content-length` off the request for
+  // their `body_size` log field. Returning `undefined` is the honest default — Express omits the
+  // header on a bodyless request — and exercises the `?? 0` fallback rather than papering over it.
+  const headers: Record<string, string | undefined> = { 'content-length': undefined };
+
+  return {
+    params: { uid: MEETING_ID },
+    query: {},
+    body: {},
+    path: '/api/meetings',
+    get: (name: string) => headers[name.toLowerCase()],
+    ...overrides,
+  } as unknown as Request;
 }
 
 describe('MeetingController', () => {
@@ -329,6 +345,25 @@ describe('MeetingController', () => {
       expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
       expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
     });
+
+    // `email` is the only identity a new registrant has, and `createBatchResponse` keys its per-item
+    // results by it — so an entry without one used to reach upstream as a create carrying nothing but
+    // the meeting UID and come back keyed by `undefined`. Spreading `null` is legal, so the mapping
+    // itself never threw; the entry just stopped looking empty once `meeting_id` was added.
+    it.each([
+      ['a null entry', [null]],
+      ['an empty object', [{}]],
+      ['a blank email', [{ email: '   ' }]],
+      ['a non-string email', [{ email: 42 }]],
+    ])('rejects %s rather than creating a registrant with no email', async (_label, body) => {
+      const req = buildReq({ body });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
+      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateMeetingRegistrants', () => {
@@ -351,18 +386,30 @@ describe('MeetingController', () => {
     // The body map runs before `startOperation` and outside the `try`, and `routes/meetings.route.ts`
     // registers a bare async arrow that Express 4 does not catch — so a throw here is an unhandled
     // rejection that kills the SSR worker with no log line at all. `changes` and the array-ness of the
-    // body are compile-time guarantees only; both of these bodies are reachable over HTTP.
-    it('handles an entry that omits changes instead of throwing', async () => {
-      meetingSvc.updateMeetingRegistrant.mockImplementation((_req: Request, _uid: string, _regUid: string, changes: Record<string, unknown>) =>
-        Promise.resolve(changes)
-      );
-      const req = buildReq({ body: [{ uid: 'reg-1' }] });
+    // body are compile-time guarantees only; every body below is reachable over HTTP.
+    //
+    // Rejected rather than forwarded, and both halves matter. Not throwing is the unhandled-rejection
+    // guarantee; the 400 is what stops an entry with nothing to apply from reaching upstream as a
+    // `PUT .../registrants/reg-1` carrying a literal `{}` — an empty write whose field semantics are
+    // ITX's to define, echoed back to the client as the "updated" registrant.
+    it.each([
+      ['omits changes', [{ uid: 'reg-1' }]],
+      ['sends an empty changes object', [{ uid: 'reg-1', changes: {} }]],
+      // `Object.keys('ab')` is `['0', '1']`, so a primitive would count as two changes if the guard
+      // read keys without checking the type first.
+      ['sends a primitive as changes', [{ uid: 'reg-1', changes: 'ab' }]],
+      // `committee_uid` is stripped before forwarding, so an entry carrying only that key still
+      // forwards an empty write.
+      ['sends only a committee_uid', [{ uid: 'reg-1', changes: { committee_uid: V1_COMMITTEE_SFID } }]],
+      ['sends a null entry', [null]],
+    ])('rejects an entry that %s instead of forwarding an empty write', async (_label, body) => {
+      const req = buildReq({ body });
 
       await controller.updateMeetingRegistrants(req, buildRes(), next);
 
       expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
-      const [, , , forwarded] = meetingSvc.updateMeetingRegistrant.mock.calls[0];
-      expect(forwarded).toEqual({ meeting_id: MEETING_ID });
+      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(meetingSvc.updateMeetingRegistrant).not.toHaveBeenCalled();
     });
 
     it('rejects a non-array body as a validation error rather than throwing', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -113,12 +113,11 @@ function buildRes(): Response {
   return res;
 }
 
-function buildReq(overrides: Partial<Request> = {}): Request {
+function buildReq(overrides: Partial<Request> = {}, headers: Record<string, string> = {}): Request {
   // `get` is stubbed because the registrant batch endpoints read `content-length` off the request for
-  // their `body_size` log field. Returning `undefined` is the honest default — Express omits the
-  // header on a bodyless request — and exercises the `?? 0` fallback rather than papering over it.
-  const headers: Record<string, string | undefined> = { 'content-length': undefined };
-
+  // their `content_length` log field. These reqs are built by hand rather than sent over HTTP, so no
+  // header exists unless a test asks for one — which is also the state a chunked request arrives in,
+  // and what exercises `readContentLength`'s `null` fallback.
   return {
     params: { uid: MEETING_ID },
     query: {},
@@ -346,10 +345,14 @@ describe('MeetingController', () => {
       expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
     });
 
-    // `email` is the only identity a new registrant has, and `createBatchResponse` keys its per-item
-    // results by it — so an entry without one used to reach upstream as a create carrying nothing but
-    // the meeting UID and come back keyed by `undefined`. Spreading `null` is legal, so the mapping
-    // itself never threw; the entry just stopped looking empty once `meeting_id` was added.
+    // `email` is the only identity a new registrant has, and the per-failure log line is keyed by it —
+    // so an entry without one used to reach upstream as a create with a literal `{}` body (the mapper
+    // deletes the `meeting_id` added here) and be logged against `undefined`. Spreading `null` is
+    // legal, so the mapping itself never threw; the entry just stopped looking empty once
+    // `meeting_id` was added.
+    //
+    // The asserted field name is what distinguishes the email guard from the two checks that run
+    // before it — without it these cases would keep passing if the guard were deleted.
     it.each([
       ['a null entry', [null]],
       ['an empty object', [{}]],
@@ -361,8 +364,26 @@ describe('MeetingController', () => {
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
       expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
-      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ fields: { 'registrants.email': 'required' } }));
       expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
+    });
+
+    it('records the declared content length on the operation when the request carries the header', async () => {
+      const req = buildReq({ body: [{ email: 'a@example.com' }] }, { 'content-length': '2048' });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ content_length: 2048 }));
+    });
+
+    it('records a null content length when the request declares none', async () => {
+      const req = buildReq({ body: [{ email: 'a@example.com' }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      // `null`, not `0`: a chunked request omits the header, and logging it as `0` would make it
+      // indistinguishable from an empty body.
+      expect(logger.startOperation).toHaveBeenCalledWith(req, 'add_meeting_registrants', expect.objectContaining({ content_length: null }));
     });
   });
 
@@ -392,6 +413,10 @@ describe('MeetingController', () => {
     // guarantee; the 400 is what stops an entry with nothing to apply from reaching upstream as a
     // `PUT .../registrants/reg-1` carrying a literal `{}` — an empty write whose field semantics are
     // ITX's to define, echoed back to the client as the "updated" registrant.
+    // Each case asserts `registrants.changes` specifically. Asserting only `FakeValidationError`
+    // would let a case pass on one of the two checks that run first — `[null]` in particular is
+    // rejected for its missing UID and never reaches this guard at all, which is why it's a separate
+    // test below rather than a row here.
     it.each([
       ['omits changes', [{ uid: 'reg-1' }]],
       ['sends an empty changes object', [{ uid: 'reg-1', changes: {} }]],
@@ -401,15 +426,43 @@ describe('MeetingController', () => {
       // `committee_uid` is stripped before forwarding, so an entry carrying only that key still
       // forwards an empty write.
       ['sends only a committee_uid', [{ uid: 'reg-1', changes: { committee_uid: V1_COMMITTEE_SFID } }]],
-      ['sends a null entry', [null]],
+      // The three keys below survive `stripCommitteeUid` but not `toUpstreamRegistrantBody`:
+      // `meeting_id` is deleted outright, and the renamed fields are dropped when nullish. Counting
+      // raw keys let all three through the guard and into the empty `PUT` it exists to reject.
+      ['sends only a meeting_id', [{ uid: 'reg-1', changes: { meeting_id: MEETING_ID } }]],
+      ['sends only a null org_name', [{ uid: 'reg-1', changes: { org_name: null } }]],
+      ['sends only nullish renamed fields', [{ uid: 'reg-1', changes: { org_name: null, avatar_url: undefined, occurrence_id: null } }]],
     ])('rejects an entry that %s instead of forwarding an empty write', async (_label, body) => {
       const req = buildReq({ body });
 
       await controller.updateMeetingRegistrants(req, buildRes(), next);
 
       expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
-      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ fields: { 'registrants.changes': 'required' } }));
       expect(meetingSvc.updateMeetingRegistrant).not.toHaveBeenCalled();
+    });
+
+    // Spreading `null` is legal and yields `{}`, so the body map doesn't throw — the entry simply
+    // arrives with no UID, and the UID check is what turns it away.
+    it('rejects a null entry on the missing-UID check rather than throwing', async () => {
+      const req = buildReq({ body: [null] });
+
+      await controller.updateMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalledWith(expect.any(TypeError));
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ fields: { 'registrants.uid': 'required' } }));
+      expect(meetingSvc.updateMeetingRegistrant).not.toHaveBeenCalled();
+    });
+
+    // A non-nullish value on a renamed field is a real change, so the guard has to let it through —
+    // the drop list is about nullish values, not about the keys themselves.
+    it('forwards an entry whose only change is a renamed field with a value', async () => {
+      const req = buildReq({ body: [{ uid: 'reg-1', changes: { org_name: 'Acme' } }] });
+
+      await controller.updateMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(meetingSvc.updateMeetingRegistrant).toHaveBeenCalledWith(req, MEETING_ID, 'reg-1', expect.objectContaining({ org_name: 'Acme' }));
     });
 
     it('rejects a non-array body as a validation error rather than throwing', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -623,18 +623,22 @@ export class MeetingController {
   public async addMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
     // Shape-guarded for the same reason as `updateMeetingRegistrants`: this runs outside the `try`,
-    // so a non-array body would throw before any log line exists to explain it.
-    const registrantData: CreateMeetingRegistrantRequest[] = Array.isArray(req.body)
-      ? req.body.map((registrant: CreateMeetingRegistrantRequest) => ({
-          ...registrant,
-          meeting_id: uid,
-        }))
-      : [];
+    // so a non-array body would throw before any log line exists to explain it. The raw entries are
+    // kept because the mapping below adds `meeting_id` to every one of them, which is enough to make
+    // even `[null]` look like a registrant — the `registrants.email` check inside the `try` judges the
+    // raw entry instead. Spreading `null` is legal, so this cannot throw on a null element.
+    const rawRegistrants: (CreateMeetingRegistrantRequest | null | undefined)[] = Array.isArray(req.body) ? req.body : [];
+    const registrantData: CreateMeetingRegistrantRequest[] = rawRegistrants.map((registrant) => ({
+      ...registrant,
+      meeting_id: uid,
+    })) as CreateMeetingRegistrantRequest[];
 
     const startTime = logger.startOperation(req, 'add_meeting_registrants', {
       meeting_id: uid,
       registrant_count: registrantData.length,
-      body_size: JSON.stringify(req.body).length,
+      // `content-length` rather than re-serializing the parsed body: the JSON limit is 15mb, and
+      // stringifying only to read `.length` allocates a second copy of it on every request.
+      body_size: Number(req.get('content-length') ?? 0),
     });
 
     try {
@@ -660,6 +664,22 @@ export class MeetingController {
         });
 
         // Send the validation error to the next middleware
+        next(validationError);
+        return;
+      }
+
+      // `email` is the one required field on `CreateMeetingRegistrantRequest` and the only identity
+      // a new registrant has — the batch response even keys its per-item results by it. Judged on the
+      // raw entries, since the mapping above already gave every one of them a `meeting_id`. Left
+      // unguarded, `[null]` and `[{}]` both cleared every check and sent upstream a create carrying
+      // nothing but the meeting UID, then reported the result back keyed by `undefined`.
+      if (rawRegistrants.some((registrant) => typeof registrant?.email !== 'string' || registrant.email.trim().length === 0)) {
+        const validationError = ServiceValidationError.forField('registrants.email', 'One or more registrants are missing an email address', {
+          operation: 'add_meeting_registrants',
+          service: 'meeting_controller',
+          path: req.path,
+        });
+
         next(validationError);
         return;
       }
@@ -719,22 +739,25 @@ export class MeetingController {
     // `Array.isArray` rather than `req.body?.map`, and `update?.changes` rather than `update.changes`:
     // this runs before `startOperation` and outside the `try`, so a throw here escapes the handler as
     // an unhandled rejection with no log line at all. The declared types are a compile-time guarantee
-    // only — a client can PUT `{}` or `[{ "uid": "x" }]` past them. An empty list falls through to the
-    // "No registrants provided" validation below, which is the 400 those bodies deserve.
-    const updateData: { uid: string; changes: UpdateMeetingRegistrantRequest }[] = Array.isArray(req.body)
-      ? req.body.map((update: { uid: string; changes?: UpdateMeetingRegistrantRequest }) => ({
-          ...update,
-          changes: {
-            ...MeetingController.stripCommitteeUid(update?.changes),
-            meeting_id: uid,
-          },
-        }))
-      : [];
+    // only — a client can PUT `{}` or `[{ "uid": "x" }]` past them. `{}` yields an empty list, which
+    // the "No registrants provided" check below answers with a 400; entries that carry a UID but no
+    // usable `changes` are caught by the third check, since by then every mapped `changes` looks
+    // non-empty because of the `meeting_id` added here.
+    const rawUpdates: { uid: string; changes?: UpdateMeetingRegistrantRequest }[] = Array.isArray(req.body) ? req.body : [];
+    const updateData: { uid: string; changes: UpdateMeetingRegistrantRequest }[] = rawUpdates.map((update) => ({
+      ...update,
+      changes: {
+        ...MeetingController.stripCommitteeUid(update?.changes),
+        meeting_id: uid,
+      },
+    }));
 
     const startTime = logger.startOperation(req, 'update_meeting_registrants', {
       meeting_id: uid,
       registrant_count: updateData.length,
-      body_size: JSON.stringify(req.body).length,
+      // `content-length` rather than re-serializing the parsed body: the JSON limit is 15mb, and
+      // stringifying only to read `.length` allocates a second copy of it on every request.
+      body_size: Number(req.get('content-length') ?? 0),
     });
 
     try {
@@ -765,6 +788,22 @@ export class MeetingController {
       // Check if the registrant UIDs are provided
       if (updateData.some((update) => !update.uid)) {
         const validationError = ServiceValidationError.forField('registrants.uid', 'One or more registrants are missing UID', {
+          operation: 'update_meeting_registrants',
+          service: 'meeting_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
+      // Check that every entry actually asks for a change. Judged on `rawUpdates`, not `updateData`:
+      // the mapping above adds `meeting_id` to every `changes`, so by then even `[{ "uid": "x" }]`
+      // looks like a change. Left unguarded it cleared all three checks and sent upstream a
+      // `PUT .../registrants/x` with a literal `{}` body — an empty write whose field semantics are
+      // ITX's to define, and the client got `{ meeting_id }` echoed back as the "updated" registrant.
+      if (rawUpdates.some((update) => !MeetingController.hasRegistrantChanges(update?.changes))) {
+        const validationError = ServiceValidationError.forField('registrants.changes', 'One or more registrants have no changes to apply', {
           operation: 'update_meeting_registrants',
           service: 'meeting_controller',
           path: req.path,
@@ -1901,6 +1940,23 @@ export class MeetingController {
   }
 
   /**
+   * Whether a client-supplied `changes` object asks for anything this endpoint can actually apply.
+   *
+   * Deliberately typed `unknown`: the declared `UpdateMeetingRegistrantRequest` is a compile-time
+   * guarantee only, and this reads straight off `req.body`. Arrays and primitives are rejected
+   * rather than counted — `Object.keys('ab')` is `['0', '1']`, which would otherwise pass as two
+   * changes. `committee_uid` doesn't count either, since `stripCommitteeUid` removes it before the
+   * body is forwarded, so an entry carrying only that key would still forward an empty write.
+   */
+  private static hasRegistrantChanges(changes: unknown): boolean {
+    if (typeof changes !== 'object' || changes === null || Array.isArray(changes)) {
+      return false;
+    }
+
+    return Object.keys(MeetingController.stripCommitteeUid(changes as UpdateMeetingRegistrantRequest)).length > 0;
+  }
+
+  /**
    * The v2 UIDs of the committees actually attached to a meeting — the allowlist that
    * `resolveRegistrantCommitteeUids` checks a client-supplied `committee_uid` against.
    *
@@ -1996,18 +2052,6 @@ export class MeetingController {
    * leading budget's worth of signal, so a descriptor the organizer typed is never silently discarded
    * in full and the client guard mirrors this one exactly.
    */
-  /**
-   * Narrows a client-supplied meeting type to the enum, or drops it.
-   * @description `meetingType` is the one prompt input with a closed value set, and
-   * `getMeetingTypeDescription` already falls back to a generic descriptor for anything it doesn't
-   * recognise — so a value outside the set carries no signal and only exists to be logged and
-   * interpolated. Dropping it is strictly better than truncating it, which is what the free-text
-   * descriptors get.
-   */
-  private static readMeetingType(value: unknown): MeetingType | undefined {
-    return typeof value === 'string' && (Object.values(MeetingType) as string[]).includes(value) ? (value as MeetingType) : undefined;
-  }
-
   private static readPromptField(value: unknown): string | undefined {
     if (typeof value !== 'string') {
       return undefined;
@@ -2020,6 +2064,18 @@ export class MeetingController {
     }
 
     return truncateToUtf16Units(trimmed, MEETING_AGENDA_PROMPT_MAX_LENGTH);
+  }
+
+  /**
+   * Narrows a client-supplied meeting type to the enum, or drops it.
+   * @description `meetingType` is the one prompt input with a closed value set, and
+   * `AiService.getMeetingTypeDescription` already falls back to a generic descriptor for anything it
+   * doesn't recognise — so a value outside the set carries no signal and only exists to be logged and
+   * interpolated. Dropping it is strictly better than truncating it, which is what the free-text
+   * descriptors above get.
+   */
+  private static readMeetingType(value: unknown): MeetingType | undefined {
+    return typeof value === 'string' && (Object.values(MeetingType) as string[]).includes(value) ? (value as MeetingType) : undefined;
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -23,7 +23,7 @@ import {
 import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
-import { NULLISH_DROPPED_REGISTRANT_KEYS } from '../constants';
+import { NULLISH_DROPPED_REGISTRANT_KEYS, UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS } from '../constants';
 import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
 import { AuthorizationError, ServiceValidationError } from '../errors';
 import {
@@ -641,12 +641,14 @@ export class MeetingController {
     const startTime = logger.startOperation(req, 'add_meeting_registrants', {
       meeting_id: uid,
       registrant_count: registrantData.length,
-      // `content_length`, not `body_size`: the sibling operations in this file log `body_size` by
-      // re-serializing `req.body`, and that is a different measurement — a gzipped or chunked request
-      // makes the two disagree. The two batch endpoints are the ones most likely to carry a body near
-      // the 15mb JSON limit, so they read the header instead of allocating a second copy of it, and
-      // the field is named for what it actually holds so the two can't be aggregated together.
-      content_length: MeetingController.readContentLength(req),
+      // `request_content_length`, not `body_size`: the sibling operations in this file log `body_size`
+      // by re-serializing `req.body`, and that is a different measurement — a gzipped or chunked
+      // request makes the two disagree. The two batch endpoints are the ones most likely to carry a
+      // body near the 15mb JSON limit, so they read the header instead of allocating a second copy of
+      // it. The name is qualified because a bare `content_length` is already three other things in
+      // this codebase — a raw header string, an upstream *response* Content-Length, and a character
+      // count — and none of them can be aggregated with this one.
+      request_content_length: MeetingController.readContentLength(req),
     });
 
     try {
@@ -773,12 +775,14 @@ export class MeetingController {
     const startTime = logger.startOperation(req, 'update_meeting_registrants', {
       meeting_id: uid,
       registrant_count: updateData.length,
-      // `content_length`, not `body_size`: the sibling operations in this file log `body_size` by
-      // re-serializing `req.body`, and that is a different measurement — a gzipped or chunked request
-      // makes the two disagree. The two batch endpoints are the ones most likely to carry a body near
-      // the 15mb JSON limit, so they read the header instead of allocating a second copy of it, and
-      // the field is named for what it actually holds so the two can't be aggregated together.
-      content_length: MeetingController.readContentLength(req),
+      // `request_content_length`, not `body_size`: the sibling operations in this file log `body_size`
+      // by re-serializing `req.body`, and that is a different measurement — a gzipped or chunked
+      // request makes the two disagree. The two batch endpoints are the ones most likely to carry a
+      // body near the 15mb JSON limit, so they read the header instead of allocating a second copy of
+      // it. The name is qualified because a bare `content_length` is already three other things in
+      // this codebase — a raw header string, an upstream *response* Content-Length, and a character
+      // count — and none of them can be aggregated with this one.
+      request_content_length: MeetingController.readContentLength(req),
     });
 
     try {
@@ -1972,14 +1976,16 @@ export class MeetingController {
    * The count is taken over the keys that survive the outbound mapper, not over the raw ones,
    * because every key the mapper drops is a key that cannot reach upstream:
    * - `committee_uid` — `stripCommitteeUid` removes it here, before the body is forwarded.
-   * - `meeting_id` — `toUpstreamRegistrantBody` deletes it; the meeting is addressed by the path.
-   * - `org_name` / `avatar_url` / `occurrence_id` — the mapper renames these to `org`,
-   *   `profile_picture` and `occurrence`, but only when the value is non-nullish, so a `null` here
-   *   contributes nothing to the outbound body.
+   * - {@link UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS} — `toUpstreamRegistrantBody` deletes these
+   *   whatever their value is.
+   * - {@link NULLISH_DROPPED_REGISTRANT_KEYS} — the mapper renames these, but only when the value is
+   *   non-nullish, so a `null` here contributes nothing to the outbound body.
    *
    * Counting the raw keys instead let `{ "meeting_id": "M1" }` and `{ "org_name": null }` through
-   * the guard and straight into the empty `PUT` it exists to prevent. Keep this list in step with
-   * `MeetingService.toUpstreamRegistrantBody`.
+   * the guard and straight into the empty `PUT` it exists to prevent. The two lists are the same
+   * ones `toUpstreamRegistrantBody`'s delete loop reads — it consumes their union as
+   * `APP_ONLY_REGISTRANT_KEYS` — so a key added to either half reaches the mapper and this guard in
+   * one edit, and neither can be updated without the other.
    */
   private static hasRegistrantChanges(changes: unknown): boolean {
     if (typeof changes !== 'object' || changes === null || Array.isArray(changes)) {
@@ -1989,12 +1995,12 @@ export class MeetingController {
     const stripped = MeetingController.stripCommitteeUid(changes as UpdateMeetingRegistrantRequest) as unknown as Record<string, unknown>;
 
     return Object.entries(stripped).some(([key, value]) => {
-      if (key === 'meeting_id') {
+      // Widened for the lookups only: `includes` on a `readonly ['org_name', ...]` won't accept an
+      // arbitrary string, and the keys here come off untyped JSON.
+      if ((UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS as readonly string[]).includes(key)) {
         return false;
       }
 
-      // Widened for the lookup only: `includes` on a `readonly ['org_name', ...]` won't accept an
-      // arbitrary string, and the keys here come off untyped JSON.
       return (NULLISH_DROPPED_REGISTRANT_KEYS as readonly string[]).includes(key) ? value != null : true;
     });
   }
@@ -2144,15 +2150,22 @@ export class MeetingController {
   }
 
   /**
-   * The request's declared `Content-Length`, or `null` when it carries none.
+   * The request's declared `Content-Length`, or `null` when it declares none this can trust.
    * @description A chunked request omits the header entirely, so `null` is a real outcome and not an
-   * error — logging it as `0` would make it indistinguishable from an empty body. A non-numeric value
-   * is normalised the same way: `Number('abc')` is `NaN`, which Pino serializes as `null` anyway, so
-   * this only makes that deliberate instead of incidental.
+   * error — logging it as `0` would make it indistinguishable from a declared empty body. That is why
+   * the raw header is checked before the conversion rather than after: `Number('')` is `0`, so an
+   * empty or whitespace-only header would otherwise be logged as the very value `null` exists to stay
+   * distinct from.
+   *
+   * Anything that isn't a non-negative integer is `null` too. `Content-Length` is defined as a count
+   * of octets, so `-1` and `12.5` are as malformed as `abc`; logging them verbatim would put values
+   * into the field that no real request can produce, and a reader aggregating it can't tell those
+   * apart from a genuine measurement.
    */
   private static readContentLength(req: Request): number | null {
-    const declared = Number(req.get('content-length'));
+    const declared = Number(req.get('content-length')?.trim() || Number.NaN);
 
-    return Number.isFinite(declared) ? declared : null;
+    // `isInteger` implies finite, so this rejects `NaN` and `Infinity` as well.
+    return Number.isInteger(declared) && declared >= 0 ? declared : null;
   }
 }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -2152,9 +2152,9 @@ export class MeetingController {
   /**
    * The request's declared `Content-Length`, or `null` when it declares none this can trust.
    * @description A chunked request omits the header entirely, so `null` is a real outcome and not an
-   * error — logging it as `0` would make it indistinguishable from a declared empty body. That is why
-   * the raw header is checked before the conversion rather than after: `Number('')` is `0`, so an
-   * empty or whitespace-only header would otherwise be logged as the very value `null` exists to stay
+   * error — logging it as `0` would make it indistinguishable from a declared empty body. The raw
+   * header is truthiness-checked before conversion for that reason: `Number('')` is `0`, so an absent
+   * or whitespace-only header would otherwise land as the very value the `null` exists to stay
    * distinct from.
    *
    * Anything that isn't a non-negative integer is `null` too. `Content-Length` is defined as a count
@@ -2163,9 +2163,12 @@ export class MeetingController {
    * apart from a genuine measurement.
    */
   private static readContentLength(req: Request): number | null {
-    const declared = Number(req.get('content-length')?.trim() || Number.NaN);
+    const raw = req.get('content-length')?.trim();
 
-    // `isInteger` implies finite, so this rejects `NaN` and `Infinity` as well.
-    return Number.isInteger(declared) && declared >= 0 ? declared : null;
+    // Matched as digits before converting rather than range-checked after. `Content-Length` is
+    // defined as `1*DIGIT`, but `Number` also accepts forms no HTTP client sends and this field can't
+    // represent honestly, and a range check runs too late to catch them: `'0x10'` becomes 16 and
+    // `'1e3'` becomes 1000, both of which are non-negative integers and would have been logged.
+    return raw && /^\d+$/.test(raw) ? Number(raw) : null;
   }
 }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -23,6 +23,7 @@ import {
 import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
+import { NULLISH_DROPPED_REGISTRANT_KEYS } from '../constants';
 import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
 import { AuthorizationError, ServiceValidationError } from '../errors';
 import {
@@ -618,7 +619,11 @@ export class MeetingController {
 
   /**
    * POST /meetings/:uid/registrants
-   * @description Adds one or more registrants with partial success support
+   * @description Adds one or more registrants with partial success support. Partial success covers
+   * upstream failures only — a per-item 207 says "this row was attempted and upstream refused it".
+   * Client-shape validation is all-or-nothing and answers 400 before anything is attempted: a body
+   * with a malformed row is a client bug the client is going to fix and resend, and creating the
+   * other rows first would make that resend duplicate every one of them.
    */
   public async addMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
@@ -636,9 +641,12 @@ export class MeetingController {
     const startTime = logger.startOperation(req, 'add_meeting_registrants', {
       meeting_id: uid,
       registrant_count: registrantData.length,
-      // `content-length` rather than re-serializing the parsed body: the JSON limit is 15mb, and
-      // stringifying only to read `.length` allocates a second copy of it on every request.
-      body_size: Number(req.get('content-length') ?? 0),
+      // `content_length`, not `body_size`: the sibling operations in this file log `body_size` by
+      // re-serializing `req.body`, and that is a different measurement — a gzipped or chunked request
+      // makes the two disagree. The two batch endpoints are the ones most likely to carry a body near
+      // the 15mb JSON limit, so they read the header instead of allocating a second copy of it, and
+      // the field is named for what it actually holds so the two can't be aggregated together.
+      content_length: MeetingController.readContentLength(req),
     });
 
     try {
@@ -668,11 +676,14 @@ export class MeetingController {
         return;
       }
 
-      // `email` is the one required field on `CreateMeetingRegistrantRequest` and the only identity
-      // a new registrant has — the batch response even keys its per-item results by it. Judged on the
-      // raw entries, since the mapping above already gave every one of them a `meeting_id`. Left
-      // unguarded, `[null]` and `[{}]` both cleared every check and sent upstream a create carrying
-      // nothing but the meeting UID, then reported the result back keyed by `undefined`.
+      // `email` is the only identity a not-yet-created registrant has — it's what
+      // `createBatchResponse` passes to `getIdentifier` for the per-failure log line, so without it a
+      // failure is logged against `undefined` and can't be traced back to a row. (Three more fields
+      // are non-optional on `CreateMeetingRegistrantRequest`, but `meeting_id` is supplied here from
+      // the path and upstream requires none of them, so only `email` is checked.) Judged on the raw
+      // entries, since the mapping above already gave every one of them a `meeting_id` —
+      // `toUpstreamRegistrantBody` deletes that again, so `[null]` and `[{}]` used to clear every
+      // check and send upstream a create with a literal `{}` body.
       if (rawRegistrants.some((registrant) => typeof registrant?.email !== 'string' || registrant.email.trim().length === 0)) {
         const validationError = ServiceValidationError.forField('registrants.email', 'One or more registrants are missing an email address', {
           operation: 'add_meeting_registrants',
@@ -732,7 +743,10 @@ export class MeetingController {
 
   /**
    * PUT /meetings/:uid/registrants
-   * @description Updates one or more registrants with partial success support
+   * @description Updates one or more registrants with partial success support. As on the create path,
+   * partial success covers upstream failures only; a body with a malformed row answers 400 before
+   * anything is attempted, so the client's fix-and-resend re-applies the whole batch rather than
+   * re-applying the rows that already landed.
    */
   public async updateMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
@@ -743,9 +757,13 @@ export class MeetingController {
     // the "No registrants provided" check below answers with a 400; entries that carry a UID but no
     // usable `changes` are caught by the third check, since by then every mapped `changes` looks
     // non-empty because of the `meeting_id` added here.
-    const rawUpdates: { uid: string; changes?: UpdateMeetingRegistrantRequest }[] = Array.isArray(req.body) ? req.body : [];
+    const rawUpdates: ({ uid: string; changes?: UpdateMeetingRegistrantRequest } | null | undefined)[] = Array.isArray(req.body) ? req.body : [];
+    // `uid` is read off the entry rather than spread, and defaulted to `''` rather than left
+    // `undefined`: a `null` entry has no `uid` at all, and the "missing UID" check below is what
+    // rejects it. Defaulting keeps that the single place the requirement is enforced, instead of
+    // splitting it between a type assertion here and a runtime check there.
     const updateData: { uid: string; changes: UpdateMeetingRegistrantRequest }[] = rawUpdates.map((update) => ({
-      ...update,
+      uid: update?.uid ?? '',
       changes: {
         ...MeetingController.stripCommitteeUid(update?.changes),
         meeting_id: uid,
@@ -755,9 +773,12 @@ export class MeetingController {
     const startTime = logger.startOperation(req, 'update_meeting_registrants', {
       meeting_id: uid,
       registrant_count: updateData.length,
-      // `content-length` rather than re-serializing the parsed body: the JSON limit is 15mb, and
-      // stringifying only to read `.length` allocates a second copy of it on every request.
-      body_size: Number(req.get('content-length') ?? 0),
+      // `content_length`, not `body_size`: the sibling operations in this file log `body_size` by
+      // re-serializing `req.body`, and that is a different measurement — a gzipped or chunked request
+      // makes the two disagree. The two batch endpoints are the ones most likely to carry a body near
+      // the 15mb JSON limit, so they read the header instead of allocating a second copy of it, and
+      // the field is named for what it actually holds so the two can't be aggregated together.
+      content_length: MeetingController.readContentLength(req),
     });
 
     try {
@@ -797,7 +818,8 @@ export class MeetingController {
         return;
       }
 
-      // Check that every entry actually asks for a change. Judged on `rawUpdates`, not `updateData`:
+      // Check that every entry actually asks for a change — measured against what survives the
+      // outbound mapper, not against the raw key count. Judged on `rawUpdates`, not `updateData`:
       // the mapping above adds `meeting_id` to every `changes`, so by then even `[{ "uid": "x" }]`
       // looks like a change. Left unguarded it cleared all three checks and sent upstream a
       // `PUT .../registrants/x` with a literal `{}` body — an empty write whose field semantics are
@@ -1945,15 +1967,36 @@ export class MeetingController {
    * Deliberately typed `unknown`: the declared `UpdateMeetingRegistrantRequest` is a compile-time
    * guarantee only, and this reads straight off `req.body`. Arrays and primitives are rejected
    * rather than counted — `Object.keys('ab')` is `['0', '1']`, which would otherwise pass as two
-   * changes. `committee_uid` doesn't count either, since `stripCommitteeUid` removes it before the
-   * body is forwarded, so an entry carrying only that key would still forward an empty write.
+   * changes.
+   *
+   * The count is taken over the keys that survive the outbound mapper, not over the raw ones,
+   * because every key the mapper drops is a key that cannot reach upstream:
+   * - `committee_uid` — `stripCommitteeUid` removes it here, before the body is forwarded.
+   * - `meeting_id` — `toUpstreamRegistrantBody` deletes it; the meeting is addressed by the path.
+   * - `org_name` / `avatar_url` / `occurrence_id` — the mapper renames these to `org`,
+   *   `profile_picture` and `occurrence`, but only when the value is non-nullish, so a `null` here
+   *   contributes nothing to the outbound body.
+   *
+   * Counting the raw keys instead let `{ "meeting_id": "M1" }` and `{ "org_name": null }` through
+   * the guard and straight into the empty `PUT` it exists to prevent. Keep this list in step with
+   * `MeetingService.toUpstreamRegistrantBody`.
    */
   private static hasRegistrantChanges(changes: unknown): boolean {
     if (typeof changes !== 'object' || changes === null || Array.isArray(changes)) {
       return false;
     }
 
-    return Object.keys(MeetingController.stripCommitteeUid(changes as UpdateMeetingRegistrantRequest)).length > 0;
+    const stripped = MeetingController.stripCommitteeUid(changes as UpdateMeetingRegistrantRequest) as unknown as Record<string, unknown>;
+
+    return Object.entries(stripped).some(([key, value]) => {
+      if (key === 'meeting_id') {
+        return false;
+      }
+
+      // Widened for the lookup only: `includes` on a `readonly ['org_name', ...]` won't accept an
+      // arbitrary string, and the keys here come off untyped JSON.
+      return (NULLISH_DROPPED_REGISTRANT_KEYS as readonly string[]).includes(key) ? value != null : true;
+    });
   }
 
   /**
@@ -2098,5 +2141,18 @@ export class MeetingController {
     }
 
     return floored;
+  }
+
+  /**
+   * The request's declared `Content-Length`, or `null` when it carries none.
+   * @description A chunked request omits the header entirely, so `null` is a real outcome and not an
+   * error — logging it as `0` would make it indistinguishable from an empty body. A non-numeric value
+   * is normalised the same way: `Number('abc')` is `NaN`, which Pino serializes as `null` anyway, so
+   * this only makes that deliberate instead of incidental.
+   */
+  private static readContentLength(req: Request): number | null {
+    const declared = Number(req.get('content-length'));
+
+    return Number.isFinite(declared) ? declared : null;
   }
 }

--- a/apps/lfx-one/src/server/helpers/url-validation.spec.ts
+++ b/apps/lfx-one/src/server/helpers/url-validation.spec.ts
@@ -6,6 +6,8 @@ import type https from 'node:https';
 import type { AddressInfo } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
+import { encodePathSegment } from './url-validation';
+
 /**
  * Drives the REAL `fetchSafeUrl` against a real socket.
  *
@@ -91,5 +93,43 @@ describe('fetchSafeUrl response byte ceiling', () => {
     vi.mocked(dns.promises.resolve4).mockResolvedValueOnce(['10.0.0.5']);
 
     await expect(fetchSafeUrl('https://events.example.com/page', new AbortController().signal)).rejects.toThrow(/private IP/);
+  });
+});
+
+/**
+ * `encodePathSegment` is a one-line alias for `encodeURIComponent`, and that is exactly why it is
+ * tested: the thing worth pinning is not the encoding itself but the property the call sites depend
+ * on — that whatever an attacker puts in an identifier, the result is still one path segment.
+ *
+ * Without this, the function reads like a pointless wrapper and the obvious "simplification" is to
+ * inline it or drop it, silently un-fixing a traversal that reaches an internal service under the
+ * caller's own credentials.
+ */
+describe('encodePathSegment', () => {
+  it.each([
+    ['a parent-directory traversal', '../../itx/projects/pwn'],
+    ['an absolute path', '/itx/projects/pwn'],
+    ['a bare separator', 'a/b'],
+    ['an already-encoded separator, so it cannot be decoded back into one', '..%2F..%2Fadmin'],
+  ])('leaves no path separator in the output for %s', (_label, hostile) => {
+    const encoded = encodePathSegment(hostile);
+
+    expect(encoded).not.toContain('/');
+    // The URL parser resolves `.` and `..` only between separators, so removing the separators is
+    // what defuses the traversal — the dots themselves are harmless.
+    expect(new URL(`https://svc.example/itx/meetings/${encoded}/registrants`).pathname).toBe(`/itx/meetings/${encoded}/registrants`);
+  });
+
+  it('strips the query and fragment delimiters that would otherwise truncate the path', () => {
+    // `?` and `#` end the path, so an unencoded one turns the rest of the template — including the
+    // sub-resource the route was aiming at — into a query string the upstream router never sees.
+    expect(encodePathSegment('uid?x=1#frag')).toBe('uid%3Fx%3D1%23frag');
+  });
+
+  it.each([
+    ['a uuid', '7f3c1a2e-4b5d-4e6f-8a9b-0c1d2e3f4a5b'],
+    ['a slug', 'cncf-kubernetes'],
+  ])('is a no-op on %s, the shape every legitimate identifier has', (_label, identifier) => {
+    expect(encodePathSegment(identifier)).toBe(identifier);
   });
 });

--- a/apps/lfx-one/src/server/helpers/url-validation.ts
+++ b/apps/lfx-one/src/server/helpers/url-validation.ts
@@ -27,6 +27,22 @@
  */
 
 /**
+ * Escapes a value so it can only ever be one segment of an upstream URL path
+ * @description Upstream paths are built by interpolating identifiers into a template string, and
+ * some of those identifiers arrive in a request *body*, where Express applies no per-segment
+ * parsing at all. A raw `../../something` would then be normalized away by the URL parser and aim
+ * the request at a different endpoint on the same service, still carrying the caller's bearer
+ * token. Encoding keeps a traversal attempt as a literal (unmatched) identifier, so it 404s
+ * upstream instead of resolving somewhere else.
+ *
+ * A well-formed identifier — the UUIDs the meeting service issues — contains nothing
+ * `encodeURIComponent` touches, so this is a no-op on every legitimate value.
+ * @param segment - The identifier to interpolate
+ * @returns The percent-encoded segment
+ */
+export const encodePathSegment = (segment: string): string => encodeURIComponent(segment);
+
+/**
  * Validates and sanitizes a URL to prevent open redirect attacks
  * @param url - The URL to validate
  * @param allowedDomains - Array of allowed domains (optional)

--- a/apps/lfx-one/src/server/helpers/url-validation.ts
+++ b/apps/lfx-one/src/server/helpers/url-validation.ts
@@ -29,11 +29,17 @@
 /**
  * Escapes a value so it can only ever be one segment of an upstream URL path
  * @description Upstream paths are built by interpolating identifiers into a template string, and
- * some of those identifiers arrive in a request *body*, where Express applies no per-segment
- * parsing at all. A raw `../../something` would then be normalized away by the URL parser and aim
- * the request at a different endpoint on the same service, still carrying the caller's bearer
- * token. Encoding keeps a traversal attempt as a literal (unmatched) identifier, so it 404s
- * upstream instead of resolving somewhere else.
+ * `MicroserviceProxyService` concatenates the result onto the base URL without encoding anything.
+ * A raw `../../something` is then normalized away by the URL parser and aims the request at a
+ * different endpoint on the same service, still carrying the caller's credentials. Encoding keeps a
+ * traversal attempt as a literal (unmatched) identifier, so it 404s upstream instead of resolving
+ * somewhere else.
+ *
+ * Applied to every interpolated identifier, whatever its source. A body-supplied id is the obvious
+ * case, but a path parameter is not safe either: Express percent-decodes `req.params`, so a `%2F` in
+ * the request URL arrives as a real `/` in the value. The distinction is not worth tracking per call
+ * site — an id that reaches this function is either already URL-safe, in which case encoding is a
+ * no-op, or it is not, in which case encoding is exactly what was missing.
  *
  * A well-formed identifier — the UUIDs the meeting service issues — contains nothing
  * `encodeURIComponent` touches, so this is a no-op on every legitimate value.

--- a/apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts
@@ -8,9 +8,12 @@ import { aiRateLimiter } from './rate-limit.middleware';
 
 // `aiRateLimiter` counts in the default in-process MemoryStore, so the counter is shared across
 // every test in this file. express-rate-limit exposes no reset, so each test has to use its own key
-// instead — and the keys are derived from the test's own name rather than written by hand, so a test
+// instead — and the keys are keyed off the test's own name rather than written by hand, so a test
 // added later cannot silently land in a bucket an earlier test already drained.
 const AI_LIMIT = 10;
+
+/** The /56 prefix handed to each test name on first use — see `testIpv6Prefix`. */
+const ipv6PrefixesByTest = new Map<string, string>();
 
 /** A `sub` unique to the running test, so no two tests share a rate-limit bucket. */
 function testSub(): string {
@@ -23,16 +26,23 @@ function testSub(): string {
  * The limiter masks anonymous callers to /56 — the first three groups plus the high byte of the
  * fourth — so tests that need two addresses inside one bucket vary only the fourth group's low byte,
  * and a different prefix is a different bucket.
+ *
+ * Handed out sequentially on first use rather than hashed from the test name: a hash has to fold the
+ * name into the 16 bits the third group holds, so two names could collide onto one prefix and share a
+ * bucket — which is the exact failure this function exists to rule out.
  */
 function testIpv6Prefix(): string {
   const name = expect.getState().currentTestName ?? 'unknown';
-  let hash = 0;
+  const existing = ipv6PrefixesByTest.get(name);
 
-  for (const character of name) {
-    hash = (hash * 31 + character.charCodeAt(0)) % 0x10000;
+  if (existing) {
+    return existing;
   }
 
-  return `2001:db8:${hash.toString(16).padStart(4, '0')}`;
+  const prefix = `2001:db8:${(ipv6PrefixesByTest.size + 1).toString(16).padStart(4, '0')}`;
+  ipv6PrefixesByTest.set(name, prefix);
+
+  return prefix;
 }
 
 // Minimal Express stand-ins. express-rate-limit only reads `req.ip`, `req.oidc` (through our

--- a/apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts
@@ -2,14 +2,38 @@
 // SPDX-License-Identifier: MIT
 
 import type { NextFunction, Request, Response } from 'express';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { aiRateLimiter } from './rate-limit.middleware';
 
 // `aiRateLimiter` counts in the default in-process MemoryStore, so the counter is shared across
-// every test in this file. Each test therefore uses its own key (a distinct `sub` or IP) rather
-// than trying to reset the store, which express-rate-limit does not expose.
+// every test in this file. express-rate-limit exposes no reset, so each test has to use its own key
+// instead — and the keys are derived from the test's own name rather than written by hand, so a test
+// added later cannot silently land in a bucket an earlier test already drained.
 const AI_LIMIT = 10;
+
+/** A `sub` unique to the running test, so no two tests share a rate-limit bucket. */
+function testSub(): string {
+  return `auth0|${(expect.getState().currentTestName ?? 'unknown').replace(/[^a-z0-9]+/gi, '-')}`;
+}
+
+/**
+ * An IPv6 /56 prefix unique to the running test.
+ *
+ * The limiter masks anonymous callers to /56 — the first three groups plus the high byte of the
+ * fourth — so tests that need two addresses inside one bucket vary only the fourth group's low byte,
+ * and a different prefix is a different bucket.
+ */
+function testIpv6Prefix(): string {
+  const name = expect.getState().currentTestName ?? 'unknown';
+  let hash = 0;
+
+  for (const character of name) {
+    hash = (hash * 31 + character.charCodeAt(0)) % 0x10000;
+  }
+
+  return `2001:db8:${hash.toString(16).padStart(4, '0')}`;
+}
 
 // Minimal Express stand-ins. express-rate-limit only reads `req.ip`, `req.oidc` (through our
 // keyGenerator) and `req.app.get('trust proxy')`, and only writes through `res.setHeader` plus
@@ -49,23 +73,32 @@ function buildRes(): Response & { statusCode?: number; headers: Record<string, s
 }
 
 /** Drives the limiter once and reports whether the request was allowed through. */
-async function request(opts: { sub?: string; ip?: string }): Promise<{ allowed: boolean; statusCode?: number; headers: Record<string, string> }> {
+async function request(opts: { sub?: string; ip?: string } = {}): Promise<{
+  allowed: boolean;
+  statusCode?: number;
+  headers: Record<string, string>;
+  body: unknown;
+}> {
   const req = buildReq(opts);
   const res = buildRes();
   const next = vi.fn() as unknown as NextFunction;
 
   await aiRateLimiter(req, res, next);
 
-  return { allowed: (next as unknown as ReturnType<typeof vi.fn>).mock.calls.length > 0, statusCode: res.statusCode, headers: res.headers };
+  const sent = res.send as unknown as ReturnType<typeof vi.fn>;
+
+  return {
+    allowed: (next as unknown as ReturnType<typeof vi.fn>).mock.calls.length > 0,
+    statusCode: res.statusCode,
+    headers: res.headers,
+    // `undefined` when the limiter let the request through — it only writes a body on reject.
+    body: sent.mock.calls[0]?.[0],
+  };
 }
 
 describe('aiRateLimiter', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('allows the first ten requests in the window and rejects the eleventh with 429', async () => {
-    const sub = 'auth0|budget-holder';
+    const sub = testSub();
 
     for (let attempt = 1; attempt <= AI_LIMIT; attempt++) {
       const result = await request({ sub });
@@ -80,10 +113,16 @@ describe('aiRateLimiter', () => {
     expect(rejected.allowed).toBe(false);
     expect(rejected.statusCode).toBe(429);
     expect(rejected.headers['Retry-After']).toBe('60');
+    // Asserted so the shape is on record: the limiter is configured with no `handler` and no
+    // `message`, so a throttled caller gets express-rate-limit's default plain-text body — not this
+    // app's JSON error envelope, and not something `HttpErrorService` can pull a `message` out of.
+    // The client shows its own copy for a 429, so the body is unread today; a change to it is a
+    // change to the endpoint's contract and should have to update this line.
+    expect(rejected.body).toBe('Too many requests, please try again later.');
   });
 
   it('advertises the limit in the standard RateLimit headers, not the legacy X-RateLimit ones', async () => {
-    const result = await request({ sub: 'auth0|header-reader' });
+    const result = await request({ sub: testSub() });
 
     expect(result.headers['RateLimit-Limit']).toBe(String(AI_LIMIT));
     expect(result.headers['RateLimit-Policy']).toBe(`${AI_LIMIT};w=60`);
@@ -92,30 +131,35 @@ describe('aiRateLimiter', () => {
 
   it('keys on the authenticated sub so one user cannot exhaust a shared egress IP', async () => {
     const sharedIp = '198.51.100.7';
+    const noisyNeighbour = `${testSub()}|noisy`;
+    const innocentBystander = `${testSub()}|innocent`;
 
     // Burn the whole budget for one user behind the shared IP.
     for (let attempt = 1; attempt <= AI_LIMIT; attempt++) {
-      await request({ sub: 'auth0|noisy-neighbour', ip: sharedIp });
+      await request({ sub: noisyNeighbour, ip: sharedIp });
     }
 
-    expect((await request({ sub: 'auth0|noisy-neighbour', ip: sharedIp })).allowed).toBe(false);
+    expect((await request({ sub: noisyNeighbour, ip: sharedIp })).allowed).toBe(false);
 
     // A different user on the same IP still has their own budget — the whole point of keying on
     // `sub` rather than letting the IP fallback bucket a corporate NAT together.
-    expect((await request({ sub: 'auth0|innocent-bystander', ip: sharedIp })).allowed).toBe(true);
+    expect((await request({ sub: innocentBystander, ip: sharedIp })).allowed).toBe(true);
   });
 
   it('falls back to a /56-masked IP key for anonymous callers', async () => {
+    const prefix = testIpv6Prefix();
+
     // Two addresses inside the same IPv6 /56 must share a bucket: masking is what stops a caller
     // with a routed prefix from minting a fresh budget per address.
     for (let attempt = 1; attempt <= AI_LIMIT; attempt++) {
-      await request({ ip: '2001:db8:aaaa:0001:0:0:0:1' });
+      await request({ ip: `${prefix}:0001:0:0:0:1` });
     }
 
-    expect((await request({ ip: '2001:db8:aaaa:0001:0:0:0:1' })).allowed).toBe(false);
-    expect((await request({ ip: '2001:db8:aaaa:00ff:0:0:0:9' })).allowed).toBe(false);
+    expect((await request({ ip: `${prefix}:0001:0:0:0:1` })).allowed).toBe(false);
+    expect((await request({ ip: `${prefix}:00ff:0:0:0:9` })).allowed).toBe(false);
 
-    // A different /56 is a different caller and keeps its own budget.
-    expect((await request({ ip: '2001:db8:bbbb:0001:0:0:0:1' })).allowed).toBe(true);
+    // A different /56 is a different caller and keeps its own budget. The fourth group's *high* byte
+    // is what has to differ — `0100` and above leave the exhausted /56.
+    expect((await request({ ip: `${prefix}:0100:0:0:0:1` })).allowed).toBe(true);
   });
 });

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -64,8 +64,9 @@ export class AiService {
       // `meetingType` is typed as the enum but arrives from a request body, and a type is not a
       // runtime guarantee — an unrecognized value would be logged verbatim. `getMeetingTypeDescription`
       // already defaults anything off the enum to a generic descriptor, so it never reaches the
-      // prompt; this log line was the only place an arbitrary string still got through.
-      meetingType: AiService.knownMeetingType(request.meetingType),
+      // prompt. The only HTTP caller now narrows before calling, so this is the second of two gates
+      // rather than the last one; it stays because nothing stops a future caller from skipping the first.
+      meetingType: AiService.knownMeetingType(request.meetingType) ?? null,
       titleLength: request.title?.length ?? 0,
       hasContext: !!request.context,
       hasProjectName: !!request.projectName,
@@ -563,11 +564,6 @@ export class AiService {
   }
 
   /** `default` also covers an unset type — the helper is reachable before one is chosen. */
-  /** Returns the value only when it is an actual `MeetingType` member, else `null`. */
-  private static knownMeetingType(value: unknown): MeetingType | null {
-    return typeof value === 'string' && (Object.values(MeetingType) as string[]).includes(value) ? (value as MeetingType) : null;
-  }
-
   private getMeetingTypeDescription(meetingType?: MeetingType): string {
     switch (meetingType) {
       case MeetingType.BOARD:
@@ -587,6 +583,18 @@ export class AiService {
       default:
         return 'project team';
     }
+  }
+
+  /**
+   * Returns the value only when it is an actual `MeetingType` member, else `undefined`.
+   *
+   * Duplicated in `MeetingController.readMeetingType` on purpose rather than shared: this service is
+   * a library its callers can reach directly, and `generateMeetingAgenda` takes a request object
+   * whose `meetingType` is typed but not validated. The controller's copy exists so the HTTP
+   * boundary rejects junk early; this one exists so the service is safe even when it doesn't.
+   */
+  private static knownMeetingType(value: unknown): MeetingType | undefined {
+    return typeof value === 'string' && (Object.values(MeetingType) as string[]).includes(value) ? (value as MeetingType) : undefined;
   }
 
   private assertConfigured(): void {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -64,6 +64,7 @@ vi.mock('./logger.service', () => ({
 
 import type { Request } from 'express';
 
+import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
 
 const req = {} as unknown as Request;
@@ -996,7 +997,12 @@ describe('MeetingService registrant write payloads', () => {
 
   beforeEach(() => {
     proxyRequest.mockReset();
+    // `{}` is a body with no usable fields, which is the fallback branch on every write path here.
+    // The outbound-payload tests below don't care — they read `proxyRequest`'s arguments — but the
+    // tests that assert on a *returned* registrant have to set their own response, or they'd be
+    // checking the fallback while claiming to check the mapping.
     proxyRequest.mockResolvedValue({});
+    vi.mocked(logger.success).mockClear();
     service = new MeetingService();
   });
 
@@ -1098,6 +1104,63 @@ describe('MeetingService registrant write payloads', () => {
 
     expect(result).toMatchObject({ uid: 'reg-1', org_name: 'Acme' });
     expect(result).not.toHaveProperty('email');
+  });
+
+  // Same reasoning as the update fallback above, on the two create paths: `ApiClientService` maps an
+  // empty response body to `null`, and a 201 carrying a literal `{}` is truthy — so both were mapped
+  // straight through and reported a created registrant with every field missing. The submitted payload
+  // is the closest description of what upstream now holds; `uid` is the one thing it can't supply.
+  it.each([
+    ['null', null],
+    ['an empty object', {}],
+  ])('falls back to the submitted payload when the create answers with %s', async (_label, body) => {
+    proxyRequest.mockResolvedValue(body);
+
+    const result = await service.addMeetingRegistrant(req, {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+    });
+
+    expect(result).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
+    expect(result.uid).toBeUndefined();
+  });
+
+  // Self-registration is the path a registrant drives from the public meeting page, so the same
+  // unusable body used to surface to them as a `{}` "created" record. Its success line has to say
+  // which branch produced the result — without `has_upstream_body` and an explicit `null` uid, Pino
+  // drops the undefined `uid` and the line is indistinguishable from a create whose log shape changed.
+  it('logs which branch the self-registration create returned from when upstream sends no body', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.addMeetingRegistrantSelf(req, 'meeting-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+    });
+
+    expect(result).toMatchObject({ email: 'a@example.com' });
+    expect(logger.success).toHaveBeenCalledWith(
+      req,
+      'add_meeting_registrant_self',
+      expect.anything(),
+      expect.objectContaining({ registrant_uid: null, has_upstream_body: false })
+    );
+  });
+
+  it('reports the upstream branch on the self-registration create when upstream does answer', async () => {
+    proxyRequest.mockResolvedValue({ uid: 'reg-1' });
+
+    await service.addMeetingRegistrantSelf(req, 'meeting-1', { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    expect(logger.success).toHaveBeenCalledWith(
+      req,
+      'add_meeting_registrant_self',
+      expect.anything(),
+      expect.objectContaining({ registrant_uid: 'reg-1', has_upstream_body: true })
+    );
   });
 
   // Self-registration builds its own payload against a different endpoint, and it's the one path

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -900,7 +900,10 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ registrantData });
     logger.debug(req, 'add_meeting_registrant', 'Creating meeting registrant', sanitizedPayload);
 
-    const newRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
+    // `| null` in the type parameter because that is what actually comes back: `ApiClientService`
+    // maps an empty response body to `null`. Same reasoning as `updateMeetingRegistrant` below —
+    // declaring it non-nullable would make the guard read as always-true to TypeScript.
+    const newRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${registrantData.meeting_id}/registrants`,
@@ -909,7 +912,13 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(registrantData)
     );
 
-    return this.fromUpstreamRegistrant(newRegistrant);
+    // Keys, not truthiness: a 201 carrying a literal `{}` is truthy, and mapping it would report a
+    // registrant with every field missing as a successful create.
+    if (newRegistrant && Object.keys(newRegistrant).length > 0) {
+      return this.fromUpstreamRegistrant(newRegistrant);
+    }
+
+    return MeetingService.registrantFromSubmittedPayload(registrantData);
   }
 
   /**
@@ -1958,7 +1967,9 @@ export class MeetingService {
       ...(registrantData.occurrence_id && { occurrence: registrantData.occurrence_id }),
     };
 
-    const upstreamRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
+    // `| null` in the type parameter because that is what actually comes back: `ApiClientService`
+    // maps an empty response body to `null`.
+    const upstreamRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${meetingId}/registrants/self`,
@@ -1967,11 +1978,20 @@ export class MeetingService {
       payload,
       { 'X-Sync': 'true' }
     );
-    const newRegistrant = this.fromUpstreamRegistrant(upstreamRegistrant);
+    // Keys, not truthiness — see `addMeetingRegistrant`. This path is the public registration one, so
+    // an unusable body used to surface to an anonymous registrant as a `{}` "created" record.
+    const hasUpstreamBody = !!upstreamRegistrant && Object.keys(upstreamRegistrant).length > 0;
+    const newRegistrant = hasUpstreamBody
+      ? this.fromUpstreamRegistrant(upstreamRegistrant)
+      : MeetingService.registrantFromSubmittedPayload(registrantData);
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {
       meeting_id: meetingId,
-      registrant_uid: newRegistrant.uid,
+      // `?? null` rather than leaving it `undefined`: Pino drops undefined values, so a create whose
+      // upstream body carried no UID logged as a success line with no `registrant_uid` field at all,
+      // indistinguishable from a log-shape change. `upstream_body` says which branch produced it.
+      registrant_uid: newRegistrant.uid ?? null,
+      upstream_body: hasUpstreamBody,
     });
 
     return newRegistrant;
@@ -2304,5 +2324,19 @@ export class MeetingService {
       ...(occurrence === undefined ? {} : { occurrence_id: occurrence }),
       ...(modified_at === undefined ? {} : { updated_at: modified_at }),
     } as MeetingRegistrant;
+  }
+
+  /**
+   * Fallback registrant for a create that upstream acknowledged with no usable body.
+   *
+   * The submitted payload is the closest available description of what upstream now stores, on the
+   * same reasoning `updateMeetingRegistrant` uses for its fallback. The one thing it cannot supply is
+   * `uid` — that's upstream's to mint — so the caller sees a registrant with no UID rather than a
+   * `{}` with no fields at all, and the M2M path's success log says which branch it came from.
+   * Deliberately not thrown: the write already succeeded, and throwing here would report a created
+   * registrant as a failure. Callers that need the UID have to read the registrant back.
+   */
+  private static registrantFromSubmittedPayload(registrantData: CreateMeetingRegistrantRequest): MeetingRegistrant {
+    return { ...registrantData } as MeetingRegistrant;
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -53,9 +53,10 @@ import {
 } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { AuthorizationError, ResourceNotFoundError, ServiceValidationError } from '../errors';
+import { ResourceNotFoundError, AuthorizationError, ServiceValidationError } from '../errors';
 import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
 import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from '../helpers/meeting-rsvp.helper';
+import { APP_ONLY_REGISTRANT_KEYS } from '../constants';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
@@ -900,9 +901,10 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ registrantData });
     logger.debug(req, 'add_meeting_registrant', 'Creating meeting registrant', sanitizedPayload);
 
-    // `| null` in the type parameter because that is what actually comes back: `ApiClientService`
-    // maps an empty response body to `null`. Same reasoning as `updateMeetingRegistrant` below —
-    // declaring it non-nullable would make the guard read as always-true to TypeScript.
+    // `| null` in the type parameter because the contract permits it: `ITXZoomMeetingRegistrant`,
+    // the only response this POST declares, has no `required:` block, so a literal `{}` — or no body
+    // at all, which `ApiClientService` maps to `null` — is schema-valid. Declaring it non-nullable
+    // would make the guard read as always-true to TypeScript.
     const newRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
@@ -933,8 +935,9 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ updateData });
     logger.debug(req, 'update_meeting_registrant', 'Updating meeting registrant payload', sanitizedPayload);
 
-    // `| null` in the type parameter because that is what actually comes back: `ApiClientService`
-    // maps an empty response body to `null`. Declaring it non-nullable made the guard below read as
+    // `| null` in the type parameter because that is what always comes back: this PUT declares only
+    // `204 No Content`, so an empty body is the documented response, not a degenerate case, and
+    // `ApiClientService` maps one to `null`. Declaring it non-nullable made the guard below read as
     // always-true to TypeScript, so a future cleanup could have deleted the fallback without a
     // compile error.
     const updatedRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
@@ -1967,8 +1970,9 @@ export class MeetingService {
       ...(registrantData.occurrence_id && { occurrence: registrantData.occurrence_id }),
     };
 
-    // `| null` in the type parameter because that is what actually comes back: `ApiClientService`
-    // maps an empty response body to `null`.
+    // `| null` in the type parameter because the contract permits it — see `addMeetingRegistrant`:
+    // `ITXZoomMeetingRegistrant` declares no required properties, so an empty body is schema-valid,
+    // and `ApiClientService` maps one to `null`.
     const upstreamRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
@@ -1978,8 +1982,8 @@ export class MeetingService {
       payload,
       { 'X-Sync': 'true' }
     );
-    // Keys, not truthiness — see `addMeetingRegistrant`. This path is the public registration one, so
-    // an unusable body used to surface to an anonymous registrant as a `{}` "created" record.
+    // Keys, not truthiness — see `addMeetingRegistrant`. This is the path a registrant drives from the
+    // public meeting page, so an unusable body used to surface to them as a `{}` "created" record.
     const hasUpstreamBody = !!upstreamRegistrant && Object.keys(upstreamRegistrant).length > 0;
     const newRegistrant = hasUpstreamBody
       ? this.fromUpstreamRegistrant(upstreamRegistrant)
@@ -1989,9 +1993,9 @@ export class MeetingService {
       meeting_id: meetingId,
       // `?? null` rather than leaving it `undefined`: Pino drops undefined values, so a create whose
       // upstream body carried no UID logged as a success line with no `registrant_uid` field at all,
-      // indistinguishable from a log-shape change. `upstream_body` says which branch produced it.
+      // indistinguishable from a log-shape change. `has_upstream_body` says which branch produced it.
       registrant_uid: newRegistrant.uid ?? null,
-      upstream_body: hasUpstreamBody,
+      has_upstream_body: hasUpstreamBody,
     });
 
     return newRegistrant;
@@ -2264,17 +2268,10 @@ export class MeetingService {
     const { org_name, avatar_url, occurrence_id } = body;
     const upstream: Record<string, unknown> = { ...body };
 
-    // Intersection, not union: a union only rejects a key once it's gone from *both* interfaces, so a
-    // rename on one of them would still compile while the `delete` quietly stopped matching. All four
-    // keys exist on both, so the intersection compiles as-is and does fail the build on either rename.
-    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[] = [
-      'meeting_id',
-      'org_name',
-      'avatar_url',
-      'occurrence_id',
-    ];
-
-    for (const appOnlyKey of appOnlyKeys) {
+    // Shared with `MeetingController.hasRegistrantChanges`, which has to know exactly which keys
+    // vanish here to tell an empty update apart from a real one — see the constant's own docs for
+    // why it's typed as the intersection of the two request interfaces.
+    for (const appOnlyKey of APP_ONLY_REGISTRANT_KEYS) {
       delete upstream[appOnlyKey];
     }
 

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -56,7 +56,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError, AuthorizationError, ServiceValidationError } from '../errors';
 import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
 import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from '../helpers/meeting-rsvp.helper';
-import { APP_ONLY_REGISTRANT_KEYS } from '../constants';
+import { APP_ONLY_REGISTRANT_KEYS, RENAMED_REGISTRANT_KEYS } from '../constants';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { encodePathSegment } from '../helpers/url-validation';
@@ -213,7 +213,7 @@ export class MeetingService {
 
     // All meetings are now ITX-managed, use the ITX endpoint
     const meeting = normalizeIndexedMeetingInviteResponses(
-      await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}`, 'GET')
+      await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${encodePathSegment(meetingUid)}`, 'GET')
     );
 
     // Set the meeting ID from the URL param
@@ -317,7 +317,12 @@ export class MeetingService {
       past_meeting_id: pastMeetingUid,
     });
 
-    const meeting = await this.microserviceProxy.proxyRequest<PastMeeting>(req, 'LFX_V2_SERVICE', `/itx/past_meetings/${pastMeetingUid}`, 'GET');
+    const meeting = await this.microserviceProxy.proxyRequest<PastMeeting>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}`,
+      'GET'
+    );
 
     if (!meeting) {
       throw new ResourceNotFoundError('Past Meeting', pastMeetingUid, {
@@ -551,7 +556,7 @@ export class MeetingService {
       operation: 'create_meeting',
       pollFn: async () => {
         try {
-          const meeting = await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingId}`, 'GET');
+          const meeting = await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${encodePathSegment(meetingId)}`, 'GET');
           meeting.id = meetingId;
           fetchedMeeting = meeting;
           return true;
@@ -577,7 +582,7 @@ export class MeetingService {
    */
   public async updateMeeting(req: Request, meetingUid: string, meetingData: UpdateMeetingRequest, editType?: 'single' | 'future'): Promise<ApiResponse<void>> {
     // Fetch existing meeting to merge organizers
-    const existingMeeting = await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}`, 'GET');
+    const existingMeeting = await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${encodePathSegment(meetingUid)}`, 'GET');
 
     // Get the logged-in user's username to maintain organizer if not provided
     const username = await getUsernameFromAuth(req);
@@ -603,7 +608,14 @@ export class MeetingService {
 
     const query = editType ? { editType } : undefined;
 
-    return await this.microserviceProxy.proxyRequestWithResponse<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}`, 'PUT', query, updatePayload);
+    return await this.microserviceProxy.proxyRequestWithResponse<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${encodePathSegment(meetingUid)}`,
+      'PUT',
+      query,
+      updatePayload
+    );
   }
 
   /**
@@ -614,7 +626,7 @@ export class MeetingService {
       meeting_id: meetingUid,
     });
 
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}`, 'DELETE');
+    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${encodePathSegment(meetingUid)}`, 'DELETE');
 
     // After deleting, poll the query service until the meeting no longer appears.
     // The upstream service uses eventual consistency, so the resource may still be indexed briefly.
@@ -641,7 +653,12 @@ export class MeetingService {
       occurrence_id: occurrenceId,
     });
 
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}/occurrences/${occurrenceId}`, 'DELETE');
+    await this.microserviceProxy.proxyRequest<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${encodePathSegment(meetingUid)}/occurrences/${encodePathSegment(occurrenceId)}`,
+      'DELETE'
+    );
   }
 
   /**
@@ -909,7 +926,7 @@ export class MeetingService {
     const newRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${registrantData.meeting_id}/registrants`,
+      `/itx/meetings/${encodePathSegment(registrantData.meeting_id)}/registrants`,
       'POST',
       undefined,
       this.toUpstreamRegistrantBody(registrantData)
@@ -1021,7 +1038,7 @@ export class MeetingService {
     const response = await this.microserviceProxy.proxyRequest<{ join_url: string; link: string }>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/join_link`,
+      `/itx/meetings/${encodePathSegment(meetingUid)}/join_link`,
       'GET',
       params
     );
@@ -1384,7 +1401,7 @@ export class MeetingService {
     const updatedSummary = await this.microserviceProxy.proxyRequest<PastMeetingSummary>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${pastMeetingUid}/summaries/${summaryUid}`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/summaries/${encodePathSegment(summaryUid)}`,
       'PUT',
       undefined,
       updateData
@@ -1429,7 +1446,7 @@ export class MeetingService {
     const result = await this.microserviceProxy.proxyRequest<ITXMeetingResponseResult>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/responses`,
+      `/itx/meetings/${encodePathSegment(meetingUid)}/responses`,
       'POST',
       {},
       requestData
@@ -1641,7 +1658,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<MeetingAttachment>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/attachments`,
+      `/itx/meetings/${encodePathSegment(meetingUid)}/attachments`,
       'POST',
       undefined,
       attachmentData
@@ -1658,7 +1675,7 @@ export class MeetingService {
     await this.microserviceProxy.proxyRequest<void>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/attachments/${attachmentUid}`,
+      `/itx/meetings/${encodePathSegment(meetingUid)}/attachments/${encodePathSegment(attachmentUid)}`,
       'PUT',
       undefined,
       updateData
@@ -1671,7 +1688,12 @@ export class MeetingService {
   public async deleteMeetingAttachment(req: Request, meetingUid: string, attachmentUid: string): Promise<void> {
     logger.debug(req, 'delete_meeting_attachment', 'Deleting meeting attachment', { meeting_id: meetingUid, attachment_uid: attachmentUid });
 
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}/attachments/${attachmentUid}`, 'DELETE');
+    await this.microserviceProxy.proxyRequest<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${encodePathSegment(meetingUid)}/attachments/${encodePathSegment(attachmentUid)}`,
+      'DELETE'
+    );
   }
 
   /**
@@ -1680,7 +1702,12 @@ export class MeetingService {
   public async getMeetingAttachmentInfo(req: Request, meetingUid: string, attachmentUid: string): Promise<MeetingAttachment> {
     logger.debug(req, 'get_meeting_attachment_info', 'Fetching meeting attachment info', { meeting_id: meetingUid, attachment_uid: attachmentUid });
 
-    return this.microserviceProxy.proxyRequest<MeetingAttachment>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}/attachments/${attachmentUid}`, 'GET');
+    return this.microserviceProxy.proxyRequest<MeetingAttachment>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${encodePathSegment(meetingUid)}/attachments/${encodePathSegment(attachmentUid)}`,
+      'GET'
+    );
   }
 
   /**
@@ -1692,7 +1719,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<PresignAttachmentResponse>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/attachments/presign`,
+      `/itx/meetings/${encodePathSegment(meetingUid)}/attachments/presign`,
       'POST',
       undefined,
       presignData
@@ -1753,7 +1780,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<AttachmentDownloadUrlResponse>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/attachments/${attachmentUid}/download`,
+      `/itx/meetings/${encodePathSegment(meetingUid)}/attachments/${encodePathSegment(attachmentUid)}/download`,
       'GET'
     );
   }
@@ -1792,7 +1819,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<PastMeetingAttachment>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/attachments/${encodeURIComponent(attachmentUid)}`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/attachments/${encodePathSegment(attachmentUid)}`,
       'GET'
     );
   }
@@ -1806,7 +1833,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<AttachmentDownloadUrlResponse>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/attachments/${encodeURIComponent(attachmentUid)}/download`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/attachments/${encodePathSegment(attachmentUid)}/download`,
       'GET'
     );
   }
@@ -1824,7 +1851,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<PastMeetingAttachment>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/attachments`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/attachments`,
       'POST',
       undefined,
       attachmentData
@@ -1840,7 +1867,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<PresignAttachmentResponse>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/attachments/presign`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/attachments/presign`,
       'POST',
       undefined,
       presignData
@@ -1899,7 +1926,7 @@ export class MeetingService {
     await this.microserviceProxy.proxyRequest<void>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/attachments/${encodeURIComponent(attachmentUid)}`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/attachments/${encodePathSegment(attachmentUid)}`,
       'DELETE'
     );
   }
@@ -1990,7 +2017,7 @@ export class MeetingService {
     const upstreamRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingId}/registrants/self`,
+      `/itx/meetings/${encodePathSegment(meetingId)}/registrants/self`,
       'POST',
       undefined,
       payload,
@@ -2277,22 +2304,27 @@ export class MeetingService {
    * ("blank = all occurrences"), so a wrong guess silently rescopes an invite.
    */
   private toUpstreamRegistrantBody(body: CreateMeetingRegistrantRequest | UpdateMeetingRegistrantRequest): Record<string, unknown> {
-    const { org_name, avatar_url, occurrence_id } = body;
     const upstream: Record<string, unknown> = { ...body };
 
     // Shared with `MeetingController.hasRegistrantChanges`, which has to know exactly which keys
     // vanish here to tell an empty update apart from a real one — see the constant's own docs for
-    // why it's typed as the intersection of the two request interfaces.
+    // why it's keyed on the intersection of the two request interfaces.
     for (const appOnlyKey of APP_ONLY_REGISTRANT_KEYS) {
       delete upstream[appOnlyKey];
     }
 
-    return {
-      ...upstream,
-      ...(org_name == null ? {} : { org: org_name }),
-      ...(avatar_url == null ? {} : { profile_picture: avatar_url }),
-      ...(occurrence_id == null ? {} : { occurrence: occurrence_id }),
-    };
+    // Driven off the same map the delete loop's second half is derived from, so a key can't be
+    // deleted here and then forgotten on the way back in — which would be silent data loss with no
+    // type error to catch it.
+    for (const [appKey, upstreamKey] of Object.entries(RENAMED_REGISTRANT_KEYS)) {
+      const value = body[appKey as keyof typeof body];
+
+      if (value != null) {
+        upstream[upstreamKey] = value;
+      }
+    }
+
+    return upstream;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -59,6 +59,7 @@ import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from '../hel
 import { APP_ONLY_REGISTRANT_KEYS } from '../constants';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { encodePathSegment } from '../helpers/url-validation';
 import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { CommitteeService } from './committee.service';
@@ -943,7 +944,9 @@ export class MeetingService {
     const updatedRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown> | null>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${meetingUid}/registrants/${registrantUid}`,
+      // `registrantUid` is client-supplied through the batch endpoint's *body*, where nothing splits
+      // the request into path segments for us — see `encodePathSegment`.
+      `/itx/meetings/${encodePathSegment(meetingUid)}/registrants/${encodePathSegment(registrantUid)}`,
       'PUT',
       undefined,
       this.toUpstreamRegistrantBody(updateData)
@@ -976,7 +979,13 @@ export class MeetingService {
       registrant_uid: registrantUid,
     });
 
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}/registrants/${registrantUid}`, 'DELETE');
+    // Same body-supplied identifier as the update path above — see `encodePathSegment`.
+    await this.microserviceProxy.proxyRequest<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${encodePathSegment(meetingUid)}/registrants/${encodePathSegment(registrantUid)}`,
+      'DELETE'
+    );
   }
 
   /**
@@ -989,7 +998,12 @@ export class MeetingService {
     });
 
     // Call the LFX API endpoint for resending invitation
-    await this.microserviceProxy.proxyRequest<void>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}/registrants/${registrantId}/resend`, 'POST');
+    await this.microserviceProxy.proxyRequest<void>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${encodePathSegment(meetingUid)}/registrants/${encodePathSegment(registrantId)}/resend`,
+      'POST'
+    );
   }
 
   /**
@@ -1985,9 +1999,7 @@ export class MeetingService {
     // Keys, not truthiness — see `addMeetingRegistrant`. This is the path a registrant drives from the
     // public meeting page, so an unusable body used to surface to them as a `{}` "created" record.
     const hasUpstreamBody = !!upstreamRegistrant && Object.keys(upstreamRegistrant).length > 0;
-    const newRegistrant = hasUpstreamBody
-      ? this.fromUpstreamRegistrant(upstreamRegistrant)
-      : MeetingService.registrantFromSubmittedPayload(registrantData);
+    const newRegistrant = hasUpstreamBody ? this.fromUpstreamRegistrant(upstreamRegistrant) : MeetingService.registrantFromSubmittedPayload(registrantData);
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {
       meeting_id: meetingId,

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -693,29 +693,15 @@ export interface DashboardMeetingCardProps {
 }
 
 /**
- * Dashboard quick link
- * @description Navigation shortcut displayed in the dashboard header or sidebar. Each link carries
- * its own visibility predicate, because the permission a link needs is the permission of the thing
- * it opens — not a single permission shared by the whole row.
+ * The half of a dashboard quick link that every variant carries
+ * @description Not used directly — {@link DashboardQuickLink} pairs it with whichever action the
+ * link performs.
  */
-export interface DashboardQuickLink {
+interface DashboardQuickLinkBase {
   /** Display label for the quick link */
   label: string;
   /** FontAwesome icon class (e.g. 'fa-light fa-calendar') */
   icon: string;
-  /**
-   * Router link path segments.
-   * @description Required unless `command` is set. With neither, the link renders as an anchor with
-   * no `routerLink` — a dead, unfocusable row with no visible error — so a link that navigates has
-   * to declare this.
-   */
-  route?: string[];
-  /**
-   * Click handler for links that open something over the current page rather than navigate.
-   * @description Renders a button instead of an anchor, so nothing about the row promises a
-   * destination it doesn't have. Takes precedence over `route` when both are set.
-   */
-  command?: () => void;
   /**
    * Whether the current user can use this link. Omitted means always visible.
    * @description Read inside a computed, so it must be a signal read or an equivalently reactive
@@ -725,6 +711,45 @@ export interface DashboardQuickLink {
   /** Pre-computed data-testid slug (e.g. 'create-meeting') */
   testId: string;
 }
+
+/**
+ * Dashboard quick link
+ * @description Navigation shortcut displayed in the dashboard sidebar. Each link carries its own
+ * visibility predicate, because the permission a link needs is the permission of the thing it opens
+ * — not a single permission shared by the whole row.
+ *
+ * A union rather than one interface with two optional keys: a link either navigates or runs a
+ * command, and the template picks its element from which one is set. Declaring both optional made
+ * "exactly one of these" a sentence in a doc comment that nothing checked, and a link with neither
+ * still compiled — rendering an anchor whose `routerLink` is `undefined`, which still emits an
+ * `href` and still takes focus, so it reads as a working link and does nothing when activated.
+ */
+export type DashboardQuickLink = DashboardQuickLinkBase &
+  (
+    | {
+        /** Router link path segments. */
+        route: string[];
+        command?: never;
+        hasPopup?: never;
+      }
+    | {
+        route?: never;
+        /**
+         * Click handler for links that open something over the current page rather than navigate.
+         * @description Renders a button instead of an anchor, so nothing about the row promises a
+         * destination it doesn't have.
+         */
+        command: () => void;
+        /**
+         * What the command opens, announced to assistive tech as `aria-haspopup`.
+         * @description Declared by the link rather than assumed by the template: what a command
+         * opens is the command's own business, and a template that hard-codes `dialog` for every
+         * button announces one for a command that opens nothing. Omitted means the button opens no
+         * overlay.
+         */
+        hasPopup?: 'dialog' | 'menu';
+      }
+  );
 
 /**
  * Committee selector option

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -701,8 +701,14 @@ export interface DashboardQuickLink {
   label: string;
   /** FontAwesome icon class (e.g. 'fa-light fa-calendar') */
   icon: string;
-  /** Router link path segments */
-  route: string[];
+  /** Router link path segments. Omitted when `command` opens an in-page surface instead of navigating. */
+  route?: string[];
+  /**
+   * Click handler for links that open something over the current page rather than navigate.
+   * @description Renders a button instead of an anchor, so nothing about the row promises a
+   * destination it doesn't have. Takes precedence over `route` when both are set.
+   */
+  command?: () => void;
   /** Pre-computed data-testid slug (e.g. 'create-meeting') */
   testId: string;
 }

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -694,14 +694,21 @@ export interface DashboardMeetingCardProps {
 
 /**
  * Dashboard quick link
- * @description Navigation shortcut displayed in the dashboard header for write-enabled users
+ * @description Navigation shortcut displayed in the dashboard header or sidebar. Each link carries
+ * its own visibility predicate, because the permission a link needs is the permission of the thing
+ * it opens — not a single permission shared by the whole row.
  */
 export interface DashboardQuickLink {
   /** Display label for the quick link */
   label: string;
   /** FontAwesome icon class (e.g. 'fa-light fa-calendar') */
   icon: string;
-  /** Router link path segments. Omitted when `command` opens an in-page surface instead of navigating. */
+  /**
+   * Router link path segments.
+   * @description Required unless `command` is set. With neither, the link renders as an anchor with
+   * no `routerLink` — a dead, unfocusable row with no visible error — so a link that navigates has
+   * to declare this.
+   */
   route?: string[];
   /**
    * Click handler for links that open something over the current page rather than navigate.
@@ -709,6 +716,12 @@ export interface DashboardQuickLink {
    * destination it doesn't have. Takes precedence over `route` when both are set.
    */
   command?: () => void;
+  /**
+   * Whether the current user can use this link. Omitted means always visible.
+   * @description Read inside a computed, so it must be a signal read or an equivalently reactive
+   * expression rather than a value captured at construction.
+   */
+  visible?: () => boolean;
   /** Pre-computed data-testid slug (e.g. 'create-meeting') */
   testId: string;
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -754,6 +754,27 @@ export interface MeetingRegistrantWithState extends MeetingRegistrant {
 }
 
 /**
+ * A guest list row, with every derived string precomputed
+ * @description The composer's guest list is projected into these once per `guests()` change rather
+ * than recomputed per binding: the frontend checklist bars method calls in render-time expressions,
+ * and the display name alone was read three times per row (label, tooltip, remove button's
+ * accessible name). `trackId` is the identity the `@for` tracks on — a saved guest has a `uid`, one
+ * added in this session only has a `tempId`.
+ */
+export interface ComposerGuestRow {
+  /** The registrant this row renders, for the handlers and the fields read directly. */
+  guest: MeetingRegistrantWithState;
+  /** `uid` when saved, `tempId` while pending. */
+  trackId: string;
+  /** Avatar initials, from the name when known and the email otherwise. */
+  initials: string;
+  /** `first last`, as typed — no fallback, since both are required to add a guest. */
+  displayName: string;
+  /** `email · org`, collapsing to just the email when the org is unknown. */
+  secondaryLine: string;
+}
+
+/**
  * Batch update request for meeting registrants
  * @description Request payload for updating multiple registrants at once
  */


### PR DESCRIPTION
> **Stack 13 of 20.** Based on PR 12 (`fix/issue-1463-registrant-identity`). Followed by PR 14 (`style/issue-1460-dropdown-tiles`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Encodes every interpolated upstream path segment and closes the remaining test gaps across the composer and registrant paths.

## How

- Wraps all interpolated `/itx/...` path segments in `encodeURIComponent`, so a uid containing a slash or a percent can no longer alter the upstream route.
- Guards empty registrant writes and zero-byte attachment sizes.
- Labels the custom duration input for screen readers.
- Adds the missing specs across the composer and registrant controllers.

## Protected files

This PR touches files flagged by `.claude/hooks/guard-protected-files.sh`. Requesting code-owner review from @linuxfoundation/lfx-platform.

| File | Why it is protected | What this PR changes |
| --- | --- | --- |
| `apps/lfx-one/src/server/middleware/rate-limit.middleware.spec.ts` | Request middleware. Changes affect request processing for all routes. | Extends the limiter specs to cover the malformed-IP and empty-key cases. Test-only. |
| `apps/lfx-one/src/server/services/ai.service.ts` | AI integration service. Changes affect AI-powered features. | Logs honest byte counts and rejects dot-only segments on the paths this service builds. |

## Commits

5 commit(s), 29 files changed, 1510 insertions(+), 192 deletions(-).

- `fix(meetings): label the custom duration input and guard zero-byte sizes`
- `fix(review): guard empty registrant writes and misplaced docs`
- `fix(meetings): make the empty-registrant-write guard true`
- `fix(review): address reviewer findings across composer and registrants`
- `fix(review): encode every upstream path segment and close test gaps`

## Related

- Closes #1463
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
