### PR TITLE
Embed Gatewaze admin modules in LFX One — LFX host integration (outlet, route, /api/gw proxy)

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { authGuard } from './shared/guards/auth.guard';
 import { authenticatedMatchGuard } from './shared/guards/authenticated-match.guard';
 import { dashboardAccessGuard } from './shared/guards/dashboard-access.guard';
 import { campaignAccessGuard } from './shared/guards/campaign-access.guard';
+import { gatewazeEmbedEnabledGuard } from './shared/guards/gatewaze-embed-enabled.guard';
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { marketingImpactAccessGuard } from './shared/guards/marketing-impact-access.guard';
 import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
@@ -285,6 +286,17 @@ export const routes: Routes = [
         canMatch: [mktgOsAgentsEnabledGuard],
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/mktg-os-agents/mktg-os-agents.routes').then((m) => m.MKTG_OS_AGENTS_ROUTES),
+      },
+      // Gatewaze admin embed pilot — dark-launched behind `gatewaze-embed-enabled` (CanMatch);
+      // invisible when the flag is off. Mounts the `@gatewaze/admin-embed` React app natively
+      // (no iframe) via GwModuleOutletComponent, which owns all sub-navigation once mounted —
+      // a single wildcard child route in GW_ROUTES is enough for the whole subtree.
+      {
+        path: `foundation/gw`,
+        data: { lens: 'foundation' },
+        canMatch: [gatewazeEmbedEnabledGuard],
+        canActivate: [authGuard],
+        loadChildren: () => import('./modules/gw/gw.routes').then((m) => m.GW_ROUTES),
       },
       {
         path: 'foundation/votes',

--- a/apps/lfx-one/src/app/modules/gw/gw-module-outlet/gw-module-outlet.component.html
+++ b/apps/lfx-one/src/app/modules/gw/gw-module-outlet/gw-module-outlet.component.html
@@ -1,0 +1,16 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-4">
+  <!-- Unconditional siblings: the embed mounts into #embedRoot and renders portals (dialogs,
+       toasts, etc.) into #embedPortals. Both must exist in the DOM before mount() runs. -->
+  <div #embedRoot id="gw-embed-root"></div>
+  <div #embedPortals id="gw-embed-portals"></div>
+
+  @if (mountError()) {
+    <div class="flex flex-col gap-2 rounded border border-red-300 bg-red-50 p-4 text-red-700" role="alert">
+      <p class="font-semibold">The embedded admin module couldn't be loaded.</p>
+      <p>{{ mountError() }}</p>
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/gw/gw-module-outlet/gw-module-outlet.component.ts
+++ b/apps/lfx-one/src/app/modules/gw/gw-module-outlet/gw-module-outlet.component.ts
@@ -1,0 +1,149 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { afterNextRender, Component, DestroyRef, ElementRef, inject, PLATFORM_ID, signal, TransferState, viewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { GwEmbedFatalError, GwHostContext } from '@lfx-one/shared/interfaces';
+
+import { getRuntimeConfig } from '../../../shared/providers/runtime-config.provider';
+
+/**
+ * Handle returned by `@gatewaze/admin-embed`'s `mount()`. Kept local (not in the shared interface
+ * file) since it's purely an implementation detail of this component's own cleanup, not part of
+ * the host-context contract the embed reads.
+ */
+interface GwEmbedMountHandle {
+  unmount: () => void;
+}
+
+/**
+ * Native (no-iframe) host for the embedded Gatewaze admin pilot at `/foundation/gw`.
+ *
+ * Mirrors `rich-editor.component.ts`'s SSR-safe lazy-mount pattern: on the server this renders two
+ * empty mount points and nothing else; in the browser, `afterNextRender` dynamically imports
+ * `@gatewaze/admin-embed` and hands it a `GwHostContext` to mount itself into `#embedRoot`.
+ *
+ * `@gatewaze/admin-embed` is published from the separate `gatewaze` repo and is out of scope for
+ * this change — until it exists as a resolvable workspace/npm dependency, the dynamic import below
+ * will fail. That failure is expected and is handled the same way a genuine runtime failure from
+ * the embed would be: caught, logged, and surfaced via `mountError` for the inline fallback.
+ */
+@Component({
+  selector: 'lfx-gw-module-outlet',
+  imports: [],
+  templateUrl: './gw-module-outlet.component.html',
+})
+export class GwModuleOutletComponent {
+  // 1. Private injections
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router);
+  private readonly transferState = inject(TransferState);
+
+  // viewChild mount points — both are unconditional siblings in the template so they exist in the
+  // DOM (and are stable references) before the embed ever mounts.
+  protected readonly embedRoot = viewChild.required<ElementRef<HTMLDivElement>>('embedRoot');
+  protected readonly embedPortals = viewChild.required<ElementRef<HTMLDivElement>>('embedPortals');
+
+  // 5. WritableSignals
+  protected readonly mountError = signal<string | null>(null);
+
+  // Plain (non-signal) mount bookkeeping — not template-bound, so no need for reactivity here.
+  private destroyed = false;
+  private mounting = false;
+  private mountHandle: GwEmbedMountHandle | null = null;
+
+  // 7. Constructor
+  public constructor() {
+    afterNextRender(() => {
+      void this.mountEmbed();
+    });
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.mountHandle?.unmount();
+      this.mountHandle = null;
+    });
+  }
+
+  // 10. Private initializer
+  private async mountEmbed(): Promise<void> {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    // The embed itself is documented to guard against being mounted twice into the same node, but
+    // we still guard here so a second `afterNextRender` firing (or any future re-entrant caller)
+    // can't kick off a redundant import + mount while one is already in flight or done.
+    if (this.mounting || this.mountHandle) {
+      return;
+    }
+    this.mounting = true;
+
+    try {
+      const runtimeConfig = getRuntimeConfig(this.transferState);
+
+      const ctx: GwHostContext = {
+        basename: '/foundation/gw',
+        supabase: {
+          url: runtimeConfig.gwSupabaseUrl,
+          anonKey: runtimeConfig.gwSupabaseAnonKey,
+        },
+        // Empty string tells the embed to default to same-origin `/api/gw` (see gw-embed.interface.ts).
+        apiBaseUrl: '',
+        enabled: {
+          // ASSUMPTION (spec truncated before describing per-cohort module/feature enablement):
+          // ship everything the embed exposes for now rather than a curated allowlist. Revisit
+          // once the cohort-membership/enablement mechanism is specified.
+          moduleIds: [],
+          features: [],
+        },
+        signIn: {
+          lfidStartUrl: runtimeConfig.gwLfidStartUrl,
+          returnUrl: window.location.href,
+        },
+        portalContainer: this.embedPortals().nativeElement,
+        onFatal: (err) => this.onFatal(err),
+        navigateHost: (path) => void this.router.navigateByUrl(path),
+      };
+
+      // ASSUMPTION (spec truncated before confirming the exact handshake): the embed is documented
+      // to read its host context off this global ahead of / during `mount()`. Setting it here,
+      // immediately before the dynamic import resolves, is the safest ordering we can guarantee
+      // without the real package to verify against.
+      (globalThis as unknown as { __GATEWAZE_CONFIG__?: GwHostContext }).__GATEWAZE_CONFIG__ = ctx;
+
+      // NOTE: @gatewaze/admin-embed is published from the separate `gatewaze` repo (out of scope
+      // here) and does not exist as an installable package yet. This import is expected to fail to
+      // resolve until that package ships and is added as a dependency of apps/lfx-one — see the
+      // final report for details. The catch block below is what handles that (and any genuine
+      // future runtime failure) identically.
+      const mod = await import('@gatewaze/admin-embed');
+
+      // The component may have been torn down while the import was in flight (fast navigation away
+      // from /foundation/gw) — don't mount into a host node that's about to be removed.
+      if (this.destroyed) {
+        return;
+      }
+
+      this.mountHandle = mod.mount(this.embedRoot().nativeElement, ctx);
+    } catch (error) {
+      // No client-side error-reporting service exists yet; console.error is the established
+      // fallback used throughout apps/lfx-one/src/app/shared (no-console isn't a lint rule here).
+      console.error('[GwModuleOutlet] Failed to load or mount @gatewaze/admin-embed', error);
+      this.onFatal({
+        error_type: 'import_failed',
+        code: 'GW_EMBED_IMPORT_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to load the embedded admin module.',
+        recoverable: false,
+      });
+    } finally {
+      this.mounting = false;
+    }
+  }
+
+  // 10. Private initializer
+  private onFatal(err: GwEmbedFatalError): void {
+    this.mountError.set(err.message || 'The embedded admin module failed to load.');
+  }
+}

