### PR TITLE
fix(meetings): address the full-branch review and cover the composer

### DIFF
--- a/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
+++ b/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Meeting owner as the displayed organizer + owner picker in the edit wizard — GH-1673.
+ * Meeting owner as the displayed organizer + owner picker in the edit composer — GH-1673.
  *
  * Coverage:
  *   - Meeting cards show the owner as the primary organizer, replacing created_by; a zero-valued
  *     owner (meetings predating the field) falls back to the human created_by.
  *   - The "Organized by me" filter follows ownership: a meeting owned by the viewer matches even
  *     when someone else created it, and a meeting the viewer created but transferred away does not.
- *   - The edit wizard's Meeting Details step renders the saved owner directly in the organizer
- *     search box (as "Name (email)"); an untouched save omits the `owner` key entirely so upstream
- *     preserves the stored owner (including profile_picture, which the form never carries).
+ *   - The edit composer's Details & Access section renders the saved owner directly in the
+ *     organizer search box (as "Name (email)"); an untouched save omits the `owner` key entirely so
+ *     upstream preserves the stored owner (including profile_picture, which the form never carries).
  *   - Picking a user in the organizer field sends `owner: {username, name, email}` on update, and
  *     the box re-renders to show the freshly picked name/email instead of the previous selection.
  *   - The search pool is the same committee-member directory Invite Guests uses; the picker's
  *     "Enter details manually" affordance still covers anyone outside it. Manual entry sends
- *     `owner: {name, email}` (no username) and an invalid email blocks the step.
+ *     `owner: {name, email}` (no username) and an invalid email blocks the save.
  *   - Clearing (in-field ⊗ or the "Revert" button) restores the saved owner rather than emptying
  *     the field — upstream has no owner-removal path, so the following save still omits the
  *     `owner` key (create flow with no saved owner instead empties every control).
@@ -37,7 +37,7 @@ const ELEMENT_TIMEOUT = 10_000;
 
 const MEETINGS_URL = '/meetings';
 
-// Deterministic, far-future start so `hasMeetingEnded` never drops the fixtures and the wizard's
+// Deterministic, far-future start so `hasMeetingEnded` never drops the fixtures and the composer's
 // futureDateTimeValidator keeps the hydrated form valid.
 const FUTURE_START = '2099-03-04T15:00:00Z';
 
@@ -229,7 +229,7 @@ function buildProjectStub() {
     uid: PROJECT_UID,
     slug: PROJECT_SLUG,
     name: PROJECT_NAME,
-    description: `${PROJECT_NAME} for meeting-owner wizard specs`,
+    description: `${PROJECT_NAME} for meeting-owner composer specs`,
     public: true,
     parent_uid: '',
     stage: 'Active',
@@ -274,7 +274,7 @@ async function setProjectCookie(page: Page): Promise<void> {
   ]);
 }
 
-async function stubWizardContext(page: Page): Promise<void> {
+async function stubComposerContext(page: Page): Promise<void> {
   await page.route('**/api/user/personas*', (route) =>
     fulfillJson(route, { personas: ['executive-director'], personaProjects: {}, projects: [], organizations: [], isRootWriter: true })
   );
@@ -298,12 +298,12 @@ async function stubWizardContext(page: Page): Promise<void> {
   });
 }
 