--- a/apps/lfx-one/src/app/modules/gw/gw.routes.ts
+++ b/apps/lfx-one/src/app/modules/gw/gw.routes.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Routes } from '@angular/router';
+
+import { authGuard } from '../../shared/guards/auth.guard';
+
+/**
+ * Route tree for the embedded Gatewaze admin pilot (`/foundation/gw`).
+ *
+ * A single wildcard entry is deliberate, not a placeholder: once `GwModuleOutletComponent` mounts
+ * `@gatewaze/admin-embed`, the embed's own router owns every sub-path under this mount (the
+ * spec's dual-router contract) — Angular only ever needs to match once for the whole subtree.
+ */
+export const GW_ROUTES: Routes = [
+  {
+    path: '**',
+    loadComponent: () => import('./gw-module-outlet/gw-module-outlet.component').then((m) => m.GwModuleOutletComponent),
+    canActivate: [authGuard],
+  },
+];

--- a/apps/lfx-one/src/app/shared/guards/gatewaze-embed-enabled.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/gatewaze-embed-enabled.guard.spec.ts
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PLATFORM_ID, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Route, Router, UrlSegment } from '@angular/router';
+import { GATEWAZE_EMBED_ENABLED_FLAG } from '@lfx-one/shared/constants';
+import { FeatureFlagService } from '@shared/services/feature-flag.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { gatewazeEmbedEnabledGuard } from './gatewaze-embed-enabled.guard';
+
+describe('gatewazeEmbedEnabledGuard', () => {
+  let getFlagOverride: ReturnType<typeof vi.fn>;
+  let providerReady: ReturnType<typeof signal<boolean>>;
+  let getBooleanFlag: ReturnType<typeof vi.fn>;
+  let waitForReady: ReturnType<typeof vi.fn>;
+  let router: {
+    parseUrl: ReturnType<typeof vi.fn>;
+  };
+
+  const route: Route = { path: 'foundation/gw', data: { lens: 'foundation' } };
+  const segments: UrlSegment[] = [];
+
+  const runGuard = (): ReturnType<typeof gatewazeEmbedEnabledGuard> => TestBed.runInInjectionContext(() => gatewazeEmbedEnabledGuard(route, segments));
+
+  beforeEach(() => {
+    getFlagOverride = vi.fn().mockReturnValue(undefined);
+    providerReady = signal(true);
+    getBooleanFlag = vi.fn().mockReturnValue(signal(false));
+    waitForReady = vi.fn().mockImplementation(
+      (_context: unknown, timeoutMs = 5000) =>
+        new Promise((resolve) => {
+          if (providerReady()) {
+            resolve(true);
+            return;
+          }
+          setTimeout(() => resolve(false), timeoutMs);
+        })
+    );
+
+    router = {
+      parseUrl: vi.fn().mockImplementation((url: string) => ({ redirected: url })),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: FeatureFlagService,
+          useValue: { getFlagOverride, providerReady: providerReady.asReadonly(), getBooleanFlag, waitForReady },
+        },
+        { provide: Router, useValue: router },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+  });
+
+  it('allows on the server without evaluating the flag (SSR fast path)', async () => {
+    TestBed.overrideProvider(PLATFORM_ID, { useValue: 'server' });
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getFlagOverride).not.toHaveBeenCalled();
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+
+  it('allows when the local override says the flag is on, without waiting for READY', async () => {
+    getFlagOverride.mockReturnValue(true);
+    providerReady.set(false);
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(waitForReady).not.toHaveBeenCalled();
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+
+  it('redirects to / when the local override says the flag is off, without waiting for READY', async () => {
+    getFlagOverride.mockReturnValue(false);
+    providerReady.set(false);
+
+    const result = await runGuard();
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toEqual({ redirected: '/' });
+    expect(waitForReady).not.toHaveBeenCalled();
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+
+  it('allows once the provider is ready and the flag is on', async () => {
+    getBooleanFlag.mockReturnValue(signal(true));
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+  });
+
+  it('redirects to / once the provider is ready and the flag is off', async () => {
+    getBooleanFlag.mockReturnValue(signal(false));
+
+    const result = await runGuard();
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toEqual({ redirected: '/' });
+  });
+
+  it('fails closed to / when the provider never becomes ready', async () => {
+    vi.useFakeTimers();
+    providerReady.set(false);
+
+    const pending = runGuard();
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await pending;
+
+    vi.useRealTimers();
+
+    expect(waitForReady).toHaveBeenCalledWith({ guard: 'gatewazeEmbedEnabledGuard', flag: GATEWAZE_EMBED_ENABLED_FLAG });
+    expect(router.parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toEqual({ redirected: '/' });
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/app/shared/guards/gatewaze-embed-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/gatewaze-embed-enabled.guard.ts
@@ -1,0 +1,47 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { CanMatchFn, Router } from '@angular/router';
+import { GATEWAZE_EMBED_ENABLED_FLAG } from '@lfx-one/shared/constants';
+
+import { FeatureFlagService } from '../services/feature-flag.service';
+
+/**
+ * CanMatch guard gating the embedded Gatewaze admin pilot (`/foundation/gw`) behind the
+ * `gatewaze-embed-enabled` flag. SSR defers to the browser, a local override decides before the
+ * provider is consulted, and an unready provider fails closed to the Foundation Lens dashboard.
+ */
+export const gatewazeEmbedEnabledGuard: CanMatchFn = async () => {
+  const platformId = inject(PLATFORM_ID);
+
+  // LaunchDarkly is unavailable during SSR, so the browser run of this guard makes the real decision.
+  if (!isPlatformBrowser(platformId)) {
+    return true;
+  }
+
+  const featureFlagService = inject(FeatureFlagService);
+  const router = inject(Router);
+
+  // A locally pinned value decides on its own, before the provider is consulted at all — waiting
+  // first would let a readiness timeout answer for it, and a pinned `false` must never be
+  // overridden. Non-production builds only; see `FEATURE_FLAG_OVERRIDE_STORAGE_KEY`.
+  const override = featureFlagService.getFlagOverride(GATEWAZE_EMBED_ENABLED_FLAG);
+  if (override !== undefined) {
+    return override ? true : router.parseUrl('/');
+  }
+
+  if (!featureFlagService.providerReady()) {
+    const ready = await featureFlagService.waitForReady({ guard: 'gatewazeEmbedEnabledGuard', flag: GATEWAZE_EMBED_ENABLED_FLAG });
+    // Provider never became ready in time (no client id / LD unreachable) → fail CLOSED. This is a
+    // pilot behind a dark launch, so failing open would expose an unfinished, unaudited embed to
+    // every user whenever LaunchDarkly is slow — turning an outage into a release. waitForReady()
+    // reports the timeout to RUM.
+    if (!ready) {
+      return router.parseUrl('/');
+    }
+  }
+
+  return featureFlagService.getBooleanFlag(GATEWAZE_EMBED_ENABLED_FLAG, false)() ? true : router.parseUrl('/');
+};

--- a/apps/lfx-one/src/app/shared/providers/runtime-config.provider.ts
+++ b/apps/lfx-one/src/app/shared/providers/runtime-config.provider.ts
@@ -15,6 +15,9 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   allowedTracingUrls: [],
   intercomAppId: '',
   stripePublishableKey: '',
+  gwSupabaseUrl: '',
+  gwSupabaseAnonKey: '',
+  gwLfidStartUrl: '',
 };
 
 /**

--- a/apps/lfx-one/src/server/controllers/gw-proxy.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/gw-proxy.controller.spec.ts
@@ -1,0 +1,189 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loggerMocks = vi.hoisted(() => ({
+  startOperation: vi.fn(() => 0),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+}));
+const flagMocks = vi.hoisted(() => ({
+  isServerFeatureEnabled: vi.fn(() => true),
+}));
+const gwApiMocks = vi.hoisted(() => ({
+  getGwApiBaseUrl: vi.fn(() => 'https://gw.example.com'),
+}));
+const streamMocks = vi.hoisted(() => ({
+  pipeline: vi.fn(() => Promise.resolve()),
+  fromWeb: vi.fn(() => ({ pipedFromWeb: true })),
+}));
+
+vi.mock('../services/logger.service', () => ({ logger: loggerMocks }));
+vi.mock('../helpers/server-feature-flag.helper', async () => {
+  const actual = await vi.importActual<typeof import('../helpers/server-feature-flag.helper')>('../helpers/server-feature-flag.helper');
+  return { ...actual, isServerFeatureEnabled: flagMocks.isServerFeatureEnabled };
+});
+vi.mock('../helpers/gw-api.helper', () => gwApiMocks);
+vi.mock('node:stream/promises', () => ({ pipeline: streamMocks.pipeline }));
+vi.mock('node:stream', () => ({ Readable: { fromWeb: streamMocks.fromWeb } }));
+
+import type { NextFunction, Request, Response } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { GwProxyController } from './gw-proxy.controller';
+
+function buildReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'GET',
+    url: '/orgs/123',
+    path: '/api/gw/orgs/123',
+    headers: { cookie: 'session=abc', 'x-custom': 'keep-me' },
+    bearerToken: 'token-1',
+    ...overrides,
+  } as unknown as Request;
+}
+
+function buildRes(): Response & {
+  setHeader: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+} {
+  const res = {
+    headersSent: false,
+    writableEnded: false,
+    setHeader: vi.fn(),
+    status: vi.fn(function (this: any) {
+      return this;
+    }),
+    json: vi.fn(),
+    end: vi.fn(),
+    setHeaders: vi.fn(),
+  };
+  return res as unknown as Response & {
+    setHeader: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('GwProxyController', () => {
+  let controller: GwProxyController;
+  let next: NextFunction & ReturnType<typeof vi.fn>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    flagMocks.isServerFeatureEnabled.mockReturnValue(true);
+    gwApiMocks.getGwApiBaseUrl.mockReturnValue('https://gw.example.com');
+    controller = new GwProxyController();
+    next = vi.fn() as NextFunction & ReturnType<typeof vi.fn>;
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('answers 404 gw_flag_disabled (with X-Request-Id) when the server flag is off, without calling fetch', async () => {
+    flagMocks.isServerFeatureEnabled.mockReturnValue(false);
+    const req = buildReq();
+    const res = buildRes();
+
+    await controller.proxy(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', expect.any(String));
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'gw_flag_disabled', requestId: expect.any(String) });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('answers the identical 404 gw_flag_disabled when the flag is on but the caller has no bearer token', async () => {
+    flagMocks.isServerFeatureEnabled.mockReturnValue(true);
+    const req = buildReq({ bearerToken: undefined });
+    const res = buildRes();
+
+    await controller.proxy(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'gw_flag_disabled', requestId: expect.any(String) });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards method/path/query to GW_API_URL, sets Authorization from bearerToken, strips Cookie, and does not follow redirects', async () => {
+    const upstreamHeaders = new Headers({ 'content-type': 'application/json' });
+    fetchMock.mockResolvedValue({ status: 200, headers: upstreamHeaders, body: {} });
+    const req = buildReq({ url: '/orgs/123?foo=bar' });
+    const res = buildRes();
+
+    await controller.proxy(req, res, next);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe('https://gw.example.com/orgs/123?foo=bar');
+    expect(calledInit.method).toBe('GET');
+    expect(calledInit.redirect).toBe('manual');
+    const headers = calledInit.headers as Headers;
+    expect(headers.get('authorization')).toBe('Bearer token-1');
+    expect(headers.get('cookie')).toBeNull();
+    expect(headers.get('x-custom')).toBe('keep-me');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('streams a non-GET/HEAD request body upstream with duplex half', async () => {
+    const upstreamHeaders = new Headers();
+    fetchMock.mockResolvedValue({ status: 201, headers: upstreamHeaders, body: {} });
+    const req = buildReq({ method: 'POST', url: '/orgs' });
+    const res = buildRes();
+
+    await controller.proxy(req, res, next);
+
+    const [, calledInit] = fetchMock.mock.calls[0];
+    expect(calledInit.body).toBe(req);
+    expect(calledInit.duplex).toBe('half');
+  });
+
+  it('passes an upstream 3xx straight through (redirect: manual means fetch resolves it, not throws)', async () => {
+    const upstreamHeaders = new Headers({ location: 'https://gw.example.com/elsewhere' });
+    fetchMock.mockResolvedValue({ status: 302, headers: upstreamHeaders, body: null });
+    const res = buildRes();
+
+    await controller.proxy(buildReq(), res, next);
+
+    expect(res.status).toHaveBeenCalledWith(302);
+    expect(res.setHeader).toHaveBeenCalledWith('Location', 'https://gw.example.com/elsewhere');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('delegates a misconfigured GW_API_URL to next(error) as a 503 MicroserviceError, never calling logger.error itself', async () => {
+    const configError = new MicroserviceError('GW_API_URL environment variable is not configured', 503, 'GW_API_URL_MISCONFIGURED', {
+      operation: 'gw_proxy_request',
+    });
+    gwApiMocks.getGwApiBaseUrl.mockImplementation(() => {
+      throw configError;
+    });
+    const res = buildRes();
+
+    await controller.proxy(buildReq(), res, next);
+
+    expect(next).toHaveBeenCalledWith(configError);
+    expect(loggerMocks.error).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still sets X-Request-Id on the error path before delegating to next()', async () => {
+    gwApiMocks.getGwApiBaseUrl.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const res = buildRes();
+
+    await controller.proxy(buildReq(), res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-Id', expect.any(String));
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/server/controllers/gw-proxy.controller.ts
+++ b/apps/lfx-one/src/server/controllers/gw-proxy.controller.ts
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { randomUUID } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { ReadableStream as NodeReadableStream } from 'node:stream/web';
+
+import { NextFunction, Request, Response } from 'express';
+
+import { getGwApiBaseUrl } from '../helpers/gw-api.helper';
+import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
+import { logger } from '../services/logger.service';
+
+/** Extends the DOM `RequestInit` typings with undici's streaming-body option (not declared in lib.dom.d.ts). */
+type FetchRequestInit = RequestInit & { duplex?: 'half' };
+
+/** Request headers that must never reach the upstream Gatewaze service. */
+const STRIPPED_REQUEST_HEADERS = new Set(['cookie', 'host', 'content-length', 'connection', 'authorization']);
+
+/**
+ * BFF proxy in front of the embedded Gatewaze admin pilot's own backend (`GW_API_URL`), mounted
+ * at `/api/gw/*` — see `gw-proxy.route.ts` for the mount and `server.ts` for why this path is
+ * excluded from the global body-parsing/compression middleware.
+ *
+ * Every response, success or failure, carries a fresh `X-Request-Id` (`crypto.randomUUID()`) so a
+ * caller and this service's logs can be correlated. This is scoped to this route only and does
+ * NOT touch the global pino-http request-id configuration.
+ */
+export class GwProxyController {
+  public async proxy(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const requestId = randomUUID();
+    res.setHeader('X-Request-Id', requestId);
+
+    const startTime = logger.startOperation(req, 'gw_proxy_request', {
+      method: req.method,
+      path: req.path,
+    });
+
+    // Flag-off and "not authenticated" are answered with the exact same status, body shape and
+    // code path so a caller cannot distinguish "the pilot isn't enabled here" from "you're not
+    // signed in" from "no such route" — see GatewazeEmbedEnabled's doc comment for why.
+    //
+    // ASSUMPTION (spec truncated before detailing the auth check): `req.bearerToken` — set by
+    // auth.middleware.ts once a session/token has been validated — is the "authenticated" signal
+    // checked here. Worth flagging: in this app's CURRENT global configuration every `/api/*`
+    // path already requires a bearer token before a request reaches this controller at all (see
+    // auth.middleware.ts's `DEFAULT_ROUTE_CONFIG`), so an actually-unauthenticated caller is
+    // today turned away with a generic 401 upstream of this code, not this 404. This check is
+    // kept anyway, per the spec's explicit instruction, as defense-in-depth / correctness
+    // insurance should that global classification ever change for this path.
+    if (!isServerFeatureEnabled(ServerFeatureFlag.GatewazeEmbedEnabled) || !req.bearerToken) {
+      res.status(404).json({ error: 'gw_flag_disabled', requestId });
+      return;
+    }
+
+    try {
+      const baseUrl = getGwApiBaseUrl('gw_proxy_request');
+      // `req.url` inside a router mounted at `/api/gw` is already relative to that mount point
+      // (Express strips the matched prefix), and still carries the original query string — so
+      // this single concatenation forwards both the remaining path and the query.
+      const upstreamUrl = `${baseUrl}${req.url}`;
+
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(req.headers)) {
+        if (value === undefined || STRIPPED_REQUEST_HEADERS.has(name.toLowerCase())) {
+          continue;
+        }
+        headers.set(name, Array.isArray(value) ? value.join(', ') : value);
+      }
+      // Guaranteed present: the gate above already returned 404 when it was absent.
+      headers.set('Authorization', `Bearer ${req.bearerToken}`);
+
+      const hasRequestBody = req.method !== 'GET' && req.method !== 'HEAD';
+
+      const requestInit: FetchRequestInit = {
+        method: req.method,
+        headers,
+        // Never follow upstream redirects — pass 3xx through untouched so whatever is on the
+        // other end of this proxy (the embed, or its own client) decides what to do with a
+        // Location header, rather than this BFF silently chasing it.
+        redirect: 'manual',
+      };
+
+      if (hasRequestBody) {
+        // `/api/gw` is excluded from express.json()/express.urlencoded() (see server.ts) so `req`
+        // is still an unconsumed raw stream here — forwarding it directly (rather than buffering
+        // and re-serializing) proxies the body byte-for-byte regardless of content type.
+        requestInit.body = req as unknown as ReadableStream<Uint8Array>;
+        requestInit.duplex = 'half';
+      }
+
+      const upstream = await fetch(upstreamUrl, requestInit);
+
+      res.status(upstream.status);
+      const contentType = upstream.headers.get('content-type');
+      if (contentType) {
+        res.setHeader('Content-Type', contentType);
+      }
+      const contentLength = upstream.headers.get('content-length');
+      if (contentLength) {
+        res.setHeader('Content-Length', contentLength);
+      }
+      const location = upstream.headers.get('location');
+      if (location) {
+        res.setHeader('Location', location);
+      }
+
+      if (upstream.body) {
+        // pipeline() propagates stream errors to the catch block instead of hanging.
+        await pipeline(Readable.fromWeb(upstream.body as NodeReadableStream<Uint8Array>), res);
+      } else {
+        res.end();
+      }
+
+      logger.success(req, 'gw_proxy_request', startTime, {
+        method: req.method,
+        path: req.path,
+        upstream_status: upstream.status,
+      });
+    } catch (error) {
+      // Headers already committed — can only end the stream. This is the one place a controller
+      // in this codebase calls logger.error() directly, because next(error) can no longer produce
+      // a clean response once streaming has begun.
+      if (res.headersSent) {
+        logger.error(req, 'gw_proxy_request', startTime, error, {
+          method: req.method,
+          path: req.path,
+          stage: 'streaming',
+        });
+        if (!res.writableEnded) {
+          res.end();
+        }
+        return;
+      }
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/helpers/gw-api.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/gw-api.helper.spec.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MicroserviceError } from '../errors';
+import { getGwApiBaseUrl } from './gw-api.helper';
+
+describe('getGwApiBaseUrl', () => {
+  const originalGwApiUrl = process.env['GW_API_URL'];
+  const originalNodeEnv = process.env['NODE_ENV'];
+
+  beforeEach(() => {
+    delete process.env['GW_API_URL'];
+  });
+
+  afterEach(() => {
+    if (originalGwApiUrl === undefined) {
+      delete process.env['GW_API_URL'];
+    } else {
+      process.env['GW_API_URL'] = originalGwApiUrl;
+    }
+    process.env['NODE_ENV'] = originalNodeEnv;
+  });
+
+  it('throws a 503 MicroserviceError when GW_API_URL is unset', () => {
+    expect(() => getGwApiBaseUrl('gw_proxy_request')).toThrow(MicroserviceError);
+    try {
+      getGwApiBaseUrl('gw_proxy_request');
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(MicroserviceError);
+      expect((error as MicroserviceError).statusCode).toBe(503);
+      expect((error as MicroserviceError).code).toBe('GW_API_URL_MISCONFIGURED');
+    }
+  });
+
+  it('throws when GW_API_URL is set but empty/whitespace-only', () => {
+    process.env['GW_API_URL'] = '   ';
+    expect(() => getGwApiBaseUrl('gw_proxy_request')).toThrow(MicroserviceError);
+  });
+
+  it('throws when GW_API_URL has a trailing slash', () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['GW_API_URL'] = 'https://gw.example.com/';
+    expect(() => getGwApiBaseUrl('gw_proxy_request')).toThrow(/trailing slash/);
+  });
+
+  it('throws when GW_API_URL is non-https outside dev/local/test NODE_ENV', () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['GW_API_URL'] = 'http://gw.example.com';
+    expect(() => getGwApiBaseUrl('gw_proxy_request')).toThrow(/https/);
+  });
+
+  it('allows non-https GW_API_URL when NODE_ENV is development', () => {
+    process.env['NODE_ENV'] = 'development';
+    process.env['GW_API_URL'] = 'http://localhost:5050';
+    expect(getGwApiBaseUrl('gw_proxy_request')).toBe('http://localhost:5050');
+  });
+
+  it('allows non-https GW_API_URL when NODE_ENV is local', () => {
+    process.env['NODE_ENV'] = 'local';
+    process.env['GW_API_URL'] = 'http://localhost:5050';
+    expect(getGwApiBaseUrl('gw_proxy_request')).toBe('http://localhost:5050');
+  });
+
+  it('returns the trimmed URL unchanged when valid', () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['GW_API_URL'] = '  https://gw.example.com  ';
+    expect(getGwApiBaseUrl('gw_proxy_request')).toBe('https://gw.example.com');
+  });
+});

--- a/apps/lfx-one/src/server/helpers/gw-api.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gw-api.helper.ts
@@ -1,0 +1,52 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MicroserviceError } from '../errors';
+
+/**
+ * Resolves the upstream Gatewaze admin service base URL from the `GW_API_URL` env var.
+ *
+ * Mirrors `getApiGatewayBaseUrl`'s lazy-validate-on-first-use pattern: nothing reads or checks
+ * this at module load, so a misconfigured deployment fails the first proxied request with a
+ * clear 503 rather than crashing at startup or building a malformed upstream URL.
+ *
+ * Validation, beyond "is it set":
+ * - Trailing slashes are rejected (not stripped) so `gw-proxy.controller.ts`'s naive
+ *   `${base}${req.url}` concatenation can't silently produce a double slash.
+ * - Outside `NODE_ENV` values of `development`/`local`/`test`, the URL must be `https:` — this
+ *   proxy forwards `Authorization` and (for non-GET/HEAD requests) the full request body
+ *   upstream, so an accidental `http://` target in a real environment would leak both in transit.
+ *
+ * @param operation - Logical operation name for error metadata (e.g. `gw_proxy_request`).
+ */
+export function getGwApiBaseUrl(operation: string): string {
+  const gwApiUrl = process.env['GW_API_URL'];
+
+  if (!gwApiUrl || !gwApiUrl.trim()) {
+    throw new MicroserviceError('GW_API_URL environment variable is not configured', 503, 'GW_API_URL_MISCONFIGURED', {
+      operation,
+      service: 'gw_proxy',
+    });
+  }
+
+  const trimmed = gwApiUrl.trim();
+
+  if (trimmed.endsWith('/')) {
+    throw new MicroserviceError('GW_API_URL must not have a trailing slash', 503, 'GW_API_URL_MISCONFIGURED', {
+      operation,
+      service: 'gw_proxy',
+    });
+  }
+
+  const nodeEnv = (process.env['NODE_ENV'] || '').toLowerCase();
+  const isDevLocal = nodeEnv === 'development' || nodeEnv === 'local' || nodeEnv === 'test';
+
+  if (!isDevLocal && !trimmed.startsWith('https://')) {
+    throw new MicroserviceError('GW_API_URL must use https:// outside local development', 503, 'GW_API_URL_MISCONFIGURED', {
+      operation,
+      service: 'gw_proxy',
+    });
+  }
+
+  return trimmed;
+}

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -396,6 +396,29 @@ export enum ServerFeatureFlag {
    * pixels; a flag that ships the PII is not a gate.
    */
   OrgLensCompanyEmails = 'LFX_ORG_LENS_COMPANY_EMAILS_ENABLED',
+
+  /**
+   * Gates `/api/gw/*` (`gw-proxy.route.ts`), the BFF proxy in front of the embedded Gatewaze
+   * admin pilot (`GwModuleOutletComponent`, `/foundation/gw`). OFF answers every request under
+   * the prefix with an identical 404 `gw_flag_disabled`, whether or not the caller is
+   * authenticated — the point is that an unauthenticated probe cannot distinguish "flag off"
+   * from "no such route" from "not authenticated".
+   *
+   * Deliberately paired with, and independent of, the client-side `gatewaze-embed-enabled`
+   * OpenFeature flag (`gatewaze-embed-enabled.guard.ts`). The Web SDK never runs server-side, so
+   * the client flag hides the route and nav but leaves the BFF reachable by direct call — this
+   * flag is what makes the dark launch a real kill switch. Both must be on for the pilot to work.
+   *
+   * ASSUMPTION (spec truncated before describing per-cohort membership): this is a boolean,
+   * all-or-nothing gate rather than a per-user/per-org allowlist. Revisit if a cohort mechanism
+   * is specified later — until then this flag being on means the pilot is reachable by every
+   * authenticated caller, not just the intended pilot cohort.
+   *
+   * OFF by default. No overlap hazard during a rolling update: every route this gates is
+   * stateless and read/write-through to the upstream Gatewaze service, so a request either
+   * reaches a flag-on pod and proxies, or a flag-off pod and 404s — never a partial write.
+   */
+  GatewazeEmbedEnabled = 'LFX_GATEWAZE_EMBED_ENABLED',
 }
 
 /**

--- a/apps/lfx-one/src/server/routes/gw-proxy.route.ts
+++ b/apps/lfx-one/src/server/routes/gw-proxy.route.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { GwProxyController } from '../controllers/gw-proxy.controller';
+
+const router = Router();
+const gwProxyController = new GwProxyController();
+
+// Catch-all: every method, every sub-path under this router's `/api/gw` mount forwards to the
+// same controller, which resolves the remaining path (and query string) off `req.url`.
+router.use((req, res, next) => gwProxyController.proxy(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -34,6 +34,7 @@ import createPickerRouter from './routes/create-picker.route';
 import documentsRouter from './routes/documents.route';
 import enrollmentRouter from './routes/enrollment.route';
 import eventsRouter from './routes/events.route';
+import gwProxyRouter from './routes/gw-proxy.route';
 import impersonationRouter from './routes/impersonation.route';
 import mailingListsRouter from './routes/mailing-lists.route';
 import meetingsRouter from './routes/meetings.route';
@@ -116,11 +117,40 @@ app.use(
   compression({
     level: 6,
     threshold: 1024,
+    // Exclude /api/gw: gw-proxy.route.ts streams the upstream Gatewaze response body straight
+    // through byte-for-byte (including whatever Content-Encoding it already carries), so this
+    // middleware must never re-compress or re-wrap it.
+    filter: (req: Request, res: Response) => {
+      if (req.path.startsWith('/api/gw')) {
+        return false;
+      }
+      return compression.filter(req, res);
+    },
   })
 );
 
-app.use(express.json({ limit: '15mb' }));
-app.use(express.urlencoded({ extended: true, limit: '15mb' }));
+// /api/gw (gw-proxy.route.ts) is excluded from both parsers below: it forwards the request body to
+// GW_API_URL byte-for-byte and content-type-agnostically (JSON, multipart, or anything else), so it
+// needs the raw, unconsumed request stream rather than a parsed body it would have to
+// re-serialize. These two mounts run before authMiddleware (like the parsers they wrap), so
+// exclusion by path is used here rather than mounting gwProxyRouter "before" them — see
+// gw-proxy.route.ts's own mount below, after authMiddleware, for the auth-ordering half of this.
+const jsonBodyParser = express.json({ limit: '15mb' });
+const urlencodedBodyParser = express.urlencoded({ extended: true, limit: '15mb' });
+app.use((req: Request, res: Response, next: NextFunction) => {
+  if (req.path.startsWith('/api/gw')) {
+    next();
+    return;
+  }
+  jsonBodyParser(req, res, next);
+});
+app.use((req: Request, res: Response, next: NextFunction) => {
+  if (req.path.startsWith('/api/gw')) {
+    next();
+    return;
+  }
+  urlencodedBodyParser(req, res, next);
+});
 
 // Liveness and readiness endpoints registered before the static handler,
 // logger, auth, and rate-limit middleware so:
@@ -376,6 +406,12 @@ app.use('/api/ossprey', (req, res) => {
 });
 // Marketing OS Agents: Guild proxy, gated to authenticated users (LD flag controls UI visibility).
 app.use('/api/mktg-agents', mktgAgentsRouter);
+// Gatewaze admin embed pilot proxy — forwards to GW_API_URL, gated server-side by
+// GatewazeEmbedEnabled (see server-feature-flag.helper.ts) with a uniform 404 when the flag is
+// off or the caller is unauthenticated. Mounted here, after authMiddleware and the rate limiters
+// above, per the spec; see the body-parser/compression exclusions above for the other half of
+// this route's isolation from global middleware.
+app.use('/api/gw', gwProxyRouter);
 
 app.use('/public/api/*', apiErrorHandler);
 app.use('/api/*', apiErrorHandler);
@@ -393,6 +429,15 @@ const crowdfundingCallbackController = new CrowdfundingController();
 app.get('/crowdfunding/callback', authRateLimiter, (req, res) => crowdfundingCallbackController.handleCrowdfundingAuthCallback(req, res));
 
 const crowdfundingAuthService = new CrowdfundingAuthService();
+
+// Minimal frame protection for the embedded Gatewaze admin pilot page only — NOT applied
+// globally. Scoped narrowly because the rest of the app's framing behavior is out of scope for
+// this pilot; a global change here would be a much bigger blast radius than this task calls for.
+app.use('/foundation/gw', (_req: Request, res: Response, next: NextFunction) => {
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+  res.setHeader('Content-Security-Policy', "frame-ancestors 'self'");
+  next();
+});
 
 app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
   const ssrStartTime = Date.now();
@@ -488,6 +533,12 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
     allowedTracingUrls: [process.env['LFX_V2_SERVICE'], process.env['PCC_BASE_URL']].filter(Boolean) as string[],
     intercomAppId: process.env['INTERCOM_APP_ID'] || '',
     stripePublishableKey: process.env['STRIPE_PUBLISHABLE_KEY'] || '',
+    // Gatewaze admin embed pilot (/foundation/gw) — see RuntimeConfig's doc comments for the
+    // ASSUMPTION notes: no real Supabase project or LFID start URL exist for this pilot yet, so
+    // these are empty (falsy) until the real values are provided.
+    gwSupabaseUrl: process.env['GW_SUPABASE_URL'] || '',
+    gwSupabaseAnonKey: process.env['GW_SUPABASE_ANON_KEY'] || '',
+    gwLfidStartUrl: process.env['GW_LFID_START_URL'] || '',
   };
 
   logger.debug(req, 'intercom_ssr_context', 'Intercom SSR inputs resolved', {

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -95,6 +95,20 @@ export const MARKETING_OPS_FGA_ENABLED_FLAG = 'marketing-ops-fga-enabled';
 export const MENTORSHIP_ENABLED_FLAG = 'mentorship-enabled';
 
 /**
+ * Dark-launch gate for the embedded Gatewaze admin pilot — the `/foundation/gw` route tree that
+ * mounts the `@gatewaze/admin-embed` React app natively (no iframe) inside LFX One. Default false:
+ * this is a pilot for a small cohort, and the route guard fails closed like `akritesEnabledGuard`
+ * and `mentorshipEnabledGuard` rather than open, since the embed is not ready for general users.
+ *
+ * **UI-only** — evaluated through `FeatureFlagService.getBooleanFlag`, which is the OpenFeature Web
+ * SDK and never runs server-side, so it cannot gate an Express handler. The BFF proxy
+ * (`/api/gw/*`) is gated independently, server-side, by `ServerFeatureFlag.GatewazeEmbedEnabled`
+ * (`server-feature-flag.helper.ts`) — an env-var kill switch that also defaults off. Both must be
+ * enabled for the pilot to actually be reachable.
+ */
+export const GATEWAZE_EMBED_ENABLED_FLAG = 'gatewaze-embed-enabled';
+
+/**
  * `localStorage` key holding a `Record<string, boolean>` of locally-forced flag values, read by
  * `FeatureFlagService.getBooleanFlag` in **non-production builds only**.
  *

--- a/packages/shared/src/interfaces/gw-embed.interface.ts
+++ b/packages/shared/src/interfaces/gw-embed.interface.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Host context passed to `@gatewaze/admin-embed`'s `mount()` when the Gatewaze admin pilot is
+ * mounted natively (no iframe) inside LFX One at `/foundation/gw` (`GwModuleOutletComponent`).
+ *
+ * The embed package itself lives in the `gatewaze` repo (`packages/admin`) and is out of scope
+ * here — this interface is the LFX-side half of that contract, kept in sync with the embed's
+ * expectations by convention rather than a shared type package.
+ */
+export interface GwHostContext {
+  /** Router basename the embed should mount under, e.g. `/foundation/gw`. */
+  basename: string;
+  supabase: {
+    url: string;
+    anonKey: string;
+  };
+  /** Empty string defaults to `/api/gw` inside the embed. */
+  apiBaseUrl: string;
+  enabled: {
+    moduleIds: string[];
+    features: string[];
+  };
+  signIn: {
+    lfidStartUrl: string;
+    returnUrl: string;
+  };
+  storageKeySuffix?: string;
+  portalContainer?: HTMLElement;
+  onFatal?: (err: GwEmbedFatalError) => void;
+  navigateHost?: (path: string) => void;
+  telemetry?: (event: { name: string; [key: string]: unknown }) => void;
+}
+
+/** Fatal error shape reported by `@gatewaze/admin-embed` via `GwHostContext.onFatal`. */
+export interface GwEmbedFatalError {
+  error_type: 'config_invalid' | 'import_failed' | 'mount_aborted' | 'render_crash';
+  code: string;
+  message: string;
+  field?: string;
+  recoverable: boolean;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -337,6 +337,9 @@ export * from './foundation-message.interface';
 // Social Listening interfaces (LFXV2-3002)
 export * from './social-listening.interface';
 
+// Gatewaze admin embed host-context contract (embedded React-in-Angular pilot)
+export * from './gw-embed.interface';
+
 // Per-user preference store + BFF wire contracts (LFXV2-3002 Block 0)
 export * from './user-preference.interface';
 

--- a/packages/shared/src/interfaces/runtime-config.interface.ts
+++ b/packages/shared/src/interfaces/runtime-config.interface.ts
@@ -44,4 +44,29 @@ export interface RuntimeConfig {
    * Safe to expose in the browser — see https://stripe.com/docs/keys
    */
   stripePublishableKey: string;
+
+  /**
+   * Supabase project URL for the embedded Gatewaze admin pilot (`GwModuleOutletComponent`,
+   * `/foundation/gw`). Publicly-publishable per Supabase's own client-key model — the anon key
+   * below carries no privileged access on its own.
+   *
+   * ASSUMPTION (ticket context did not include real Gatewaze/Supabase project values): empty
+   * string until a real pilot project exists. `GwModuleOutletComponent` treats an empty value as
+   * "not configured" rather than passing a broken URL to the embed.
+   */
+  gwSupabaseUrl: string;
+
+  /**
+   * Supabase anonymous/public API key paired with {@link gwSupabaseUrl}. Safe to expose in the
+   * browser — see Supabase's docs on the anon key.
+   *
+   * ASSUMPTION: same caveat as `gwSupabaseUrl` — empty until a real pilot project exists.
+   */
+  gwSupabaseAnonKey: string;
+
+  /**
+   * LFID (LF SSO) sign-in start URL the embed redirects to when it needs the user to
+   * (re-)authenticate. ASSUMPTION: no confirmed value for the pilot yet; empty until provided.
+   */
+  gwLfidStartUrl: string;
 }


### PR DESCRIPTION
Implements Embed Gatewaze admin modules in LFX One — LFX host integration (outlet, route, /api/gw proxy).