-/** Fully-valid meeting detail payload for the edit wizard; `owner` included only when given. */
+/** Fully-valid meeting detail payload for the edit composer; `owner` included only when given. */
 function buildEditMeeting(owner?: Record<string, string>) {
   return {
     id: MOCK_MEETING_UID,
     title: 'Owner E2E Sync',
-    description: 'Meeting stub for meeting-owner wizard specs',
+    description: 'Meeting stub for meeting-owner composer specs',
     project_uid: PROJECT_UID,
     project_slug: PROJECT_SLUG,
     project_name: PROJECT_NAME,
@@ -330,8 +330,8 @@ function buildEditMeeting(owner?: Record<string, string>) {
 }
 
 /**
- * Stubs every meeting endpoint the edit wizard touches and captures the PUT payload the wizard
- * sends on "Update Meeting" — the assertion surface for prepareOwnerData()'s include/omit rules.
+ * Stubs every meeting endpoint the edit composer touches and captures the PUT payload it sends on
+ * "Save changes" — the assertion surface for prepareOwnerData()'s include/omit rules.
  */
 async function stubMeetingEdit(page: Page, meeting: Record<string, unknown>): Promise<{ put: Record<string, unknown> | null }> {
   const captured: { put: Record<string, unknown> | null } = { put: null };
@@ -384,43 +384,50 @@ async function gotoEditPage(page: Page): Promise<void> {
   }, `/project/meetings/${MOCK_MEETING_UID}/edit`);
 }
 
-/** Step 1 (Meeting Type) → step 2 (Meeting Details), where the organizer picker lives. */
-async function openDetailsStep(page: Page): Promise<void> {
-  await expect(page.getByTestId('meeting-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-  await page.getByTestId('meeting-manage-next-btn').click();
-  await expect(page.getByTestId('meeting-details-organizer-search')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+/**
+ * Waits for the composer drawer to land on Details & Access, where the organizer picker lives.
+ * @description Details & Access is the composer's first section, so an edit open arrives there with
+ * no navigation of its own — the wait is for the meeting fetch that hydrates the picker, not for a
+ * step change. Waiting on the picker rather than the drawer header is deliberate: the header renders
+ * while the fetch is still in flight.
+ */
+async function openDetailsSection(page: Page): Promise<void> {
+  await expect(page.getByTestId('composer-organizer-search')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 }
 
-/** Steps 2 → 5 via the shared Next control (edit mode), then "Update Meeting" fires the PUT. */
-async function saveFromDetailsStep(page: Page): Promise<void> {
-  await page.getByTestId('meeting-manage-next-btn').click(); // Platform & Features
-  await page.getByTestId('meeting-manage-next-btn').click(); // Resources & Links
-  await page.getByTestId('meeting-manage-next-btn').click(); // Invite Guests
-  const updateButton = page.getByTestId('meeting-manage-update-btn');
-  await expect(updateButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
-  await updateButton.click();
+/**
+ * Saves from wherever the composer is — "Save changes" fires the PUT.
+ * @description Edit mode has no Next control and no last-section gate: the footer offers Cancel and
+ * Save, and Save is enabled on whole-form validity rather than on having visited every section.
+ */
+async function saveFromComposer(page: Page): Promise<void> {
+  // The disabled state lives on the wrapper's inner native button, not the lfx-button host the
+  // testid is on, so both the wait and the click target the inner button.
+  const saveButton = page.getByTestId('meeting-composer-save').locator('button');
+  await expect(saveButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+  await saveButton.click();
 }
 
-test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
+test.describe('Meeting edit composer — owner picker (GH-1673)', () => {
   test.beforeEach(async ({ page }) => {
     await setPersonaAndLensCookies(page, ['executive-director'], 'project');
     await setProjectCookie(page);
-    await stubWizardContext(page);
+    await stubComposerContext(page);
   });
 
   test('renders the saved owner directly in the box and an untouched save omits the owner key', async ({ page }) => {
     const captured = await stubMeetingEdit(page, buildEditMeeting({ user_id: 'u-owner-e2e', ...OWNER }));
 
     await gotoEditPage(page);
-    await openDetailsStep(page);
+    await openDetailsSection(page);
 
     // The box is the single source of display truth — hydration renders "Name (email)" directly,
     // no separate confirmation line needed.
-    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    await expect(page.getByTestId('composer-organizer-search').locator('input')).toHaveValue(`${OWNER.name} (${OWNER.email})`);
     // Untouched picker → no saved/current mismatch → the revert row stays hidden.
-    await expect(page.getByTestId('meeting-details-organizer-saved')).toHaveCount(0);
+    await expect(page.getByTestId('composer-organizer-saved')).toHaveCount(0);
 
-    await saveFromDetailsStep(page);
+    await saveFromComposer(page);
 
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
     // Untouched picker → key omitted → upstream preserves the stored owner (incl. its avatar).
@@ -432,9 +439,9 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [DIFFERENT_PICKED_USER] }));
 
     await gotoEditPage(page);
-    await openDetailsStep(page);
+    await openDetailsSection(page);
 
-    const input = page.getByTestId('meeting-details-organizer-search').locator('input');
+    const input = page.getByTestId('composer-organizer-search').locator('input');
     await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
 
     // Pick a different organizer — the box re-renders with the fresh pick, and the saved-owner row
@@ -443,14 +450,14 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await input.fill('Radia');
     await page.getByRole('option').filter({ hasText: pickedName }).click();
     await expect(input).toHaveValue(`${pickedName} (${DIFFERENT_PICKED_USER.email})`);
-    await expect(page.getByTestId('meeting-details-organizer-saved')).toContainText(`Saved organizer: ${OWNER.name} (${OWNER.email})`);
+    await expect(page.getByTestId('composer-organizer-saved')).toContainText(`Saved organizer: ${OWNER.name} (${OWNER.email})`);
 
     // Revert restores the saved owner and hides the row again.
-    await page.getByTestId('meeting-details-organizer-revert').click();
+    await page.getByTestId('composer-organizer-revert').click();
     await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
-    await expect(page.getByTestId('meeting-details-organizer-saved')).toHaveCount(0);
+    await expect(page.getByTestId('composer-organizer-saved')).toHaveCount(0);
 
-    await saveFromDetailsStep(page);
+    await saveFromComposer(page);
 
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
     // Reverted controls match the hydrated baseline → key omitted → upstream keeps the stored
@@ -463,18 +470,18 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
 
     await gotoEditPage(page);
-    await openDetailsStep(page);
+    await openDetailsSection(page);
 
     // No saved owner → box starts empty.
-    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue('');
+    await expect(page.getByTestId('composer-organizer-search').locator('input')).toHaveValue('');
 
-    await page.getByTestId('meeting-details-organizer-search').locator('input').fill('Grace');
+    await page.getByTestId('composer-organizer-search').locator('input').fill('Grace');
     await page.getByRole('option').filter({ hasText: OWNER.name }).click();
-    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    await expect(page.getByTestId('composer-organizer-search').locator('input')).toHaveValue(`${OWNER.name} (${OWNER.email})`);
     // No saved owner to compare against, so no revert row even though a pick was made.
-    await expect(page.getByTestId('meeting-details-organizer-saved')).toHaveCount(0);
+    await expect(page.getByTestId('composer-organizer-saved')).toHaveCount(0);
 
-    await saveFromDetailsStep(page);
+    await saveFromComposer(page);
 
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
     expect((captured.put as Record<string, unknown>)['owner']).toEqual({ username: OWNER.username, name: OWNER.name, email: OWNER.email });
@@ -485,19 +492,19 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
 
     await gotoEditPage(page);
-    await openDetailsStep(page);
+    await openDetailsSection(page);
 
-    const input = page.getByTestId('meeting-details-organizer-search').locator('input');
+    const input = page.getByTestId('composer-organizer-search').locator('input');
     await input.fill('Grace');
     await page.getByRole('option').filter({ hasText: OWNER.name }).click();
     await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
 
     // In-field clear on a create-style (no saved-owner) edit empties the box outright — there's
     // nothing to revert to.
-    await page.getByTestId('meeting-details-organizer-search').locator('.p-autocomplete-clear-icon').click();
+    await page.getByTestId('composer-organizer-search').locator('.p-autocomplete-clear-icon').click();
     await expect(input).toHaveValue('');
 
-    await saveFromDetailsStep(page);
+    await saveFromComposer(page);
 
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
     expect(Object.keys(captured.put as Record<string, unknown>)).not.toContain('owner');
@@ -511,28 +518,29 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
 
     await gotoEditPage(page);
-    await openDetailsStep(page);
+    await openDetailsSection(page);
 
-    await page.getByTestId('meeting-details-organizer-search').locator('input').fill('Radia');
+    await page.getByTestId('composer-organizer-search').locator('input').fill('Radia');
     await page.getByRole('button', { name: 'Enter details manually' }).click();
 
     // Manual mode swaps the search out for name/email inputs.
-    await expect(page.getByTestId('meeting-details-organizer-manual')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
-    await expect(page.getByTestId('meeting-details-organizer-search')).toHaveCount(0);
+    await expect(page.getByTestId('composer-organizer-manual')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('composer-organizer-search')).toHaveCount(0);
 
-    const nameInput = page.getByTestId('meeting-details-organizer-name-input').locator('input');
-    const emailInput = page.getByTestId('meeting-details-organizer-email-input').locator('input');
+    const nameInput = page.getByTestId('composer-organizer-name-input').locator('input');
+    const emailInput = page.getByTestId('composer-organizer-email-input').locator('input');
     await nameInput.fill(MANUAL_OWNER.name);
 
-    // An invalid email must gate the step (Validators.email feeds isStepValid). The disabled
-    // state lives on the wrapper's inner native button, not the lfx-button host the testid is on.
-    const nextButton = page.getByTestId('meeting-manage-next-btn').locator('button');
+    // An invalid email must gate the save (Validators.email sits on ownerEmail unconditionally, so
+    // it fails whole-form validity). The disabled state lives on the wrapper's inner native button,
+    // not the lfx-button host the testid is on.
+    const saveButton = page.getByTestId('meeting-composer-save').locator('button');
     await emailInput.fill('not-an-email');
-    await expect(nextButton).toBeDisabled();
+    await expect(saveButton).toBeDisabled();
     await emailInput.fill(MANUAL_OWNER.email);
-    await expect(nextButton).toBeEnabled();
+    await expect(saveButton).toBeEnabled();
 
-    await saveFromDetailsStep(page);
+    await saveFromComposer(page);
 
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
     // No username: a hand-typed identity is name+email only.

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -293,7 +293,7 @@ async function stubMeetingEditDetail(page: Page, meeting: ReturnType<typeof buil
 
 /**
  * Same route shapes as stubMeetingEditDetail, but the detail GET fulfills an error status —
- * exercises meeting-manage's non-404 inline error state and 404 eject (GH-2037).
+ * exercises the composer's inline load-error state and its not-found toast (GH-2037).
  */
 async function stubMeetingEditDetailError(page: Page, status: number): Promise<void> {
   await page.route('**/api/meetings*', (route) => {
@@ -509,8 +509,7 @@ function skipWhenAuthMissing(): void {
  *
  * A full `page.goto()` of an entity URL SSRs the route on the Express server — server-side
  * data fetches bypass `page.route` stubs and hit the real BFF, where the stubbed entity does
- * not exist, so the component's error path (e.g. meeting-manage's navigateBack) redirects away
- * before the client ever boots. Booting on `/` first and then navigating via
+ * not exist, so the component's error path redirects away before the client ever boots. Booting on `/` first and then navigating via
  * pushState + popstate keeps the router client-side, where every fetch is intercepted.
  *
  * Also note Playwright glob semantics: `*` does not cross `/`, so `**\/api/meetings*` matches
@@ -642,7 +641,7 @@ test.describe('Meeting edit deep-link resolves the meeting’s project context (
       name: 'Other Project',
       foundation: false,
     });
-    await expect(page.getByTestId('meeting-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-header')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // The sync derives context from the loaded meeting (Test Foundation), replacing the
     // cookie-restored Other Project — the selector and sidebar links follow the correction.
@@ -676,10 +675,13 @@ test.describe('Meeting edit deep-link resolves the meeting’s project context (
       name: 'Other Project',
       foundation: false,
     });
-    await expect(page.getByTestId('meeting-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-header')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
-    // Still on the edit page (no access-denied redirect), and the context follows the meeting.
-    expect(page.url()).toContain(`/project/meetings/${MOCK_MEETING_UID}/edit`);
+    // No access-denied redirect (that would land on /project/overview?_notice=...) — the composer
+    // route hands off to the meetings list and opens the drawer over it, so the list URL plus a
+    // visible drawer is what "the guard let us through" looks like now.
+    expect(page.url()).toContain('/project/meetings');
+    expect(page.url()).not.toContain('/overview');
     await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
   });
 
@@ -707,7 +709,7 @@ test.describe('Meeting edit deep-link resolves the meeting’s project context (
       name: 'Other Project',
       foundation: false,
     });
-    await expect(page.getByTestId('meeting-manage-title')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-header')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     await expect(page.getByTestId('project-selector')).toContainText('Test Foundation', { timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('sidebar-item-meetings')).toHaveAttribute('href', /[?&]project=test-foundation/, { timeout: ELEMENT_TIMEOUT });
@@ -739,14 +741,16 @@ test.describe('Meeting edit load failure (GH-2037)', () => {
       foundation: false,
     });
 
-    // Inline error state replaces the skeleton; no "not found" toast; URL stays on /edit.
-    await expect(page.getByTestId('meeting-manage-retry')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByTestId('meeting-manage-back')).toBeVisible();
-    await expect(page.getByTestId('meeting-manage-loading')).not.toBeVisible();
-    // Give a (never-fired) toast a render window — negative assertions pass instantly otherwise.
-    await page.waitForTimeout(500);
-    await expect(page.locator('.p-toast')).not.toBeVisible();
-    expect(page.url()).toContain(`/project/meetings/${MOCK_MEETING_UID}/edit`);
+    // Inline error state replaces the skeleton, and the drawer stays open with a way out.
+    await expect(page.getByTestId('meeting-composer-load-error')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-load-retry')).toBeVisible();
+    // Cancel, not Back: the composer's Back button is create-mode only, so Cancel is the single
+    // exit an edit-mode load failure offers.
+    await expect(page.getByTestId('meeting-composer-cancel')).toBeVisible();
+    await expect(page.getByTestId('meeting-composer-loading')).not.toBeVisible();
+    // The composer route redirects to the list and opens the drawer over it, so the surviving URL
+    // assertion is that nothing ejected us out of the meetings section entirely.
+    expect(page.url()).toContain('/project/meetings');
   });
 
   test('Retry after a transient failure re-fetches the meeting and renders the form (AC-1, AC-3)', async ({ page }) => {
@@ -758,16 +762,16 @@ test.describe('Meeting edit load failure (GH-2037)', () => {
       name: 'Other Project',
       foundation: false,
     });
-    await expect(page.getByTestId('meeting-manage-retry')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-load-retry')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // "Backend recovered": re-registering the detail route takes precedence over the error
     // stub (Playwright matches in reverse registration order), so the retry fetch gets a 200.
     await stubMeetingEditDetail(page, buildMeetingStub(true));
-    await page.getByTestId('meeting-manage-retry').click();
+    await page.getByTestId('meeting-composer-load-retry').click();
 
-    await expect(page.getByTestId('meeting-manage-stepper')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
-    await expect(page.getByTestId('meeting-manage-load-error')).not.toBeVisible();
-    expect(page.url()).toContain(`/project/meetings/${MOCK_MEETING_UID}/edit`);
+    await expect(page.getByTestId('meeting-composer-rail')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-load-error')).not.toBeVisible();
+    expect(page.url()).toContain('/project/meetings');
   });
 
   test('a real 404 still ejects to the meetings list with the not-found toast (AC-2)', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.html
@@ -2,7 +2,14 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!-- No nested card or heading: this panel only ever renders under the "Custom" cadence chip, inside the
-     recurring card that already frames and titles it. A rule stands in for the border it used to draw. -->
+     recurring card that already frames and titles it. A rule stands in for the border it used to draw.
+
+     Every choice below is a native `<input>` visually hidden inside its `<label>` chip rather than an
+     `lfx-radio-button`: the wrapper renders PrimeNG's radio dot plus a text label with no styleClass
+     passthrough, so it cannot become the outlined pill this row is specified as. Hiding the real control
+     keeps native radiogroup semantics (arrow-key traversal, one tab stop per group) and the chip carries
+     its focus ring through `has-[:focus-visible]` — see `chipSelectedClass` in the component. The values
+     still write through the same `monthlyTypeUI` / `endTypeUI` controls the wrapper bound. -->
 <div class="flex flex-col gap-4 border-t border-gray-200 pt-3" [formGroup]="recurrenceForm()">
   <!-- Interval -->
   <div class="flex flex-col gap-1.5">

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-recurrence-pattern/meeting-recurrence-pattern.component.ts
@@ -41,12 +41,14 @@ export class MeetingRecurrencePatternComponent implements OnInit {
    * Outlined-pill styling for every choice in this panel.
    * @description Same shape as the meeting-type, duration and cadence chips the panel sits under, so the
    * whole schedule column reads as one control language. Whole class strings rather than a toggled
-   * fragment because Tailwind only emits what it can see literally.
+   * fragment because Tailwind only emits what it can see literally. The real radio/checkbox is `sr-only`
+   * inside the label, so the chip carries the keyboard focus ring on its behalf via `has-[:focus-visible]`
+   * — without it the panel is keyboard-navigable but invisibly so (WCAG 2.4.7).
    */
   protected readonly chipSelectedClass =
-    'cursor-pointer rounded-full border border-blue-500 bg-blue-50 px-2.5 py-1 text-sm font-medium text-blue-700 transition-colors';
+    'cursor-pointer rounded-full border border-blue-500 bg-blue-50 px-2.5 py-1 text-sm font-medium text-blue-700 transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 has-[:focus-visible]:ring-offset-2';
   protected readonly chipUnselectedClass =
-    'cursor-pointer rounded-full border border-gray-200 px-2.5 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50';
+    'cursor-pointer rounded-full border border-gray-200 px-2.5 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-50 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-blue-500 has-[:focus-visible]:ring-offset-2';
 
   // Get the recurrence FormGroup from parent
   public readonly recurrenceForm = computed(() => this.form().get('recurrence') as FormGroup);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -22,7 +22,7 @@ import {
   MIN_EMAIL_REMINDER_HOURS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
 } from '@lfx-one/shared/constants';
-import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
+import { CancelOnCommitteeRemoval, MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   BatchRegistrantOperationResponse,
   Committee,
@@ -36,10 +36,12 @@ import {
   MeetingComposerMode,
   MeetingComposerSection,
   MeetingComposerSectionId,
+  MeetingOwnerInput,
   MeetingRecurrence,
   MeetingRegistrant,
   MeetingRegistrantOperationResult,
   MeetingRegistrantWithState,
+  MeetingUserInfo,
   PendingAttachment,
   RegistrantPendingChanges,
   UpdateMeetingRequest,
@@ -52,6 +54,7 @@ import {
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
+  resolveMeetingOwner,
 } from '@lfx-one/shared/utils';
 import { editModeDateTimeValidator, futureDateTimeValidator } from '@lfx-one/shared/validators';
 import { CommitteeService } from '@services/committee.service';
@@ -67,6 +70,7 @@ import {
   forkJoin,
   from,
   map,
+  merge,
   mergeMap,
   Observable,
   of,
@@ -124,6 +128,24 @@ export class MeetingComposerFormService {
 
   public readonly committeeContext = signal<Committee | null>(null);
   public readonly originalStartTime = signal<string | null>(null);
+
+  /**
+   * Owner hydrated from the loaded meeting, and the baseline the save diffs the picker against.
+   * @description Upstream replaces `owner` as a whole object, so re-sending an unchanged one would drop
+   * the stored `profile_picture` — the form carries no control for it (`UserSearchResult` has no avatar
+   * field). `prepareOwnerData()` compares against this and omits the key when the picker is untouched.
+   * Null on create, and for a stored owner that resolves to a service account or a zero-valued record.
+   */
+  public readonly hydratedOwner = signal<MeetingUserInfo | null>(null);
+
+  /**
+   * Whether the organizer picker is in hand-typed mode rather than directory search.
+   * @description Owned here for the same reason `guests` is: the host's `@switch` destroys the Details &
+   * Access section on every section change, so a section-local flag would silently drop the organizer
+   * back into search mode — and out of the only inputs that can reach a non-committee-member — the first
+   * time they stepped away and back.
+   */
+  public readonly ownerManualEntry = signal<boolean>(false);
 
   /**
    * Project the composer was opened against, when the entry point knew it.
@@ -211,6 +233,8 @@ export class MeetingComposerFormService {
     this.guestsLoadFailed.set(false);
     this.suppressedGuestEmails.set(new Set());
     this.committeeContext.set(null);
+    this.hydratedOwner.set(null);
+    this.ownerManualEntry.set(false);
     this.contextProjectUid.set(context.projectUid ?? null);
     this.submitting.set(false);
     this.loading.set(false);
@@ -286,7 +310,14 @@ export class MeetingComposerFormService {
 
     switch (section) {
       case 'details-access':
-        return !!(form.get('title')?.value && form.get('title')?.valid && form.get('meeting_type')?.value);
+        return !!(
+          form.get('title')?.value &&
+          form.get('title')?.valid &&
+          form.get('meeting_type')?.value &&
+          // Optional field, so `?? true` rather than `.valid`: absent means nothing to block on. Only a
+          // hand-typed organizer email can fail it, and the error only renders in manual-entry mode.
+          (form.get('ownerEmail')?.valid ?? true)
+        );
 
       case 'date-schedule':
         return !!(
@@ -493,6 +524,52 @@ export class MeetingComposerFormService {
     );
   }
 
+  /**
+   * Switches the organizer picker to hand-typed name/email.
+   * @description The search pool is the committee-member directory Invite Guests uses, so manual entry
+   * is what covers anyone outside it — an external organizer, say. Any lingering username is dropped on
+   * the first manual edit (see `wireFormSubscriptions`), not here, so switching modes without typing
+   * anything stays side-effect free and still saves as "unchanged".
+   */
+  public switchToOwnerManualEntry(): void {
+    this.ownerManualEntry.set(true);
+  }
+
+  /** Returns the organizer picker to directory search, discarding an invalid hand-typed email. */
+  public backToOwnerSearch(): void {
+    // An invalid manual email would keep gating the section invisibly after the switch: its error
+    // message only renders in manual mode, and the remounted search box is a separate control that
+    // cannot edit `ownerEmail`. A typed name stays — name-only owners are valid upstream — and remains
+    // visible and clearable through the picker's own display value.
+    const ownerEmailControl = this.form().get('ownerEmail');
+    if (ownerEmailControl?.invalid) {
+      ownerEmailControl.setValue(null);
+    }
+
+    this.ownerManualEntry.set(false);
+  }
+
+  /**
+   * Clears the organizer picker, reverting to the stored owner when there is one.
+   * @description On an edit with a saved organizer, "clearing" restores it rather than emptying the
+   * field: upstream has no owner-removal path, so once an owner is saved there is no true empty state to
+   * revert to. Without one (create, or an edit whose owner was never set) this empties all three
+   * controls, and the save omits the `owner` key either way.
+   */
+  public revertOwnerToSaved(): void {
+    const form = this.form();
+    const saved = this.hydratedOwner();
+
+    // Also the manual-entry mode's only clear affordance (no autocomplete there, so no in-field cross),
+    // so flip the mode *before* patching. The manual-edit guard in `wireFormSubscriptions` only drops
+    // `ownerUsername` while `ownerManualEntry()` is true; patching name and email first would make it
+    // read this programmatic revert as a hand edit and wipe the username it just restored.
+    this.ownerManualEntry.set(false);
+    form.get('ownerUsername')?.setValue(saved?.username || null);
+    form.get('ownerName')?.setValue(saved?.name || null);
+    form.get('ownerEmail')?.setValue(saved?.email || null);
+  }
+
   public deleteAttachment(attachmentId: string): void {
     this.pendingAttachmentDeletions.update((current) => [...current, attachmentId]);
   }
@@ -660,6 +737,11 @@ export class MeetingComposerFormService {
         restricted: new FormControl(false),
 
         title: new FormControl('', [Validators.required]),
+        // Optional meeting organizer (owner). No profile_picture control — `UserSearchResult` carries no
+        // avatar; upstream keeps the stored one as long as the `owner` key is omitted from the payload.
+        ownerUsername: new FormControl<string | null>(null),
+        ownerName: new FormControl<string | null>(null),
+        ownerEmail: new FormControl<string | null>(null, [Validators.email]),
         description: new FormControl('', [Validators.maxLength(MEETING_AGENDA_MAX_LENGTH)]),
         // Deliberately carries no validator, and must stay that way. `aiPrompt` is a scratch field
         // that never reaches the save payload, but it lives in the group `validateForSubmit()` reads,
@@ -703,6 +785,11 @@ export class MeetingComposerFormService {
         zoom_ai_enabled: new FormControl(false),
         require_ai_summary_approval: new FormControl(false),
         artifact_visibility: new FormControl(DEFAULT_ARTIFACT_VISIBILITY),
+        // Only ever rendered by `lfx-meeting-committee-manager`, which both composer surfaces mount and
+        // which binds this name unconditionally once a group is linked on a public meeting. It has to
+        // exist in the group whether or not that block is on screen: `lfx-select` binds through
+        // `formControlName`, so a missing control throws rather than degrading.
+        cancel_on_committee_removal: new FormControl(CancelOnCommitteeRemoval.INHERIT),
         auto_email_reminder_enabled: new FormControl(false),
         reminderHours: new FormControl({ value: DEFAULT_EMAIL_REMINDER_HOURS, disabled: true }, [
           Validators.required,
@@ -758,6 +845,25 @@ export class MeetingComposerFormService {
     if (durationControl) {
       this.syncCustomDurationValidators(form, durationControl.value);
       this.formSubscriptions.add(durationControl.valueChanges.subscribe((value) => this.syncCustomDurationValidators(form, value)));
+    }
+
+    // A hand-edited name or email can no longer be tied to an LFID, so the first actual edit in manual
+    // mode drops any username left over from a search pick or from hydration. Clearing on edit rather
+    // than on the mode switch keeps an accidental "manual -> back to search" round trip a no-op:
+    // `prepareOwnerData()` still sees the hydrated owner unchanged and omits the key. Wired here rather
+    // than in the Details & Access section because `@switch` destroys that section on every section
+    // change, which would take the subscription with it.
+    const ownerNameControl = form.get('ownerName');
+    const ownerEmailControl = form.get('ownerEmail');
+    const ownerUsernameControl = form.get('ownerUsername');
+    if (ownerNameControl && ownerEmailControl && ownerUsernameControl) {
+      this.formSubscriptions.add(
+        merge(ownerNameControl.valueChanges, ownerEmailControl.valueChanges).subscribe(() => {
+          if (this.ownerManualEntry() && ownerUsernameControl.value) {
+            ownerUsernameControl.setValue(null);
+          }
+        })
+      );
     }
 
     // When Board meeting type is selected, default to private + restricted access.
@@ -910,6 +1016,13 @@ export class MeetingComposerFormService {
       ai_summary_enabled: formValue.zoom_ai_enabled || false,
       require_ai_summary_approval: formValue.zoom_ai_enabled ? formValue.require_ai_summary_approval || false : false,
       artifact_visibility: formValue.recording_enabled || formValue.zoom_ai_enabled ? formValue.artifact_visibility || DEFAULT_ARTIFACT_VISIBILITY : null,
+      // Upstream reads this only for public meetings with linked groups; anywhere else the override has
+      // nothing to act on, so a stale non-inherit value left over from an earlier edit is sent back as
+      // `inherit` rather than being carried forward invisibly.
+      cancel_on_committee_removal:
+        formValue.visibility === MeetingVisibility.PUBLIC && formValue.committees?.length
+          ? formValue.cancel_on_committee_removal || CancelOnCommitteeRemoval.INHERIT
+          : CancelOnCommitteeRemoval.INHERIT,
       auto_email_reminder_enabled: formValue.auto_email_reminder_enabled || false,
       // Total whole minutes before start, clamped to the upstream 120-1440 range. Omitted when disabled:
       // ITX resets the stored time to 0 whenever enabled is explicitly false, so no time value is needed.
@@ -917,6 +1030,37 @@ export class MeetingComposerFormService {
       recurrence: recurrenceObject,
       platform: formValue.platform || DEFAULT_MEETING_TOOL,
       committees: formValue.committees || [],
+      ...this.prepareOwnerData(formValue),
+    };
+  }
+
+  /**
+   * Contributes `owner` to the payload only when the picker was actually used.
+   * @description Empty controls omit the key entirely: on create upstream defaults the owner to the
+   * creator, and on update the stored owner is preserved (there is no unset path). An edit whose picker
+   * still matches `hydratedOwner` omits it too, so upstream keeps the stored owner object intact —
+   * including the `profile_picture` this form never carries and would otherwise blank out.
+   */
+  private prepareOwnerData(formValue: Record<string, any>): { owner?: MeetingOwnerInput } {
+    const username = ((formValue['ownerUsername'] as string | null) || '').trim();
+    const name = ((formValue['ownerName'] as string | null) || '').trim();
+    const email = ((formValue['ownerEmail'] as string | null) || '').trim();
+
+    if (!username && !name && !email) {
+      return {};
+    }
+
+    const hydrated = this.hydratedOwner();
+    if (hydrated && hydrated.username === username && hydrated.name === name && hydrated.email === email) {
+      return {};
+    }
+
+    return {
+      owner: {
+        ...(username ? { username } : {}),
+        ...(name ? { name } : {}),
+        ...(email ? { email } : {}),
+      },
     };
   }
 
@@ -1000,8 +1144,17 @@ export class MeetingComposerFormService {
       }
     }
 
+    // Hydrate the organizer picker from the stored owner. Zero-valued records (meetings that predate
+    // the field) and service accounts resolve to null, so the picker shows empty and `prepareOwnerData()`
+    // omits the key on save rather than overwriting whatever upstream holds.
+    const ownerInfo = resolveMeetingOwner(meeting);
+    this.hydratedOwner.set(ownerInfo);
+
     form.patchValue({
       title: meeting.title,
+      ownerUsername: ownerInfo?.username || null,
+      ownerName: ownerInfo?.name || null,
+      ownerEmail: ownerInfo?.email || null,
       description: meeting.description,
       // Blank the legacy `None` sentinel so the required validator fires and the field shows its own
       // error instead of silently blocking save. Any other stored value is kept verbatim and the
@@ -1022,6 +1175,7 @@ export class MeetingComposerFormService {
       zoom_ai_enabled: meeting.ai_summary_enabled || false,
       require_ai_summary_approval: meeting.require_ai_summary_approval ?? false,
       artifact_visibility: meeting.artifact_visibility ?? DEFAULT_ARTIFACT_VISIBILITY,
+      cancel_on_committee_removal: meeting.cancel_on_committee_removal ?? CancelOnCommitteeRemoval.INHERIT,
       auto_email_reminder_enabled: meeting.auto_email_reminder_enabled ?? false,
       reminderHours: reminderHours,
       reminderMinutes: reminderTotalMinutes % 60,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
@@ -1,0 +1,369 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal, type WritableSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY } from '@lfx-one/shared/constants';
+import type { Meeting } from '@lfx-one/shared/interfaces';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { MessageService } from 'primeng/api';
+import { of, Subject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerHostComponent } from './meeting-composer-host.component';
+import { MeetingComposerService } from './meeting-composer.service';
+
+/**
+ * Covers the host's own decisions: which section the footer navigation lands on, when Save is allowed
+ * to fire, what the post-create toast carries, and the two ways an open composer closes without the
+ * organizer asking. None of it is reachable from the section specs — the host is the only place that
+ * holds both composer services, and its `submit()` subscription is the single path between a saved
+ * meeting and the toast that is now the only route back to it.
+ */
+describe('MeetingComposerHostComponent', () => {
+  let fixture: ComponentFixture<MeetingComposerHostComponent>;
+  let component: MeetingComposerHostComponent;
+  let composer: MeetingComposerService;
+  let formService: MeetingComposerFormService;
+  let messageService: { add: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn> };
+  let canWrite: WritableSignal<boolean>;
+  let canWriteMeetings: WritableSignal<boolean>;
+
+  const createdMeeting = { id: 'meeting-1', title: 'Weekly sync' } as Meeting;
+
+  /** The `toObservable` bridges in the constructor emit on effect flush, so every signal write needs one. */
+  const flush = async (): Promise<void> => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+  };
+
+  const openCreate = async (): Promise<void> => {
+    composer.open({ mode: 'create', projectUid: 'project-1' });
+    await flush();
+  };
+
+  /** The smallest set that satisfies every required control plus the group-level future-date validator. */
+  const fillRequiredFields = (): void => {
+    formService.form().patchValue({
+      title: 'Weekly sync',
+      meeting_type: 'Technical',
+      startDate: new Date(2030, 0, 8),
+      // `combineDateTime` parses a 12-hour string only; a 24-hour one returns '' and the validator passes
+      // for the wrong reason.
+      startTime: '10:00 AM',
+      timezone: 'America/New_York',
+    });
+  };
+
+  const lastToast = () => messageService.add.mock.calls[messageService.add.mock.calls.length - 1][0];
+
+  beforeEach(async () => {
+    messageService = { add: vi.fn(), clear: vi.fn() };
+    canWrite = signal(false);
+    canWriteMeetings = signal(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: MessageService, useValue: messageService },
+        { provide: CommitteeService, useValue: {} },
+        {
+          provide: MeetingService,
+          useValue: {
+            getMeeting: vi.fn(() => of({ id: 'meeting-1', title: 'Weekly sync', start_time: '2030-01-08T15:00:00Z', timezone: 'America/New_York' })),
+            getMeetingAttachments: vi.fn(() => of([])),
+            getMeetingRegistrants: vi.fn(() => of([])),
+            getMeetingDetail: vi.fn(() => of(null)),
+          },
+        },
+        // `canWrite` is fed to `toObservable`, so it has to be a real signal rather than a plain getter.
+        { provide: ProjectContextService, useValue: { canWrite, canWriteMeetings, activeContextUid: () => '' } },
+        // Only reached by the project-context fallback, which never runs while no meeting is loaded.
+        { provide: ProjectService, useValue: {} },
+        { provide: Router, useValue: { events: new Subject(), url: '/meetings', parseUrl: () => ({ queryParams: {} }) } },
+      ],
+    });
+    // `set` replaces only the listed metadata keys, so the component's own `providers` survive and the
+    // host still supplies the form service instance the tests read below.
+    TestBed.overrideComponent(MeetingComposerHostComponent, { set: { template: '', imports: [] } });
+
+    fixture = TestBed.createComponent(MeetingComposerHostComponent);
+    component = fixture.componentInstance;
+    composer = TestBed.inject(MeetingComposerService);
+    // Component-provided, so `TestBed.inject` would hand back a second instance the host never reads.
+    formService = fixture.debugElement.injector.get(MeetingComposerFormService);
+    await flush();
+  });
+
+  describe('section navigation', () => {
+    it('tracks the active section by position', () => {
+      composer.setSection('platform-features');
+
+      expect(component['activeIndex']()).toBe(2);
+      expect(component['isLastSection']()).toBe(false);
+      expect(component['activeSectionLabel']()).toBe('Platform & features');
+    });
+
+    it('reports the final section as last', () => {
+      composer.setSection('agenda-resources');
+
+      expect(component['isLastSection']()).toBe(true);
+    });
+
+    it('advances one section and records the visit', () => {
+      component['onNext']();
+
+      expect(composer.activeSection()).toBe(MEETING_COMPOSER_SECTIONS[1].id);
+      expect(composer.visitedSections().has(MEETING_COMPOSER_SECTIONS[1].id)).toBe(true);
+    });
+
+    it('does nothing when Next is reached on the last section', () => {
+      composer.setSection('agenda-resources');
+
+      component['onNext']();
+
+      // The footer hides Next here, but the handler is also the keyboard path — walking off the end
+      // would leave `activeIndex` at -1 and blank the header label.
+      expect(composer.activeSection()).toBe('agenda-resources');
+    });
+
+    it('steps back one section', () => {
+      composer.setSection('date-schedule');
+
+      component['onBack']();
+
+      expect(composer.activeSection()).toBe('details-access');
+    });
+
+    it('does nothing when Back is pressed on the first section', () => {
+      component['onBack']();
+
+      expect(composer.activeSection()).toBe('details-access');
+    });
+
+    it('jumps to the section that owns the title field', () => {
+      composer.setSection('guests');
+
+      component['onGoToTitleSection']();
+
+      expect(composer.activeSection()).toBe('details-access');
+    });
+  });
+
+  describe('closing', () => {
+    it('closes the composer when the drawer reports itself hidden', async () => {
+      await openCreate();
+
+      component['onVisibleChange'](false);
+
+      expect(composer.isOpen()).toBe(false);
+    });
+
+    it('leaves the composer open when the drawer reports itself visible', async () => {
+      await openCreate();
+
+      component['onVisibleChange'](true);
+
+      expect(composer.isOpen()).toBe(true);
+    });
+
+    it('closes an open composer when write access is lost', async () => {
+      canWrite.set(true);
+      await flush();
+      await openCreate();
+
+      canWrite.set(false);
+      await flush();
+
+      expect(composer.isOpen()).toBe(false);
+    });
+
+    it('leaves the composer open when write access only resolves late', async () => {
+      await openCreate();
+
+      // `canWrite` starts false and stays false while the grants request is unresolved, so a deep-linked
+      // open would be closed under the organizer if any false counted rather than only a true -> false.
+      canWrite.set(true);
+      await flush();
+
+      expect(composer.isOpen()).toBe(true);
+    });
+  });
+
+  describe('submit gating', () => {
+    it('blocks save while the create form is empty', async () => {
+      await openCreate();
+
+      expect(component['canSubmit']()).toBe(false);
+    });
+
+    it('allows save once every required field is answered', async () => {
+      await openCreate();
+
+      fillRequiredFields();
+
+      expect(component['canSubmit']()).toBe(true);
+    });
+
+    it('ignores a submit while one is already in flight', async () => {
+      await openCreate();
+      const submit = vi.spyOn(formService, 'submit');
+      formService.submitting.set(true);
+
+      component['onSubmit']();
+
+      expect(submit).not.toHaveBeenCalled();
+    });
+
+    it('ignores a submit the form validation rejects', async () => {
+      await openCreate();
+      const submit = vi.spyOn(formService, 'submit');
+      vi.spyOn(formService, 'validateForSubmit').mockReturnValue(false);
+
+      component['onSubmit']();
+
+      expect(submit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('post-create announcement', () => {
+    beforeEach(async () => {
+      await openCreate();
+      vi.spyOn(formService, 'validateForSubmit').mockReturnValue(true);
+    });
+
+    it('raises a sticky keyed toast carrying the created meeting', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of(createdMeeting));
+
+      component['onSubmit']();
+
+      expect(lastToast()).toMatchObject({
+        key: MEETING_COMPOSER_TOAST_KEY,
+        severity: 'success',
+        summary: 'Meeting created',
+        detail: 'Weekly sync',
+        sticky: true,
+        closable: true,
+        data: { meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1', meetingQueryParams: {} },
+      });
+    });
+
+    it('retires the previous announcement before raising its own', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of(createdMeeting));
+
+      component['onSubmit']();
+
+      // Sticky toasts never expire, so creating several meetings in a row would stack them over the page.
+      expect(messageService.clear).toHaveBeenCalledWith(MEETING_COMPOSER_TOAST_KEY);
+    });
+
+    it('carries the password to the meeting link when the meeting has one', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of({ ...createdMeeting, password: 'secret' } as Meeting));
+
+      component['onSubmit']();
+
+      // Without it the join page bounces every private or restricted meeting to /meetings/not-found.
+      expect(lastToast().data.meetingQueryParams).toEqual({ password: 'secret' });
+    });
+
+    it('names an untitled meeting rather than showing a blank toast', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of({ id: 'meeting-2' } as Meeting));
+
+      component['onSubmit']();
+
+      expect(lastToast().data.meetingTitle).toBe('Untitled meeting');
+    });
+
+    it('falls back to a plain confirmation when the create returns no meeting', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of(null));
+
+      component['onSubmit']();
+
+      // A keyed toast here would offer two actions that dead-end: there is no uid to link to.
+      expect(lastToast()).toEqual({ severity: 'success', summary: 'Meeting created', detail: 'Open it from the list to review the details.' });
+      expect(lastToast().key).toBeUndefined();
+    });
+
+    it('confirms an edit instead of announcing a creation', () => {
+      formService.mode.set('edit');
+      vi.spyOn(formService, 'submit').mockReturnValue(of(null));
+
+      component['onSubmit']();
+
+      expect(lastToast()).toMatchObject({ summary: 'Meeting updated', detail: 'Your changes have been saved.' });
+    });
+
+    it('records the save and closes the composer', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of(createdMeeting));
+
+      component['onSubmit']();
+
+      expect(composer.saveCount()).toBe(1);
+      expect(composer.isOpen()).toBe(false);
+    });
+
+    it('acts once even if the save stream emits again', () => {
+      vi.spyOn(formService, 'submit').mockReturnValue(of(createdMeeting, { id: 'meeting-2' } as Meeting));
+
+      component['onSubmit']();
+
+      // The handler closes the composer, so a second emission would announce a meeting over a surface
+      // that has already moved on.
+      expect(messageService.add).toHaveBeenCalledTimes(1);
+      expect(composer.saveCount()).toBe(1);
+    });
+  });
+
+  describe('editing from the toast', () => {
+    it('refuses while another composer is open', async () => {
+      await openCreate();
+
+      expect(component['editFromToastBlockedReason']()).toBe('Close the open composer first');
+    });
+
+    it('allows the reopen once the composer is closed', () => {
+      expect(component['editFromToastBlockedReason']()).toBeNull();
+    });
+
+    it('refuses once meeting-write access is gone', () => {
+      canWriteMeetings.set(false);
+
+      expect(component['editFromToastBlockedReason']()).toBe('You no longer have write access');
+    });
+
+    it('does nothing when the action is blocked', async () => {
+      await openCreate();
+
+      component['onEditCreatedMeeting']({ meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1', meetingQueryParams: {} });
+
+      // Reopening here would silently discard the draft in the open composer.
+      expect(composer.context()).toMatchObject({ mode: 'create' });
+    });
+
+    it('clears the toast and reopens the composer in edit mode', () => {
+      component['onEditCreatedMeeting']({ meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1', meetingQueryParams: {} });
+
+      expect(messageService.clear).toHaveBeenCalledWith(MEETING_COMPOSER_TOAST_KEY);
+      expect(composer.context()).toEqual({ mode: 'edit', meetingUid: 'meeting-1' });
+    });
+  });
+
+  describe('switching a quick create to the drawer', () => {
+    it('drops the quick-create defaults before moving surfaces', async () => {
+      composer.open({ mode: 'create', projectUid: 'project-1', variant: 'quick' });
+      await flush();
+      const dropDefaults = vi.spyOn(formService, 'dropQuickCreateDefaults');
+
+      component['onSwitchToAdvanced']();
+
+      // Order matters only in that both run: the drawer must stop rewriting fields the organizer
+      // already answered in the dialog.
+      expect(dropDefaults).toHaveBeenCalledOnce();
+      expect(composer.isQuickCreate()).toBe(false);
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -2,18 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, type Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_POSITION } from '@lfx-one/shared/constants';
-import type { Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
+import type { EntityWithProject, Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
+import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { ToastModule } from 'primeng/toast';
 import type { ToastPositionType } from 'primeng/types/toast';
-import { filter, pairwise } from 'rxjs';
+import { filter, pairwise, take } from 'rxjs';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerPreviewComponent } from './meeting-composer-preview.component';
@@ -57,6 +60,10 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
 export class MeetingComposerHostComponent {
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly projectService = inject(ProjectService);
+  private readonly meetingService = inject(MeetingService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly composer = inject(MeetingComposerService);
   protected readonly formService = inject(MeetingComposerFormService);
@@ -120,6 +127,10 @@ export class MeetingComposerHostComponent {
    * composer would discard that draft, and reopening after write access was lost would only fail on save.
    */
   protected readonly editFromToastBlockedReason: Signal<string | null> = this.initEditFromToastBlockedReason();
+  /**
+   * The open meeting reshaped for the project-context syncs, or `null` when nothing should drive them.
+   */
+  private readonly meetingEntityContext: Signal<EntityWithProject | null> = this.initMeetingEntityContext();
 
   public constructor() {
     toObservable(this.composer.context)
@@ -140,6 +151,20 @@ export class MeetingComposerHostComponent {
         takeUntilDestroyed()
       )
       .subscribe(() => this.composer.close());
+
+    // Derive the project context from the meeting being edited so a context-less edit link
+    // (/project/meetings/:id/edit) lands in the meeting's project, not the cookie-restored
+    // last-visited project. The route component redirects to the meetings list and opens the
+    // composer over it, so nothing else on that navigation carries the meeting's project.
+    // The fallback covers BFF project-enrichment failure.
+    // preferEntityKind: a foundation-owned meeting can be edited under a /project/* URL, so the
+    // meeting's own is_foundation (not the route prefix) picks the slot and re-points the route
+    // lens kind. Opt-in — the other syncEntityProjectContext callers keep URL-prefix behavior.
+    syncEntityProjectContext(this.meetingEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    syncEntityProjectContextFallback(this.meetingEntityContext, this.projectService, this.projectContextService, this.router, this.destroyRef, {
+      entityKind: 'meeting',
+      freshFetch: (uid) => this.meetingService.getMeetingDetail(uid, { skipCache: true }),
+    });
   }
 
   protected onVisibleChange(visible: boolean): void {
@@ -188,17 +213,21 @@ export class MeetingComposerHostComponent {
     const wasEditMode = this.formService.isEditMode();
 
     // `submit()` completes without emitting when the save outlived its open, so reaching here always
-    // means the current open is the one that was saved.
-    this.formService.submit().subscribe((meeting) => {
-      if (wasEditMode) {
-        this.messageService.add({ severity: 'success', summary: 'Meeting updated', detail: 'Your changes have been saved.' });
-      } else {
-        this.announceCreatedMeeting(meeting);
-      }
+    // means the current open is the one that was saved. `take(1)` because the stream is single-shot and
+    // this handler closes the composer: nothing downstream should ever run twice.
+    this.formService
+      .submit()
+      .pipe(take(1))
+      .subscribe((meeting) => {
+        if (wasEditMode) {
+          this.messageService.add({ severity: 'success', summary: 'Meeting updated', detail: 'Your changes have been saved.' });
+        } else {
+          this.announceCreatedMeeting(meeting);
+        }
 
-      this.composer.notifySaved();
-      this.composer.close();
-    });
+        this.composer.notifySaved();
+        this.composer.close();
+      });
   }
 
   /**
@@ -217,6 +246,32 @@ export class MeetingComposerHostComponent {
 
   protected onDismissToast(): void {
     this.messageService.clear(this.toastKey);
+  }
+
+  /**
+   * Maps the meeting being edited to the {@link EntityWithProject} shape the project-context syncs
+   * consume — Meeting carries `id`, not `uid`, and pre-enrichment payloads can lack the project
+   * fields entirely, so absent values map to null there.
+   * @description Gated on the composer being open in edit mode, which the route-scoped page this
+   * replaced got for free from its own lifetime. This host is mounted once and retained, and both
+   * syncs re-apply on every NavigationEnd for as long as they live — without the gate the last
+   * meeting edited would keep re-pointing the project context long after its composer closed.
+   */
+  private initMeetingEntityContext(): Signal<EntityWithProject | null> {
+    return computed(() => {
+      const meeting = this.formService.meeting();
+      if (!meeting || !this.composer.isOpen() || !this.formService.isEditMode()) {
+        return null;
+      }
+
+      return {
+        uid: meeting.id,
+        project_uid: meeting.project_uid,
+        project_slug: meeting.project_slug,
+        project_name: meeting.project_name,
+        is_foundation: meeting.is_foundation ?? null,
+      };
+    });
   }
 
   private initEditFromToastBlockedReason(): Signal<string | null> {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-create-menu.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-create-menu.component.ts
@@ -43,6 +43,13 @@ export class MeetingCreateMenuComponent {
   public readonly projectUid = input<string | undefined>(undefined);
 
   /**
+   * Which of the trigger's edges the panel lines up with.
+   * @description Defaults to `'right'`, for a trigger that is itself the right edge of its layout —
+   * the case that made the dropdown position itself in the first place.
+   */
+  public readonly align = input<MeetingCreateMenuAlign>('right');
+
+  /**
    * Quick start per meeting type, then the full drawer.
    * @description The trigger has no default action of its own — creating a meeting always starts by
    * choosing one of these rows, so this model is the only entry point into either composer surface.
@@ -51,13 +58,6 @@ export class MeetingCreateMenuComponent {
    * could seed a type here that the select then hides, leaving it set but uneditable.
    */
   protected readonly createMenuItems: Signal<MenuItem[]> = this.initCreateMenuItems();
-
-  /**
-   * Which of the trigger's edges the panel lines up with.
-   * @description Defaults to `'right'`, for a trigger that is itself the right edge of its layout —
-   * the case that made the dropdown position itself in the first place.
-   */
-  public readonly align = input<MeetingCreateMenuAlign>('right');
 
   /** Smallest gap left between the popup and either viewport edge, in px. */
   private readonly viewportGutter = 8;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -4,12 +4,26 @@
 <!-- Quick create dialog (GH-1460) -->
 
 <!-- Declarative `<p-dialog>` rather than `DialogService.open()`, which `docs/reviews/frontend-checklist.md`
-     marks as the rule: this dialog is one of two surfaces the composer opens — the drawer is the other —
-     and both are driven off the same `MeetingComposerService` signals from a single always-mounted host,
-     so the open/close state has one owner and one lifecycle. `DialogService.open()` is imperative and
-     returns its own ref, which would split that ownership in two and leave the service's `isOpen()` and
-     the ref's lifetime to be kept in step by hand. Called out here so the deviation reads as a decision;
-     it is not the only one in the app (eight other templates mount `<p-dialog>` directly today). -->
+     § 3 marks as the rule. Two reasons, in order of weight:
+
+     1. Dependency scope. `MeetingComposerFormService` is `@Injectable()` (not `providedIn: 'root'`) and is
+        supplied by `MeetingComposerHostComponent`'s own `providers`, so each open gets a fresh form and no
+        draft leaks between sessions. This dialog and three of its children inject it. `DialogService.open()`
+        builds the dynamic component with `elementInjector: new DynamicDialogInjector(this.injector, map)` —
+        `this.injector` being the one *DialogService* was provided in, not the caller's (see
+        `primeng/fesm2022/primeng-dynamicdialog.mjs`). A component opened that way therefore cannot resolve a
+        provider declared on the host, and the only way to make it resolve is to root-provide the form
+        service — turning per-session scoped state into app-wide mutable state. That trade is worse than the
+        deviation.
+     2. State ownership. This dialog is one of two surfaces the composer opens — the drawer is the other —
+        and both are driven off the same `MeetingComposerService` signals from a single always-mounted host.
+        `DialogService.open()` is imperative and returns its own ref, which would split that ownership and
+        leave the service's `isOpen()` and the ref's lifetime to be kept in step by hand.
+
+     Called out here so the deviation reads as a decision, not an oversight; it is not the only one in the
+     app (eight other templates mount `<p-dialog>` directly today). Note that where the scope constraint
+     does not apply, this feature does use the rule: `AddLinkDialogComponent` and `ManualGuestDialogComponent`
+     are both opened with `DialogService.open()`. -->
 <!-- `blockScroll` is on for the same reason it is on the drawer: PrimeNG appends the agenda popovers to
      `body` and positions them in document coordinates, so scrolling the page behind a fixed dialog slides
      an open panel off the button it hangs from. -->
@@ -63,6 +77,7 @@
         [form]="formService.form()"
         [showHeading]="false"
         [showTypeSelect]="false"
+        [showOrganizer]="false"
         [titleHint]="prefilledTitle() ? 'Pre-filled for this meeting type — edit freely.' : null" />
 
       <lfx-composer-agenda-field

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.spec.ts
@@ -1,0 +1,234 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
+import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from '@lfx-one/shared/constants';
+import type { PendingAttachment } from '@lfx-one/shared/interfaces';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
+import { ComposerAgendaResourcesComponent } from './composer-agenda-resources.component';
+
+/**
+ * Covers the attachment gate and the link-removal bookkeeping. Both are enforced only here: a rejected
+ * file has no validator behind it, and a saved link that is removed without being reported as a deletion
+ * simply reappears on the next open.
+ */
+describe('ComposerAgendaResourcesComponent', () => {
+  let fixture: ComponentFixture<ComposerAgendaResourcesComponent>;
+  let component: ComposerAgendaResourcesComponent;
+  let formService: MeetingComposerFormService;
+  let messageService: { add: ReturnType<typeof vi.fn> };
+
+  const attachments = () => (formService.form().get('attachments')?.value ?? []) as PendingAttachment[];
+  const linksArray = () => formService.form().get('important_links') as FormArray;
+  const rejectionDetail = (): string => messageService.add.mock.calls[0][0].detail;
+
+  /** A PDF of a given name, sized without allocating the bytes — the cap is 100MB. */
+  const pdf = (name: string, size = 1024): File => {
+    const file = new File(['%PDF-1.4'], name, { type: 'application/pdf' });
+    Object.defineProperty(file, 'size', { value: size });
+    return file;
+  };
+
+  const linkRow = (uid: string | null): FormGroup =>
+    new FormGroup({
+      id: new FormControl(crypto.randomUUID()),
+      title: new FormControl('Charter'),
+      url: new FormControl('https://example.test/charter'),
+      uid: new FormControl<string | null>(uid),
+    });
+
+  beforeEach(async () => {
+    messageService = { add: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: messageService },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerAgendaResourcesComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerAgendaResourcesComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  describe('queueing files', () => {
+    it('queues an allowed file with the fields the upload pass needs', () => {
+      component['onFileSelect']({ files: [pdf('charter.pdf', 2048)] });
+
+      expect(attachments()).toEqual([
+        expect.objectContaining({ fileName: 'charter.pdf', fileSize: 2048, mimeType: 'application/pdf', uploading: false, uploaded: false }),
+      ]);
+      expect(messageService.add).not.toHaveBeenCalled();
+    });
+
+    it('gives each queued file its own id', () => {
+      component['onFileSelect']({ files: [pdf('one.pdf'), pdf('two.pdf')] });
+
+      const [first, second] = attachments();
+
+      expect(first.id).toBeTruthy();
+      expect(second.id).not.toBe(first.id);
+    });
+
+    it('appends to the existing queue rather than replacing it', () => {
+      component['onFileSelect']({ files: [pdf('first.pdf')] });
+
+      component['onFileSelect']({ files: [pdf('second.pdf')] });
+
+      expect(attachments().map((attachment) => attachment.fileName)).toEqual(['first.pdf', 'second.pdf']);
+    });
+
+    it('accepts the file picker\'s own "currentFiles" shape', () => {
+      component['onFileSelect']({ currentFiles: [pdf('charter.pdf')] });
+
+      expect(attachments()).toHaveLength(1);
+    });
+
+    it('does nothing on an empty selection', () => {
+      component['onFileSelect']({ files: [] });
+
+      expect(attachments()).toEqual([]);
+      expect(messageService.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejecting files', () => {
+    it('rejects a file over the size cap and names the limit', () => {
+      component['onFileSelect']({ files: [pdf('huge.pdf', MAX_FILE_SIZE_BYTES + 1)] });
+
+      expect(attachments()).toEqual([]);
+      expect(rejectionDetail()).toBe(`"huge.pdf" is larger than ${MAX_FILE_SIZE_MB}MB.`);
+    });
+
+    it('accepts a file sitting exactly on the cap', () => {
+      component['onFileSelect']({ files: [pdf('exact.pdf', MAX_FILE_SIZE_BYTES)] });
+
+      expect(attachments()).toHaveLength(1);
+    });
+
+    it('rejects a disallowed file type and lists what is allowed', () => {
+      const executable = new File(['MZ'], 'installer.exe', { type: 'application/x-msdownload' });
+
+      component['onFileSelect']({ files: [executable] });
+
+      expect(attachments()).toEqual([]);
+      expect(rejectionDetail()).toContain("files aren't supported");
+    });
+
+    it('rejects a filename already queued in an earlier selection', () => {
+      component['onFileSelect']({ files: [pdf('charter.pdf')] });
+
+      component['onFileSelect']({ files: [pdf('charter.pdf')] });
+
+      expect(attachments()).toHaveLength(1);
+      expect(rejectionDetail()).toBe('"charter.pdf" has already been added.');
+    });
+
+    it('rejects a filename repeated within one selection', () => {
+      // The duplicate check reads the accumulator as well as the committed queue, so the second copy
+      // has to be caught before either one is written.
+      component['onFileSelect']({ files: [pdf('charter.pdf'), pdf('charter.pdf')] });
+
+      expect(attachments()).toHaveLength(1);
+      expect(rejectionDetail()).toBe('"charter.pdf" has already been added.');
+    });
+
+    it('lets a failed upload be retried under the same name', () => {
+      const failed: PendingAttachment = {
+        id: 'a1',
+        fileName: 'charter.pdf',
+        file: pdf('charter.pdf'),
+        fileSize: 10,
+        mimeType: 'application/pdf',
+        uploading: false,
+        uploaded: false,
+        uploadError: 'boom',
+      };
+      formService.form().get('attachments')?.setValue([failed]);
+
+      component['onFileSelect']({ files: [pdf('charter.pdf')] });
+
+      expect(attachments()).toHaveLength(2);
+      expect(messageService.add).not.toHaveBeenCalled();
+    });
+
+    it('rejects a traversal filename', () => {
+      component['onFileSelect']({ files: [pdf('../../etc/passwd.pdf')] });
+
+      expect(attachments()).toEqual([]);
+      expect(rejectionDetail()).toContain('is not a valid filename');
+    });
+
+    it('rejects a dot-prefixed filename', () => {
+      component['onFileSelect']({ files: [pdf('.hidden.pdf')] });
+
+      expect(attachments()).toEqual([]);
+      expect(rejectionDetail()).toContain('is not a valid filename');
+    });
+
+    it('keeps the good files from a mixed selection', () => {
+      component['onFileSelect']({ files: [pdf('good.pdf'), pdf('huge.pdf', MAX_FILE_SIZE_BYTES + 1), pdf('also-good.pdf')] });
+
+      expect(attachments().map((attachment) => attachment.fileName)).toEqual(['good.pdf', 'also-good.pdf']);
+      expect(messageService.add).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('removing resources', () => {
+    it('drops only the queued file that was removed', () => {
+      component['onFileSelect']({ files: [pdf('first.pdf'), pdf('second.pdf')] });
+      const [first] = attachments();
+
+      component['onRemoveAttachment'](first.id);
+
+      expect(attachments().map((attachment) => attachment.fileName)).toEqual(['second.pdf']);
+    });
+
+    it('reports a saved link as a deletion when its row is removed', () => {
+      linksArray().push(linkRow('link-uid-1'));
+
+      component['onRemoveLink'](0);
+
+      expect(formService.pendingAttachmentDeletions()).toEqual(['link-uid-1']);
+      expect(linksArray().length).toBe(0);
+    });
+
+    it('removes an unsaved link row without reporting a deletion', () => {
+      linksArray().push(linkRow(null));
+
+      component['onRemoveLink'](0);
+
+      // The link never reached upstream, so there is nothing there to delete.
+      expect(formService.pendingAttachmentDeletions()).toEqual([]);
+      expect(linksArray().length).toBe(0);
+    });
+
+    it('removes the row at the given index, not the last one', () => {
+      linksArray().push(linkRow('first-uid'));
+      linksArray().push(linkRow('second-uid'));
+
+      component['onRemoveLink'](0);
+
+      expect(formService.pendingAttachmentDeletions()).toEqual(['first-uid']);
+      expect((linksArray().at(0) as FormGroup).get('uid')?.value).toBe('second-uid');
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
@@ -1,0 +1,212 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WEEKDAY_CODES } from '@lfx-one/shared/constants';
+import { RecurrenceType } from '@lfx-one/shared/enums';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
+import { ComposerDateScheduleComponent } from './composer-date-schedule.component';
+
+/**
+ * Covers the simple-cadence → `recurrence` mapping this section owns. The payload it writes is what
+ * reaches Zoom, and two of its conversions are silent off-by-ones waiting to happen: `weekly_days` is
+ * 1-7 upstream while `Date.getDay()` is 0-6, and the last occurrence of a weekday in a month is `-1`
+ * rather than its week number. Neither is caught by a validator.
+ */
+describe('ComposerDateScheduleComponent', () => {
+  let fixture: ComponentFixture<ComposerDateScheduleComponent>;
+  let component: ComposerDateScheduleComponent;
+  let formService: MeetingComposerFormService;
+
+  // Thursday 8 January 2026 — the 2nd Thursday of a month with five of them, so `weekOfMonth` is a
+  // plain 2 and `isLastWeek` is false. Its Thursday makes `getDay()` 4, so `weekly_days` must be '5'.
+  const SECOND_THURSDAY = new Date(2026, 0, 8);
+  // Thursday 29 January 2026 — the last Thursday of the same month.
+  const LAST_THURSDAY = new Date(2026, 0, 29);
+
+  const control = (name: string) => formService.form().get(name);
+  const recurrence = () => formService.form().get('recurrence');
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerDateScheduleComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerDateScheduleComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    // Explicit rather than relying on auto-detection: every subscription under test is wired in
+    // `ngOnInit`, so nothing below works until first change detection has run.
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  describe('cadence options', () => {
+    it('offers nothing while there is no start date to name a day from', () => {
+      control('startDate')?.setValue(null);
+
+      expect(component['cadenceOptions']()).toEqual([]);
+    });
+
+    it('names the weekly cadence after the start date day', () => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+
+      expect(component['cadenceOptions']().find((option) => option.value === 'weekly')?.label).toBe('Weekly on Thursday');
+    });
+
+    it('offers the nth-weekday cadence for a date mid-month', () => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+
+      const monthly = component['cadenceOptions']().find((option) => option.value.startsWith('monthly'));
+
+      expect(monthly).toEqual({ label: 'Monthly on the 2nd Thursday', value: 'monthly_nth' });
+    });
+
+    it('swaps to the last-weekday cadence for the final occurrence in the month', () => {
+      control('startDate')?.setValue(LAST_THURSDAY);
+
+      const monthly = component['cadenceOptions']().find((option) => option.value.startsWith('monthly'));
+
+      expect(monthly).toEqual({ label: 'Monthly on the last Thursday', value: 'monthly_last' });
+    });
+  });
+
+  describe('recurring toggle', () => {
+    it('starts a recurring meeting on the weekly cadence', () => {
+      control('isRecurring')?.setValue(true);
+
+      expect(control('recurrenceType')?.value).toBe('weekly');
+    });
+
+    it('keeps a cadence that is already set when recurrence is switched on', () => {
+      // Edit mode hydrates the cadence before the toggle settles, so defaulting unconditionally to
+      // weekly would overwrite a saved daily or monthly meeting on open.
+      control('recurrenceType')?.setValue('daily');
+
+      control('isRecurring')?.setValue(true);
+
+      expect(control('recurrenceType')?.value).toBe('daily');
+    });
+
+    it('clears the cadence when recurrence is turned off', () => {
+      control('isRecurring')?.setValue(true);
+
+      control('isRecurring')?.setValue(false);
+
+      expect(control('recurrenceType')?.value).toBe('none');
+    });
+
+    it('reveals the custom pattern editor only for the custom cadence', () => {
+      control('recurrenceType')?.setValue('custom');
+      expect(component['showCustomRecurrence']()).toBe(true);
+
+      control('recurrenceType')?.setValue('weekly');
+      expect(component['showCustomRecurrence']()).toBe(false);
+    });
+  });
+
+  describe('recurrence payload', () => {
+    beforeEach(() => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+    });
+
+    it('maps daily to a one-day interval with no day selection', () => {
+      control('recurrenceType')?.setValue('daily');
+
+      expect(recurrence()?.value).toMatchObject({ type: RecurrenceType.DAILY, repeat_interval: 1, weekly_days: null });
+    });
+
+    it('maps weekly to the start date day in upstream 1-7 numbering', () => {
+      control('recurrenceType')?.setValue('weekly');
+
+      // Thursday is `getDay()` 4 but weekday 5 upstream.
+      expect(recurrence()?.value).toMatchObject({ type: RecurrenceType.WEEKLY, repeat_interval: 1, weekly_days: '5' });
+    });
+
+    it('maps every-weekday to the Monday-to-Friday code list', () => {
+      control('recurrenceType')?.setValue('weekdays');
+
+      expect(recurrence()?.value).toMatchObject({ type: RecurrenceType.WEEKLY, repeat_interval: 1, weekly_days: WEEKDAY_CODES });
+    });
+
+    it('maps a mid-month monthly cadence to its week number', () => {
+      control('recurrenceType')?.setValue('monthly_nth');
+
+      expect(recurrence()?.value).toMatchObject({ type: RecurrenceType.MONTHLY, repeat_interval: 1, monthly_week: 2, monthly_week_day: 5 });
+    });
+
+    it('maps a last-occurrence monthly cadence to -1 rather than its week number', () => {
+      control('startDate')?.setValue(LAST_THURSDAY);
+
+      control('recurrenceType')?.setValue('monthly_last');
+
+      expect(recurrence()?.value).toMatchObject({ type: RecurrenceType.MONTHLY, monthly_week: -1, monthly_week_day: 5 });
+    });
+
+    it('clears the previous cadence fields when the cadence changes', () => {
+      control('recurrenceType')?.setValue('monthly_nth');
+
+      control('recurrenceType')?.setValue('daily');
+
+      // Leftover monthly fields would ride along in the payload and contradict the daily type.
+      expect(recurrence()?.value).toMatchObject({ monthly_week: null, monthly_week_day: null });
+    });
+
+    it('leaves the cleared group alone for a non-recurring meeting', () => {
+      control('recurrenceType')?.setValue('weekly');
+
+      control('recurrenceType')?.setValue('none');
+
+      expect(recurrence()?.value).toMatchObject({ type: null, weekly_days: null });
+    });
+  });
+
+  describe('start date changes after a cadence is chosen', () => {
+    it('re-derives the weekly day when the meeting moves to another weekday', () => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+      control('recurrenceType')?.setValue('weekly');
+
+      // Friday 9 January 2026 — `getDay()` 5, so weekday 6 upstream.
+      control('startDate')?.setValue(new Date(2026, 0, 9));
+
+      expect(recurrence()?.get('weekly_days')?.value).toBe('6');
+    });
+
+    it('flips a monthly cadence to last-occurrence when the new date is the last one', () => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+      control('recurrenceType')?.setValue('monthly_nth');
+
+      control('startDate')?.setValue(LAST_THURSDAY);
+
+      expect(control('recurrenceType')?.value).toBe('monthly_last');
+      expect(recurrence()?.get('monthly_week')?.value).toBe(-1);
+    });
+
+    it('leaves the cadence alone when the date is cleared', () => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+      control('recurrenceType')?.setValue('weekly');
+
+      control('startDate')?.setValue(null);
+
+      // Clearing the calendar input emits null; the day-derived payload has nothing to re-derive from
+      // and must not be blanked out under the organizer.
+      expect(recurrence()?.get('weekly_days')?.value).toBe('5');
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -110,6 +110,80 @@
     </div>
   }
 
+  <!-- Meeting organizer (owner) -->
+  @if (showOrganizer()) {
+    <div class="flex flex-col gap-1.5">
+      <label for="composer-organizer" class="text-sm font-medium text-gray-900">
+        Meeting organizer <span class="font-normal text-gray-400">(optional)</span>
+      </label>
+      @if (!ownerManualEntry()) {
+        <lfx-user-search
+          [form]="form()"
+          searchType="committee_member"
+          emailControl="ownerEmail"
+          usernameControl="ownerUsername"
+          [displayValue]="selectedOwnerLabel()"
+          [showClear]="true"
+          inputId="composer-organizer"
+          placeholder="Search for a user…"
+          styleClass="w-full"
+          inputStyleClass="w-full text-sm"
+          panelStyleClass="w-full"
+          dataTestId="composer-organizer-search"
+          (onUserSelect)="handleOwnerSelection($event)"
+          (onClear)="clearOwnerSelection()"
+          (onManualEntry)="switchToOwnerManualEntry()" />
+      } @else {
+        <div class="flex flex-col gap-3" data-testid="composer-organizer-manual">
+          <button
+            type="button"
+            class="self-start text-sm text-primary hover:underline"
+            (click)="backToOwnerSearch()"
+            data-testid="composer-organizer-back-to-search">
+            ← Back to search
+          </button>
+          <div class="flex flex-col gap-1">
+            <label for="composer-organizer-name" class="text-sm text-gray-900">Name</label>
+            <lfx-input-text
+              [form]="form()"
+              size="small"
+              control="ownerName"
+              id="composer-organizer-name"
+              placeholder="Enter organizer name"
+              styleClass="w-full"
+              data-testid="composer-organizer-name-input" />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label for="composer-organizer-email" class="text-sm text-gray-900">Email</label>
+            <lfx-input-text
+              [form]="form()"
+              size="small"
+              control="ownerEmail"
+              id="composer-organizer-email"
+              placeholder="Enter organizer email"
+              styleClass="w-full"
+              data-testid="composer-organizer-email-input" />
+            @if (form().get('ownerEmail')?.errors?.['email'] && form().get('ownerEmail')?.touched) {
+              <p class="text-sm text-red-600" role="alert" data-testid="composer-organizer-email-error">Enter a valid email address</p>
+            }
+          </div>
+        </div>
+      }
+
+      @if (showSavedOwnerRevert()) {
+        <div class="flex flex-wrap items-center gap-2">
+          <p class="text-xs text-gray-600" data-testid="composer-organizer-saved">Saved organizer: {{ savedOwnerLabel() }} — clearing reverts to this.</p>
+          <button type="button" class="text-xs text-primary hover:underline" (click)="clearOwnerSelection()" data-testid="composer-organizer-revert">
+            Revert
+          </button>
+        </div>
+      }
+      @if (!savedOwner()) {
+        <p class="text-xs text-gray-500">Defaults to the meeting creator.</p>
+      }
+    </div>
+  }
+
   <!-- Visibility + join restriction: two independent API fields, so two labelled cards rather than one
        card with internal legends — the heading reads as the question and the card as its answers. -->
   <fieldset>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -8,6 +8,7 @@ import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { RadioButtonComponent } from '@components/radio-button/radio-button.component';
 import { SelectComponent } from '@components/select/select.component';
+import { UserSearchComponent } from '@components/user-search/user-search.component';
 import {
   lfxColors,
   MEETING_JOIN_RESTRICTION_OPTIONS,
@@ -16,7 +17,7 @@ import {
   YOUTUBE_MEETING_TITLE_WARNING_LENGTH,
 } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
-import type { CardSelectorOption } from '@lfx-one/shared/interfaces';
+import type { CardSelectorOption, UserSearchResult } from '@lfx-one/shared/interfaces';
 import { getSelectableMeetingTypeOptions } from '@lfx-one/shared/utils';
 import { PersonaService } from '@services/persona.service';
 import { map, of, startWith, switchMap } from 'rxjs';
@@ -31,7 +32,7 @@ import { MeetingComposerFormService } from '../meeting-composer-form.service';
  */
 @Component({
   selector: 'lfx-composer-details-access',
-  imports: [NgClass, ReactiveFormsModule, InputTextComponent, SelectComponent, RadioButtonComponent],
+  imports: [NgClass, ReactiveFormsModule, InputTextComponent, SelectComponent, RadioButtonComponent, UserSearchComponent],
   templateUrl: './composer-details-access.component.html',
 })
 export class ComposerDetailsAccessComponent {
@@ -44,12 +45,23 @@ export class ComposerDetailsAccessComponent {
   /** Quick create renders the type as its own chip row above these fields, so the select would duplicate it. */
   public readonly showTypeSelect = input(true);
   /**
+   * Whether to offer the optional organizer picker.
+   * @description Off in quick create: it defaults to whoever is creating the meeting, which is the right
+   * answer for the fast path, and the drawer covers the rarer case of scheduling on someone else's behalf.
+   */
+  public readonly showOrganizer = input(true);
+  /**
    * Hint text for a title that was written by something other than the organizer.
    * @description Passed in rather than derived here because only quick create prefills from the meeting
    * type. It renders directly under the input and is wired through `aria-describedby`, so the hint is
    * reachable from the field it is about instead of sitting at the bottom of the column.
    */
   public readonly titleHint = input<string | null>(null);
+
+  /** Whether the organizer picker is hand-typing rather than searching. Lives on the form service so a section switch can't reset it. */
+  protected readonly ownerManualEntry = this.formService.ownerManualEntry;
+  /** The stored organizer this edit started from; absent on create and on meetings that never had one. */
+  protected readonly savedOwner = this.formService.hydratedOwner;
 
   protected readonly visibilityOptions = MEETING_VISIBILITY_OPTIONS;
   protected readonly joinRestrictionOptions = MEETING_JOIN_RESTRICTION_OPTIONS;
@@ -79,8 +91,90 @@ export class ComposerDetailsAccessComponent {
    * into one list instead of overwriting each other.
    */
   protected readonly titleDescribedBy: Signal<string | null> = this.initTitleDescribedBy();
+  /** Feeds the picker's own display box, so it renders whatever is committed — hydrated or freshly picked. */
+  protected readonly selectedOwnerLabel: Signal<string> = this.initSelectedOwnerLabel();
+  protected readonly savedOwnerLabel: Signal<string> = this.initSavedOwnerLabel();
+  protected readonly showSavedOwnerRevert: Signal<boolean> = this.initShowSavedOwnerRevert();
   private readonly hydratedMeetingType: Signal<MeetingType | null> = this.initHydratedMeetingType();
   protected readonly meetingTypeOptions: Signal<CardSelectorOption<MeetingType>[]> = this.initMeetingTypeOptions();
+
+  /**
+   * Composes the organizer's display name from a directory pick.
+   * @description `lfx-user-search` patches `ownerEmail` and `ownerUsername` through its own control
+   * bindings, but the name is composed here rather than bound through `firstNameControl` /
+   * `lastNameControl` — those are two separate writes and would clobber each other in the single
+   * `ownerName` control.
+   */
+  protected handleOwnerSelection(user: UserSearchResult): void {
+    this.form()
+      .get('ownerName')
+      ?.setValue([user.first_name, user.last_name].filter(Boolean).join(' ').trim() || null);
+  }
+
+  protected switchToOwnerManualEntry(): void {
+    this.formService.switchToOwnerManualEntry();
+  }
+
+  protected backToOwnerSearch(): void {
+    this.formService.backToOwnerSearch();
+  }
+
+  /**
+   * Handles both clear affordances: the search box's own cross and the saved-organizer Revert button.
+   * @description `lfx-user-search` binds `ownerEmail` and `ownerUsername` but not `ownerName`, so its
+   * built-in clear would leave a stale name behind. The form service owns the revert-or-empty rule for
+   * all three controls together.
+   */
+  protected clearOwnerSelection(): void {
+    this.formService.revertOwnerToSaved();
+  }
+
+  private initSelectedOwnerLabel(): Signal<string> {
+    return computed(() => {
+      this.formService.revision();
+      const form = this.form();
+      return this.formatOwnerLabel(form.get('ownerName')?.value as string | null, form.get('ownerEmail')?.value as string | null);
+    });
+  }
+
+  private initSavedOwnerLabel(): Signal<string> {
+    return computed(() => {
+      const saved = this.savedOwner();
+      return saved ? this.formatOwnerLabel(saved.name, saved.email) : '';
+    });
+  }
+
+  /**
+   * Whether to offer reverting to the stored organizer.
+   * @description Only once one exists, and only while the picker shows someone else — after a revert the
+   * row would just restate what the field already says. Username is compared alongside the label so two
+   * people who share a display name still trip it, matching `prepareOwnerData()`'s identity check.
+   */
+  private initShowSavedOwnerRevert(): Signal<boolean> {
+    return computed(() => {
+      const savedLabel = this.savedOwnerLabel();
+      if (!savedLabel) {
+        return false;
+      }
+
+      this.formService.revision();
+      const currentUsername = ((this.form().get('ownerUsername')?.value as string | null) || null) ?? null;
+
+      return savedLabel !== this.selectedOwnerLabel() || (this.savedOwner()?.username || null) !== currentUsername;
+    });
+  }
+
+  /** "Name (email)" where both are known, otherwise whichever one is — used for the picker and the saved row alike. */
+  private formatOwnerLabel(rawName: string | null | undefined, rawEmail: string | null | undefined): string {
+    const name = (rawName || '').trim();
+    const email = (rawEmail || '').trim();
+
+    if (name && email) {
+      return `${name} (${email})`;
+    }
+
+    return name || email;
+  }
 
   private initSelectedVisibility(): Signal<string | null> {
     return computed(() => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.spec.ts
@@ -1,0 +1,183 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  DEFAULT_EMAIL_REMINDER_HOURS,
+  DEFAULT_EMAIL_REMINDER_MINUTES,
+  MAX_EMAIL_REMINDER_HOURS,
+  MIN_EMAIL_REMINDER_HOURS,
+  RECORDING_DEPENDENCY_NOTES,
+} from '@lfx-one/shared/constants';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
+import { ComposerPlatformFeaturesComponent } from './composer-platform-features.component';
+
+/**
+ * Covers the two dependency chains this section owns: recording → transcripts/YouTube, and the email
+ * reminder → hours/minutes. Both are enforced by `valueChanges` subscriptions rather than by validators,
+ * so nothing else in the app catches them regressing — the controls would simply stay writable and reach
+ * `prepareMeetingData()` with values upstream rejects.
+ */
+describe('ComposerPlatformFeaturesComponent', () => {
+  let fixture: ComponentFixture<ComposerPlatformFeaturesComponent>;
+  let component: ComposerPlatformFeaturesComponent;
+  let formService: MeetingComposerFormService;
+
+  const control = (name: string) => formService.form().get(name);
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerPlatformFeaturesComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerPlatformFeaturesComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  describe('recording dependency', () => {
+    it('enables transcripts and YouTube upload when recording is turned on', () => {
+      control('recording_enabled')?.setValue(true);
+
+      expect(control('transcript_enabled')?.enabled).toBe(true);
+      expect(control('youtube_upload_enabled')?.enabled).toBe(true);
+    });
+
+    it('clears and disables both dependants when recording is turned back off', () => {
+      control('recording_enabled')?.setValue(true);
+      control('transcript_enabled')?.setValue(true);
+      control('youtube_upload_enabled')?.setValue(true);
+
+      control('recording_enabled')?.setValue(false);
+
+      // Disabling alone would leave the values in the payload — they have to be cleared as well.
+      expect(control('transcript_enabled')?.value).toBe(false);
+      expect(control('youtube_upload_enabled')?.value).toBe(false);
+      expect(control('transcript_enabled')?.disabled).toBe(true);
+      expect(control('youtube_upload_enabled')?.disabled).toBe(true);
+    });
+
+    it('explains why each dependant is off while recording is off', () => {
+      expect(component['transcriptNote']()).toBe(RECORDING_DEPENDENCY_NOTES['transcript_enabled']);
+      expect(component['youtubeNote']()).toBe(RECORDING_DEPENDENCY_NOTES['youtube_upload_enabled']);
+    });
+
+    it('drops both notes once recording is on', () => {
+      // Primed first: the notes are computeds, so a version that failed to recompute could only be
+      // caught from a cached value.
+      expect(component['transcriptNote']()).not.toBeNull();
+
+      control('recording_enabled')?.setValue(true);
+
+      expect(component['transcriptNote']()).toBeNull();
+      expect(component['youtubeNote']()).toBeNull();
+    });
+  });
+
+  describe('email reminder timing', () => {
+    it('resets and disables both timing controls when the reminder is turned off', () => {
+      control('auto_email_reminder_enabled')?.setValue(true);
+      control('reminderHours')?.setValue(MIN_EMAIL_REMINDER_HOURS);
+
+      control('auto_email_reminder_enabled')?.setValue(false);
+
+      expect(control('reminderHours')?.value).toBe(DEFAULT_EMAIL_REMINDER_HOURS);
+      expect(control('reminderMinutes')?.value).toBe(DEFAULT_EMAIL_REMINDER_MINUTES);
+      expect(control('reminderHours')?.disabled).toBe(true);
+      expect(control('reminderMinutes')?.disabled).toBe(true);
+    });
+
+    it('enables the hours control when the reminder is turned on', () => {
+      control('auto_email_reminder_enabled')?.setValue(true);
+
+      expect(control('reminderHours')?.enabled).toBe(true);
+    });
+
+    it('locks minutes at zero while hours sits at the 24-hour maximum', () => {
+      control('auto_email_reminder_enabled')?.setValue(true);
+
+      control('reminderHours')?.setValue(MAX_EMAIL_REMINDER_HOURS);
+
+      // 24h + any minutes would exceed the upstream maximum lead time.
+      expect(control('reminderMinutes')?.value).toBe(DEFAULT_EMAIL_REMINDER_MINUTES);
+      expect(control('reminderMinutes')?.disabled).toBe(true);
+    });
+
+    it('re-enables minutes when hours drops back below the maximum', () => {
+      control('auto_email_reminder_enabled')?.setValue(true);
+      control('reminderHours')?.setValue(MAX_EMAIL_REMINDER_HOURS);
+
+      control('reminderHours')?.setValue(MAX_EMAIL_REMINDER_HOURS - 1);
+
+      expect(control('reminderMinutes')?.enabled).toBe(true);
+    });
+
+    it('leaves minutes alone while the reminder itself is off', () => {
+      // The hours subscription fires on the programmatic reset too; without the enabled check it would
+      // re-enable a control the reminder toggle had just disabled.
+      control('auto_email_reminder_enabled')?.setValue(true);
+      control('auto_email_reminder_enabled')?.setValue(false);
+
+      control('reminderHours')?.setValue(MIN_EMAIL_REMINDER_HOURS);
+
+      expect(control('reminderMinutes')?.disabled).toBe(true);
+    });
+  });
+
+  describe('platform chips', () => {
+    it('lists unavailable platforms as disabled rather than hiding them', () => {
+      const unavailable = component['platformChipOptions'].filter((option) => option.disabled);
+
+      expect(unavailable.length).toBeGreaterThan(0);
+      unavailable.forEach((option) => expect(option.label).toContain('(Coming Soon)'));
+    });
+
+    it('leaves the available platform label unannotated', () => {
+      const available = component['platformChipOptions'].filter((option) => !option.disabled);
+
+      expect(available.length).toBeGreaterThan(0);
+      available.forEach((option) => expect(option.label).not.toContain('Coming Soon'));
+    });
+  });
+
+  describe('validation surfacing', () => {
+    it('stays silent on an untouched empty platform', () => {
+      control('platform')?.setValue(null);
+
+      expect(component['platformError']()).toBe(false);
+    });
+
+    it('reports the error once the control has been touched', () => {
+      control('platform')?.setValue(null);
+      control('platform')?.markAsTouched();
+      // `markAsTouched()` bumps neither valueChanges nor statusChanges, so the recompute rides the
+      // status change from the value write above.
+      control('platform')?.updateValueAndValidity();
+
+      expect(component['platformError']()).toBe(true);
+    });
+
+    it('tracks the title length for the YouTube counter', () => {
+      control('title')?.setValue('Weekly sync');
+
+      expect(component['titleLength']()).toBe('Weekly sync'.length);
+    });
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -12,6 +12,7 @@ import { getFormationSubStageLabel, isBoardScopedPersona, isFormationStage, isSa
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { catchError, combineLatest, filter, map, of, startWith, switchMap, tap } from 'rxjs';
 
+import { hasMeetingWriteAccess } from '../utils/write-access.util';
 import { CookieRegistryService } from './cookie-registry.service';
 import { FeatureFlagService } from './feature-flag.service';
 import { LensService } from './lens.service';
@@ -401,7 +402,7 @@ export class ProjectContextService {
               }
               return this.projectService
                 .getProject(ctx.slug, false, { meetingCoordinator: true })
-                .pipe(map((coordinatorProject) => coordinatorProject?.writer === true || coordinatorProject?.meetingCoordinator === true));
+                .pipe(map((coordinatorProject) => hasMeetingWriteAccess(coordinatorProject)));
             }),
             catchError(() => of(false))
           );

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -1953,14 +1953,20 @@ export class MeetingController {
    * whatever SFID it receives. That would route around the meeting-scoped allowlist the create path
    * enforces, using the edit endpoint instead. Attribution is set when a guest is added and never
    * edited, so stripping costs nothing.
+   *
+   * Generic over the body shape so both callers get their own type back: the update path keeps
+   * `UpdateMeetingRegistrantRequest` for the spread, and `hasRegistrantChanges` — which reads straight
+   * off `req.body` and so starts from `unknown` — gets an indexable record it can enumerate. A fixed
+   * return type forced that second caller through `as unknown as`, which erases whatever the first one
+   * declared and would have hidden a later signature change from the compiler.
    */
-  private static stripCommitteeUid(changes: UpdateMeetingRegistrantRequest | undefined): UpdateMeetingRegistrantRequest {
+  private static stripCommitteeUid<T extends object>(changes: T | undefined): Omit<T, 'committee_uid'> {
     if (!changes) {
-      return {} as UpdateMeetingRegistrantRequest;
+      return {} as Omit<T, 'committee_uid'>;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-to-strip: the key is deleted, not read
-    const { committee_uid: _dropped, ...rest } = changes as UpdateMeetingRegistrantRequest & { committee_uid?: unknown };
+    const { committee_uid: _dropped, ...rest } = changes as T & { committee_uid?: unknown };
 
     return rest;
   }
@@ -1992,7 +1998,7 @@ export class MeetingController {
       return false;
     }
 
-    const stripped = MeetingController.stripCommitteeUid(changes as UpdateMeetingRegistrantRequest) as unknown as Record<string, unknown>;
+    const stripped = MeetingController.stripCommitteeUid(changes as Record<string, unknown>);
 
     return Object.entries(stripped).some(([key, value]) => {
       // Widened for the lookups only: both arrays are typed by their registrant key unions, so

--- a/docs/architecture/backend/rate-limiting.md
+++ b/docs/architecture/backend/rate-limiting.md
@@ -1,16 +1,19 @@
 # Rate Limiting
 
-All API routes and auth flows sit behind per-IP rate limiters implemented with [`express-rate-limit`](https://www.npmjs.com/package/express-rate-limit). The limiters live in `apps/lfx-one/src/server/middleware/rate-limit.middleware.ts` and are wired into `server.ts` as global middleware on their URL prefixes.
+All API routes and auth flows sit behind rate limiters implemented with [`express-rate-limit`](https://www.npmjs.com/package/express-rate-limit). The limiters live in `apps/lfx-one/src/server/middleware/rate-limit.middleware.ts`. Most are wired into `server.ts` as global middleware on their URL prefixes; a route-scoped limiter is instead mounted on the individual route in its router.
 
 ## Limiters
 
-| Limiter                | Mounted at                                             | Window | Max req/IP | Purpose                                          |
-| ---------------------- | ------------------------------------------------------ | ------ | ---------- | ------------------------------------------------ |
-| `apiRateLimiter`       | `/api/*`                                               | 1 min  | 500        | General authenticated API traffic.               |
-| `publicApiRateLimiter` | `/public/api/*`                                        | 1 min  | 100        | Unauthenticated surfaces (e.g. public meetings). |
-| `authRateLimiter`      | `/login`, `/passwordless/callback`, `/social/callback` | 1 min  | 20         | Auth flows — brute-force mitigation.             |
+| Limiter                | Mounted at                                             | Window | Max req | Keyed on                     | Purpose                                          |
+| ---------------------- | ------------------------------------------------------ | ------ | ------- | ---------------------------- | ------------------------------------------------ |
+| `apiRateLimiter`       | `/api/*`                                               | 1 min  | 500     | IP                           | General authenticated API traffic.               |
+| `publicApiRateLimiter` | `/public/api/*`                                        | 1 min  | 100     | IP                           | Unauthenticated surfaces (e.g. public meetings). |
+| `authRateLimiter`      | `/login`, `/passwordless/callback`, `/social/callback` | 1 min  | 20      | IP                           | Auth flows — brute-force mitigation.             |
+| `aiRateLimiter`        | `POST /api/meetings/generate-agenda`                   | 1 min  | 10      | `req.oidc.user.sub`, else IP | LiteLLM-backed AI generation.                    |
 
-All three limiters use `standardHeaders: true` (modern `RateLimit-*` response headers) and `legacyHeaders: false` (no `X-RateLimit-*`). The window is 1 minute across the board.
+All four limiters use `standardHeaders: true` (modern `RateLimit-*` response headers) and `legacyHeaders: false` (no `X-RateLimit-*`). The window is 1 minute across the board.
+
+`aiRateLimiter` is the one limiter that is not per-IP and not mounted on a prefix. It stacks on top of `apiRateLimiter` (which still applies, since the route sits under `/api/`) and is keyed on the authenticated user so a single caller on a shared egress IP can't exhaust the budget for everyone behind it; anonymous callers fall back to a /56-masked IP key via `ipKeyGenerator`. Two known limits: it is not yet applied to the other LiteLLM callers (newsletter generation, weekly-brief action-item extraction), and its counter lives in the default in-process `MemoryStore`, so the effective ceiling is `limit × replicas` — exact today, since `ecosystem.config.js` runs a single instance, but a shared store would be needed under horizontal scaling.
 
 ## Wiring in `server.ts`
 
@@ -24,15 +27,21 @@ app.get('/passwordless/callback', authRateLimiter /* handler */);
 app.get('/social/callback', authRateLimiter /* handler */);
 ```
 
+```typescript
+// apps/lfx-one/src/server/routes/meetings.route.ts (excerpt)
+router.post('/generate-agenda', aiRateLimiter, (req, res, next) => meetingController.generateAgenda(req, res, next));
+```
+
 - `app.use(prefix, limiter)` applies the limiter to every request matching the prefix.
 - The explicit `.get()` registrations on the Auth0 callbacks layer the limiter in front of the callback-specific handler so it runs before any token exchange work.
 - Public routes are rate-limited **before** the generic `/api/` limiter would match, because `/public/api/*` has the stricter budget.
+- A route-scoped limiter like `aiRateLimiter` is registered in its own router rather than `server.ts`, and runs _after_ the prefix limiter — both budgets have to allow the request.
 
 ## Behavior on limit hit
 
 - Returns **HTTP 429** with the standard `RateLimit-*` headers indicating remaining budget and reset time.
 - No body payload beyond the library default — clients should surface "too many requests, please retry" to the user.
-- The limiter counts per-IP using the default `req.ip` key. In production behind load balancers, ensure Express `trust proxy` is configured upstream so the correct client IP is used.
+- Limiters count per-IP using the default `req.ip` key unless they declare a `keyGenerator` (`aiRateLimiter` keys on the authenticated user). In production behind load balancers, ensure Express `trust proxy` is configured upstream so the correct client IP is used.
 
 ## Adding a new limiter
 
@@ -40,7 +49,8 @@ When adding a new rate-limited surface (e.g. a privileged admin endpoint), follo
 
 1. Declare the limiter in `rate-limit.middleware.ts` alongside the existing ones — reuse `standardHeaders: true`, `legacyHeaders: false`, and the 1-minute window unless there's a specific reason to diverge.
 2. Mount it in `server.ts` via `app.use(prefix, limiter)` or inline on the route `.get(limiter, handler)`.
-3. If the route is extremely sensitive (credential flows, password reset), prefer a lower max and consider adding a per-identity key via the `keyGenerator` option instead of relying on IP alone.
+3. If the route is extremely sensitive (credential flows, password reset) or expensive per call (AI generation), prefer a lower max and add a per-identity key via the `keyGenerator` option instead of relying on IP alone — fall back to `ipKeyGenerator(req.ip)` rather than the raw IP, so IPv6 callers are grouped by prefix.
+4. Note that the default `MemoryStore` is per-process: a limit enforced across replicas needs a shared store.
 
 ## Related
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -20,7 +20,7 @@ import {
   VOTE_COLOR,
 } from '../constants';
 import { lfxColors } from '../constants/colors.constants';
-import { RecurrenceType, CommitteeMemberVotingStatus, MeetingType } from '../enums';
+import { CommitteeMemberVotingStatus, MeetingType, RecurrenceType } from '../enums';
 import { PollStatus } from '../enums/poll.enum';
 import type {
   BuildMeetingOccurrenceRouteOptions,


### PR DESCRIPTION
> **Stack 16 of 20.** Based on PR 15 (`feat/issue-1460-quick-create-handoff`). Followed by PR 17 (`fix/issue-1451-save-paths-and-labels`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Closes out the full-branch review: the findings that were accepted across the whole composer, plus unit specs for the four composer files that had shipped without them.

## How

- Binds `cancel_on_committee_removal` in the composer form group — the committee manager bound the control unconditionally, so it had to exist.
- Ports the owner/organizer picker the wizard had and restores the project-context sync the route-scoped edit page used to provide.
- Unsubscribes the host's submit stream with `take(1)`, reuses the shared write-access predicate in `canWriteMeetings`, and gives the recurrence chips a visible focus indicator (WCAG 2.4.7).
- Makes `stripCommitteeUid` generic instead of casting through `Record`, moves the create menu's `align` input above the computeds, sorts the enum import in `meeting.utils`, and refreshes the rate-limiting doc.
- Migrates the two e2e specs that still drove the deleted `meeting-manage` wizard onto the composer surface.
- Adds specs for the composer host (section navigation, submit gating, the post-create toast, the write-access guard) and for the recording/reminder dependency chains, the cadence-to-recurrence mapping and the attachment gate.

## Notes for reviewers

- Test and review-fix only — no new product surface. +79 unit tests.

## Commits

2 commit(s), 18 files changed, 1558 insertions(+), 130 deletions(-).

- `fix(meetings): address full-branch review findings`
- `test(meetings): cover the composer host and three sections`

## Related

- Refs #1452
- Refs #1453
- Refs #1454
- Refs #1456
- Refs #1458
- Refs #1459
- Refs #1463
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
