### PR TITLE
feat(formation): wire the BFF to lfx-v2-formation-service

### DIFF
--- a/apps/lfx-one/e2e/fixtures/mock-data/formation-item.mock.ts
+++ b/apps/lfx-one/e2e/fixtures/mock-data/formation-item.mock.ts
@@ -14,6 +14,8 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
     {
       uid: 'formation-item:cascade-data-alliance:draft-project-record',
       formation_uid: 'formation:cascade-data-alliance',
+      project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
+      version: 1,
       template_item_key: 'draft-project-record',
       section_key: 'legal_and_entity',
       section_title: 'Legal and entity',
@@ -37,6 +39,8 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
     {
       uid: 'formation-item:cascade-data-alliance:contribution-agreement-executed',
       formation_uid: 'formation:cascade-data-alliance',
+      project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
+      version: 1,
       template_item_key: 'contribution-agreement-executed',
       section_key: 'legal_and_entity',
       section_title: 'Legal and entity',
@@ -60,6 +64,8 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
     {
       uid: 'formation-item:cascade-data-alliance:domain-and-dns-transfer',
       formation_uid: 'formation:cascade-data-alliance',
+      project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
+      version: 1,
       template_item_key: 'domain-and-dns-transfer',
       section_key: 'community_and_launch',
       section_title: 'Community and launch',
@@ -83,6 +89,8 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
     {
       uid: 'formation-item:cascade-data-alliance:mailing-lists',
       formation_uid: 'formation:cascade-data-alliance',
+      project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
+      version: 1,
       template_item_key: 'mailing-lists',
       section_key: 'community_and_launch',
       section_title: 'Community and launch',
@@ -109,6 +117,8 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
     {
       uid: 'formation-item:cascade-data-alliance:formation-sets-active',
       formation_uid: 'formation:cascade-data-alliance',
+      project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
+      version: 1,
       template_item_key: 'formation-sets-active',
       section_key: 'community_and_launch',
       section_title: 'Community and launch',

--- a/apps/lfx-one/e2e/fixtures/mock-data/formation-item.mock.ts
+++ b/apps/lfx-one/e2e/fixtures/mock-data/formation-item.mock.ts
@@ -12,11 +12,11 @@ import { FormationActivity, FormationItem } from '@lfx-one/shared/interfaces';
 export const mockFormationItems: Record<string, FormationItem[]> = {
   'formation:cascade-data-alliance': [
     {
-      uid: 'formation-item:cascade-data-alliance:draft-project-record',
+      uid: 'formation-item:cascade-data-alliance:draft_project_record',
       formation_uid: 'formation:cascade-data-alliance',
       project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
       version: 1,
-      template_item_key: 'draft-project-record',
+      template_item_key: 'draft_project_record',
       section_key: 'legal_and_entity',
       section_title: 'Legal and entity',
       title: 'Draft project record (Prospect)',
@@ -37,11 +37,11 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
       updated_at: new Date(0).toISOString(),
     },
     {
-      uid: 'formation-item:cascade-data-alliance:contribution-agreement-executed',
+      uid: 'formation-item:cascade-data-alliance:contribution_agreement_executed',
       formation_uid: 'formation:cascade-data-alliance',
       project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
       version: 1,
-      template_item_key: 'contribution-agreement-executed',
+      template_item_key: 'contribution_agreement_executed',
       section_key: 'legal_and_entity',
       section_title: 'Legal and entity',
       title: 'Contribution agreement executed',
@@ -62,11 +62,11 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
       updated_at: new Date(0).toISOString(),
     },
     {
-      uid: 'formation-item:cascade-data-alliance:domain-and-dns-transfer',
+      uid: 'formation-item:cascade-data-alliance:domain_and_dns_transfer',
       formation_uid: 'formation:cascade-data-alliance',
       project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
       version: 1,
-      template_item_key: 'domain-and-dns-transfer',
+      template_item_key: 'domain_and_dns_transfer',
       section_key: 'community_and_launch',
       section_title: 'Community and launch',
       title: 'Domain and DNS transfer',
@@ -87,11 +87,11 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
       updated_at: new Date(0).toISOString(),
     },
     {
-      uid: 'formation-item:cascade-data-alliance:mailing-lists',
+      uid: 'formation-item:cascade-data-alliance:mailing_lists',
       formation_uid: 'formation:cascade-data-alliance',
       project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
       version: 1,
-      template_item_key: 'mailing-lists',
+      template_item_key: 'mailing_lists',
       section_key: 'community_and_launch',
       section_title: 'Community and launch',
       title: 'Mailing lists',
@@ -115,11 +115,11 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
       updated_at: new Date(0).toISOString(),
     },
     {
-      uid: 'formation-item:cascade-data-alliance:formation-sets-active',
+      uid: 'formation-item:cascade-data-alliance:formation_sets_active',
       formation_uid: 'formation:cascade-data-alliance',
       project_uid: 'e19f1234-f567-4abc-b890-1234567890de',
       version: 1,
-      template_item_key: 'formation-sets-active',
+      template_item_key: 'formation_sets_active',
       section_key: 'community_and_launch',
       section_title: 'Community and launch',
       title: 'Formation sets stage to Active',
@@ -143,11 +143,11 @@ export const mockFormationItems: Record<string, FormationItem[]> = {
 };
 
 export const mockFormationActivity: Record<string, FormationActivity[]> = {
-  'formation-item:cascade-data-alliance:contribution-agreement-executed': [
+  'formation-item:cascade-data-alliance:contribution_agreement_executed': [
     {
       uid: 'formation-activity:1',
       formation_uid: 'formation:cascade-data-alliance',
-      formation_item_uid: 'formation-item:cascade-data-alliance:contribution-agreement-executed',
+      formation_item_uid: 'formation-item:cascade-data-alliance:contribution_agreement_executed',
       type: 'note_added',
       actor: { username: 'sam.chen', name: 'Sam Chen' },
       message: 'updated notes',

--- a/apps/lfx-one/e2e/fixtures/mock-data/formation.mock.ts
+++ b/apps/lfx-one/e2e/fixtures/mock-data/formation.mock.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { SEEDED_FORMATION_TEMPLATE_UID } from '@lfx-one/shared/constants';
-import { Formation, FormationTemplate } from '@lfx-one/shared/interfaces';
+import { Formation, FormationQueueRow, FormationTemplate } from '@lfx-one/shared/interfaces';
 
 /** Minimal e2e-side mirror of the server's seeded template — self-contained so e2e specs never import from `src/server`. */
 export const mockFormationTemplate: FormationTemplate = {
@@ -46,46 +46,63 @@ export const mockFormations: Record<string, Formation> = {
   },
 };
 
-/** A queue-only list, independent of `mockFormations` — the Formations queue table (GH-1958) is root-scoped, not tied to a single project-page test. */
-export const mockFormationsQueue: Formation[] = [
-  mockFormations['cascade-data-alliance'],
+/**
+ * A queue-only list, independent of `mockFormations` — the Formations queue table (GH-1958) is
+ * root-scoped, not tied to a single project-page test. Shaped as `FormationQueueRow` (GH-2267 gap
+ * 2 — the real indexed queue projection, not the checklist-read `Formation` shape): `progress`
+ * replaces `gating_items_open`/`gating_items_total`, and `gates_cleared` mirrors what each row's
+ * old `is_activating` value implied (open === 0).
+ */
+export const mockFormationsQueue: FormationQueueRow[] = [
   {
-    uid: 'formation:harbor-data-exchange',
-    parent_project_uid: 'e29f1234-f567-4abc-b890-1234567890df',
-    parent_project_slug: 'harbor-data-exchange',
-    parent_project_name: 'Harbor Data Exchange',
-    is_foundation: false,
-    parent_uid: 'e19f1234-f567-4abc-b890-1234567890de',
-    template_uid: SEEDED_FORMATION_TEMPLATE_UID,
-    template_version: 1,
-    sub_stage: 'on_hold',
-    announcement_date: null,
+    formation_uid: mockFormations['cascade-data-alliance'].uid!,
+    project_uid: mockFormations['cascade-data-alliance'].parent_project_uid,
+    project_name: mockFormations['cascade-data-alliance'].parent_project_name,
+    project_slug: mockFormations['cascade-data-alliance'].parent_project_slug,
+    is_foundation: mockFormations['cascade-data-alliance'].is_foundation,
+    parent_uid: mockFormations['cascade-data-alliance'].parent_uid,
+    sub_stage: mockFormations['cascade-data-alliance'].sub_stage,
+    lifecycle: 'formation',
+    gates_cleared: false,
     is_activating: false,
-    gating_items_open: 6,
-    gating_items_total: 6,
-    blocking_item_title: 'Intake review',
-    subtitle: 'Under Cascade Data Alliance',
-    created_at: new Date(0).toISOString(),
-    updated_at: new Date(0).toISOString(),
+    announcement_date: mockFormations['cascade-data-alliance'].announcement_date,
+    // Mirrors mockFormationItems['formation:cascade-data-alliance']: draft-project-record=done,
+    // contribution-agreement-executed=in_progress.
+    progress: { not_started: 0, in_progress: 1, blocked: 0, awaiting_acceptance: 0, done: 1, skipped: 0 },
+    blocked_item_titles: ['Contribution agreement executed'],
+    assignees: [],
   },
   {
-    uid: 'formation:brightpath-working-group',
-    parent_project_uid: 'e39f1234-f567-4abc-b890-1234567890e0',
-    parent_project_slug: 'brightpath-working-group',
-    parent_project_name: 'Brightpath Working Group',
+    formation_uid: 'formation:harbor-data-exchange',
+    project_uid: 'e29f1234-f567-4abc-b890-1234567890df',
+    project_name: 'Harbor Data Exchange',
+    project_slug: 'harbor-data-exchange',
     is_foundation: false,
     parent_uid: 'e19f1234-f567-4abc-b890-1234567890de',
-    template_uid: SEEDED_FORMATION_TEMPLATE_UID,
-    template_version: 1,
+    sub_stage: 'on_hold',
+    lifecycle: 'formation',
+    gates_cleared: false,
+    is_activating: false,
+    announcement_date: null,
+    progress: { not_started: 0, in_progress: 6, blocked: 0, awaiting_acceptance: 0, done: 0, skipped: 0 },
+    blocked_item_titles: ['Intake review'],
+    assignees: [],
+  },
+  {
+    formation_uid: 'formation:brightpath-working-group',
+    project_uid: 'e39f1234-f567-4abc-b890-1234567890e0',
+    project_name: 'Brightpath Working Group',
+    project_slug: 'brightpath-working-group',
+    is_foundation: false,
+    parent_uid: 'e19f1234-f567-4abc-b890-1234567890de',
     sub_stage: 'engaged',
-    announcement_date: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+    lifecycle: 'formation',
+    gates_cleared: true,
     is_activating: true,
-    gating_items_open: 0,
-    gating_items_total: 4,
-    blocking_item_title: null,
-    subtitle: 'Under Cascade Data Alliance · Gating items complete',
-    created_at: new Date(0).toISOString(),
-    updated_at: new Date(0).toISOString(),
+    announcement_date: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+    progress: { not_started: 0, in_progress: 0, blocked: 0, awaiting_acceptance: 0, done: 4, skipped: 0 },
+    blocked_item_titles: [],
+    assignees: [],
   },
 ];
 

--- a/apps/lfx-one/e2e/fixtures/mock-data/formation.mock.ts
+++ b/apps/lfx-one/e2e/fixtures/mock-data/formation.mock.ts
@@ -34,7 +34,7 @@ export const mockFormations: Record<string, Formation> = {
     announcement_date: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
     is_activating: false,
     // Mirrors mockFormationItems['formation:cascade-data-alliance']: 2 gating items
-    // (draft-project-record=done, contribution-agreement-executed=in_progress) — this same fixture
+    // (draft_project_record=done, contribution_agreement_executed=in_progress) — this same fixture
     // backs both the checklist (counts derived from items) and the queue (counts read from this
     // row), so a mismatch here would render two different "N of M open" numbers for one formation.
     gating_items_open: 1,
@@ -66,8 +66,8 @@ export const mockFormationsQueue: FormationQueueRow[] = [
     gates_cleared: false,
     is_activating: false,
     announcement_date: mockFormations['cascade-data-alliance'].announcement_date,
-    // Mirrors mockFormationItems['formation:cascade-data-alliance']: draft-project-record=done,
-    // contribution-agreement-executed=in_progress.
+    // Mirrors mockFormationItems['formation:cascade-data-alliance']: draft_project_record=done,
+    // contribution_agreement_executed=in_progress.
     progress: { not_started: 0, in_progress: 1, blocked: 0, awaiting_acceptance: 0, done: 1, skipped: 0 },
     blocked_item_titles: ['Contribution agreement executed'],
     assignees: [],

--- a/apps/lfx-one/e2e/formation-checklist-robust.spec.ts
+++ b/apps/lfx-one/e2e/formation-checklist-robust.spec.ts
@@ -205,7 +205,7 @@ test.describe('Formation checklist section — structural contract', () => {
     });
 
     test('an item with history nests entries under the history container', async ({ page }) => {
-      const itemWithHistory = ITEMS.find((item) => item.uid.endsWith('contribution-agreement-executed'));
+      const itemWithHistory = ITEMS.find((item) => item.uid.endsWith('contribution_agreement_executed'));
       if (!itemWithHistory) throw new Error('Expected the seeded item with activity history.');
 
       await page.getByTestId(`formation-checklist-row-title-${itemWithHistory.uid}`).click();

--- a/apps/lfx-one/e2e/formation-checklist.spec.ts
+++ b/apps/lfx-one/e2e/formation-checklist.spec.ts
@@ -13,6 +13,7 @@ import {
   mockFormationChecklistApis,
   stubFormationFlag,
 } from './helpers/formation-checklist.helper';
+import { FormationItem } from '@lfx-one/shared/interfaces';
 import { expect, test } from '@playwright/test';
 
 test.setTimeout(120_000);
@@ -157,15 +158,20 @@ test.describe('Formation Checklist section (GH-1958)', () => {
     // Each PATCH .../complete is held open until this test explicitly releases it, keyed by uid —
     // lets two different items' writes stay in flight at once, which is what this regression needs.
     const pendingResolvers = new Map<string, () => void>();
-    await page.route('**/api/formation-items/*/complete', async (route) => {
+    await page.route('**/api/formations/*/items/*/complete', async (route) => {
       const segments = new URL(route.request().url()).pathname.split('/');
-      const uid = decodeURIComponent(segments[segments.length - 2] ?? '');
+      const itemsIndex = segments.indexOf('items');
+      const projectUid = decodeURIComponent(segments[itemsIndex - 1] ?? '');
+      const itemKey = decodeURIComponent(segments[itemsIndex + 1] ?? '');
+      // Keyed by (project_uid, item_key), matching GH-2267 Phase 2 addressing — a single string key
+      // is fine here since both seeded items belong to the same formation/project in this test.
+      const uid = `${projectUid}:${itemKey}`;
       await new Promise<void>((resolve) => pendingResolvers.set(uid, resolve));
-      const item = items.find((candidate) => candidate.uid === uid);
+      const item = items.find((candidate) => candidate.project_uid === projectUid && candidate.template_item_key === itemKey);
       if (!item) {
         // Fixture drift — fail loudly rather than silently fulfilling a partial body (mirrors
         // FormationApiMockHelper.setupFormationItemActionMock's same rationale).
-        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this uid' }) });
+        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this address' }) });
         return;
       }
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...item, status: 'done', skip_reason: null }) });
@@ -201,6 +207,10 @@ test.describe('Formation Checklist section (GH-1958)', () => {
       await expect(drawer).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     }
 
+    // Route mock above keys pendingResolvers by `${project_uid}:${item_key}` (GH-2267 Phase 2
+    // addressing), not by the fixture uid used for the row's own testid.
+    const addressOf = (item: FormationItem): string => `${item.project_uid}:${item.template_item_key}`;
+
     // Start A's write, then close the drawer while it's still in flight — nothing gates onClose() on
     // a pending write, and neither does the mask/ESC dismiss p-drawer offers by default.
     await openItem(itemA.uid);
@@ -229,8 +239,8 @@ test.describe('Formation Checklist section (GH-1958)', () => {
 
     // Release A's held response and wait for the actual network round trip to land (not a fixed
     // sleep — any erroneous state change is provoked synchronously by this same response).
-    const itemAResponse = page.waitForResponse((response) => response.url().includes(`/${encodeURIComponent(itemA.uid)}/complete`));
-    await releaseHeldRequest(itemA.uid);
+    const itemAResponse = page.waitForResponse((response) => response.url().includes(`/${encodeURIComponent(itemA.template_item_key)}/complete`));
+    await releaseHeldRequest(addressOf(itemA));
     await itemAResponse;
 
     // B's write is still pending and was never touched by A's response landing — reopening it must
@@ -244,7 +254,7 @@ test.describe('Formation Checklist section (GH-1958)', () => {
     // Release B's held response too — now B's own write really is done. B is still what the drawer
     // shows, so this is a real (uid-matching) completion — onDrawerItemChanged closes the drawer
     // itself, same as any other successful Mark complete.
-    await releaseHeldRequest(itemB.uid);
+    await releaseHeldRequest(addressOf(itemB));
     await expect(drawer).toBeHidden({ timeout: DATA_LOAD_TIMEOUT });
 
     // A's guard must have been correctly retired when its response was released above — reopening it

--- a/apps/lfx-one/e2e/formation-checklist.spec.ts
+++ b/apps/lfx-one/e2e/formation-checklist.spec.ts
@@ -32,7 +32,7 @@ test.describe('Formation Checklist section (GH-1958)', () => {
     // Both seeded-template sections render with at least one row.
     await expect(section.getByText('Legal and entity')).toBeVisible();
     await expect(section.getByText('Community and launch')).toBeVisible();
-    await expect(page.getByTestId('formation-checklist-row-title-formation-item:cascade-data-alliance:draft-project-record')).toBeVisible();
+    await expect(page.getByTestId('formation-checklist-row-title-formation-item:cascade-data-alliance:draft_project_record')).toBeVisible();
   });
 
   test('redirects to project overview for a project not in a Formation stage', async ({ page }) => {
@@ -59,7 +59,7 @@ test.describe('Formation Checklist section (GH-1958)', () => {
     await mockFormationChecklistApis(page, { project: buildBaseProject(FORMATION_PROJECT_SLUG) });
     await gotoProjectFormation(page, FORMATION_PROJECT_SLUG);
 
-    const rowTitle = page.getByTestId('formation-checklist-row-title-formation-item:cascade-data-alliance:contribution-agreement-executed');
+    const rowTitle = page.getByTestId('formation-checklist-row-title-formation-item:cascade-data-alliance:contribution_agreement_executed');
     await expect(rowTitle).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await rowTitle.click();
 

--- a/apps/lfx-one/e2e/formations-queue-robust.spec.ts
+++ b/apps/lfx-one/e2e/formations-queue-robust.spec.ts
@@ -128,13 +128,13 @@ test.describe('Formations queue — structural contract', () => {
 
     test('renders one row per queue formation, keyed by uid', async ({ page }) => {
       for (const row of mockFormationsQueue) {
-        await expect(page.getByTestId(`formations-table-row-${row.uid}`)).toBeAttached();
+        await expect(page.getByTestId(`formations-table-row-${row.formation_uid}`)).toBeAttached();
       }
     });
 
     test('a formation name is a real link to its project page', async ({ page }) => {
       for (const row of mockFormationsQueue) {
-        const link = page.getByTestId(`formations-table-open-${row.uid}`);
+        const link = page.getByTestId(`formations-table-open-${row.formation_uid}`);
         await expect(link).toBeAttached();
         expect(await link.evaluate((el) => el.tagName)).toBe('A');
       }

--- a/apps/lfx-one/e2e/formations-queue.spec.ts
+++ b/apps/lfx-one/e2e/formations-queue.spec.ts
@@ -90,7 +90,7 @@ test.describe('Formations queue (GH-1958)', () => {
     await expect(page.getByTestId('formations-table')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
 
     for (const row of mockFormationsQueue) {
-      await expect(page.getByTestId(`formations-table-row-${row.uid}`)).toBeVisible();
+      await expect(page.getByTestId(`formations-table-row-${row.formation_uid}`)).toBeVisible();
     }
   });
 

--- a/apps/lfx-one/e2e/helpers/formation-api-mock.helper.ts
+++ b/apps/lfx-one/e2e/helpers/formation-api-mock.helper.ts
@@ -32,16 +32,18 @@ export class FormationApiMockHelper {
     });
   }
 
-  /** Mocks `GET /api/formation-items/:uid` for the item drawer. */
+  /** Mocks `GET /api/formations/:projectUid/items/:itemKey` for the item drawer (GH-2267 Phase 2 addressing). */
   static async setupFormationItemMock(page: Page): Promise<void> {
-    await page.route('**/api/formation-items/*', async (route) => {
+    await page.route('**/api/formations/*/items/*', async (route) => {
       if (route.request().method() !== 'GET') {
         await route.continue();
         return;
       }
 
-      const uid = decodeURIComponent(route.request().url().split('/').pop() ?? '');
-      const item = Object.values(getMockFormationItems('formation:cascade-data-alliance')).find((candidate) => candidate.uid === uid);
+      const { projectUid, itemKey } = FormationApiMockHelper.parseItemAddress(route.request().url());
+      const item = getMockFormationItems('formation:cascade-data-alliance').find(
+        (candidate) => candidate.project_uid === projectUid && candidate.template_item_key === itemKey
+      );
 
       if (!item) {
         await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'Formation item not found' }) });
@@ -51,9 +53,19 @@ export class FormationApiMockHelper {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ item, history: mockFormationActivity[uid] ?? [] }),
+        body: JSON.stringify({ item, history: mockFormationActivity[item.uid] ?? [] }),
       });
     });
+  }
+
+  /** Splits an `/api/formations/:projectUid/items/:itemKey[...]` URL into its two address segments. */
+  private static parseItemAddress(url: string): { projectUid: string; itemKey: string } {
+    const segments = new URL(url).pathname.split('/');
+    const itemsIndex = segments.indexOf('items');
+    return {
+      projectUid: decodeURIComponent(segments[itemsIndex - 1] ?? ''),
+      itemKey: decodeURIComponent(segments[itemsIndex + 1] ?? ''),
+    };
   }
 
   /** Mocks `GET /api/formations` (queue), honoring `sub_stage`/`search` query params like the real BFF does. */
@@ -70,7 +82,7 @@ export class FormationApiMockHelper {
 
       let filtered = rows;
       if (subStage) filtered = filtered.filter((row) => row.sub_stage === subStage);
-      if (search) filtered = filtered.filter((row) => row.parent_project_name.toLowerCase().includes(search));
+      if (search) filtered = filtered.filter((row) => row.project_name.toLowerCase().includes(search));
 
       const tiles: FormationsQueueResponse['tiles'] = {
         exploratory: rows.filter((row) => row.sub_stage === 'exploratory').length,
@@ -88,57 +100,57 @@ export class FormationApiMockHelper {
   }
 
   /**
-   * Mocks `PATCH /api/formation-items/:uid/{complete,skip,request}` with a canned success or error
-   * response per test. The success body is the full seeded `FormationItem` (status field updated to
-   * match the action) — not just `{ status: '...' }` — since `FormationItemDrawerComponent` consumes
-   * the response body directly (`itemChanged.emit(updated)`, `${updated.title} is done`); a partial
-   * body would leave those fields `undefined` in a way the real BFF never does.
+   * Mocks `PATCH /api/formations/:projectUid/items/:itemKey/{complete,skip,request}` (GH-2267 Phase
+   * 2 addressing) with a canned success or error response per test. The success body is the full
+   * seeded `FormationItem` (status field updated to match the action) — not just `{ status: '...' }`
+   * — since `FormationItemDrawerComponent` consumes the response body directly
+   * (`itemChanged.emit(updated)`, `${updated.title} is done`); a partial body would leave those
+   * fields `undefined` in a way the real BFF never does.
    */
   static async setupFormationItemActionMock(
     page: Page,
     options: { complete?: 'success' | 'error'; skip?: 'success' | 'error'; request?: 'success' | 'error' } = {}
   ): Promise<void> {
     const findItem = (url: string): FormationItem | undefined => {
-      const segments = new URL(url).pathname.split('/');
-      const uid = decodeURIComponent(segments[segments.length - 2] ?? '');
-      return getMockFormationItems('formation:cascade-data-alliance').find((item) => item.uid === uid);
+      const { projectUid, itemKey } = FormationApiMockHelper.parseItemAddress(url);
+      return getMockFormationItems('formation:cascade-data-alliance').find((item) => item.project_uid === projectUid && item.template_item_key === itemKey);
     };
 
-    await page.route('**/api/formation-items/*/complete', async (route) => {
+    await page.route('**/api/formations/*/items/*/complete', async (route) => {
       if (options.complete === 'error') {
         await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
         return;
       }
       const item = findItem(route.request().url());
       if (!item) {
-        // Fixture drift (a test targets a uid not in the cascade-data-alliance fixture, or the
-        // fixture's uid scheme changed) — fail loudly rather than silently falling back to the
+        // Fixture drift (a test targets an address not in the cascade-data-alliance fixture, or the
+        // fixture's addressing scheme changed) — fail loudly rather than silently falling back to the
         // partial { status } body this mock was changed to stop producing.
-        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this uid' }) });
+        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this address' }) });
         return;
       }
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...item, status: 'done', skip_reason: null }) });
     });
-    await page.route('**/api/formation-items/*/skip', async (route) => {
+    await page.route('**/api/formations/*/items/*/skip', async (route) => {
       if (options.skip === 'error') {
         await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
         return;
       }
       const item = findItem(route.request().url());
       if (!item) {
-        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this uid' }) });
+        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this address' }) });
         return;
       }
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...item, status: 'skipped' }) });
     });
-    await page.route('**/api/formation-items/*/request', async (route) => {
+    await page.route('**/api/formations/*/items/*/request', async (route) => {
       if (options.request === 'error') {
         await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
         return;
       }
       const item = findItem(route.request().url());
       if (!item) {
-        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this uid' }) });
+        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No mock item for this address' }) });
         return;
       }
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...item, status: 'blocked' }) });

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-checklist-row/formation-checklist-row.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-checklist-row/formation-checklist-row.component.spec.ts
@@ -35,6 +35,7 @@ function buildItem(overrides: Partial<FormationItem>): FormationItem {
     can_complete: true,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
+    version: 1,
     ...overrides,
   };
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-checklist-section/formation-checklist-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-checklist-section/formation-checklist-section.component.html
@@ -66,7 +66,8 @@
 </section>
 
 <lfx-formation-item-drawer
-  [itemUid]="drawerItemUid()"
+  [itemProjectUid]="drawerItemAddress()?.projectUid ?? null"
+  [itemKey]="drawerItemAddress()?.itemKey ?? null"
   [mutationInFlight]="drawerItemMutationInFlight()"
   [skipInFlight]="drawerItemSkipInFlight()"
   [(visible)]="drawerVisible"

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-checklist-section/formation-checklist-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-checklist-section/formation-checklist-section.component.ts
@@ -51,6 +51,8 @@ export class FormationChecklistSectionComponent {
 
   public readonly drawerVisible = signal(false);
   public readonly drawerItemUid = signal<string | null>(null);
+  /** Set alongside `drawerItemUid` in `onOpenDrawer` — the drawer's `itemProjectUid`/`itemKey` inputs read off this, since GH-2267 Phase 2 addresses items by `(project_uid, item_key)`, not by uid. */
+  public readonly drawerItemAddress = signal<{ projectUid: string; itemKey: string } | null>(null);
 
   /**
    * Item uids with a mutation currently in flight, tagged by kind — guards a double-click (or a
@@ -100,12 +102,16 @@ export class FormationChecklistSectionComponent {
 
   protected onOpenDrawer(item: FormationItem): void {
     this.drawerItemUid.set(item.uid);
+    this.drawerItemAddress.set({ projectUid: item.project_uid, itemKey: item.template_item_key });
     this.drawerVisible.set(true);
   }
 
   protected onRowAction(item: FormationItem): void {
     if (!this.beginSubmitting(item.uid, 'row')) return;
-    const call$ = item.action === 'request' ? this.formationService.requestFormationItem(item.uid) : this.formationService.completeFormationItem(item.uid);
+    const call$ =
+      item.action === 'request'
+        ? this.formationService.requestFormationItem(item.project_uid, item.template_item_key)
+        : this.formationService.completeFormationItem(item.project_uid, item.template_item_key);
 
     call$
       .pipe(
@@ -126,7 +132,7 @@ export class FormationChecklistSectionComponent {
     if (!this.beginSubmitting(change.item.uid, 'row')) return;
 
     this.formationService
-      .updateFormationItemStatus(change.item.uid, change.status)
+      .updateFormationItemStatus(change.item.project_uid, change.item.template_item_key, change.status)
       .pipe(
         take(1),
         finalize(() => this.endSubmitting(change.item.uid))
@@ -162,7 +168,7 @@ export class FormationChecklistSectionComponent {
       if (!result?.reason || !this.beginSubmitting(item.uid, 'row')) return;
 
       this.formationService
-        .updateFormationItemStatus(item.uid, 'blocked', result.reason)
+        .updateFormationItemStatus(item.project_uid, item.template_item_key, 'blocked', result.reason)
         .pipe(
           take(1),
           finalize(() => this.endSubmitting(item.uid))
@@ -182,7 +188,7 @@ export class FormationChecklistSectionComponent {
     if (!this.beginSubmitting(item.uid, 'row')) return;
 
     this.formationService
-      .completeFormationItem(item.uid)
+      .completeFormationItem(item.project_uid, item.template_item_key)
       .pipe(
         take(1),
         finalize(() => this.endSubmitting(item.uid))
@@ -249,7 +255,7 @@ export class FormationChecklistSectionComponent {
       if (!result?.reason || !this.beginSubmitting(item.uid, 'skip')) return;
 
       this.formationService
-        .skipFormationItem(item.uid, result.reason)
+        .skipFormationItem(item.project_uid, item.template_item_key, result.reason)
         .pipe(
           take(1),
           finalize(() => this.endSubmitting(item.uid))

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-entry-card/formation-entry-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-entry-card/formation-entry-card.component.spec.ts
@@ -37,6 +37,7 @@ function buildItem(overrides: Partial<FormationItem>): FormationItem {
     can_complete: true,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
+    version: 1,
     ...overrides,
   };
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -13,7 +13,7 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { FormationService } from '@services/formation.service';
 import type { FormationDrawerData, FormationItem, FormationItemLink } from '@lfx-one/shared/interfaces';
 import { createEmptyFormationDrawerData, FORMATION_ITEM_STATUS_LABELS, FORMATION_ITEM_STATUS_SEVERITY } from '@lfx-one/shared/constants';
-import { isValidUrl } from '@lfx-one/shared/utils';
+import { isValidUrl, parseLocalDateString, toLocalDateOnlyString } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { catchError, finalize, map, merge, of, skip, Subject, switchMap, take, tap } from 'rxjs';
@@ -177,7 +177,7 @@ export class FormationItemDrawerComponent {
       .updateFormationItem(item.project_uid, item.template_item_key, {
         notes: this.editForm.value.notes ?? '',
         owner_username: this.editForm.value.ownerUsername ?? '',
-        due_date: this.editForm.value.dueDate ? this.toDateOnlyString(this.editForm.value.dueDate) : null,
+        due_date: this.editForm.value.dueDate ? toLocalDateOnlyString(this.editForm.value.dueDate) : null,
       })
       .pipe(
         take(1),
@@ -261,7 +261,11 @@ export class FormationItemDrawerComponent {
     this.editForm.setValue({
       notes: item.notes ?? '',
       ownerUsername: item.owner?.username ?? '',
-      dueDate: item.due_date ? new Date(item.due_date) : null,
+      // `item.due_date` is a bare `YYYY-MM-DD` — `new Date(...)` would parse it as UTC midnight,
+      // rendering the previous day in the picker for any viewer west of UTC, and `toLocalDateOnlyString`
+      // above would then faithfully save that wrong day back. `parseLocalDateString` reads it as a
+      // local calendar day so the load->save round-trip is symmetric.
+      dueDate: item.due_date ? parseLocalDateString(item.due_date) : null,
     });
   }
 
@@ -276,17 +280,5 @@ export class FormationItemDrawerComponent {
       next.delete(uid);
       return next;
     });
-  }
-
-  /**
-   * `date.toISOString()` reports the UTC calendar day, which is a different day than the one the
-   * calendar picker shows for any viewer not at UTC+0 — a positive-offset viewer picking the 31st
-   * would send the 30th. `updateFormationItem` requires a `YYYY-MM-DD` day, so build it from the
-   * picker's local date parts instead of converting to a UTC instant first.
-   */
-  private toDateOnlyString(date: Date): string {
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${date.getFullYear()}-${month}-${day}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -264,8 +264,10 @@ export class FormationItemDrawerComponent {
       // `item.due_date` is a bare `YYYY-MM-DD` — `new Date(...)` would parse it as UTC midnight,
       // rendering the previous day in the picker for any viewer west of UTC, and `toLocalDateOnlyString`
       // above would then faithfully save that wrong day back. `parseLocalDateString` reads it as a
-      // local calendar day so the load->save round-trip is symmetric.
-      dueDate: item.due_date ? parseLocalDateString(item.due_date) : null,
+      // local calendar day so the load->save round-trip is symmetric. It throws on anything that
+      // isn't exactly `YYYY-MM-DD`, so guard the shape first — a malformed value should empty the
+      // picker, not fail the whole item load.
+      dueDate: item.due_date && /^\d{4}-\d{2}-\d{2}$/.test(item.due_date) ? parseLocalDateString(item.due_date) : null,
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -30,7 +30,9 @@ export class FormationItemDrawerComponent {
 
   public readonly visible = model<boolean>(false);
 
-  public readonly itemUid = input<string | null>(null);
+  /** Together address the item being shown — the drawer reads via these on open, but every mutation below routes off the loaded `item()`'s own `project_uid`/`template_item_key` (GH-2267 Phase 2). */
+  public readonly itemProjectUid = input<string | null>(null);
+  public readonly itemKey = input<string | null>(null);
   /**
    * True while the section has *any* mutation in flight for this item — a row action
    * (provisionable/request), a submitted skip, or this drawer's own Mark complete/Save (echoed back
@@ -133,7 +135,7 @@ export class FormationItemDrawerComponent {
     this.writeStarted.emit(item.uid);
 
     this.formationService
-      .completeFormationItem(item.uid)
+      .completeFormationItem(item.project_uid, item.template_item_key)
       .pipe(
         take(1),
         finalize(() => {
@@ -172,7 +174,7 @@ export class FormationItemDrawerComponent {
     this.writeStarted.emit(item.uid);
 
     this.formationService
-      .updateFormationItem(item.uid, {
+      .updateFormationItem(item.project_uid, item.template_item_key, {
         notes: this.editForm.value.notes ?? '',
         owner_username: this.editForm.value.ownerUsername ?? '',
         due_date: this.editForm.value.dueDate ? this.editForm.value.dueDate.toISOString() : null,
@@ -192,7 +194,7 @@ export class FormationItemDrawerComponent {
           // but only if the drawer is still showing the item this save was actually for; otherwise
           // the reload would fetch (and overwrite the form of) whatever item the user has since
           // switched to, using this stale save's response as the trigger.
-          if (this.itemUid() === item.uid) this.reload$.next();
+          if (this.itemProjectUid() === item.project_uid && this.itemKey() === item.template_item_key) this.reload$.next();
           this.messageService.add({ severity: 'success', summary: 'Saved', detail: 'Item details updated.' });
         },
         error: (error: unknown) => {
@@ -218,8 +220,9 @@ export class FormationItemDrawerComponent {
     return toSignal(
       merge(openTrigger$, reloadTrigger$).pipe(
         switchMap((trigger) => {
-          const uid = this.itemUid();
-          if (!this.visible() || !uid) {
+          const projectUid = this.itemProjectUid();
+          const itemKey = this.itemKey();
+          if (!this.visible() || !projectUid || !itemKey) {
             lastData = createEmptyFormationDrawerData();
             return of(lastData);
           }
@@ -229,7 +232,7 @@ export class FormationItemDrawerComponent {
             this.loading.set(true);
           }
 
-          return this.formationService.getFormationItem(uid).pipe(
+          return this.formationService.getFormationItem(projectUid, itemKey).pipe(
             tap((data) => {
               this.syncForm(data.item);
               lastData = data;

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -13,7 +13,7 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { FormationService } from '@services/formation.service';
 import type { FormationDrawerData, FormationItem, FormationItemLink } from '@lfx-one/shared/interfaces';
 import { createEmptyFormationDrawerData, FORMATION_ITEM_STATUS_LABELS, FORMATION_ITEM_STATUS_SEVERITY } from '@lfx-one/shared/constants';
-import { isValidUrl, parseLocalDateString, toLocalDateOnlyString } from '@lfx-one/shared/utils';
+import { isValidUrl, toLocalDateOnlyString, tryParseLocalDateString } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { catchError, finalize, map, merge, of, skip, Subject, switchMap, take, tap } from 'rxjs';
@@ -263,11 +263,10 @@ export class FormationItemDrawerComponent {
       ownerUsername: item.owner?.username ?? '',
       // `item.due_date` is a bare `YYYY-MM-DD` — `new Date(...)` would parse it as UTC midnight,
       // rendering the previous day in the picker for any viewer west of UTC, and `toLocalDateOnlyString`
-      // above would then faithfully save that wrong day back. `parseLocalDateString` reads it as a
-      // local calendar day so the load->save round-trip is symmetric. It throws on anything that
-      // isn't exactly `YYYY-MM-DD`, so guard the shape first — a malformed value should empty the
-      // picker, not fail the whole item load.
-      dueDate: item.due_date && /^\d{4}-\d{2}-\d{2}$/.test(item.due_date) ? parseLocalDateString(item.due_date) : null,
+      // above would then faithfully save that wrong day back. `tryParseLocalDateString` reads it as a
+      // local calendar day so the load->save round-trip is symmetric, and returns null instead of
+      // throwing on a malformed value, so a bad date empties the picker rather than failing the load.
+      dueDate: tryParseLocalDateString(item.due_date),
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -177,7 +177,7 @@ export class FormationItemDrawerComponent {
       .updateFormationItem(item.project_uid, item.template_item_key, {
         notes: this.editForm.value.notes ?? '',
         owner_username: this.editForm.value.ownerUsername ?? '',
-        due_date: this.editForm.value.dueDate ? this.editForm.value.dueDate.toISOString() : null,
+        due_date: this.editForm.value.dueDate ? this.toDateOnlyString(this.editForm.value.dueDate) : null,
       })
       .pipe(
         take(1),
@@ -276,5 +276,17 @@ export class FormationItemDrawerComponent {
       next.delete(uid);
       return next;
     });
+  }
+
+  /**
+   * `date.toISOString()` reports the UTC calendar day, which is a different day than the one the
+   * calendar picker shows for any viewer not at UTC+0 — a positive-offset viewer picking the 31st
+   * would send the 30th. `updateFormationItem` requires a `YYYY-MM-DD` day, so build it from the
+   * picker's local date parts instead of converting to a UTC instant first.
+   */
+  private toDateOnlyString(date: Date): string {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.html
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.html
@@ -82,7 +82,11 @@
             </td>
             <td class="text-sm text-gray-700">{{ row.announcement_date ? (row.announcement_date | date: 'MMM d') : 'Not set' }}</td>
             <td class="text-sm text-gray-700">
-              {{ row.blocked_item_titles[0] || (row.gates_cleared ? 'Formation to set Active' : '—') }}
+              @if (row.blocked_item_titles.length > 0) {
+                {{ row.blocked_item_titles.join(', ') }}
+              } @else {
+                {{ row.gates_cleared ? 'Formation to set Active' : '—' }}
+              }
             </td>
           </tr>
         </ng-template>

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.html
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.html
@@ -60,32 +60,30 @@
         </ng-template>
 
         <ng-template #body let-row let-rowIndex="rowIndex">
-          <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'formations-table-row-' + row.uid">
+          <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'formations-table-row-' + row.formation_uid">
             <td>
               <a
                 [routerLink]="['/project/overview']"
-                [queryParams]="{ project: row.parent_project_slug }"
+                [queryParams]="{ project: row.project_slug }"
                 class="flex flex-col gap-0.5 no-underline hover:underline"
-                [class.pl-4]="row.isChildRow"
-                [attr.data-testid]="'formations-table-open-' + row.uid">
-                <span class="text-sm font-medium text-gray-900">{{ row.parent_project_name }}</span>
-                @if (row.subtitle) {
-                  <span class="text-xs text-gray-500">{{ row.subtitle }}</span>
-                }
+                [attr.data-testid]="'formations-table-open-' + row.formation_uid">
+                <span class="text-sm font-medium text-gray-900">{{ row.project_name }}</span>
               </a>
             </td>
             <td class="text-sm text-gray-700">{{ row.entityTypeLabel }}</td>
             <td><lfx-tag [value]="row.stageLabel" [severity]="row.stageSeverity" /></td>
             <td>
               <div class="flex items-center gap-2">
-                <span class="text-sm text-gray-700 tabular-nums">{{ row.gating_items_total - row.gating_items_open }} of {{ row.gating_items_total }}</span>
-                @if (row.is_activating) {
+                <span class="text-sm text-gray-700 tabular-nums">{{ row.doneCount }} of {{ row.totalCount }}</span>
+                @if (row.gates_cleared) {
                   <lfx-tag value="Gates cleared" severity="warn" />
                 }
               </div>
             </td>
             <td class="text-sm text-gray-700">{{ row.announcement_date ? (row.announcement_date | date: 'MMM d') : 'Not set' }}</td>
-            <td class="text-sm text-gray-700">{{ row.blocking_item_title || (row.is_activating ? 'Formation to set Active' : '—') }}</td>
+            <td class="text-sm text-gray-700">
+              {{ row.blocked_item_titles[0] || (row.gates_cleared ? 'Formation to set Active' : '—') }}
+            </td>
           </tr>
         </ng-template>
       </lfx-table>

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.spec.ts
@@ -3,30 +3,27 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { Formation } from '@lfx-one/shared/interfaces';
+import { FormationQueueRow } from '@lfx-one/shared/interfaces';
 import { describe, expect, it } from 'vitest';
 
 import { FormationsTableComponent } from './formations-table.component';
 
-function buildRow(overrides: Partial<Formation>): Formation {
+function buildRow(overrides: Partial<FormationQueueRow>): FormationQueueRow {
   return {
-    uid: 'formation:test',
-    parent_project_uid: 'project:test',
-    parent_project_slug: 'test-project',
-    parent_project_name: 'Test Project',
+    formation_uid: 'formation:test',
+    project_uid: 'project:test',
+    project_slug: 'test-project',
+    project_name: 'Test Project',
     is_foundation: false,
     parent_uid: null,
-    template_uid: 'template:test',
-    template_version: 1,
     sub_stage: 'engaged',
-    announcement_date: null,
+    lifecycle: 'formation',
+    gates_cleared: false,
     is_activating: false,
-    gating_items_open: 1,
-    gating_items_total: 3,
-    blocking_item_title: null,
-    subtitle: null,
-    created_at: '2026-01-01T00:00:00Z',
-    updated_at: '2026-01-01T00:00:00Z',
+    announcement_date: null,
+    progress: { not_started: 1, in_progress: 1, blocked: 0, awaiting_acceptance: 0, done: 1, skipped: 0 },
+    blocked_item_titles: [],
+    assignees: [],
     ...overrides,
   };
 }
@@ -34,7 +31,7 @@ function buildRow(overrides: Partial<Formation>): Formation {
 describe('FormationsTableComponent', () => {
   let fixture: ComponentFixture<FormationsTableComponent>;
 
-  const render = async (rows: Formation[]): Promise<void> => {
+  const render = async (rows: FormationQueueRow[]): Promise<void> => {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [FormationsTableComponent],
@@ -48,38 +45,18 @@ describe('FormationsTableComponent', () => {
     fixture.detectChanges();
   };
 
-  const nameCell = (uid: string): HTMLAnchorElement | null => fixture.nativeElement.querySelector(`[data-testid="formations-table-open-${uid}"]`);
   const readinessHeaderButton = (): HTMLButtonElement | null => fixture.nativeElement.querySelector('[data-testid="formations-sort-readiness"] button');
   const announcementHeaderButton = (): HTMLButtonElement | null => fixture.nativeElement.querySelector('[data-testid="formations-sort-announcement"] button');
   const rowUidsInOrder = (): (string | null)[] =>
     Array.from(fixture.nativeElement.querySelectorAll('[data-row-index]')).map((el) => (el as HTMLElement).getAttribute('data-testid'));
 
-  it('indents a child row whose parent formation is present in the current result', async () => {
+  it('sorts by readiness (fewest open items first) ascending, then toggles to descending on repeat click', async () => {
     await render([
-      buildRow({ uid: 'formation:foundation', parent_project_name: 'Acme Foundation', is_foundation: true, parent_uid: null }),
+      buildRow({ formation_uid: 'formation:more-open', progress: { not_started: 3, in_progress: 0, blocked: 0, awaiting_acceptance: 0, done: 0, skipped: 0 } }),
       buildRow({
-        uid: 'formation:child',
-        parent_project_name: 'Acme Child Project',
-        parent_formation_name: 'Acme Foundation',
-        is_foundation: false,
-        parent_uid: 'project:acme-foundation',
+        formation_uid: 'formation:fewer-open',
+        progress: { not_started: 0, in_progress: 0, blocked: 0, awaiting_acceptance: 0, done: 3, skipped: 0 },
       }),
-    ]);
-
-    expect(nameCell('formation:foundation')?.classList.contains('pl-4')).toBe(false);
-    expect(nameCell('formation:child')?.classList.contains('pl-4')).toBe(true);
-  });
-
-  it('does not indent a row whose named parent is absent from the current result', async () => {
-    await render([buildRow({ uid: 'formation:orphan', parent_project_name: 'Orphan Project', parent_formation_name: 'Not In Result' })]);
-
-    expect(nameCell('formation:orphan')?.classList.contains('pl-4')).toBe(false);
-  });
-
-  it('sorts by readiness (fewest open gating items first) ascending, then toggles to descending on repeat click', async () => {
-    await render([
-      buildRow({ uid: 'formation:more-open', gating_items_open: 3, gating_items_total: 3 }),
-      buildRow({ uid: 'formation:fewer-open', gating_items_open: 0, gating_items_total: 3 }),
     ]);
 
     readinessHeaderButton()?.click();
@@ -95,9 +72,9 @@ describe('FormationsTableComponent', () => {
 
   it('sorts by announcement date ascending by default, with rows lacking a date always last', async () => {
     await render([
-      buildRow({ uid: 'formation:no-date', announcement_date: null }),
-      buildRow({ uid: 'formation:later', announcement_date: '2026-06-01' }),
-      buildRow({ uid: 'formation:earlier', announcement_date: '2026-01-01' }),
+      buildRow({ formation_uid: 'formation:no-date', announcement_date: null }),
+      buildRow({ formation_uid: 'formation:later', announcement_date: '2026-06-01' }),
+      buildRow({ formation_uid: 'formation:earlier', announcement_date: '2026-01-01' }),
     ]);
 
     expect(rowUidsInOrder()).toEqual([

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.spec.ts
@@ -70,6 +70,18 @@ describe('FormationsTableComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="formations-sort-readiness"]').getAttribute('aria-sort')).toBe('descending');
   });
 
+  it('counts a skipped item as resolved in the progress column and readiness sort', async () => {
+    await render([
+      buildRow({
+        formation_uid: 'formation:all-skipped',
+        progress: { not_started: 0, in_progress: 0, blocked: 0, awaiting_acceptance: 0, done: 0, skipped: 3 },
+      }),
+    ]);
+
+    const progressText = fixture.nativeElement.querySelector('[data-testid="formations-table-row-formation:all-skipped"] td:nth-child(4) span').textContent;
+    expect(progressText.trim()).toBe('3 of 3');
+  });
+
   it('sorts by announcement date ascending by default, with rows lacking a date always last', async () => {
     await render([
       buildRow({ formation_uid: 'formation:no-date', announcement_date: null }),

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.ts
@@ -129,7 +129,10 @@ export class FormationsTableComponent {
         stageLabel: FORMATION_SUB_STAGE_LABELS[row.sub_stage],
         stageSeverity: FORMATION_SUB_STAGE_SEVERITY[row.sub_stage],
         entityTypeLabel: FORMATION_ENTITY_TYPE_LABELS[deriveFormationEntityType(row)],
-        doneCount: row.progress['done'] ?? 0,
+        // A skipped item is resolved, not remaining work — folded into doneCount so a formation
+        // whose only open items are skipped renders (and sorts) as complete, not as permanently
+        // incomplete. totalCount deliberately stays every status bucket (see the class doc comment).
+        doneCount: (row.progress['done'] ?? 0) + (row.progress['skipped'] ?? 0),
         totalCount: Object.values(row.progress).reduce((sum: number, count) => sum + (count ?? 0), 0),
       }));
       return this.sortDisplayRows(displayRows);

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.ts
@@ -130,7 +130,7 @@ export class FormationsTableComponent {
         stageSeverity: FORMATION_SUB_STAGE_SEVERITY[row.sub_stage],
         entityTypeLabel: FORMATION_ENTITY_TYPE_LABELS[deriveFormationEntityType(row)],
         doneCount: row.progress['done'] ?? 0,
-        totalCount: Object.values(row.progress).reduce((sum, count) => sum + count, 0),
+        totalCount: Object.values(row.progress).reduce((sum: number, count) => sum + (count ?? 0), 0),
       }));
       return this.sortDisplayRows(displayRows);
     });

--- a/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/components/formations-table/formations-table.component.ts
@@ -13,7 +13,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { FORMATION_ENTITY_TYPE_LABELS, FORMATION_QUEUE_SUB_STAGES, FORMATION_SUB_STAGE_LABELS, FORMATION_SUB_STAGE_SEVERITY } from '@lfx-one/shared/constants';
-import type { FilterPillOption, Formation, FormationsQueueFilterState, FormationSubStage, FormationTableRow } from '@lfx-one/shared/interfaces';
+import type { FilterPillOption, FormationQueueRow, FormationsQueueFilterState, FormationSubStage, FormationTableRow } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType } from '@lfx-one/shared/utils';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs';
 
@@ -41,7 +41,7 @@ type FormationSortableField = 'readiness' | 'announcement_date';
 export class FormationsTableComponent {
   private readonly destroyRef = inject(DestroyRef);
 
-  public readonly rows = input.required<Formation[]>();
+  public readonly rows = input.required<FormationQueueRow[]>();
   public readonly loading = input<boolean>(false);
 
   public readonly filtersChange = output<FormationsQueueFilterState>();
@@ -116,21 +116,21 @@ export class FormationsTableComponent {
   }
 
   /**
-   * PrimeNG types the `#body` row context `any` — precomputing the chip label/severity, indentation,
-   * and sort order here lets the template do a plain property read instead of a method call.
-   * `isChildRow` is derived (not stored) per `parent_formation_name`'s doc comment: a row indents
-   * only when its parent formation is also present in the current filtered result.
+   * PrimeNG types the `#body` row context `any` — precomputing the chip label/severity and sort
+   * order here lets the template do a plain property read instead of a method call.
+   * `doneCount`/`totalCount` sum {@link FormationQueueRow.progress} once per row rather than in the
+   * template (GH-2267 gap 2 — the queue projection has no precomputed gating open/total pair).
    */
   private initDisplayRows(): Signal<FormationTableRow[]> {
     return computed(() => {
       const rows = this.rows();
-      const namesInResult = new Set(rows.map((row) => row.parent_project_name));
       const displayRows = rows.map((row) => ({
         ...row,
         stageLabel: FORMATION_SUB_STAGE_LABELS[row.sub_stage],
         stageSeverity: FORMATION_SUB_STAGE_SEVERITY[row.sub_stage],
         entityTypeLabel: FORMATION_ENTITY_TYPE_LABELS[deriveFormationEntityType(row)],
-        isChildRow: !!row.parent_formation_name && namesInResult.has(row.parent_formation_name),
+        doneCount: row.progress['done'] ?? 0,
+        totalCount: Object.values(row.progress).reduce((sum, count) => sum + count, 0),
       }));
       return this.sortDisplayRows(displayRows);
     });
@@ -141,7 +141,7 @@ export class FormationsTableComponent {
     if (!field) return rows;
     const direction = this.sortOrder() === 'ASC' ? 1 : -1;
     const getSortValue = (row: FormationTableRow): number | null => {
-      if (field === 'readiness') return row.gating_items_open;
+      if (field === 'readiness') return row.totalCount - row.doneCount;
       return row.announcement_date ? new Date(row.announcement_date).getTime() : null;
     };
     // Nulls (no announcement date set) always sort last, regardless of direction.

--- a/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
@@ -76,7 +76,7 @@ export class FormationsQueueComponent {
           iconContainerClass: 'bg-blue-50 text-blue-600',
         },
         {
-          value: this.rows().filter((row) => row.is_activating).length,
+          value: this.rows().filter((row) => row.gates_cleared).length,
           label: 'Ready to activate',
           subLine: 'Gating items done',
           icon: 'fa-light fa-flag-checkered',

--- a/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
@@ -30,47 +30,83 @@ describe('FormationService', () => {
     req.flush({});
   });
 
-  it('getFormationItem GETs /api/formation-items/:uid', () => {
-    service.getFormationItem('formation-item:1').subscribe();
+  it('getFormationItem GETs /api/formations/:projectUid/items/:itemKey, URI-encoding both', () => {
+    service.getFormationItem('project/1', 'item key').subscribe();
 
-    const req = http.expectOne('/api/formation-items/formation-item%3A1');
+    const req = http.expectOne('/api/formations/project%2F1/items/item%20key');
     expect(req.request.method).toBe('GET');
     req.flush({});
   });
 
-  it('completeFormationItem PATCHes /complete with optional notes', () => {
-    service.completeFormationItem('formation-item:1', 'done early').subscribe();
+  it('completeFormationItem PATCHes .../complete with optional notes', () => {
+    service.completeFormationItem('project-1', 'item-1', 'done early').subscribe();
 
-    const req = http.expectOne('/api/formation-items/formation-item%3A1/complete');
+    const req = http.expectOne('/api/formations/project-1/items/item-1/complete');
     expect(req.request.method).toBe('PATCH');
     expect(req.request.body).toEqual({ notes: 'done early' });
     req.flush({});
   });
 
-  it('skipFormationItem PATCHes /skip with the reason', () => {
-    service.skipFormationItem('formation-item:1', 'blocked upstream').subscribe();
+  it('skipFormationItem PATCHes .../skip with the reason', () => {
+    service.skipFormationItem('project-1', 'item-1', 'blocked upstream').subscribe();
 
-    const req = http.expectOne('/api/formation-items/formation-item%3A1/skip');
+    const req = http.expectOne('/api/formations/project-1/items/item-1/skip');
     expect(req.request.method).toBe('PATCH');
     expect(req.request.body).toEqual({ reason: 'blocked upstream' });
     req.flush({});
   });
 
-  it('requestFormationItem PATCHes /request with an empty body', () => {
-    service.requestFormationItem('formation-item:1').subscribe();
+  it('requestFormationItem PATCHes .../request with an empty body', () => {
+    service.requestFormationItem('project-1', 'item-1').subscribe();
 
-    const req = http.expectOne('/api/formation-items/formation-item%3A1/request');
+    const req = http.expectOne('/api/formations/project-1/items/item-1/request');
     expect(req.request.method).toBe('PATCH');
     expect(req.request.body).toEqual({});
     req.flush({});
   });
 
-  it('updateFormationItem PATCHes the bare item uid with the given patch', () => {
-    service.updateFormationItem('formation-item:1', { notes: 'x', due_date: null }).subscribe();
+  it('updateFormationItemStatus PATCHes .../status with the status and optional note', () => {
+    service.updateFormationItemStatus('project-1', 'item-1', 'blocked', 'waiting on legal').subscribe();
 
-    const req = http.expectOne('/api/formation-items/formation-item%3A1');
+    const req = http.expectOne('/api/formations/project-1/items/item-1/status');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ status: 'blocked', note: 'waiting on legal' });
+    req.flush({});
+  });
+
+  it('updateFormationItem PATCHes the bare item address with the given patch', () => {
+    service.updateFormationItem('project-1', 'item-1', { notes: 'x', due_date: null }).subscribe();
+
+    const req = http.expectOne('/api/formations/project-1/items/item-1');
     expect(req.request.method).toBe('PATCH');
     expect(req.request.body).toEqual({ notes: 'x', due_date: null });
+    req.flush({});
+  });
+
+  it('acceptFormationItem POSTs .../accept with an optional note', () => {
+    service.acceptFormationItem('project-1', 'item-1', 'looks good').subscribe();
+
+    const req = http.expectOne('/api/formations/project-1/items/item-1/accept');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ note: 'looks good' });
+    req.flush({});
+  });
+
+  it('rejectFormationItem POSTs .../reject with the required note', () => {
+    service.rejectFormationItem('project-1', 'item-1', 'missing evidence').subscribe();
+
+    const req = http.expectOne('/api/formations/project-1/items/item-1/reject');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ note: 'missing evidence' });
+    req.flush({});
+  });
+
+  it('reopenFormationItem POSTs .../reopen with an optional note', () => {
+    service.reopenFormationItem('project-1', 'item-1').subscribe();
+
+    const req = http.expectOne('/api/formations/project-1/items/item-1/reopen');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ note: undefined });
     req.flush({});
   });
 

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -13,6 +13,11 @@ import type {
 } from '@lfx-one/shared/interfaces';
 import { Observable, take } from 'rxjs';
 
+/** Builds the `/api/formations/:projectUid/items/:itemKey` base path shared by every item route (GH-2267 Phase 2). */
+function itemPath(projectUid: string, itemKey: string): string {
+  return `/api/formations/${encodeURIComponent(projectUid)}/items/${encodeURIComponent(itemKey)}`;
+}
+
 @Injectable({ providedIn: 'root' })
 export class FormationService {
   private readonly http = inject(HttpClient);
@@ -21,29 +26,48 @@ export class FormationService {
     return this.http.get<FormationChecklistResponse>(`/api/projects/${encodeURIComponent(projectSlug)}/formation`);
   }
 
-  public getFormationItem(itemUid: string): Observable<{ item: FormationItem; history: FormationActivity[] }> {
-    return this.http.get<{ item: FormationItem; history: FormationActivity[] }>(`/api/formation-items/${encodeURIComponent(itemUid)}`);
+  public getFormationItem(projectUid: string, itemKey: string): Observable<{ item: FormationItem; history: FormationActivity[] }> {
+    return this.http.get<{ item: FormationItem; history: FormationActivity[] }>(itemPath(projectUid, itemKey));
   }
 
-  public completeFormationItem(itemUid: string, notes?: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`/api/formation-items/${encodeURIComponent(itemUid)}/complete`, { notes }).pipe(take(1));
+  public completeFormationItem(projectUid: string, itemKey: string, notes?: string): Observable<FormationItem> {
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/complete`, { notes }).pipe(take(1));
   }
 
-  public skipFormationItem(itemUid: string, reason: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`/api/formation-items/${encodeURIComponent(itemUid)}/skip`, { reason }).pipe(take(1));
+  public skipFormationItem(projectUid: string, itemKey: string, reason: string): Observable<FormationItem> {
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/skip`, { reason }).pipe(take(1));
   }
 
-  public requestFormationItem(itemUid: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`/api/formation-items/${encodeURIComponent(itemUid)}/request`, {}).pipe(take(1));
+  public requestFormationItem(projectUid: string, itemKey: string): Observable<FormationItem> {
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/request`, {}).pipe(take(1));
   }
 
   /** The three "plain" status transitions (not_started / in_progress / blocked) — completion and skip keep their own dedicated endpoints. */
-  public updateFormationItemStatus(itemUid: string, status: FormationItemStatus, note?: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`/api/formation-items/${encodeURIComponent(itemUid)}/status`, { status, note }).pipe(take(1));
+  public updateFormationItemStatus(projectUid: string, itemKey: string, status: FormationItemStatus, note?: string): Observable<FormationItem> {
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/status`, { status, note }).pipe(take(1));
   }
 
-  public updateFormationItem(itemUid: string, patch: { notes?: string; owner_username?: string; due_date?: string | null }): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`/api/formation-items/${encodeURIComponent(itemUid)}`, patch).pipe(take(1));
+  public updateFormationItem(
+    projectUid: string,
+    itemKey: string,
+    patch: { notes?: string; owner_username?: string; due_date?: string | null }
+  ): Observable<FormationItem> {
+    return this.http.patch<FormationItem>(itemPath(projectUid, itemKey), patch).pipe(take(1));
+  }
+
+  /** New in GH-2267 Phase 2 — mirrors upstream's `accept` action; see `formationService.acceptFormationItem` (server) for the gating detail. */
+  public acceptFormationItem(projectUid: string, itemKey: string, note?: string): Observable<FormationItem> {
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/accept`, { note }).pipe(take(1));
+  }
+
+  /** New in GH-2267 Phase 2 — `note` is required upstream (minLength 1); the BFF/service enforce it, this method just forwards it. */
+  public rejectFormationItem(projectUid: string, itemKey: string, note: string): Observable<FormationItem> {
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reject`, { note }).pipe(take(1));
+  }
+
+  /** New in GH-2267 Phase 2 — reverses a done/skipped/awaiting-acceptance item back to in_progress. */
+  public reopenFormationItem(projectUid: string, itemKey: string, note?: string): Observable<FormationItem> {
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reopen`, { note }).pipe(take(1));
   }
 
   public getFormationsQueue(subStage?: FormationSubStage, search?: string): Observable<FormationsQueueResponse> {

--- a/apps/lfx-one/src/server/controllers/formation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/formation.controller.ts
@@ -5,7 +5,7 @@ import { FORMATION_QUEUE_SUB_STAGES } from '@lfx-one/shared/constants';
 import type { FormationSubStage } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
-import { validateUidParameter } from '../helpers/validation.helper';
+import { validateItemKeyParameter, validateUidParameter } from '../helpers/validation.helper';
 import { formationService } from '../services/formation.service';
 import { logger } from '../services/logger.service';
 
@@ -23,16 +23,19 @@ export const getProjectFormation = async (req: Request, res: Response, next: Nex
 };
 
 export const getFormationItem = async (req: Request, res: Response, next: NextFunction) => {
-  const { uid } = req.params;
-  const startTime = logger.startOperation(req, 'get_formation_item', { uid });
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'get_formation_item', { projectUid, itemKey });
 
-  if (!validateUidParameter(uid, req, next, { operation: 'get_formation_item' })) {
+  if (!validateUidParameter(projectUid, req, next, { operation: 'get_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'get_formation_item' })) {
     return;
   }
 
   try {
-    const result = await formationService.getFormationItemDetail(req, uid);
-    logger.success(req, 'get_formation_item', startTime, { uid });
+    const result = await formationService.getFormationItemDetail(req, projectUid, itemKey);
+    logger.success(req, 'get_formation_item', startTime, { projectUid, itemKey });
     return res.json(result);
   } catch (error) {
     return next(error);
@@ -46,16 +49,19 @@ export const getFormationItem = async (req: Request, res: Response, next: NextFu
  * propagates to `next(error)` below like any other service error.
  */
 export const completeFormationItem = async (req: Request, res: Response, next: NextFunction) => {
-  const { uid } = req.params;
-  const startTime = logger.startOperation(req, 'complete_formation_item', { uid });
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'complete_formation_item', { projectUid, itemKey });
 
-  if (!validateUidParameter(uid, req, next, { operation: 'complete_formation_item' })) {
+  if (!validateUidParameter(projectUid, req, next, { operation: 'complete_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'complete_formation_item' })) {
     return;
   }
 
   try {
-    const result = await formationService.completeFormationItem(req, uid, req.body?.notes);
-    logger.success(req, 'complete_formation_item', startTime, { uid });
+    const result = await formationService.completeFormationItem(req, projectUid, itemKey, req.body?.notes);
+    logger.success(req, 'complete_formation_item', startTime, { projectUid, itemKey });
     return res.json(result);
   } catch (error) {
     return next(error);
@@ -63,16 +69,19 @@ export const completeFormationItem = async (req: Request, res: Response, next: N
 };
 
 export const skipFormationItem = async (req: Request, res: Response, next: NextFunction) => {
-  const { uid } = req.params;
-  const startTime = logger.startOperation(req, 'skip_formation_item', { uid });
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'skip_formation_item', { projectUid, itemKey });
 
-  if (!validateUidParameter(uid, req, next, { operation: 'skip_formation_item' })) {
+  if (!validateUidParameter(projectUid, req, next, { operation: 'skip_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'skip_formation_item' })) {
     return;
   }
 
   try {
-    const result = await formationService.skipFormationItem(req, uid, req.body?.reason);
-    logger.success(req, 'skip_formation_item', startTime, { uid });
+    const result = await formationService.skipFormationItem(req, projectUid, itemKey, req.body?.reason);
+    logger.success(req, 'skip_formation_item', startTime, { projectUid, itemKey });
     return res.json(result);
   } catch (error) {
     return next(error);
@@ -80,16 +89,19 @@ export const skipFormationItem = async (req: Request, res: Response, next: NextF
 };
 
 export const requestFormationItem = async (req: Request, res: Response, next: NextFunction) => {
-  const { uid } = req.params;
-  const startTime = logger.startOperation(req, 'request_formation_item', { uid });
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'request_formation_item', { projectUid, itemKey });
 
-  if (!validateUidParameter(uid, req, next, { operation: 'request_formation_item' })) {
+  if (!validateUidParameter(projectUid, req, next, { operation: 'request_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'request_formation_item' })) {
     return;
   }
 
   try {
-    const result = await formationService.requestFormationItem(req, uid);
-    logger.success(req, 'request_formation_item', startTime, { uid });
+    const result = await formationService.requestFormationItem(req, projectUid, itemKey);
+    logger.success(req, 'request_formation_item', startTime, { projectUid, itemKey });
     return res.json(result);
   } catch (error) {
     return next(error);
@@ -97,16 +109,19 @@ export const requestFormationItem = async (req: Request, res: Response, next: Ne
 };
 
 export const updateFormationItem = async (req: Request, res: Response, next: NextFunction) => {
-  const { uid } = req.params;
-  const startTime = logger.startOperation(req, 'update_formation_item', { uid });
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'update_formation_item', { projectUid, itemKey });
 
-  if (!validateUidParameter(uid, req, next, { operation: 'update_formation_item' })) {
+  if (!validateUidParameter(projectUid, req, next, { operation: 'update_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'update_formation_item' })) {
     return;
   }
 
   try {
-    const result = await formationService.updateFormationItem(req, uid, req.body ?? {});
-    logger.success(req, 'update_formation_item', startTime, { uid });
+    const result = await formationService.updateFormationItem(req, projectUid, itemKey, req.body ?? {});
+    logger.success(req, 'update_formation_item', startTime, { projectUid, itemKey });
     return res.json(result);
   } catch (error) {
     return next(error);
@@ -118,16 +133,84 @@ export const updateFormationItem = async (req: Request, res: Response, next: Nex
  * status menu (GH-1958 finding #2). Completion and skip keep their own dedicated endpoints above.
  */
 export const updateFormationItemStatus = async (req: Request, res: Response, next: NextFunction) => {
-  const { uid } = req.params;
-  const startTime = logger.startOperation(req, 'update_formation_item_status', { uid });
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'update_formation_item_status', { projectUid, itemKey });
 
-  if (!validateUidParameter(uid, req, next, { operation: 'update_formation_item_status' })) {
+  if (!validateUidParameter(projectUid, req, next, { operation: 'update_formation_item_status' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'update_formation_item_status' })) {
     return;
   }
 
   try {
-    const result = await formationService.updateFormationItemStatus(req, uid, req.body?.status, req.body?.note);
-    logger.success(req, 'update_formation_item_status', startTime, { uid });
+    const result = await formationService.updateFormationItemStatus(req, projectUid, itemKey, req.body?.status, req.body?.note);
+    logger.success(req, 'update_formation_item_status', startTime, { projectUid, itemKey });
+    return res.json(result);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * New in GH-2267 Phase 2 — mirrors upstream's `accept`/`reject`/`reopen` actions (design.go items
+ * 4-6). Fixture-era gating substitutes `gate_writer` for the real `team:formation` check; see
+ * `formationService.acceptFormationItem`'s doc comment.
+ */
+export const acceptFormationItem = async (req: Request, res: Response, next: NextFunction) => {
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'accept_formation_item', { projectUid, itemKey });
+
+  if (!validateUidParameter(projectUid, req, next, { operation: 'accept_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'accept_formation_item' })) {
+    return;
+  }
+
+  try {
+    const result = await formationService.acceptFormationItem(req, projectUid, itemKey, req.body?.note);
+    logger.success(req, 'accept_formation_item', startTime, { projectUid, itemKey });
+    return res.json(result);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const rejectFormationItem = async (req: Request, res: Response, next: NextFunction) => {
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'reject_formation_item', { projectUid, itemKey });
+
+  if (!validateUidParameter(projectUid, req, next, { operation: 'reject_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'reject_formation_item' })) {
+    return;
+  }
+
+  try {
+    const result = await formationService.rejectFormationItem(req, projectUid, itemKey, req.body?.note);
+    logger.success(req, 'reject_formation_item', startTime, { projectUid, itemKey });
+    return res.json(result);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+export const reopenFormationItem = async (req: Request, res: Response, next: NextFunction) => {
+  const { projectUid, itemKey } = req.params;
+  const startTime = logger.startOperation(req, 'reopen_formation_item', { projectUid, itemKey });
+
+  if (!validateUidParameter(projectUid, req, next, { operation: 'reopen_formation_item' })) {
+    return;
+  }
+  if (!validateItemKeyParameter(itemKey, req, next, { operation: 'reopen_formation_item' })) {
+    return;
+  }
+
+  try {
+    const result = await formationService.reopenFormationItem(req, projectUid, itemKey, req.body?.note);
+    logger.success(req, 'reopen_formation_item', startTime, { projectUid, itemKey });
     return res.json(result);
   } catch (error) {
     return next(error);

--- a/apps/lfx-one/src/server/errors/index.ts
+++ b/apps/lfx-one/src/server/errors/index.ts
@@ -4,7 +4,7 @@
 export { BaseApiError } from './base.error';
 export { AuthenticationError, AuthorizationError } from './authentication.error';
 export { MicroserviceError } from './microservice.error';
-export { ServiceValidationError, ResourceNotFoundError, ConflictError } from './service-validation.error';
+export { ServiceValidationError, ResourceNotFoundError, ConflictError, PreconditionFailedError } from './service-validation.error';
 
 // Type guards for error identification
 import { AuthenticationError } from './authentication.error';

--- a/apps/lfx-one/src/server/errors/service-validation.error.ts
+++ b/apps/lfx-one/src/server/errors/service-validation.error.ts
@@ -96,8 +96,10 @@ export class ResourceNotFoundError extends BaseApiError {
 }
 
 /**
- * Error class for precondition-failed scenarios (e.g. an action requires
- * some dependent resource/configuration that doesn't exist yet).
+ * Error class for state-conflict scenarios (e.g. an action is invalid for the resource's current
+ * state — a read-only checklist, an invalid status transition, self-acceptance). Always 409; the
+ * caller-supplied `code` names the specific conflict (e.g. the upstream `reason` uppercased).
+ * NOT for optimistic-locking version mismatches — see {@link PreconditionFailedError} (412) for those.
  */
 export class ConflictError extends BaseApiError {
   public constructor(
@@ -110,5 +112,24 @@ export class ConflictError extends BaseApiError {
     } = {}
   ) {
     super(message, 409, code, options);
+  }
+}
+
+/**
+ * Error class for optimistic-locking version mismatches (upstream `reason: 'version_mismatch'`,
+ * HTTP 412 on a mutation whose `If-Match` no longer matches the resource's current `version`).
+ * Distinct from {@link ConflictError} (409): a 412 means the caller's local copy is stale and a
+ * reload is needed before retrying, not that the requested transition itself is invalid.
+ */
+export class PreconditionFailedError extends BaseApiError {
+  public constructor(
+    message = 'The resource has changed since it was last read',
+    options: {
+      operation?: string;
+      service?: string;
+      path?: string;
+    } = {}
+  ) {
+    super(message, 412, 'PRECONDITION_FAILED', options);
   }
 }

--- a/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
@@ -8,11 +8,14 @@
  * (`FORMATION_BACKEND=live`). Both are env-driven rather than a hardcoded flip so the same build can
  * be pointed at either backend per-environment.
  *
- * This is the **only** switch — every formation read and mutation
- * (`getProjectFormation`/`getFormationsQueue`/`completeFormationItem`/`skipFormationItem`/
- * `requestFormationItem`/`updateFormationItem`/`updateFormationItemStatus`) branches on it. Per
- * Phase 7 of GH-2267, this stays the single documented switch for a staged cutover; if no staged
- * rollout turns out to be needed, delete this helper entirely and call the real proxy directly.
+ * This is the **only** switch — `getFormationsQueue`, every item mutation
+ * (`completeFormationItem`/`skipFormationItem`/`requestFormationItem`/`updateFormationItem`/
+ * `updateFormationItemStatus`/`acceptFormationItem`/`rejectFormationItem`/`reopenFormationItem`)
+ * branches on it. `getProjectFormation` does not yet — its live branch is
+ * `// TODO(GH-2267 Phase 1 remainder)` and unconditionally throws, so flipping this on before that
+ * lands 404s the checklist read while everything else goes live. Per Phase 7 of GH-2267, this stays
+ * the single documented switch for a staged cutover; if no staged rollout turns out to be needed,
+ * delete this helper entirely and call the real proxy directly.
  *
  * No `NODE_ENV==='production'` hard-block (unlike the mock-backend precedents `isEngagementMockBackend()`/
  * `WEEKLY_BRIEF_BACKEND`): production isn't "reachable with a misconfigured env var flipping on

--- a/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
@@ -6,7 +6,10 @@
  * a formation-only base-URL override is configured (`LFX_V2_FORMATION_SERVICE`, e.g. pointing the
  * BFF at dev while everything else still talks to prod) or the operator opts in explicitly
  * (`FORMATION_BACKEND=live`). Both are env-driven rather than a hardcoded flip so the same build can
- * be pointed at either backend per-environment.
+ * be pointed at either backend per-environment — but `LFX_V2_FORMATION_SERVICE` is effectively
+ * local-dev-only: `charts/lfx-self-serve/templates/_helpers.tpl`'s `gatewayOnlyValidate` deny-list
+ * now `fail()`s Helm rendering if it's set, so `FORMATION_BACKEND=live` is the only arm reachable in
+ * any Helm-deployed environment (staging/prod). Keep the two in sync if either changes.
  *
  * This is the **only** switch — `getFormationsQueue`, every item mutation
  * (`completeFormationItem`/`skipFormationItem`/`requestFormationItem`/`updateFormationItem`/

--- a/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
@@ -2,29 +2,23 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * TODO(#1957): the single swap point for the real `lfx-v2-formation-service`. Currently hardcoded
- * `false` — there is no live backend to switch to yet, unlike `isEngagementMockBackend()`/
- * `WEEKLY_BRIEF_BACKEND`, which stand in for a real backend that already exists and is only being
- * bypassed as an explicit opt-in. Deliberately NOT an env-var pair
- * (`FORMATION_BACKEND=mock|live`): a `live` value would name a target that doesn't exist, inviting
- * someone to "fix" it into pointing at a service that isn't ready. Once #1957 ships, either flip
- * this to a real env-var/feature-flag-driven check (if a staged cutover is needed) or delete it and
- * call the real proxy directly if no staged rollout is required. Today only `getProjectFormation`
- * actually branches on this function; `getFormationsQueue` and the mutating methods in
- * `formation.service.ts` always touch the in-memory fixture store (see their own
- * `// TODO(#1957)` comments there), so the swap is not yet fully contained here — extending it to
- * those methods is part of #1957.
+ * The single swap point for the real `lfx-v2-formation-service` (GH-2267/#1957). `true` when either
+ * a formation-only base-URL override is configured (`LFX_V2_FORMATION_SERVICE`, e.g. pointing the
+ * BFF at dev while everything else still talks to prod) or the operator opts in explicitly
+ * (`FORMATION_BACKEND=live`). Both are env-driven rather than a hardcoded flip so the same build can
+ * be pointed at either backend per-environment.
  *
- * No `NODE_ENV==='production'` hard-block either (unlike the mock-backend precedents): production
- * isn't "reachable with a misconfigured env var flipping on fabricated data next to real data," it
- * is the only mode there is right now. Both read endpoints (`getProjectFormation`,
- * `getFormationsQueue`) label their response bodies `data_source: 'fixture'`; every mutating
- * method in `formation.service.ts` (`completeFormationItem`, `skipFormationItem`,
- * `requestFormationItem`, `updateFormationItem`) carries its own `// TODO(#1957)` comment instead,
- * since it only ever touches the in-memory fixture store, never a real record. Formation fixture
- * data is synthetic end-to-end — there's no real-identity-plus-fake-numbers juxtaposition risk to
- * guard against the way `isEngagementMockBackend()` does.
+ * This is the **only** switch — every formation read and mutation
+ * (`getProjectFormation`/`getFormationsQueue`/`completeFormationItem`/`skipFormationItem`/
+ * `requestFormationItem`/`updateFormationItem`/`updateFormationItemStatus`) branches on it. Per
+ * Phase 7 of GH-2267, this stays the single documented switch for a staged cutover; if no staged
+ * rollout turns out to be needed, delete this helper entirely and call the real proxy directly.
+ *
+ * No `NODE_ENV==='production'` hard-block (unlike the mock-backend precedents `isEngagementMockBackend()`/
+ * `WEEKLY_BRIEF_BACKEND`): production isn't "reachable with a misconfigured env var flipping on
+ * fabricated data next to real data" — it is the only mode there is right now, and this switch
+ * turns the live client on rather than a fixture off.
  */
 export function isFormationServiceLive(): boolean {
-  return false;
+  return !!process.env['LFX_V2_FORMATION_SERVICE'] || process.env['FORMATION_BACKEND'] === 'live';
 }

--- a/apps/lfx-one/src/server/helpers/formation-fixture.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/formation-fixture.helper.spec.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import '@angular/compiler';
+
 import { FORMATION_TEMPLATE } from '@lfx-one/shared/constants';
 import { describe, expect, it } from 'vitest';
 

--- a/apps/lfx-one/src/server/helpers/formation-fixture.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-fixture.helper.ts
@@ -8,12 +8,13 @@ import type {
   FormationItem,
   FormationItemStatus,
   FormationSubItem,
-  FormationSubStage,
   FormationTemplate,
   FormationTemplateSubItem,
   FormationUser,
 } from '@lfx-one/shared/interfaces';
 import crypto from 'crypto';
+
+import { deriveFormationSubStage } from './formation-mapper.helper';
 
 /**
  * Fixture data generators for the Formation Checklist section and Formations queue (GH-1958),
@@ -74,18 +75,6 @@ function deriveSubItems(seed: string, subItems: FormationTemplateSubItem[] | und
   }));
 }
 
-function mapProjectStageToSubStage(stage: ProjectStage | string | undefined): FormationSubStage {
-  switch (stage) {
-    case ProjectStage.FormationExploratory:
-      return 'exploratory';
-    case ProjectStage.FormationOnHold:
-      return 'on_hold';
-    case ProjectStage.FormationEngaged:
-    default:
-      return 'engaged';
-  }
-}
-
 interface GenerateFormationInput {
   projectUid: string;
   projectSlug: string;
@@ -94,8 +83,14 @@ interface GenerateFormationInput {
   stage: ProjectStage | string | undefined;
 }
 
-/** Deterministic per-project fixture generator (SHA-256-seeded off `projectUid`, never `Math.random()`) — same request yields the same response every reload. */
-export function generateMockFormation(input: GenerateFormationInput): { formation: Formation; items: FormationItem[] } {
+/**
+ * Deterministic per-project fixture generator (SHA-256-seeded off `projectUid`, never
+ * `Math.random()`) — same request yields the same response every reload. The returned
+ * `formation.uid` is always set (unlike the checklist read's own optional `Formation.uid` — see
+ * its doc comment) — narrowed here so callers can hand it straight to the write store, which is
+ * keyed by uid.
+ */
+export function generateMockFormation(input: GenerateFormationInput): { formation: Formation & { uid: string }; items: FormationItem[] } {
   const flatItems = FORMATION_TEMPLATE.sections.flatMap((section) => section.items.map((item) => ({ section, item })));
   const total = flatItems.length;
 
@@ -134,6 +129,9 @@ export function generateMockFormation(input: GenerateFormationInput): { formatio
       can_complete: false,
       created_at: new Date(0).toISOString(),
       updated_at: new Date(0).toISOString(),
+      // Fixture items have no real optimistic-locking history — 1 is a fixed starting value, never
+      // incremented, since only the real service (#1957) enforces If-Match.
+      version: 1,
     };
   });
 
@@ -144,7 +142,7 @@ export function generateMockFormation(input: GenerateFormationInput): { formatio
   const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
   const blockingItemTitle = blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null;
 
-  const formation: Formation = {
+  const formation: Formation & { uid: string } = {
     uid: `formation:${input.projectUid}`,
     parent_project_uid: input.projectUid,
     parent_project_slug: input.projectSlug,
@@ -153,7 +151,7 @@ export function generateMockFormation(input: GenerateFormationInput): { formatio
     parent_uid: input.parentProjectUid,
     template_uid: SEEDED_FORMATION_TEMPLATE_UID,
     template_version: 1,
-    sub_stage: mapProjectStageToSubStage(input.stage),
+    sub_stage: deriveFormationSubStage(input.stage),
     announcement_date: isActivating ? new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString() : null,
     is_activating: isActivating,
     gating_items_open: openGatingItems.length,
@@ -171,7 +169,7 @@ export function generateMockFormation(input: GenerateFormationInput): { formatio
 // needs exactly one of each interesting scenario for UI testing, which a generator would fight
 // against (a generator can't guarantee "exactly one Withdrawn row" the way a curated list can).
 
-export const STATIC_QUEUE_FORMATIONS: Formation[] = [
+export const STATIC_QUEUE_FORMATIONS: (Formation & { uid: string })[] = [
   {
     uid: 'formation:queue-project-1',
     parent_project_uid: 'queue-project-1',

--- a/apps/lfx-one/src/server/helpers/formation-fixture.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-fixture.helper.ts
@@ -112,10 +112,7 @@ export function generateMockFormation(input: GenerateFormationInput): { formatio
       owner_team: item.owner_team,
       owner,
       due_date: null,
-      // FormationActionType's enum members share the exact string values of FormationItemAction's
-      // union, but TS treats string enums nominally — bridge the gap with a double cast rather than
-      // duplicating every seed entry under two parallel types.
-      action: item.action as unknown as FormationItem['action'],
+      action: item.action,
       // The template's own action_link, if any — no seeded row sets one today, so this is null
       // across the board (including domain_dns, which correctly ships with no destination).
       action_href: item.action_link ?? null,

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -16,10 +16,12 @@ import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
 /**
  * Maps `lfx-v2-formation-service`'s wire shapes (GH-2267 Phase 0's contract table, source of truth
  * `cmd/formation-api/design/design.go` at `linuxfoundation/lfx-v2-formation-service@main`) onto
- * this repo's `Formation`/`FormationItem` shared types. Every field this file derives rather than
- * copies verbatim (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream
- * source at all — see the GH-2267 plan's Phase 5 "checklist read" section for why each one is
- * derived from the seeded `FORMATION_TEMPLATE` instead. The raw upstream shapes themselves
+ * this repo's `FormationItem` shared type — `mapUpstreamFormationItem`, one upstream item at a time.
+ * Formation-level mapping (`UpstreamFormationChecklist` → `Formation`) is deferred; see the trailing
+ * note at the bottom of this file. Every field this file derives rather than copies verbatim
+ * (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream source at all — see
+ * the GH-2267 plan's Phase 5 "checklist read" section for why each one is derived from the seeded
+ * `FORMATION_TEMPLATE` instead. The raw upstream shapes themselves
  * (`UpstreamFormationItem`/`UpstreamFormationChecklist`/`FormationItemMapContext`) live in
  * `@lfx-one/shared/interfaces` rather than here, per this repo's "no local interface in
  * apps/lfx-one" convention.

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -3,7 +3,14 @@
 
 import { FORMATION_TEMPLATE } from '@lfx-one/shared/constants';
 import { ProjectStage } from '@lfx-one/shared/enums';
-import type { Formation, FormationItem, FormationItemLink, FormationItemStatus, FormationSubItem, FormationSubStage } from '@lfx-one/shared/interfaces';
+import type {
+  FormationItem,
+  FormationItemLink,
+  FormationItemMapContext,
+  FormationSubItem,
+  FormationSubStage,
+  UpstreamFormationItem,
+} from '@lfx-one/shared/interfaces';
 import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
 
 /**
@@ -12,52 +19,11 @@ import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
  * this repo's `Formation`/`FormationItem` shared types. Every field this file derives rather than
  * copies verbatim (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream
  * source at all — see the GH-2267 plan's Phase 5 "checklist read" section for why each one is
- * derived from the seeded `FORMATION_TEMPLATE` instead.
+ * derived from the seeded `FORMATION_TEMPLATE` instead. The raw upstream shapes themselves
+ * (`UpstreamFormationItem`/`UpstreamFormationChecklist`/`FormationItemMapContext`) live in
+ * `@lfx-one/shared/interfaces` rather than here, per this repo's "no local interface in
+ * apps/lfx-one" convention.
  */
-
-/** Raw item shape from `GET /formations/{project_uid}` / a mutation response — one entry of `FormationChecklist.items[]`. */
-export interface UpstreamFormationItem {
-  uid: string;
-  item_key: string;
-  section_key: string;
-  position: number;
-  title: string;
-  owner_team?: string | null;
-  gate: boolean;
-  requires_writer: boolean;
-  status_source: 'user' | 'platform';
-  is_required: boolean;
-  checklist_type: string;
-  platform_check?: string | null;
-  action_link?: string | null;
-  evidence_link?: string | null;
-  status: FormationItemStatus;
-  assignee?: string | null;
-  due_date?: string | null;
-  note?: string | null;
-  skip_reason?: string | null;
-  resolved_ref?: string | null;
-  sub_items?: { key: string; title: string; status: FormationItemStatus }[];
-  version: number;
-}
-
-/** Raw response shape from `GET /formations/{project_uid}?v=1` — the plan's gap 3 (no `formation_uid`/timestamps). */
-export interface UpstreamFormationChecklist {
-  project_uid: string;
-  template_uid: string;
-  template_version: number;
-  lifecycle: string;
-  sections: { key: string; title: string; position: number }[];
-  items: UpstreamFormationItem[];
-  is_activating: boolean;
-}
-
-/** Everything the mapper needs beyond the raw item itself — none of it is on the wire (see the file doc comment). */
-export interface FormationItemMapContext {
-  formationUid: string;
-  projectUid: string;
-  projectSlug: string;
-}
 
 const TEMPLATE_ITEMS_BY_KEY = new Map(FORMATION_TEMPLATE.sections.flatMap((section) => section.items.map((item) => [item.key, item])));
 const TEMPLATE_SECTION_TITLES_BY_KEY = new Map(FORMATION_TEMPLATE.sections.map((section) => [section.key as string, section.title]));
@@ -73,7 +39,7 @@ const TEMPLATE_SECTION_TITLES_BY_KEY = new Map(FORMATION_TEMPLATE.sections.map((
 function deriveItemAction(raw: UpstreamFormationItem): FormationItem['action'] {
   if (raw.status_source === 'platform') return 'provisionable';
   const templateItem = TEMPLATE_ITEMS_BY_KEY.get(raw.item_key);
-  return (templateItem?.action as unknown as FormationItem['action']) ?? 'manual';
+  return templateItem?.action ?? 'manual';
 }
 
 /**
@@ -155,43 +121,6 @@ export function mapUpstreamFormationItem(raw: UpstreamFormationItem, ctx: Format
   };
 }
 
-/**
- * Maps `GET /formations/{project_uid}`'s checklist-level fields onto `Formation`, given the
- * project record already resolved for slug→uid (`ProjectService.getProjectById`) — the plan's
- * "checklist read" §5: `parent_project_*`/`is_foundation`/`sub_stage`/`announcement_date` have no
- * checklist-response source at all and come from the project record instead.
- * `gating_items_open`/`gating_items_total`/`blocking_item_title`/`subtitle` are derived from
- * `items` (already collapsed for ROOT and enriched by the caller), mirroring
- * `FormationService.refreshFormationReadiness`'s fixture-era rollup so both data sources agree on
- * what "activating" means. `Formation.uid` is left absent (gap 3 — raised upstream on #1957) and
- * so are `created_at`/`updated_at` (same gap).
- */
-export function mapUpstreamFormationChecklist(
-  raw: UpstreamFormationChecklist,
-  project: { slug: string; name: string; parent_uid: string | null | undefined },
-  collapsedParentUid: string | null,
-  subStage: Formation['sub_stage'],
-  announcementDate: string | null,
-  items: FormationItem[]
-): Formation {
-  const gatingItems = items.filter((item) => item.is_gating);
-  const openGatingItems = gatingItems.filter((item) => item.status !== 'done' && item.status !== 'skipped');
-  const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
-
-  return {
-    parent_project_uid: raw.project_uid,
-    parent_project_slug: project.slug,
-    parent_project_name: project.name,
-    is_foundation: !collapsedParentUid,
-    parent_uid: collapsedParentUid,
-    template_uid: raw.template_uid,
-    template_version: raw.template_version,
-    sub_stage: subStage,
-    announcement_date: announcementDate,
-    is_activating: raw.is_activating,
-    gating_items_open: openGatingItems.length,
-    gating_items_total: gatingItems.length,
-    blocking_item_title: blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null,
-    subtitle: null,
-  };
-}
+// Note: `getProjectFormation`'s live branch (mapping `UpstreamFormationChecklist` onto `Formation`)
+// is not yet wired — see the GH-2267 plan's Phase 1 remainder. A `mapUpstreamFormationChecklist`
+// helper belongs here once that lands, matching `mapUpstreamFormationItem`'s shape.

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -1,0 +1,197 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { FORMATION_TEMPLATE } from '@lfx-one/shared/constants';
+import { ProjectStage } from '@lfx-one/shared/enums';
+import type { Formation, FormationItem, FormationItemLink, FormationItemStatus, FormationSubItem, FormationSubStage } from '@lfx-one/shared/interfaces';
+import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
+
+/**
+ * Maps `lfx-v2-formation-service`'s wire shapes (GH-2267 Phase 0's contract table, source of truth
+ * `cmd/formation-api/design/design.go` at `linuxfoundation/lfx-v2-formation-service@main`) onto
+ * this repo's `Formation`/`FormationItem` shared types. Every field this file derives rather than
+ * copies verbatim (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream
+ * source at all — see the GH-2267 plan's Phase 5 "checklist read" section for why each one is
+ * derived from the seeded `FORMATION_TEMPLATE` instead.
+ */
+
+/** Raw item shape from `GET /formations/{project_uid}` / a mutation response — one entry of `FormationChecklist.items[]`. */
+export interface UpstreamFormationItem {
+  uid: string;
+  item_key: string;
+  section_key: string;
+  position: number;
+  title: string;
+  owner_team?: string | null;
+  gate: boolean;
+  requires_writer: boolean;
+  status_source: 'user' | 'platform';
+  is_required: boolean;
+  checklist_type: string;
+  platform_check?: string | null;
+  action_link?: string | null;
+  evidence_link?: string | null;
+  status: FormationItemStatus;
+  assignee?: string | null;
+  due_date?: string | null;
+  note?: string | null;
+  skip_reason?: string | null;
+  resolved_ref?: string | null;
+  sub_items?: { key: string; title: string; status: FormationItemStatus }[];
+  version: number;
+}
+
+/** Raw response shape from `GET /formations/{project_uid}?v=1` — the plan's gap 3 (no `formation_uid`/timestamps). */
+export interface UpstreamFormationChecklist {
+  project_uid: string;
+  template_uid: string;
+  template_version: number;
+  lifecycle: string;
+  sections: { key: string; title: string; position: number }[];
+  items: UpstreamFormationItem[];
+  is_activating: boolean;
+}
+
+/** Everything the mapper needs beyond the raw item itself — none of it is on the wire (see the file doc comment). */
+export interface FormationItemMapContext {
+  formationUid: string;
+  projectUid: string;
+  projectSlug: string;
+}
+
+const TEMPLATE_ITEMS_BY_KEY = new Map(FORMATION_TEMPLATE.sections.flatMap((section) => section.items.map((item) => [item.key, item])));
+const TEMPLATE_SECTION_TITLES_BY_KEY = new Map(FORMATION_TEMPLATE.sections.map((section) => [section.key as string, section.title]));
+
+/**
+ * `status_source: 'platform'` always means `provisionable` regardless of the seeded template's own
+ * action (GH-2267 Phase 5) — LFX itself provisioned/checked the resource, so the row is never a
+ * manual/link/request affordance no matter what the template says. Anything else falls back to the
+ * template's own `action` by `item_key`; an item_key the template doesn't know (a future upstream
+ * addition this BFF hasn't been updated for) defaults to `'manual'` rather than throwing, since a
+ * checklist row missing its action affordance is a display gap, not a fatal one.
+ */
+function deriveItemAction(raw: UpstreamFormationItem): FormationItem['action'] {
+  if (raw.status_source === 'platform') return 'provisionable';
+  const templateItem = TEMPLATE_ITEMS_BY_KEY.get(raw.item_key);
+  return (templateItem?.action as unknown as FormationItem['action']) ?? 'manual';
+}
+
+/**
+ * Upstream deliberately leaves `{{project.slug}}` unresolved in a template's `action_link`
+ * (GH-2267 Phase 5) — substituted here, once, rather than rendered raw. A link that still fails
+ * scheme/shape validation after substitution is dropped (`null`) rather than passed through: a
+ * broken href is worse than no link, and this field is untrusted service output bound into `[href]`
+ * downstream (see `FormationItem.action_href`'s doc comment).
+ */
+function resolveActionHref(actionLink: string | null | undefined, projectSlug: string): string | null {
+  if (!actionLink) return null;
+  const resolved = actionLink.replace(/\{\{\s*project\.slug\s*\}\}/g, projectSlug);
+  if (isRelativeInAppPath(resolved) || isValidUrl(resolved)) return resolved;
+  return null;
+}
+
+/** Single `http`/`https` `evidence_link` field → `links[]` (decided on #1957, 9 Sep — see the GH-2267 plan's gap 5). Never a second field. */
+function mapEvidenceLinkToLinks(evidenceLink: string | null | undefined): FormationItemLink[] {
+  if (!evidenceLink || !isValidUrl(evidenceLink)) return [];
+  return [{ label: 'Evidence', href: evidenceLink }];
+}
+
+/**
+ * Shared by the fixture generator and the live checklist mapper — `sub_stage` has no direct
+ * upstream/fixture field of its own, only `ProjectStage`, so both paths derive it identically.
+ * Lives here rather than in `formation-fixture.helper.ts` so it isn't fixture-only.
+ */
+export function deriveFormationSubStage(stage: ProjectStage | string | undefined): FormationSubStage {
+  switch (stage) {
+    case ProjectStage.FormationExploratory:
+      return 'exploratory';
+    case ProjectStage.FormationOnHold:
+      return 'on_hold';
+    case ProjectStage.FormationEngaged:
+    default:
+      return 'engaged';
+  }
+}
+
+function mapSubItems(subItems: UpstreamFormationItem['sub_items']): FormationSubItem[] {
+  if (!subItems || subItems.length === 0) return [];
+  return subItems.map((subItem) => ({ uid: subItem.key, title: subItem.title, status: subItem.status }));
+}
+
+/**
+ * Maps one upstream item onto `FormationItem`. `can_complete` is always `false` here — every caller
+ * runs the result through `FormationService.enrichSingle`/`enrichItems` afterward, same as the
+ * fixture generator's own placeholder. `created_at`/`updated_at` have no upstream source on this
+ * path (unlike `Formation`'s equivalent gap, this one isn't raised upstream yet since nothing reads
+ * an item's own timestamps today) — the mapping time stands in rather than leaving the field
+ * `undefined`, since `FormationItem.created_at`/`updated_at` are non-optional.
+ */
+export function mapUpstreamFormationItem(raw: UpstreamFormationItem, ctx: FormationItemMapContext): FormationItem {
+  const now = new Date().toISOString();
+  return {
+    uid: raw.uid,
+    formation_uid: ctx.formationUid,
+    project_uid: ctx.projectUid,
+    template_item_key: raw.item_key,
+    section_key: raw.section_key,
+    section_title: TEMPLATE_SECTION_TITLES_BY_KEY.get(raw.section_key) ?? raw.section_key,
+    title: raw.title,
+    status: raw.status,
+    is_gating: raw.gate,
+    owner_team: raw.owner_team ?? TEMPLATE_ITEMS_BY_KEY.get(raw.item_key)?.owner_team ?? null,
+    owner: raw.assignee ? { username: raw.assignee, name: raw.assignee } : null,
+    due_date: raw.due_date ?? null,
+    action: deriveItemAction(raw),
+    action_href: resolveActionHref(raw.action_link, ctx.projectSlug),
+    detail: null,
+    notes: raw.note ?? null,
+    links: mapEvidenceLinkToLinks(raw.evidence_link),
+    sub_items: mapSubItems(raw.sub_items),
+    skip_reason: raw.skip_reason ?? null,
+    can_complete: false,
+    created_at: now,
+    updated_at: now,
+    version: raw.version,
+  };
+}
+
+/**
+ * Maps `GET /formations/{project_uid}`'s checklist-level fields onto `Formation`, given the
+ * project record already resolved for slug→uid (`ProjectService.getProjectById`) — the plan's
+ * "checklist read" §5: `parent_project_*`/`is_foundation`/`sub_stage`/`announcement_date` have no
+ * checklist-response source at all and come from the project record instead.
+ * `gating_items_open`/`gating_items_total`/`blocking_item_title`/`subtitle` are derived from
+ * `items` (already collapsed for ROOT and enriched by the caller), mirroring
+ * `FormationService.refreshFormationReadiness`'s fixture-era rollup so both data sources agree on
+ * what "activating" means. `Formation.uid` is left absent (gap 3 — raised upstream on #1957) and
+ * so are `created_at`/`updated_at` (same gap).
+ */
+export function mapUpstreamFormationChecklist(
+  raw: UpstreamFormationChecklist,
+  project: { slug: string; name: string; parent_uid: string | null | undefined },
+  collapsedParentUid: string | null,
+  subStage: Formation['sub_stage'],
+  announcementDate: string | null,
+  items: FormationItem[]
+): Formation {
+  const gatingItems = items.filter((item) => item.is_gating);
+  const openGatingItems = gatingItems.filter((item) => item.status !== 'done' && item.status !== 'skipped');
+  const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
+
+  return {
+    parent_project_uid: raw.project_uid,
+    parent_project_slug: project.slug,
+    parent_project_name: project.name,
+    is_foundation: !collapsedParentUid,
+    parent_uid: collapsedParentUid,
+    template_uid: raw.template_uid,
+    template_version: raw.template_version,
+    sub_stage: subStage,
+    announcement_date: announcementDate,
+    is_activating: raw.is_activating,
+    gating_items_open: openGatingItems.length,
+    gating_items_total: gatingItems.length,
+    blocking_item_title: blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null,
+    subtitle: null,
+  };
+}

--- a/apps/lfx-one/src/server/helpers/root-project.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/root-project.helper.spec.ts
@@ -1,0 +1,96 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { natsRequest, logger } = vi.hoisted(() => ({
+  natsRequest: vi.fn(),
+  logger: { warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), success: vi.fn(), startOperation: vi.fn(() => 0) },
+}));
+
+vi.mock('../services/logger.service', () => ({ logger }));
+
+import { NatsService } from '../services/nats.service';
+import { collapseRootParentUid, resetRootProjectUidCacheForTests, resolveRootProjectUid } from './root-project.helper';
+
+const req = {} as unknown as Request;
+
+// A trivial passthrough codec keeps encode/decode out of scope — these tests are about caching and
+// fail-closed behavior, not wire encoding.
+function buildNatsService(): NatsService {
+  return {
+    getCodec: () => ({ encode: (v: string) => v, decode: (v: unknown) => v as string }),
+    request: natsRequest,
+  } as unknown as NatsService;
+}
+
+describe('resolveRootProjectUid', () => {
+  let natsService: NatsService;
+
+  beforeEach(() => {
+    natsRequest.mockReset();
+    logger.warning.mockReset();
+    resetRootProjectUidCacheForTests();
+    natsService = buildNatsService();
+  });
+
+  it('resolves the ROOT slug to its uid', async () => {
+    natsRequest.mockResolvedValue({ data: 'uid-root' });
+
+    await expect(resolveRootProjectUid(req, natsService)).resolves.toBe('uid-root');
+  });
+
+  it('caches a resolved uid within the TTL, issuing only one NATS request', async () => {
+    natsRequest.mockResolvedValue({ data: 'uid-root' });
+
+    await resolveRootProjectUid(req, natsService);
+    await resolveRootProjectUid(req, natsService);
+
+    expect(natsRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-resolves after the cache is reset via the test hook', async () => {
+    natsRequest.mockResolvedValue({ data: 'uid-root' });
+    await resolveRootProjectUid(req, natsService);
+
+    resetRootProjectUidCacheForTests();
+    await resolveRootProjectUid(req, natsService);
+
+    expect(natsRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed to null on a NATS lookup failure, without caching the failure', async () => {
+    natsRequest.mockRejectedValueOnce(new Error('nats unavailable'));
+    await expect(resolveRootProjectUid(req, natsService)).resolves.toBeNull();
+    expect(logger.warning).toHaveBeenCalled();
+
+    natsRequest.mockResolvedValue({ data: 'uid-root' });
+    await expect(resolveRootProjectUid(req, natsService)).resolves.toBe('uid-root');
+    expect(natsRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed to null on an empty response, without caching the empty result', async () => {
+    natsRequest.mockResolvedValueOnce({ data: '' });
+    await expect(resolveRootProjectUid(req, natsService)).resolves.toBeNull();
+
+    natsRequest.mockResolvedValue({ data: 'uid-root' });
+    await expect(resolveRootProjectUid(req, natsService)).resolves.toBe('uid-root');
+    expect(natsRequest).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('collapseRootParentUid', () => {
+  it('collapses a parent_uid matching the resolved ROOT uid to null', () => {
+    expect(collapseRootParentUid('uid-root', 'uid-root')).toBeNull();
+  });
+
+  it('passes through a parent_uid that does not match ROOT', () => {
+    expect(collapseRootParentUid('uid-parent', 'uid-root')).toBe('uid-parent');
+  });
+
+  it('passes through unchanged when the ROOT uid could not be resolved', () => {
+    expect(collapseRootParentUid('uid-root', null)).toBe('uid-root');
+    expect(collapseRootParentUid(null, null)).toBeNull();
+  });
+});

--- a/apps/lfx-one/src/server/helpers/root-project.helper.ts
+++ b/apps/lfx-one/src/server/helpers/root-project.helper.ts
@@ -1,0 +1,84 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ROOT_PROJECT_SLUG, ROOT_PROJECT_UID_CACHE_TTL_MS } from '@lfx-one/shared/constants';
+import { NatsSubjects } from '@lfx-one/shared/enums';
+import { Request } from 'express';
+
+import { logger } from '../services/logger.service';
+import { NatsService } from '../services/nats.service';
+
+/**
+ * Single shared cache for the ROOT project's uid, keyed by nothing (there is exactly one ROOT
+ * project per environment). This is a deliberate, documented exception to this directory's
+ * "keep helpers pure — no shared mutable state" guideline (see `docs/architecture/backend/server-helpers.md`):
+ * the state is a pure, TTL-bounded memoization of a single well-known value, losing it costs one
+ * extra NATS round-trip rather than any correctness, and the alternative — every caller keeping
+ * its own copy of this cache, as `PersonaDetectionService` did before this extraction — is strictly
+ * worse (more NATS load, and two places that can disagree about the ROOT uid).
+ */
+let rootProjectUidCache: { uid: string | null; expiresAt: number } | null = null;
+
+/**
+ * Test-only escape hatch for the module-level cache above. Without this, the cache leaks across
+ * `it()` blocks in any spec exercising `resolveRootProjectUid` (directly or via
+ * `PersonaDetectionService`/`FormationService`): one test's successful resolution silently answers
+ * a later test that expects a fresh NATS lookup (e.g. one asserting fail-closed behavior on an
+ * empty/erroring response), since the cached value wins before the mock is ever consulted. Call
+ * this from `beforeEach` in any spec that mocks the NATS lookup this helper wraps.
+ */
+export function resetRootProjectUidCacheForTests(): void {
+  rootProjectUidCache = null;
+}
+
+/**
+ * Resolves the tenant's hidden ROOT project to its uid via the `PROJECT_SLUG_TO_UID` NATS lookup,
+ * caching the result for `ROOT_PROJECT_UID_CACHE_TTL_MS`. Fails closed to `null` on any lookup
+ * failure or empty response — callers that use this to collapse `parent_uid` must treat `null` as
+ * "could not resolve, leave the value as-is", never as "no parent". A `null` is never cached, so a
+ * transient NATS glitch doesn't disable ROOT resolution for the full TTL.
+ *
+ * Extracted from `PersonaDetectionService.resolveRootUid` (originally private, per-instance) so
+ * every consumer — persona detection's root-writer bypass checks, and the formation BFF's
+ * ROOT → `null` parent collapse — shares one resolution point and one cache instead of each
+ * keeping a separate copy that could disagree.
+ */
+export async function resolveRootProjectUid(req: Request, natsService: NatsService): Promise<string | null> {
+  if (rootProjectUidCache && Date.now() < rootProjectUidCache.expiresAt) {
+    return rootProjectUidCache.uid;
+  }
+
+  try {
+    const codec = natsService.getCodec();
+    const response = await natsService.request(NatsSubjects.PROJECT_SLUG_TO_UID, codec.encode(ROOT_PROJECT_SLUG), { timeout: 5000 });
+    const uid = codec.decode(response.data).trim();
+    if (!uid) {
+      // Don't cache empty responses — a transient glitch would disable bypass for ROOT_PROJECT_UID_CACHE_TTL_MS.
+      logger.warning(req, 'resolve_root_project_uid', 'ROOT slug resolved to empty UID', { slug: ROOT_PROJECT_SLUG });
+      return null;
+    }
+    rootProjectUidCache = { uid, expiresAt: Date.now() + ROOT_PROJECT_UID_CACHE_TTL_MS };
+    return uid;
+  } catch (error) {
+    logger.warning(req, 'resolve_root_project_uid', 'ROOT slug→UID NATS lookup failed', { err: error, slug: ROOT_PROJECT_SLUG });
+    return null;
+  }
+}
+
+/**
+ * Collapses a formation/project `parent_uid` that points at the hidden ROOT project to `null`,
+ * matching `Formation.parent_uid`'s documented contract (`null` for a top-level project) at
+ * `formation.interface.ts:61-82`. Upstream never collapses this itself — a top-level project's
+ * `parent_uid` is copied verbatim from the project service, which parents it to ROOT — so the BFF
+ * is the producer that has to do it.
+ *
+ * Fail-safe direction: if `rootUid` is `null` (ROOT couldn't be resolved), this returns `parentUid`
+ * unchanged rather than guessing. A missed collapse mislabels a row as `child_project`; a wrong
+ * collapse would hide real hierarchy, which is worse.
+ */
+export function collapseRootParentUid(parentUid: string | null | undefined, rootUid: string | null): string | null | undefined {
+  if (rootUid && parentUid === rootUid) {
+    return null;
+  }
+  return parentUid;
+}

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -20,7 +20,32 @@ import { describe, expect, it, vi } from 'vitest';
 // undefined -> string | undefined) is directly, exhaustively pinned by name.
 vi.mock('@lfx-one/shared/utils', () => ({}));
 
-import { getStringQueryParam } from './validation.helper';
+import { getStringQueryParam, validateItemKeyParameter } from './validation.helper';
+
+describe('validateItemKeyParameter', () => {
+  const req = {} as any;
+  const options = { operation: 'test_operation' };
+
+  it('accepts a snake_case item key', () => {
+    const next = vi.fn();
+    expect(validateItemKeyParameter('domain_dns', req, next, options)).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a hyphenated key shape (the pre-GH-2267 e2e fixture grammar) with a 400 validation error', () => {
+    const next = vi.fn();
+    expect(validateItemKeyParameter('domain-and-dns-transfer', req, next, options)).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+    const error = next.mock.calls[0][0];
+    expect(error.statusCode).toBe(400);
+  });
+
+  it('rejects a non-string value', () => {
+    const next = vi.fn();
+    expect(validateItemKeyParameter(undefined, req, next, options)).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('getStringQueryParam', () => {
   it('returns the string value for a plain query param', () => {

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -66,6 +66,28 @@ export function validateUidParameter(uid: unknown, req: Request, next: NextFunct
   return true;
 }
 
+/** `template_item_key` / upstream `item_key` shape — lowercase snake_case, matching every key in `FORMATION_TEMPLATE` (`formation-template.constants.ts`). */
+const ITEM_KEY_PATTERN = /^[a-z0-9_]{1,100}$/;
+
+/**
+ * Validates the `:itemKey` route parameter on the `(project_uid, item_key)`-addressed formation
+ * item routes (GH-2267 Phase 2) — the item-key counterpart to `validateUidParameter` above.
+ */
+export function validateItemKeyParameter(itemKey: unknown, req: Request, next: NextFunction, options: ValidationOptions): itemKey is string {
+  if (typeof itemKey !== 'string' || !ITEM_KEY_PATTERN.test(itemKey)) {
+    const validationError = ServiceValidationError.forField('item_key', 'A valid item key is required', {
+      operation: options.operation,
+      service: options.service || 'controller',
+      path: req.path,
+    });
+
+    next(validationError);
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Validates that an array parameter exists and is not empty
  * @param array The array to validate

--- a/apps/lfx-one/src/server/routes/formations.route.ts
+++ b/apps/lfx-one/src/server/routes/formations.route.ts
@@ -4,10 +4,13 @@
 import { Router } from 'express';
 
 import {
+  acceptFormationItem,
   completeFormationItem,
   getFormationItem,
   getFormationsQueue,
   getProjectFormation,
+  rejectFormationItem,
+  reopenFormationItem,
   requestFormationItem,
   skipFormationItem,
   updateFormationItem,
@@ -20,12 +23,20 @@ const router = Router();
 // Project-page checklist (GH-1958) — standard authenticated-user access, same as every other
 // `/api/projects/:slug/*` read. gate_writer is checked per-item inside the controller, not here.
 router.get('/projects/:slug/formation', getProjectFormation);
-router.get('/formation-items/:uid', getFormationItem);
-router.patch('/formation-items/:uid/complete', completeFormationItem);
-router.patch('/formation-items/:uid/skip', skipFormationItem);
-router.patch('/formation-items/:uid/request', requestFormationItem);
-router.patch('/formation-items/:uid/status', updateFormationItemStatus);
-router.patch('/formation-items/:uid', updateFormationItem);
+
+// Items are addressed by (project_uid, item_key), matching the real service's contract (GH-2267
+// Phase 2) — not by a bare item uid. `updateFormationItem`'s bare PATCH is registered LAST among
+// these routes: Express matches the first route whose path pattern fits, so registering it earlier
+// would shadow every sub-path below (`/complete`, `/skip`, etc.) since `:itemKey` alone matches them.
+router.get('/formations/:projectUid/items/:itemKey', getFormationItem);
+router.patch('/formations/:projectUid/items/:itemKey/complete', completeFormationItem);
+router.patch('/formations/:projectUid/items/:itemKey/skip', skipFormationItem);
+router.patch('/formations/:projectUid/items/:itemKey/request', requestFormationItem);
+router.patch('/formations/:projectUid/items/:itemKey/status', updateFormationItemStatus);
+router.post('/formations/:projectUid/items/:itemKey/accept', acceptFormationItem);
+router.post('/formations/:projectUid/items/:itemKey/reject', rejectFormationItem);
+router.post('/formations/:projectUid/items/:itemKey/reopen', reopenFormationItem);
+router.patch('/formations/:projectUid/items/:itemKey', updateFormationItem);
 
 // Formations queue (GH-1958) — LF-root-scoped, auditor-only.
 router.get('/formations', requireAuditor, getFormationsQueue);

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -352,9 +352,10 @@ app.use('/api/surveys', surveysRouter);
 app.use('/api/copilot', copilotRouter);
 app.use('/api/documents', documentsRouter);
 app.use('/api/events', eventsRouter);
-// Formation checklist + Formations queue (GH-1958) — router's own paths (/projects/:slug/formation,
-// /formation-items/:uid, /formations) don't share one resource prefix, so it's mounted bare at /api
-// rather than under a single resource segment like the routers above.
+// Formation checklist + Formations queue (GH-1958/GH-2267) — router's own paths
+// (/projects/:slug/formation, /formations/:projectUid/items/:itemKey, /formations) don't share one
+// resource prefix, so it's mounted bare at /api rather than under a single resource segment like the
+// routers above.
 app.use('/api', formationsRouter);
 app.use('/api/badges', badgesRouter);
 app.use('/api/campaigns', campaignsRouter);

--- a/apps/lfx-one/src/server/services/formation-store.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation-store.service.spec.ts
@@ -21,7 +21,10 @@ import {
 
 let counter = 0;
 
-function buildFormation(overrides: Partial<Formation> = {}): Formation {
+// Every fixture built here sets `uid` explicitly, unlike the checklist-read `Formation` the
+// optional-`uid` doc comment (formation.interface.ts) is scoped to — narrow the return type so
+// call sites below don't have to guard against the `undefined` that type allows in general.
+function buildFormation(overrides: Partial<Formation> = {}): Formation & { uid: string } {
   counter += 1;
   return {
     uid: `formation:store-test-${counter}`,
@@ -70,6 +73,7 @@ function buildItem(formationUid: string, overrides: Partial<FormationItem> = {})
     can_complete: false,
     created_at: '',
     updated_at: '',
+    version: 1,
     ...overrides,
   };
 }

--- a/apps/lfx-one/src/server/services/formation-store.service.ts
+++ b/apps/lfx-one/src/server/services/formation-store.service.ts
@@ -63,7 +63,11 @@ function evictOldestFormationIfOverCapacity(): void {
   activityStore.delete(oldestUid);
 }
 
-export function seedFormation(formation: Formation, items: FormationItem[]): void {
+// The store is keyed by `formation.uid` — a checklist-read `Formation` never reaches this store
+// without one being assigned first (the checklist path's fixture generator always sets it; see
+// `Formation.uid`'s doc comment for the one read path that omits it). Both write entry points below
+// narrow the param type accordingly rather than guarding a case that can't happen here.
+export function seedFormation(formation: Formation & { uid: string }, items: FormationItem[]): void {
   if (!formationStore.has(formation.uid)) {
     formationStore.set(formation.uid, formation);
     evictOldestFormationIfOverCapacity();
@@ -100,7 +104,7 @@ export function putStoredItem(item: FormationItem): void {
   indexItem(item);
 }
 
-export function putStoredFormation(formation: Formation): void {
+export function putStoredFormation(formation: Formation & { uid: string }): void {
   const isNew = !formationStore.has(formation.uid);
   formationStore.set(formation.uid, formation);
   // A queue-sourced formation (declineFormation) never goes through seedFormation, so the cap must

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -715,6 +715,34 @@ describe('FormationService', () => {
       expect(postCall![6]).toEqual({ 'If-Match': '3' });
     });
 
+    it("acceptFormationItem preserves the item's existing note when the caller supplies none", async () => {
+      const item = rawItem({ status: 'awaiting_acceptance', gate: true, note: 'existing note' });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'POST') return Promise.resolve({ ...item, status: 'done', version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      await service.acceptFormationItem(buildReq(), 'live-project-1', 'item-key-1');
+
+      const postCall = proxyRequest.mock.calls.find((call) => call[3] === 'POST');
+      expect(postCall![5]).toEqual({ note: 'existing note' });
+    });
+
+    it("reopenFormationItem preserves the item's existing note when the caller supplies none", async () => {
+      const item = rawItem({ status: 'done', gate: false, note: 'existing note' });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'POST') return Promise.resolve({ ...item, status: 'in_progress', version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      await service.reopenFormationItem(buildReq(), 'live-project-1', 'item-key-1');
+
+      const postCall = proxyRequest.mock.calls.find((call) => call[3] === 'POST');
+      expect(postCall![5]).toEqual({ note: 'existing note' });
+    });
+
     it('clears note/assignee/due_date with empty strings, not null', async () => {
       const item = rawItem({ status: 'in_progress', note: 'old note', assignee: 'sam.chen', due_date: '2026-01-01' });
       proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -3,13 +3,12 @@
 
 import '@angular/compiler';
 
-import type { Formation, FormationItem, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import type { Formation, FormationItem, QueryServiceResponse, UpstreamFormationChecklist, UpstreamFormationItem } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MicroserviceError } from '../errors/microservice.error';
-import type { UpstreamFormationChecklist, UpstreamFormationItem } from '../helpers/formation-mapper.helper';
 
 const getProjectById = vi.fn();
 const getProjectIdBySlug = vi.fn();
@@ -40,8 +39,8 @@ vi.mock('./logger.service', () => ({
 }));
 // NatsService only backs resolveRootProjectUid's ROOT slug->uid lookup here (GH-2267 Phase 4). No
 // test in this file exercises the ROOT-collapse branch itself, so a resolved-but-empty response is
-// enough to keep every call fast and keep collapseRootParentUid a no-op — see root-project.helper.ts's
-// dedicated spec for the collapse logic itself.
+// enough to keep every call fast and keep collapseRootParentUid a no-op. `root-project.helper.ts`
+// has no dedicated spec yet — the collapse logic is only exercised indirectly through here.
 vi.mock('./nats.service', () => ({
   NatsService: vi.fn().mockImplementation(() => ({
     getCodec: () => ({
@@ -642,7 +641,7 @@ describe('FormationService', () => {
       title: 'Some item',
       gate: false,
       requires_writer: false,
-      status_source: 'user',
+      status_source: 'manual',
       is_required: true,
       checklist_type: 'manual',
       status: 'awaiting_acceptance',

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -3,14 +3,20 @@
 
 import '@angular/compiler';
 
-import type { Formation, FormationItem } from '@lfx-one/shared/interfaces';
+import type { Formation, FormationItem, QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MicroserviceError } from '../errors/microservice.error';
+import type { UpstreamFormationChecklist, UpstreamFormationItem } from '../helpers/formation-mapper.helper';
+
 const getProjectById = vi.fn();
 const getProjectIdBySlug = vi.fn();
 const canComplete = vi.fn();
+const natsRequest = vi.fn();
+const proxyRequest = vi.fn();
+const isFormationServiceLive = vi.fn(() => false);
 
 vi.mock('./project.service', () => ({
   ProjectService: class {
@@ -18,22 +24,44 @@ vi.mock('./project.service', () => ({
     public getProjectIdBySlug = getProjectIdBySlug;
   },
 }));
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = (...args: unknown[]) => proxyRequest(...args);
+  },
+}));
+vi.mock('../helpers/formation-backend.helper', () => ({
+  isFormationServiceLive: () => isFormationServiceLive(),
+}));
 vi.mock('./formation-item-access.service', () => ({
   formationItemAccessService: { canComplete: (...args: unknown[]) => canComplete(...args) },
 }));
 vi.mock('./logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
+// NatsService only backs resolveRootProjectUid's ROOT slug->uid lookup here (GH-2267 Phase 4). No
+// test in this file exercises the ROOT-collapse branch itself, so a resolved-but-empty response is
+// enough to keep every call fast and keep collapseRootParentUid a no-op — see root-project.helper.ts's
+// dedicated spec for the collapse logic itself.
+vi.mock('./nats.service', () => ({
+  NatsService: vi.fn().mockImplementation(() => ({
+    getCodec: () => ({
+      encode: (v: string) => v,
+      decode: (v: unknown) => v as string,
+    }),
+    request: natsRequest,
+  })),
+}));
 
 const { FormationService } = await import('./formation.service');
 const { seedFormation, putStoredFormation, putStoredItem, getStoredItem, getStoredFormation, getActivityForItem, resetFormationStoreForTests } =
   await import('./formation-store.service');
 const { STATIC_QUEUE_FORMATIONS } = await import('../helpers/formation-fixture.helper');
+const { resetRootProjectUidCacheForTests } = await import('../helpers/root-project.helper');
 const { logger } = await import('./logger.service');
 
 let uidCounter = 0;
 
-function buildFormation(overrides: Partial<Formation> = {}): Formation {
+function buildFormation(overrides: Partial<Formation> = {}): Formation & { uid: string } {
   uidCounter += 1;
   const uid = overrides.uid ?? `formation:test-${uidCounter}`;
   return {
@@ -58,13 +86,21 @@ function buildFormation(overrides: Partial<Formation> = {}): Formation {
   };
 }
 
+/**
+ * The default `uid` matches `FormationService.itemUidFor(project_uid, template_item_key)`'s
+ * `formation-item:<project_uid>:<item_key>` scheme (GH-2267 Phase 2) — the store is still keyed by
+ * that derived uid, and every service method below now addresses items by `(project_uid, item_key)`
+ * rather than by uid, so a caller that doesn't line the two up would silently miss the store.
+ */
 function buildItem(formationUid: string, overrides: Partial<FormationItem> = {}): FormationItem {
   uidCounter += 1;
+  const projectUid = overrides.project_uid ?? `project-${uidCounter}`;
+  const templateItemKey = overrides.template_item_key ?? 'some-key';
   return {
-    uid: overrides.uid ?? `formation-item:test-${uidCounter}`,
+    uid: overrides.uid ?? `formation-item:${projectUid}:${templateItemKey}`,
     formation_uid: formationUid,
-    project_uid: `project-${uidCounter}`,
-    template_item_key: 'some-key',
+    project_uid: projectUid,
+    template_item_key: templateItemKey,
     section_key: 'section',
     section_title: 'Section',
     title: 'Some item',
@@ -83,16 +119,17 @@ function buildItem(formationUid: string, overrides: Partial<FormationItem> = {})
     can_complete: false,
     created_at: '',
     updated_at: '',
+    version: 1,
     ...overrides,
   };
 }
 
 function buildReq(): Request {
-  return { path: '/api/formation-items/x' } as unknown as Request;
+  return { path: '/api/formations/x/items/y' } as unknown as Request;
 }
 
 /** Seeds a formation + item and returns both, for tests that don't care about the specific uids. */
-function seedItem(itemOverrides: Partial<FormationItem> = {}): { formation: Formation; item: FormationItem } {
+function seedItem(itemOverrides: Partial<FormationItem> = {}): { formation: Formation & { uid: string }; item: FormationItem } {
   const formation = buildFormation();
   const item = buildItem(formation.uid, itemOverrides);
   seedFormation(formation, [item]);
@@ -108,6 +145,12 @@ describe('FormationService', () => {
     getProjectIdBySlug.mockReset();
     canComplete.mockReset();
     vi.mocked(logger.info).mockClear();
+    natsRequest.mockReset();
+    natsRequest.mockResolvedValue({ data: '' });
+    resetRootProjectUidCacheForTests();
+    proxyRequest.mockReset();
+    isFormationServiceLive.mockReset();
+    isFormationServiceLive.mockReturnValue(false);
   });
 
   describe('getProjectFormation', () => {
@@ -154,7 +197,9 @@ describe('FormationService', () => {
 
       const first = await service.getProjectFormation(buildReq(), 'test-project-2');
       const targetItem = first.items[0];
-      putStoredFormation(first.formation);
+      // The fixture path always sets `formation.uid` (see generateMockFormation) — the checklist
+      // response type just doesn't guarantee it, since the real read path can't source it.
+      putStoredFormation(first.formation as Formation & { uid: string });
       // Mutated directly through the store (not a service mutation method) — this test only needs to
       // prove getProjectFormation reads the store, not that a mutation method writes to it correctly.
       const mutated: FormationItem = { ...getStoredItem(targetItem.uid)!, notes: 'mutated' };
@@ -172,7 +217,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({});
       canComplete.mockResolvedValue(true);
 
-      const result = await service.getFormationItemDetail(buildReq(), item.uid);
+      const result = await service.getFormationItemDetail(buildReq(), item.project_uid, item.template_item_key);
 
       expect(result.item.uid).toBe(item.uid);
       expect(result.item.can_complete).toBe(true);
@@ -182,13 +227,13 @@ describe('FormationService', () => {
 
   describe('getFormationItemOrThrow — project-scoped read access', () => {
     it("resolves the item only after the caller's own bearer token can read the parent project", async () => {
-      const { formation, item } = seedItem();
+      const { item } = seedItem();
       getProjectById.mockResolvedValue({});
 
-      const result = await service.getFormationItemOrThrow(buildReq(), item.uid);
+      const result = await service.getFormationItemOrThrow(buildReq(), item.project_uid, item.template_item_key);
 
       expect(result.uid).toBe(item.uid);
-      expect(getProjectById).toHaveBeenCalledWith(expect.anything(), formation.parent_project_uid, false);
+      expect(getProjectById).toHaveBeenCalledWith(expect.anything(), item.project_uid, false);
     });
 
     it('denies with the same "not found" shape as a missing uid, rather than returning item data, for a project the caller cannot see', async () => {
@@ -197,24 +242,25 @@ describe('FormationService', () => {
 
       // The upstream cause is deliberately not leaked in the thrown error — see assertItemProjectAccess's
       // doc comment (differentiating "doesn't exist" from "exists but denied" is an enumeration oracle).
-      await expect(service.getFormationItemOrThrow(buildReq(), item.uid)).rejects.toThrow(/not found/i);
+      await expect(service.getFormationItemOrThrow(buildReq(), item.project_uid, item.template_item_key)).rejects.toThrow(/not found/i);
     });
 
-    it('throws ResourceNotFoundError for an item uid that was never seeded, without calling the project check', async () => {
-      await expect(service.getFormationItemOrThrow(buildReq(), 'formation-item:does-not-exist')).rejects.toThrow();
+    it('throws ResourceNotFoundError for an item key that was never seeded, without calling the project check', async () => {
+      await expect(service.getFormationItemOrThrow(buildReq(), 'does-not-exist-project', 'does-not-exist-key')).rejects.toThrow();
       expect(getProjectById).not.toHaveBeenCalled();
     });
 
-    it('gives the same uid the identical error message whether it was never seeded or exists but is denied — no enumeration oracle', async () => {
-      const sharedUid = 'formation-item:shared-uid';
+    it('gives the same address the identical error message whether it was never seeded or exists but is denied — no enumeration oracle', async () => {
+      const sharedProjectUid = 'shared-project';
+      const sharedItemKey = 'shared-item';
 
-      const unseeded = await service.getFormationItemOrThrow(buildReq(), sharedUid).catch((error: Error) => error);
+      const unseeded = await service.getFormationItemOrThrow(buildReq(), sharedProjectUid, sharedItemKey).catch((error: Error) => error);
 
-      const formation = buildFormation();
-      const item = buildItem(formation.uid, { uid: sharedUid });
+      const formation = buildFormation({ parent_project_uid: sharedProjectUid });
+      const item = buildItem(formation.uid, { project_uid: sharedProjectUid, template_item_key: sharedItemKey });
       seedFormation(formation, [item]);
       getProjectById.mockRejectedValue(new Error('upstream 403'));
-      const denied = await service.getFormationItemOrThrow(buildReq(), sharedUid).catch((error: Error) => error);
+      const denied = await service.getFormationItemOrThrow(buildReq(), sharedProjectUid, sharedItemKey).catch((error: Error) => error);
 
       expect((unseeded as Error).message).toBe((denied as Error).message);
     });
@@ -222,16 +268,30 @@ describe('FormationService', () => {
 
   describe('project write access — complete/skip/request/update all require it', () => {
     it.each([
-      ['completeFormationItem', (s: InstanceType<typeof FormationService>, req: Request, uid: string) => s.completeFormationItem(req, uid)],
-      ['skipFormationItem', (s: InstanceType<typeof FormationService>, req: Request, uid: string) => s.skipFormationItem(req, uid, 'a reason')],
-      ['requestFormationItem', (s: InstanceType<typeof FormationService>, req: Request, uid: string) => s.requestFormationItem(req, uid)],
-      ['updateFormationItem', (s: InstanceType<typeof FormationService>, req: Request, uid: string) => s.updateFormationItem(req, uid, { notes: 'x' })],
+      [
+        'completeFormationItem',
+        (s: InstanceType<typeof FormationService>, req: Request, projectUid: string, itemKey: string) => s.completeFormationItem(req, projectUid, itemKey),
+      ],
+      [
+        'skipFormationItem',
+        (s: InstanceType<typeof FormationService>, req: Request, projectUid: string, itemKey: string) =>
+          s.skipFormationItem(req, projectUid, itemKey, 'a reason'),
+      ],
+      [
+        'requestFormationItem',
+        (s: InstanceType<typeof FormationService>, req: Request, projectUid: string, itemKey: string) => s.requestFormationItem(req, projectUid, itemKey),
+      ],
+      [
+        'updateFormationItem',
+        (s: InstanceType<typeof FormationService>, req: Request, projectUid: string, itemKey: string) =>
+          s.updateFormationItem(req, projectUid, itemKey, { notes: 'x' }),
+      ],
     ])('%s rejects a project viewer who is not a writer', async (_name, call) => {
       const { item } = seedItem({ is_gating: false, action: 'request' });
       getProjectById.mockResolvedValue({ writer: false });
       canComplete.mockResolvedValue(true);
 
-      await expect(call(service, buildReq(), item.uid)).rejects.toThrow(/write access/i);
+      await expect(call(service, buildReq(), item.project_uid, item.template_item_key)).rejects.toThrow(/write access/i);
       expect(getStoredItem(item.uid)?.status).toBe('not_started');
     });
 
@@ -240,7 +300,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      await service.completeFormationItem(buildReq(), item.uid);
+      await service.completeFormationItem(buildReq(), item.project_uid, item.template_item_key);
 
       expect(getProjectById).toHaveBeenCalledWith(expect.anything(), expect.anything(), true);
     });
@@ -252,7 +312,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(false);
 
-      const result = await service.completeFormationItem(buildReq(), item.uid);
+      const result = await service.completeFormationItem(buildReq(), item.project_uid, item.template_item_key);
 
       expect(result.status).toBe('awaiting_acceptance');
       expect(getStoredItem(item.uid)?.status).toBe('awaiting_acceptance');
@@ -263,7 +323,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(false);
 
-      await expect(service.skipFormationItem(buildReq(), item.uid, 'blocked upstream')).rejects.toThrow(/gate_writer/i);
+      await expect(service.skipFormationItem(buildReq(), item.project_uid, item.template_item_key, 'blocked upstream')).rejects.toThrow(/gate_writer/i);
     });
 
     it('requestFormationItem rejects a gating item when canComplete denies — closes the complete/skip bypass via request', async () => {
@@ -271,7 +331,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(false);
 
-      await expect(service.requestFormationItem(buildReq(), item.uid)).rejects.toThrow(/gate_writer/i);
+      await expect(service.requestFormationItem(buildReq(), item.project_uid, item.template_item_key)).rejects.toThrow(/gate_writer/i);
       expect(getStoredItem(item.uid)?.status).toBe('not_started');
     });
 
@@ -280,7 +340,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      const result = await service.completeFormationItem(buildReq(), item.uid);
+      const result = await service.completeFormationItem(buildReq(), item.project_uid, item.template_item_key);
 
       expect(result.status).toBe('done');
       expect(getStoredItem(item.uid)?.status).toBe('done');
@@ -291,7 +351,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      await service.requestFormationItem(buildReq(), item.uid);
+      await service.requestFormationItem(buildReq(), item.project_uid, item.template_item_key);
 
       expect(getStoredFormation(formation.uid)?.gating_items_open).toBe(1);
     });
@@ -301,11 +361,11 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      await service.completeFormationItem(buildReq(), item.uid);
+      await service.completeFormationItem(buildReq(), item.project_uid, item.template_item_key);
       expect(getStoredFormation(formation.uid)?.is_activating).toBe(true);
       expect(getStoredFormation(formation.uid)?.sub_stage).toBe('engaged');
 
-      await service.requestFormationItem(buildReq(), item.uid);
+      await service.requestFormationItem(buildReq(), item.project_uid, item.template_item_key);
       expect(getStoredFormation(formation.uid)?.is_activating).toBe(false);
       expect(getStoredFormation(formation.uid)?.sub_stage).toBe('engaged');
     });
@@ -315,7 +375,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      await service.requestFormationItem(buildReq(), item.uid);
+      await service.requestFormationItem(buildReq(), item.project_uid, item.template_item_key);
 
       expect(getStoredItem(item.uid)?.status).toBe('blocked');
       expect(getStoredFormation(formation.uid)?.blocking_item_title).toBe('Some item');
@@ -327,7 +387,7 @@ describe('FormationService', () => {
       const { formation, item } = seedItem({ notes: 'pre-existing note from the drawer' });
       getProjectById.mockResolvedValue({ writer: true });
 
-      const result = await service.updateFormationItemStatus(buildReq(), item.uid, 'blocked', 'waiting on legal');
+      const result = await service.updateFormationItemStatus(buildReq(), item.project_uid, item.template_item_key, 'blocked', 'waiting on legal');
 
       expect(result.notes).toBe('pre-existing note from the drawer');
       expect(getStoredItem(item.uid)?.notes).toBe('pre-existing note from the drawer');
@@ -340,7 +400,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(false);
 
-      await expect(service.updateFormationItemStatus(buildReq(), item.uid, 'not_started')).rejects.toThrow(/gate_writer/i);
+      await expect(service.updateFormationItemStatus(buildReq(), item.project_uid, item.template_item_key, 'not_started')).rejects.toThrow(/gate_writer/i);
       expect(getStoredItem(item.uid)?.status).toBe('done');
     });
 
@@ -349,7 +409,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(false);
 
-      await expect(service.updateFormationItemStatus(buildReq(), item.uid, 'in_progress')).rejects.toThrow(/gate_writer/i);
+      await expect(service.updateFormationItemStatus(buildReq(), item.project_uid, item.template_item_key, 'in_progress')).rejects.toThrow(/gate_writer/i);
       expect(getStoredItem(item.uid)?.status).toBe('awaiting_acceptance');
     });
 
@@ -358,7 +418,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      const result = await service.updateFormationItemStatus(buildReq(), item.uid, 'not_started');
+      const result = await service.updateFormationItemStatus(buildReq(), item.project_uid, item.template_item_key, 'not_started');
 
       expect(result.status).toBe('not_started');
     });
@@ -368,7 +428,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(false);
 
-      const result = await service.updateFormationItemStatus(buildReq(), item.uid, 'not_started');
+      const result = await service.updateFormationItemStatus(buildReq(), item.project_uid, item.template_item_key, 'not_started');
 
       expect(result.status).toBe('not_started');
     });
@@ -376,17 +436,17 @@ describe('FormationService', () => {
 
   describe('skipFormationItem — reason required', () => {
     it('rejects an empty/whitespace-only reason before even resolving the item', async () => {
-      await expect(service.skipFormationItem(buildReq(), 'formation-item:whatever', '   ')).rejects.toThrow(/reason/i);
+      await expect(service.skipFormationItem(buildReq(), 'project-x', 'item-x', '   ')).rejects.toThrow(/reason/i);
       expect(getProjectById).not.toHaveBeenCalled();
     });
 
     it('rejects a non-string reason instead of throwing a raw TypeError from .trim()', async () => {
-      await expect(service.skipFormationItem(buildReq(), 'formation-item:whatever', { not: 'a string' })).rejects.toThrow(/reason/i);
+      await expect(service.skipFormationItem(buildReq(), 'project-x', 'item-x', { not: 'a string' })).rejects.toThrow(/reason/i);
       expect(getProjectById).not.toHaveBeenCalled();
     });
 
     it('rejects a reason over 2000 characters', async () => {
-      await expect(service.skipFormationItem(buildReq(), 'formation-item:whatever', 'x'.repeat(2001))).rejects.toThrow(/reason/i);
+      await expect(service.skipFormationItem(buildReq(), 'project-x', 'item-x', 'x'.repeat(2001))).rejects.toThrow(/reason/i);
       expect(getProjectById).not.toHaveBeenCalled();
     });
 
@@ -395,7 +455,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
       canComplete.mockResolvedValue(true);
 
-      await service.skipFormationItem(buildReq(), item.uid, 'a sensitive skip justification');
+      await service.skipFormationItem(buildReq(), item.project_uid, item.template_item_key, 'a sensitive skip justification');
 
       const infoCalls = vi.mocked(logger.info).mock.calls;
       // Anchor on the call actually existing — otherwise a logger.info() that fired zero times
@@ -407,26 +467,26 @@ describe('FormationService', () => {
 
   describe('completeFormationItem — notes validation', () => {
     it('rejects a non-string notes value', async () => {
-      await expect(service.completeFormationItem(buildReq(), 'formation-item:whatever', { not: 'a string' })).rejects.toThrow(/notes/i);
+      await expect(service.completeFormationItem(buildReq(), 'project-x', 'item-x', { not: 'a string' })).rejects.toThrow(/notes/i);
       expect(getProjectById).not.toHaveBeenCalled();
     });
 
     it('rejects notes over 2000 characters', async () => {
-      await expect(service.completeFormationItem(buildReq(), 'formation-item:whatever', 'x'.repeat(2001))).rejects.toThrow(/notes/i);
+      await expect(service.completeFormationItem(buildReq(), 'project-x', 'item-x', 'x'.repeat(2001))).rejects.toThrow(/notes/i);
     });
   });
 
   describe('updateFormationItem — validation', () => {
     it('rejects a non-string notes value', async () => {
-      await expect(service.updateFormationItem(buildReq(), 'formation-item:whatever', { notes: 123 as unknown as string })).rejects.toThrow(/notes/i);
+      await expect(service.updateFormationItem(buildReq(), 'project-x', 'item-x', { notes: 123 as unknown as string })).rejects.toThrow(/notes/i);
     });
 
     it('rejects an invalid due_date', async () => {
-      await expect(service.updateFormationItem(buildReq(), 'formation-item:whatever', { due_date: 'not-a-date' })).rejects.toThrow(/due_date/i);
+      await expect(service.updateFormationItem(buildReq(), 'project-x', 'item-x', { due_date: 'not-a-date' })).rejects.toThrow(/due_date/i);
     });
 
     it('rejects a non-string due_date (e.g. an array from a malformed body)', async () => {
-      await expect(service.updateFormationItem(buildReq(), 'formation-item:whatever', { due_date: ['2026-01-01'] as unknown as string })).rejects.toThrow(
+      await expect(service.updateFormationItem(buildReq(), 'project-x', 'item-x', { due_date: ['2026-01-01'] as unknown as string })).rejects.toThrow(
         /due_date/i
       );
     });
@@ -436,7 +496,10 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
 
       const before = getActivityForItem(formation.uid, item.uid).length;
-      const result = await service.updateFormationItem(buildReq(), item.uid, { notes: '', due_date: '2026-06-01T00:00:00.000Z' });
+      const result = await service.updateFormationItem(buildReq(), item.project_uid, item.template_item_key, {
+        notes: '',
+        due_date: '2026-06-01T00:00:00.000Z',
+      });
 
       expect(result.notes).toBeNull();
       expect(getActivityForItem(formation.uid, item.uid)).toHaveLength(before + 1);
@@ -448,7 +511,7 @@ describe('FormationService', () => {
       const { formation, item } = seedItem({ notes: null });
       getProjectById.mockResolvedValue({ writer: true });
 
-      const result = await service.updateFormationItem(buildReq(), item.uid, { notes: 'blocked on legal review' });
+      const result = await service.updateFormationItem(buildReq(), item.project_uid, item.template_item_key, { notes: 'blocked on legal review' });
 
       expect(result.notes).toBe('blocked on legal review');
       expect(getActivityForItem(formation.uid, item.uid).some((activity) => activity.type === 'note_added')).toBe(true);
@@ -459,7 +522,7 @@ describe('FormationService', () => {
       getProjectById.mockResolvedValue({ writer: true });
 
       const before = getActivityForItem(formation.uid, item.uid).length;
-      const result = await service.updateFormationItem(buildReq(), item.uid, { owner_username: 'alex.rivera' });
+      const result = await service.updateFormationItem(buildReq(), item.project_uid, item.template_item_key, { owner_username: 'alex.rivera' });
 
       expect(result.owner?.username).toBe('alex.rivera');
       expect(getActivityForItem(formation.uid, item.uid)).toHaveLength(before);
@@ -470,9 +533,72 @@ describe('FormationService', () => {
       const { formation, item } = seedItem({ owner: null });
       getProjectById.mockResolvedValue({ writer: true });
 
-      await service.updateFormationItem(buildReq(), item.uid, { owner_username: 'sam.chen' });
+      await service.updateFormationItem(buildReq(), item.project_uid, item.template_item_key, { owner_username: 'sam.chen' });
 
       expect(getActivityForItem(formation.uid, item.uid).some((activity) => activity.type === 'assignee_changed')).toBe(true);
+    });
+  });
+
+  describe('acceptFormationItem / rejectFormationItem / reopenFormationItem', () => {
+    it('acceptFormationItem moves an awaiting_acceptance item to done', async () => {
+      const { item } = seedItem({ is_gating: true, status: 'awaiting_acceptance' });
+      getProjectById.mockResolvedValue({ writer: true });
+      canComplete.mockResolvedValue(true);
+
+      const result = await service.acceptFormationItem(buildReq(), item.project_uid, item.template_item_key);
+
+      expect(result.status).toBe('done');
+      expect(getStoredItem(item.uid)?.status).toBe('done');
+    });
+
+    it('acceptFormationItem rejects an item that is not awaiting acceptance', async () => {
+      const { item } = seedItem({ status: 'in_progress' });
+      getProjectById.mockResolvedValue({ writer: true });
+
+      await expect(service.acceptFormationItem(buildReq(), item.project_uid, item.template_item_key)).rejects.toThrow(/status/i);
+    });
+
+    it('rejectFormationItem requires a non-empty note and sends the item back to in_progress', async () => {
+      const { item } = seedItem({ is_gating: true, status: 'awaiting_acceptance' });
+      getProjectById.mockResolvedValue({ writer: true });
+      canComplete.mockResolvedValue(true);
+
+      await expect(service.rejectFormationItem(buildReq(), item.project_uid, item.template_item_key, '')).rejects.toThrow(/reason/i);
+
+      const result = await service.rejectFormationItem(buildReq(), item.project_uid, item.template_item_key, 'missing evidence');
+
+      expect(result.status).toBe('in_progress');
+      expect(getStoredItem(item.uid)?.status).toBe('in_progress');
+    });
+
+    it('reopenFormationItem moves a done item back to in_progress and clears skip_reason', async () => {
+      const { item } = seedItem({ is_gating: true, status: 'done' });
+      getProjectById.mockResolvedValue({ writer: true });
+      canComplete.mockResolvedValue(true);
+
+      const result = await service.reopenFormationItem(buildReq(), item.project_uid, item.template_item_key);
+
+      expect(result.status).toBe('in_progress');
+      expect(getStoredItem(item.uid)?.skip_reason).toBeNull();
+    });
+
+    it('reopenFormationItem rejects an item that is not done, skipped, or awaiting acceptance', async () => {
+      const { item } = seedItem({ status: 'not_started' });
+      getProjectById.mockResolvedValue({ writer: true });
+
+      await expect(service.reopenFormationItem(buildReq(), item.project_uid, item.template_item_key)).rejects.toThrow(/status/i);
+    });
+
+    it('accept/reject/reopen all honor the gate_writer gate', async () => {
+      const { item: acceptItem } = seedItem({ is_gating: true, status: 'awaiting_acceptance' });
+      getProjectById.mockResolvedValue({ writer: true });
+      canComplete.mockResolvedValue(false);
+
+      await expect(service.acceptFormationItem(buildReq(), acceptItem.project_uid, acceptItem.template_item_key)).rejects.toThrow(/gate_writer/i);
+      await expect(service.rejectFormationItem(buildReq(), acceptItem.project_uid, acceptItem.template_item_key, 'a note')).rejects.toThrow(/gate_writer/i);
+
+      const { item: reopenItem } = seedItem({ is_gating: true, status: 'done' });
+      await expect(service.reopenFormationItem(buildReq(), reopenItem.project_uid, reopenItem.template_item_key)).rejects.toThrow(/gate_writer/i);
     });
   });
 
@@ -488,7 +614,7 @@ describe('FormationService', () => {
       const result = await service.getFormationsQueue(buildReq(), undefined, 'CASCADE');
 
       expect(result.rows.length).toBeGreaterThan(0);
-      expect(result.rows.every((row) => row.parent_project_name.toLowerCase().includes('cascade'))).toBe(true);
+      expect(result.rows.every((row) => row.project_name.toLowerCase().includes('cascade'))).toBe(true);
     });
 
     it('returns unfiltered rows plus tiles when called with no filters', async () => {
@@ -504,6 +630,116 @@ describe('FormationService', () => {
       const result = await service.getFormationsQueue(buildReq());
 
       expect(result.tiles.foundations + result.tiles.projects).toBe(result.tiles.total);
+    });
+  });
+
+  describe('live mode (isFormationServiceLive)', () => {
+    const rawItem = (overrides: Partial<UpstreamFormationItem> = {}): UpstreamFormationItem => ({
+      uid: 'formation-item:live-project-1:item-key-1',
+      item_key: 'item-key-1',
+      section_key: 'section-1',
+      position: 1,
+      title: 'Some item',
+      gate: false,
+      requires_writer: false,
+      status_source: 'user',
+      is_required: true,
+      checklist_type: 'manual',
+      status: 'awaiting_acceptance',
+      version: 3,
+      ...overrides,
+    });
+
+    const checklist = (items: UpstreamFormationItem[]): UpstreamFormationChecklist => ({
+      project_uid: 'live-project-1',
+      template_uid: 'template-1',
+      template_version: 1,
+      lifecycle: 'formation',
+      sections: [{ key: 'section-1', title: 'Section', position: 1 }],
+      items,
+      is_activating: false,
+    });
+
+    beforeEach(() => {
+      isFormationServiceLive.mockReturnValue(true);
+      getProjectById.mockResolvedValue({ slug: 'live-project', name: 'Live Project', parent_uid: null, writer: true });
+      canComplete.mockResolvedValue(true);
+    });
+
+    it('completeFormationItem reads the checklist, PATCHes with If-Match, and maps the response', async () => {
+      const item = rawItem({ status: 'in_progress', is_required: true, gate: true });
+      proxyRequest.mockImplementation((_req, _service, path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'PATCH') return Promise.resolve({ ...item, status: 'done', version: 4 });
+        throw new Error(`unexpected call: ${method} ${path}`);
+      });
+
+      const result = await service.completeFormationItem(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.status).toBe('done');
+      expect(result.version).toBe(4);
+
+      const patchCall = proxyRequest.mock.calls.find((call) => call[3] === 'PATCH');
+      expect(patchCall).toBeDefined();
+      expect(patchCall![2]).toBe('/formations/live-project-1/items/item-key-1');
+      expect(patchCall![6]).toEqual({ 'If-Match': '3' });
+    });
+
+    it('maps a 412 from a live mutation to PreconditionFailedError', async () => {
+      const item = rawItem({ status: 'in_progress', gate: true });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'PATCH') {
+          return Promise.reject(new MicroserviceError('stale version', 412, 'PRECONDITION_FAILED', { errorBody: { message: 'version_mismatch' } }));
+        }
+        throw new Error('unexpected call');
+      });
+
+      await expect(service.completeFormationItem(buildReq(), 'live-project-1', 'item-key-1')).rejects.toMatchObject({ statusCode: 412 });
+    });
+
+    it('acceptFormationItem POSTs to /accept with If-Match', async () => {
+      const item = rawItem({ status: 'awaiting_acceptance', gate: true });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'POST') return Promise.resolve({ ...item, status: 'done', version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      const result = await service.acceptFormationItem(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.status).toBe('done');
+      const postCall = proxyRequest.mock.calls.find((call) => call[3] === 'POST');
+      expect(postCall).toBeDefined();
+      expect(postCall![2]).toBe('/formations/live-project-1/items/item-key-1/accept');
+      expect(postCall![6]).toEqual({ 'If-Match': '3' });
+    });
+
+    it('getFormationsQueue reads from the query service and collapses ROOT into null', async () => {
+      const row = {
+        formation_uid: 'formation:live-project-1',
+        project_uid: 'live-project-1',
+        project_name: 'Live Project',
+        project_slug: 'live-project',
+        is_foundation: false,
+        parent_uid: null,
+        sub_stage: 'engaged' as const,
+        lifecycle: 'formation',
+        gates_cleared: false,
+        is_activating: false,
+        announcement_date: null,
+        progress: {},
+        blocked_item_titles: [],
+        assignees: [],
+      };
+      proxyRequest.mockResolvedValue({ resources: [{ type: 'formation', id: row.formation_uid, data: row }] } satisfies QueryServiceResponse<typeof row>);
+
+      const result = await service.getFormationsQueue(buildReq());
+
+      expect(result.data_source).toBe('live');
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].project_uid).toBe('live-project-1');
+      expect(result.tiles.total).toBe(1);
     });
   });
 });

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -714,6 +714,103 @@ describe('FormationService', () => {
       expect(postCall![6]).toEqual({ 'If-Match': '3' });
     });
 
+    it('clears note/assignee/due_date with empty strings (not null) and sends due_date as YYYY-MM-DD, not a full ISO datetime', async () => {
+      const item = rawItem({ status: 'in_progress', note: 'old note', assignee: 'sam.chen', due_date: '2026-01-01' });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'PATCH') return Promise.resolve({ ...item, note: null, assignee: null, due_date: null, version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      await service.updateFormationItem(buildReq(), 'live-project-1', 'item-key-1', {
+        notes: '',
+        owner_username: '',
+        due_date: null,
+      });
+
+      const patchCall = proxyRequest.mock.calls.find((call) => call[3] === 'PATCH');
+      expect(patchCall![5]).toEqual({ note: '', assignee: '', due_date: '' });
+    });
+
+    it('sends a full ISO due_date truncated to YYYY-MM-DD, never the full datetime', async () => {
+      const item = rawItem({ status: 'in_progress', due_date: '2026-01-01' });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'PATCH') return Promise.resolve({ ...item, due_date: '2026-03-31', version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      await service.updateFormationItem(buildReq(), 'live-project-1', 'item-key-1', { due_date: '2026-03-31T00:00:00.000Z' });
+
+      const patchCall = proxyRequest.mock.calls.find((call) => call[3] === 'PATCH');
+      expect(patchCall![5]).toEqual({ due_date: '2026-03-31' });
+    });
+
+    it('percent-encodes itemKey (not just projectUid) in both the PATCH and the accept/reject/reopen path templates', async () => {
+      const item = rawItem({ item_key: 'item key/weird', status: 'in_progress', gate: false });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'PATCH') return Promise.resolve({ ...item, notes: 'x', version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      await service.updateFormationItem(buildReq(), 'live-project-1', 'item key/weird', { notes: 'x' });
+
+      const patchCall = proxyRequest.mock.calls.find((call) => call[3] === 'PATCH');
+      expect(patchCall![2]).toBe(`/formations/live-project-1/items/${encodeURIComponent('item key/weird')}`);
+    });
+
+    it('propagates a failOnPartial pagination failure from getFormationsQueue instead of returning partial rows', async () => {
+      const row = {
+        formation_uid: 'formation:live-project-1',
+        project_uid: 'live-project-1',
+        project_name: 'Live Project',
+        project_slug: 'live-project',
+        is_foundation: false,
+        parent_uid: null,
+        sub_stage: 'engaged' as const,
+        lifecycle: 'formation',
+        gates_cleared: false,
+        is_activating: false,
+        announcement_date: null,
+        progress: {},
+        blocked_item_titles: [],
+        assignees: [],
+      };
+      proxyRequest
+        .mockResolvedValueOnce({
+          resources: [{ type: 'formation', id: row.formation_uid, data: row }],
+          page_token: 'next-page',
+        } satisfies QueryServiceResponse<typeof row>)
+        .mockRejectedValueOnce(new Error('query service unavailable'));
+
+      await expect(service.getFormationsQueue(buildReq())).rejects.toThrow(/query service unavailable/);
+    });
+
+    it('defaults a row missing progress/assignees/blocked_item_titles/announcement_date instead of throwing', async () => {
+      const row = {
+        formation_uid: 'formation:live-project-1',
+        project_uid: 'live-project-1',
+        project_name: 'Live Project',
+        project_slug: 'live-project',
+        is_foundation: false,
+        parent_uid: '',
+        sub_stage: 'engaged' as const,
+        lifecycle: 'formation',
+        gates_cleared: false,
+        is_activating: false,
+      };
+      proxyRequest.mockResolvedValue({ resources: [{ type: 'formation', id: row.formation_uid, data: row }] } satisfies QueryServiceResponse<typeof row>);
+
+      const result = await service.getFormationsQueue(buildReq());
+
+      expect(result.rows[0].parent_uid).toBeNull();
+      expect(result.rows[0].announcement_date).toBeNull();
+      expect(result.rows[0].progress).toEqual({});
+      expect(result.rows[0].blocked_item_titles).toEqual([]);
+      expect(result.rows[0].assignees).toEqual([]);
+    });
+
     it('getFormationsQueue reads from the query service and collapses ROOT into null', async () => {
       const row = {
         formation_uid: 'formation:live-project-1',

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -9,6 +9,7 @@ import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MicroserviceError } from '../errors/microservice.error';
+import { ServiceValidationError } from '../errors/service-validation.error';
 
 const getProjectById = vi.fn();
 const getProjectIdBySlug = vi.fn();
@@ -497,7 +498,7 @@ describe('FormationService', () => {
       const before = getActivityForItem(formation.uid, item.uid).length;
       const result = await service.updateFormationItem(buildReq(), item.project_uid, item.template_item_key, {
         notes: '',
-        due_date: '2026-06-01T00:00:00.000Z',
+        due_date: '2026-06-01',
       });
 
       expect(result.notes).toBeNull();
@@ -714,7 +715,7 @@ describe('FormationService', () => {
       expect(postCall![6]).toEqual({ 'If-Match': '3' });
     });
 
-    it('clears note/assignee/due_date with empty strings (not null) and sends due_date as YYYY-MM-DD, not a full ISO datetime', async () => {
+    it('clears note/assignee/due_date with empty strings, not null', async () => {
       const item = rawItem({ status: 'in_progress', note: 'old note', assignee: 'sam.chen', due_date: '2026-01-01' });
       proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
         if (method === 'GET') return Promise.resolve(checklist([item]));
@@ -732,7 +733,7 @@ describe('FormationService', () => {
       expect(patchCall![5]).toEqual({ note: '', assignee: '', due_date: '' });
     });
 
-    it('sends a full ISO due_date truncated to YYYY-MM-DD, never the full datetime', async () => {
+    it('sends a YYYY-MM-DD due_date through unchanged', async () => {
       const item = rawItem({ status: 'in_progress', due_date: '2026-01-01' });
       proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
         if (method === 'GET') return Promise.resolve(checklist([item]));
@@ -740,13 +741,26 @@ describe('FormationService', () => {
         throw new Error('unexpected call');
       });
 
-      await service.updateFormationItem(buildReq(), 'live-project-1', 'item-key-1', { due_date: '2026-03-31T00:00:00.000Z' });
+      await service.updateFormationItem(buildReq(), 'live-project-1', 'item-key-1', { due_date: '2026-03-31' });
 
       const patchCall = proxyRequest.mock.calls.find((call) => call[3] === 'PATCH');
       expect(patchCall![5]).toEqual({ due_date: '2026-03-31' });
     });
 
-    it('percent-encodes itemKey (not just projectUid) in both the PATCH and the accept/reject/reopen path templates', async () => {
+    it('rejects a full ISO due_date datetime instead of silently truncating it to the wrong calendar day', async () => {
+      const item = rawItem({ status: 'in_progress', due_date: '2026-01-01' });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        throw new Error('unexpected call');
+      });
+
+      await expect(service.updateFormationItem(buildReq(), 'live-project-1', 'item-key-1', { due_date: '2026-03-31T00:00:00.000Z' })).rejects.toThrow(
+        ServiceValidationError
+      );
+      expect(proxyRequest.mock.calls.some((call) => call[3] === 'PATCH')).toBe(false);
+    });
+
+    it('percent-encodes itemKey (not just projectUid) in the PATCH path template', async () => {
       const item = rawItem({ item_key: 'item key/weird', status: 'in_progress', gate: false });
       proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
         if (method === 'GET') return Promise.resolve(checklist([item]));
@@ -758,6 +772,20 @@ describe('FormationService', () => {
 
       const patchCall = proxyRequest.mock.calls.find((call) => call[3] === 'PATCH');
       expect(patchCall![2]).toBe(`/formations/live-project-1/items/${encodeURIComponent('item key/weird')}`);
+    });
+
+    it('percent-encodes itemKey (not just projectUid) in the accept/reject/reopen path template', async () => {
+      const item = rawItem({ item_key: 'item key/weird', status: 'awaiting_acceptance', gate: true });
+      proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(checklist([item]));
+        if (method === 'POST') return Promise.resolve({ ...item, status: 'done', version: 4 });
+        throw new Error('unexpected call');
+      });
+
+      await service.acceptFormationItem(buildReq(), 'live-project-1', 'item key/weird');
+
+      const postCall = proxyRequest.mock.calls.find((call) => call[3] === 'POST');
+      expect(postCall![2]).toBe(`/formations/live-project-1/items/${encodeURIComponent('item key/weird')}/accept`);
     });
 
     it('propagates a failOnPartial pagination failure from getFormationsQueue instead of returning partial rows', async () => {

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -6,11 +6,13 @@ import type {
   FormationActivity,
   FormationChecklistResponse,
   FormationItem,
+  FormationItemMapContext,
   FormationItemStatus,
   FormationQueueRow,
   FormationsQueueResponse,
   FormationSubStage,
-  FormationUser,
+  UpstreamFormationChecklist,
+  UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
 import { FORMATION_QUEUE_SUB_STAGES } from '@lfx-one/shared/constants';
 import { QueryServiceResponse } from '@lfx-one/shared/interfaces';
@@ -20,7 +22,7 @@ import { Request } from 'express';
 import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError } from '../errors';
 import { isFormationServiceLive } from '../helpers/formation-backend.helper';
 import { generateMockFormation, SEEDED_FORMATION_TEMPLATE, STATIC_QUEUE_FORMATIONS } from '../helpers/formation-fixture.helper';
-import { FormationItemMapContext, mapUpstreamFormationItem, UpstreamFormationChecklist, UpstreamFormationItem } from '../helpers/formation-mapper.helper';
+import { mapUpstreamFormationItem } from '../helpers/formation-mapper.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { collapseRootParentUid, resolveRootProjectUid } from '../helpers/root-project.helper';
 import { getEffectiveUsername } from '../utils/auth-helper';
@@ -42,14 +44,15 @@ import { NatsService } from './nats.service';
 import { ProjectService } from './project.service';
 
 /**
- * BFF service for the Formation Checklist section and Formations queue (GH-1958). Only
- * {@link getProjectFormation} branches on {@link isFormationServiceLive} today; the item mutations
- * (complete/skip/request/update) and the queue read {@link getFormationsQueue} are fixture-only and
- * each carry their own `// TODO(#1957)` marking the real `lfx-v2-formation-service` swap.
- * {@link getFormationItemOrThrow}/{@link getFormationItemDetail} resolve against whatever the store
- * already holds and need no swap marker of their own. The fixture generator's return shape already
- * matches `Formation`/`FormationItem[]`, so downstream code (controllers, Angular services) needs no
- * change when the swap happens.
+ * BFF service for the Formation Checklist section and Formations queue (GH-1958/GH-2267). All eight
+ * item mutations (complete/skip/request/status/update/accept/reject/reopen) and the queue read
+ * {@link getFormationsQueue} branch on {@link isFormationServiceLive} and call the real
+ * `lfx-v2-formation-service` when it is live. {@link getProjectFormation} is the one method still
+ * fixture-only — its live branch is `// TODO(GH-2267 Phase 1 remainder)` and unconditionally throws
+ * until the checklist read is wired. {@link getFormationItemOrThrow}/{@link getFormationItemDetail}
+ * resolve against whatever the store already holds and need no swap marker of their own. The fixture
+ * generator's return shape already matches `Formation`/`FormationItem[]`, so downstream code
+ * (controllers, Angular services) needs no change when the remaining swap happens.
  */
 export class FormationService {
   private readonly projectService = new ProjectService();
@@ -390,10 +393,13 @@ export class FormationService {
     const dueDateChanged = patch.due_date !== undefined && patch.due_date !== item.due_date;
 
     if (isFormationServiceLive()) {
+      // Explicit `null`, never `undefined` — ApiClientService's JSON.stringify drops undefined keys,
+      // so a clear (empty notes, unassign, clear due date) would otherwise send an empty PATCH that
+      // silently leaves the upstream field unchanged.
       const body: Record<string, unknown> = {};
-      if (notesChanged) body['note'] = nextNotes ?? undefined;
-      if (ownerChanged) body['assignee'] = nextOwnerUsername ?? undefined;
-      if (dueDateChanged) body['due_date'] = patch.due_date ?? undefined;
+      if (notesChanged) body['note'] = nextNotes;
+      if (ownerChanged) body['assignee'] = nextOwnerUsername;
+      if (dueDateChanged) body['due_date'] = patch.due_date ?? null;
       const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, body, 'update_formation_item');
       const updated = await this.mapLiveItem(req, projectUid, raw);
       logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: updated.uid });
@@ -571,16 +577,32 @@ export class FormationService {
     // subStage/search are applied client-side below, not as query-service params — the contract
     // (GH-2267 plan §7's `getFormationsQueue` row) only documents `type=formation` and an
     // `assignee:<username>` tag for "Mine"; there's no confirmed server-side sub_stage/name filter.
-    const rawRows = await fetchAllQueryResources<FormationQueueRow>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<FormationQueueRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'formation',
-        ...(pageToken && { page_token: pageToken }),
-      })
+    // failOnPartial: true — buildQueueTilesFromRows below is pure counting over rawRows, and a
+    // silently-partial page set would render wrong tile totals with no indication anything failed.
+    const rawRows = await fetchAllQueryResources<FormationQueueRow>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<FormationQueueRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'formation',
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: true }
     );
 
     const rootUid = await resolveRootProjectUid(req, this.natsService);
-    let rows = rawRows.map((row) => ({ ...row, parent_uid: collapseRootParentUid(row.parent_uid, rootUid) ?? null }));
+    // The indexed projection's key set isn't fully confirmed upstream (FormationQueueRow's own doc) —
+    // default the array/object fields so a row missing one doesn't throw downstream (queue tiles,
+    // formations-table.component.ts's progress/blocked-title rendering).
+    const normalizedRows = rawRows.map((row) => ({
+      ...row,
+      parent_uid: collapseRootParentUid(row.parent_uid || null, rootUid) ?? null,
+      announcement_date: row.announcement_date ?? null,
+      progress: row.progress ?? ({} as FormationQueueRow['progress']),
+      blocked_item_titles: row.blocked_item_titles ?? [],
+      assignees: row.assignees ?? [],
+    }));
 
+    let rows = normalizedRows;
     if (subStage) {
       rows = rows.filter((row) => row.sub_stage === subStage);
     }
@@ -589,7 +611,7 @@ export class FormationService {
       rows = rows.filter((row) => row.project_name.toLowerCase().includes(term));
     }
 
-    const tiles = this.buildQueueTilesFromRows(rawRows);
+    const tiles = this.buildQueueTilesFromRows(normalizedRows);
 
     return { tiles, rows, data_source: 'live' };
   }
@@ -603,7 +625,12 @@ export class FormationService {
    */
   private async fetchLiveChecklistOrDenyNotFound(req: Request, projectUid: string, itemAddress: string): Promise<UpstreamFormationChecklist> {
     try {
-      return await this.microserviceProxy.proxyRequest<UpstreamFormationChecklist>(req, 'LFX_V2_FORMATION_SERVICE', `/formations/${projectUid}`, 'GET');
+      return await this.microserviceProxy.proxyRequest<UpstreamFormationChecklist>(
+        req,
+        'LFX_V2_FORMATION_SERVICE',
+        `/formations/${encodeURIComponent(projectUid)}`,
+        'GET'
+      );
     } catch (error) {
       if (isMicroserviceError(error) && (error.statusCode === 403 || error.statusCode === 404)) {
         logger.debug(req, 'get_formation_item', 'Denying formation-item access', { item_address: itemAddress, err: error });
@@ -642,7 +669,7 @@ export class FormationService {
       return await this.microserviceProxy.proxyRequest<UpstreamFormationItem>(
         req,
         'LFX_V2_FORMATION_SERVICE',
-        `/formations/${projectUid}/items/${itemKey}`,
+        `/formations/${encodeURIComponent(projectUid)}/items/${itemKey}`,
         'PATCH',
         undefined,
         body,
@@ -667,7 +694,7 @@ export class FormationService {
       return await this.microserviceProxy.proxyRequest<UpstreamFormationItem>(
         req,
         'LFX_V2_FORMATION_SERVICE',
-        `/formations/${projectUid}/items/${itemKey}/${action}`,
+        `/formations/${encodeURIComponent(projectUid)}/items/${itemKey}/${action}`,
         'POST',
         undefined,
         body,
@@ -725,10 +752,12 @@ export class FormationService {
       progress[item.status] += 1;
     }
 
-    const assigneesByUsername = new Map<string, FormationUser>();
+    // FormationQueueRow.assignees is bare usernames (matching the live indexer projection) — a
+    // Set, not a Map keyed by FormationUser, since the fixture has no separate display-name source.
+    const assigneeUsernames = new Set<string>();
     for (const item of items) {
       if (item.owner) {
-        assigneesByUsername.set(item.owner.username, item.owner);
+        assigneeUsernames.add(item.owner.username);
       }
     }
 
@@ -749,7 +778,7 @@ export class FormationService {
       announcement_date: formation.announcement_date,
       progress,
       blocked_item_titles: blockedGatingItems.map((item) => item.title),
-      assignees: Array.from(assigneesByUsername.values()),
+      assignees: Array.from(assigneeUsernames),
     };
   }
 

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -393,13 +393,17 @@ export class FormationService {
     const dueDateChanged = patch.due_date !== undefined && patch.due_date !== item.due_date;
 
     if (isFormationServiceLive()) {
-      // Explicit `null`, never `undefined` — ApiClientService's JSON.stringify drops undefined keys,
-      // so a clear (empty notes, unassign, clear due date) would otherwise send an empty PATCH that
-      // silently leaves the upstream field unchanged.
+      // Upstream's `note`/`assignee`/`due_date` are all plain (non-nullable) `string` fields whose
+      // clear sentinel is `''`, not `null` — `item_mutator.go` decodes them as `*string` and treats
+      // a wholly-omitted key as "leave unchanged", so a clear must still send the key, just with an
+      // empty string rather than `null` (a JSON `null` unmarshals into a nil `*string`, indistinguishable
+      // from omission, and a clear-only PATCH would then 409 `no_fields_to_update` instead of clearing).
+      // `due_date` additionally must be `YYYY-MM-DD` — upstream parses with that exact layout and
+      // 400s `due_date_invalid` on a full ISO datetime, which is what the drawer's `toISOString()` sends.
       const body: Record<string, unknown> = {};
-      if (notesChanged) body['note'] = nextNotes;
-      if (ownerChanged) body['assignee'] = nextOwnerUsername;
-      if (dueDateChanged) body['due_date'] = patch.due_date ?? null;
+      if (notesChanged) body['note'] = nextNotes ?? '';
+      if (ownerChanged) body['assignee'] = nextOwnerUsername ?? '';
+      if (dueDateChanged) body['due_date'] = patch.due_date ? patch.due_date.slice(0, 10) : '';
       const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, body, 'update_formation_item');
       const updated = await this.mapLiveItem(req, projectUid, raw);
       logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: updated.uid });
@@ -590,8 +594,9 @@ export class FormationService {
     );
 
     const rootUid = await resolveRootProjectUid(req, this.natsService);
-    // The indexed projection's key set isn't fully confirmed upstream (FormationQueueRow's own doc) —
-    // default the array/object fields so a row missing one doesn't throw downstream (queue tiles,
+    // The projection's key set is confirmed (indexer_publisher.go's projectionData always emits all
+    // six FormationItemStatus keys) — these defaults guard against a malformed document only, not an
+    // open contract question, so a row missing one doesn't throw downstream (queue tiles,
     // formations-table.component.ts's progress/blocked-title rendering).
     const normalizedRows = rawRows.map((row) => ({
       ...row,
@@ -669,7 +674,7 @@ export class FormationService {
       return await this.microserviceProxy.proxyRequest<UpstreamFormationItem>(
         req,
         'LFX_V2_FORMATION_SERVICE',
-        `/formations/${encodeURIComponent(projectUid)}/items/${itemKey}`,
+        `/formations/${encodeURIComponent(projectUid)}/items/${encodeURIComponent(itemKey)}`,
         'PATCH',
         undefined,
         body,
@@ -694,7 +699,7 @@ export class FormationService {
       return await this.microserviceProxy.proxyRequest<UpstreamFormationItem>(
         req,
         'LFX_V2_FORMATION_SERVICE',
-        `/formations/${encodeURIComponent(projectUid)}/items/${itemKey}/${action}`,
+        `/formations/${encodeURIComponent(projectUid)}/items/${encodeURIComponent(itemKey)}/${action}`,
         'POST',
         undefined,
         body,

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -2,20 +2,27 @@
 // SPDX-License-Identifier: MIT
 
 import type {
+  Formation,
   FormationActivity,
   FormationChecklistResponse,
   FormationItem,
   FormationItemStatus,
+  FormationQueueRow,
   FormationsQueueResponse,
   FormationSubStage,
+  FormationUser,
 } from '@lfx-one/shared/interfaces';
 import { FORMATION_QUEUE_SUB_STAGES } from '@lfx-one/shared/constants';
+import { QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType, isFormationStageGate } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { AuthorizationError, ResourceNotFoundError, ServiceValidationError } from '../errors';
+import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError } from '../errors';
 import { isFormationServiceLive } from '../helpers/formation-backend.helper';
 import { generateMockFormation, SEEDED_FORMATION_TEMPLATE, STATIC_QUEUE_FORMATIONS } from '../helpers/formation-fixture.helper';
+import { FormationItemMapContext, mapUpstreamFormationItem, UpstreamFormationChecklist, UpstreamFormationItem } from '../helpers/formation-mapper.helper';
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { collapseRootParentUid, resolveRootProjectUid } from '../helpers/root-project.helper';
 import { getEffectiveUsername } from '../utils/auth-helper';
 import { formationItemAccessService } from './formation-item-access.service';
 import {
@@ -30,6 +37,8 @@ import {
   seedFormation,
 } from './formation-store.service';
 import { logger } from './logger.service';
+import { MicroserviceProxyService } from './microservice-proxy.service';
+import { NatsService } from './nats.service';
 import { ProjectService } from './project.service';
 
 /**
@@ -44,6 +53,8 @@ import { ProjectService } from './project.service';
  */
 export class FormationService {
   private readonly projectService = new ProjectService();
+  private readonly natsService = new NatsService();
+  private readonly microserviceProxy = new MicroserviceProxyService();
   private static readonly plainStatusTransitions: ReadonlySet<FormationItemStatus> = new Set(['not_started', 'in_progress', 'blocked']);
 
   public async getProjectFormation(req: Request, projectSlug: string): Promise<FormationChecklistResponse> {
@@ -62,11 +73,16 @@ export class FormationService {
       if (!isFormationStageGate(project.stage)) {
         throw new ResourceNotFoundError('Formation', projectSlug, { operation: 'get_project_formation', service: 'formation_service', path: req.path });
       }
+      // ROOT collapse (GH-2267 Phase 4): a top-level project's own parent_uid is upstream's hidden
+      // ROOT project, never null — see root-project.helper.ts's doc comment for why the BFF is the
+      // producer that has to collapse it before it reaches Formation.parent_uid.
+      const rootUid = await resolveRootProjectUid(req, this.natsService);
+      const collapsedParentUid = collapseRootParentUid(project.parent_uid || null, rootUid) ?? null;
       const { formation, items } = generateMockFormation({
         projectUid: uid,
         projectSlug: project.slug,
         projectName: project.name,
-        parentProjectUid: project.parent_uid || null,
+        parentProjectUid: collapsedParentUid,
         stage: project.stage,
       });
       seedFormation(formation, items);
@@ -85,26 +101,53 @@ export class FormationService {
       };
     }
 
+    // TODO(GH-2267 Phase 1 remainder): the checklist read (Formation + FormationTemplate assembly)
+    // is deliberately not wired yet — this pass covers getFormationsQueue and the 8 mutation
+    // methods only (see the GH-2267 plan's PR A §5 for what that live branch still needs: a
+    // FormationTemplate built from the response's sections/items, and the still-open
+    // announcement_date/uid/created_at/updated_at sourcing gaps). getFormationItemOrThrow below is
+    // wired for the mutation pre-read path.
     throw new ResourceNotFoundError('Formation', projectSlug, { operation: 'get_project_formation', service: 'formation_service', path: req.path });
   }
 
   /**
-   * Every `/formation-items/:uid` caller goes through this, which is the sole enforcement point
-   * for per-item project visibility (fixes a real gap: the fixture item store is a flat, guessable-uid
-   * lookup with no access check of its own — see `assertItemProjectAccess`). Do not add a new
-   * `/formation-items/:uid` code path that resolves an item any other way.
+   * Every `/formations/:projectUid/items/:itemKey` caller goes through this, which is the sole
+   * enforcement point for per-item project visibility (fixes a real gap: the fixture item store is
+   * a flat, guessable-uid lookup with no access check of its own — see `assertItemProjectAccess`).
+   * Do not add a new item code path that resolves an item any other way.
+   *
+   * Live mode (GH-2267 Phase 1): the contract has no single-item read, only the full checklist
+   * (`GET /formations/{project_uid}`), so this fetches the whole thing and finds `itemKey` in it —
+   * every mutation method pays this cost on its pre-read too, same as the fixture path's
+   * per-request store lookup.
    */
-  public async getFormationItemOrThrow(req: Request, itemUid: string): Promise<FormationItem> {
-    const item = getStoredItem(itemUid);
-    if (!item) {
-      throw new ResourceNotFoundError('FormationItem', itemUid, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
+  public async getFormationItemOrThrow(req: Request, projectUid: string, itemKey: string): Promise<FormationItem> {
+    const itemAddress = `${projectUid}/${itemKey}`;
+
+    if (!isFormationServiceLive()) {
+      const itemUid = FormationService.itemUidFor(projectUid, itemKey);
+      const item = getStoredItem(itemUid);
+      if (!item) {
+        throw new ResourceNotFoundError('FormationItem', itemAddress, {
+          operation: 'get_formation_item',
+          service: 'formation_service',
+          path: req.path,
+        });
+      }
+      await this.assertItemProjectAccess(req, projectUid, itemAddress);
+      return item;
     }
-    await this.assertItemProjectAccess(req, item, itemUid);
-    return item;
+
+    const checklist = await this.fetchLiveChecklistOrDenyNotFound(req, projectUid, itemAddress);
+    const raw = checklist.items.find((candidate) => candidate.item_key === itemKey);
+    if (!raw) {
+      throw new ResourceNotFoundError('FormationItem', itemAddress, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
+    }
+    return this.mapLiveItem(req, projectUid, raw);
   }
 
-  public async getFormationItemDetail(req: Request, itemUid: string): Promise<{ item: FormationItem; history: FormationActivity[] }> {
-    const item = await this.getFormationItemOrThrow(req, itemUid);
+  public async getFormationItemDetail(req: Request, projectUid: string, itemKey: string): Promise<{ item: FormationItem; history: FormationActivity[] }> {
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
     const enriched = await this.enrichSingle(req, item);
     return { item: enriched, history: getActivityForItem(item.formation_uid, item.uid) };
   }
@@ -117,9 +160,9 @@ export class FormationService {
    * TODO(#1957): swap the putStoredItem/recordActivity fixture writes below for a real
    * lfx-v2-formation-service mutation call once it ships.
    */
-  public async completeFormationItem(req: Request, itemUid: string, notes?: unknown): Promise<FormationItem> {
+  public async completeFormationItem(req: Request, projectUid: string, itemKey: string, notes?: unknown): Promise<FormationItem> {
     this.assertValidNotes(notes, req, 'complete_formation_item');
-    const item = await this.getFormationItemOrThrow(req, itemUid);
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
     if (item.action === 'status_only') {
       throw ServiceValidationError.forField('action', 'status_only items are updated by external tooling and cannot be completed manually', {
         operation: 'complete_formation_item',
@@ -127,10 +170,30 @@ export class FormationService {
         path: req.path,
       });
     }
-    await this.assertItemProjectWriteAccess(req, item);
+    await this.assertItemProjectWriteAccess(req, projectUid);
     const canComplete = await formationItemAccessService.canComplete(req, item);
     const nextStatus: FormationItemStatus = item.is_gating && !canComplete ? 'awaiting_acceptance' : 'done';
-    const updated: FormationItem = { ...item, status: nextStatus, skip_reason: null, notes: notes ?? item.notes, updated_at: new Date().toISOString() };
+    const nextNotes = notes ?? item.notes;
+
+    if (isFormationServiceLive()) {
+      const raw = await this.mutateLiveItem(
+        req,
+        projectUid,
+        itemKey,
+        item.version,
+        { status: nextStatus, note: nextNotes ?? undefined },
+        'complete_formation_item'
+      );
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'complete_formation_item', 'Formation item completion recorded', {
+        item_uid: updated.uid,
+        is_gating: updated.is_gating,
+        status: updated.status,
+      });
+      return this.enrichSingle(req, updated);
+    }
+
+    const updated: FormationItem = { ...item, status: nextStatus, skip_reason: null, notes: nextNotes, updated_at: new Date().toISOString() };
     putStoredItem(updated);
     this.recordActivity(
       req,
@@ -140,15 +203,14 @@ export class FormationService {
     );
     this.refreshFormationReadiness(updated.formation_uid);
 
-    logger.info(req, 'complete_formation_item', 'Formation item completion recorded', { item_uid: itemUid, is_gating: updated.is_gating, status: nextStatus });
+    logger.info(req, 'complete_formation_item', 'Formation item completion recorded', { item_uid: item.uid, is_gating: updated.is_gating, status: nextStatus });
     return this.enrichSingle(req, updated);
   }
 
-  // TODO(#1957): swap the fixture writes below for a real lfx-v2-formation-service mutation call.
-  public async skipFormationItem(req: Request, itemUid: string, reason: unknown): Promise<FormationItem> {
+  public async skipFormationItem(req: Request, projectUid: string, itemKey: string, reason: unknown): Promise<FormationItem> {
     this.assertValidReason(reason, 'A reason is required to skip a gating item', req, 'skip_formation_item');
 
-    const item = await this.getFormationItemOrThrow(req, itemUid);
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
     if (item.action === 'status_only') {
       throw ServiceValidationError.forField('action', 'status_only items are updated by external tooling and cannot be skipped manually', {
         operation: 'skip_formation_item',
@@ -156,8 +218,16 @@ export class FormationService {
         path: req.path,
       });
     }
-    await this.assertItemProjectWriteAccess(req, item);
+    await this.assertItemProjectWriteAccess(req, projectUid);
     await this.assertCanComplete(req, item, 'skip_formation_item');
+
+    if (isFormationServiceLive()) {
+      const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, { status: 'skipped', skip_reason: reason }, 'skip_formation_item');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'skip_formation_item', 'Formation item skipped', { item_uid: updated.uid });
+      return this.enrichSingle(req, updated);
+    }
+
     const updated: FormationItem = { ...item, status: 'skipped', skip_reason: reason, updated_at: new Date().toISOString() };
     putStoredItem(updated);
     this.recordActivity(req, updated, 'item_skipped', `skipped "${updated.title}"`, { skip_reason: reason });
@@ -165,7 +235,7 @@ export class FormationService {
 
     // Reason text goes into skip_reason/activity metadata (both already persisted above), not the
     // log line — a free-text field is the wrong shape for a structured log field.
-    logger.info(req, 'skip_formation_item', 'Formation item skipped', { item_uid: itemUid });
+    logger.info(req, 'skip_formation_item', 'Formation item skipped', { item_uid: item.uid });
     return this.enrichSingle(req, updated);
   }
 
@@ -176,8 +246,8 @@ export class FormationService {
    * SLA/target-team object; that richer `request` type is #1957/Epic 2.
    * TODO(#1957): swap the fixture writes below for a real lfx-v2-formation-service mutation call.
    */
-  public async requestFormationItem(req: Request, itemUid: string): Promise<FormationItem> {
-    const item = await this.getFormationItemOrThrow(req, itemUid);
+  public async requestFormationItem(req: Request, projectUid: string, itemKey: string): Promise<FormationItem> {
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
     if (item.action !== 'request') {
       throw ServiceValidationError.forField('action', 'This item does not support the request action', {
         operation: 'request_formation_item',
@@ -185,10 +255,18 @@ export class FormationService {
         path: req.path,
       });
     }
-    await this.assertItemProjectWriteAccess(req, item);
+    await this.assertItemProjectWriteAccess(req, projectUid);
     // Same gate as complete/skip: `request` also changes `status`, so a gating item's status must
     // not be movable through this action by a caller `complete`/`skip` would deny.
     await this.assertCanComplete(req, item, 'request_formation_item');
+
+    if (isFormationServiceLive()) {
+      const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, { status: 'blocked' }, 'request_formation_item');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'request_formation_item', 'Formation item request filed', { item_uid: updated.uid });
+      return this.enrichSingle(req, updated);
+    }
+
     const updated: FormationItem = { ...item, status: 'blocked', updated_at: new Date().toISOString() };
     putStoredItem(updated);
     this.recordActivity(req, updated, 'item_requested', `requested "${updated.title}"`);
@@ -196,7 +274,7 @@ export class FormationService {
     // (e.g. a previously-done gating item moved back to blocked reopens is_activating).
     this.refreshFormationReadiness(updated.formation_uid);
 
-    logger.info(req, 'request_formation_item', 'Formation item request filed', { item_uid: itemUid });
+    logger.info(req, 'request_formation_item', 'Formation item request filed', { item_uid: item.uid });
     return this.enrichSingle(req, updated);
   }
 
@@ -211,7 +289,7 @@ export class FormationService {
    * `assertCanComplete` gate as `completeFormationItem`.
    * TODO(#1957): swap the fixture writes below for a real lfx-v2-formation-service mutation call.
    */
-  public async updateFormationItemStatus(req: Request, itemUid: string, status: unknown, note?: unknown): Promise<FormationItem> {
+  public async updateFormationItemStatus(req: Request, projectUid: string, itemKey: string, status: unknown, note?: unknown): Promise<FormationItem> {
     if (typeof status !== 'string' || !FormationService.plainStatusTransitions.has(status as FormationItemStatus)) {
       throw ServiceValidationError.forField('status', 'status must be one of not_started, in_progress, blocked', {
         operation: 'update_formation_item_status',
@@ -223,7 +301,7 @@ export class FormationService {
       this.assertValidNotes(note, req, 'update_formation_item_status');
     }
 
-    const item = await this.getFormationItemOrThrow(req, itemUid);
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
     if (item.action === 'status_only') {
       throw ServiceValidationError.forField('action', 'status_only items are updated by external tooling and cannot have their status changed manually', {
         operation: 'update_formation_item_status',
@@ -231,7 +309,7 @@ export class FormationService {
         path: req.path,
       });
     }
-    await this.assertItemProjectWriteAccess(req, item);
+    await this.assertItemProjectWriteAccess(req, projectUid);
     if (item.is_gating && (item.status === 'done' || item.status === 'awaiting_acceptance')) {
       await this.assertCanComplete(req, item, 'update_formation_item_status');
     }
@@ -239,6 +317,17 @@ export class FormationService {
     // A block reason is filed as activity metadata below, not written into `notes` — that field
     // is the drawer's free-text note and must survive a status change untouched.
     const blockNote = nextStatus === 'blocked' && typeof note === 'string' ? note : null;
+
+    if (isFormationServiceLive()) {
+      // Deliberately omits `note` from the body — same rationale as the fixture branch below: the
+      // drawer's free-text `notes` field must survive a plain status change untouched, and the
+      // block reason is metadata about the transition, not an item-note update.
+      const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, { status: nextStatus }, 'update_formation_item_status');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'update_formation_item_status', 'Formation item status changed', { item_uid: updated.uid, status: updated.status });
+      return this.enrichSingle(req, updated);
+    }
+
     const updated: FormationItem = {
       ...item,
       status: nextStatus,
@@ -249,7 +338,7 @@ export class FormationService {
     this.recordActivity(req, updated, 'item_reopened', `moved "${updated.title}" to ${nextStatus}`, blockNote !== null ? { note: blockNote } : null);
     this.refreshFormationReadiness(updated.formation_uid);
 
-    logger.info(req, 'update_formation_item_status', 'Formation item status changed', { item_uid: itemUid, status: nextStatus });
+    logger.info(req, 'update_formation_item_status', 'Formation item status changed', { item_uid: item.uid, status: nextStatus });
     return this.enrichSingle(req, updated);
   }
 
@@ -262,7 +351,8 @@ export class FormationService {
    */
   public async updateFormationItem(
     req: Request,
-    itemUid: string,
+    projectUid: string,
+    itemKey: string,
     patch: { notes?: unknown; owner_username?: string; due_date?: string | null }
   ): Promise<FormationItem> {
     this.assertValidNotes(patch.notes, req, 'update_formation_item');
@@ -288,53 +378,379 @@ export class FormationService {
       });
     }
 
-    const item = await this.getFormationItemOrThrow(req, itemUid);
-    await this.assertItemProjectWriteAccess(req, item);
-    const updated: FormationItem = { ...item, updated_at: new Date().toISOString() };
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
+    await this.assertItemProjectWriteAccess(req, projectUid);
 
-    // Normalized the same way owner_username is below: the drawer always sends '' for an empty
-    // textarea (formation-item-drawer.component.ts), while a freshly generated item has notes:
-    // null — without normalizing, '' !== null on every first save (even one that only touches
-    // due_date) would spuriously flip notes and record an "updated notes" activity that never happened.
+    // Normalized so the drawer's always-'' empty textarea (formation-item-drawer.component.ts)
+    // doesn't spuriously diff against a freshly generated item's notes: null on every first save.
     const nextNotes = patch.notes || null;
-    if (patch.notes !== undefined && nextNotes !== (item.notes ?? null)) {
+    const nextOwnerUsername = patch.owner_username || null;
+    const notesChanged = patch.notes !== undefined && nextNotes !== (item.notes ?? null);
+    const ownerChanged = patch.owner_username !== undefined && nextOwnerUsername !== (item.owner?.username ?? null);
+    const dueDateChanged = patch.due_date !== undefined && patch.due_date !== item.due_date;
+
+    if (isFormationServiceLive()) {
+      const body: Record<string, unknown> = {};
+      if (notesChanged) body['note'] = nextNotes ?? undefined;
+      if (ownerChanged) body['assignee'] = nextOwnerUsername ?? undefined;
+      if (dueDateChanged) body['due_date'] = patch.due_date ?? undefined;
+      const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, body, 'update_formation_item');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: updated.uid });
+      return this.enrichSingle(req, updated);
+    }
+
+    const updated: FormationItem = { ...item, updated_at: new Date().toISOString() };
+    if (notesChanged) {
       updated.notes = nextNotes;
       this.recordActivity(req, updated, 'note_added', 'updated notes');
     }
-    const nextOwnerUsername = patch.owner_username || null;
-    if (patch.owner_username !== undefined && nextOwnerUsername !== (item.owner?.username ?? null)) {
+    if (ownerChanged) {
       updated.owner = nextOwnerUsername ? { username: nextOwnerUsername, name: nextOwnerUsername } : null;
       this.recordActivity(req, updated, 'assignee_changed', 'changed the assignee');
     }
-    if (patch.due_date !== undefined && patch.due_date !== item.due_date) {
-      updated.due_date = patch.due_date;
+    if (dueDateChanged) {
+      updated.due_date = patch.due_date ?? null;
       this.recordActivity(req, updated, 'due_date_changed', 'changed the due date');
     }
 
     putStoredItem(updated);
-    logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: itemUid });
+    logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: item.uid });
+    return this.enrichSingle(req, updated);
+  }
+
+  /**
+   * New in GH-2267 Phase 2 — mirrors the upstream `accept` action (design.go item 4), gated there on
+   * `team:formation` membership; Epic 1 has no such team, so this fixture-era implementation reuses
+   * the existing `gate_writer` (`assertCanComplete`) gate instead. Only meaningful on an item
+   * already sitting in `awaiting_acceptance` (i.e. a non-gate-writer already submitted it via
+   * `completeFormationItem`) — accepting anything else is a state-precondition error, not a access
+   * one. TODO(#1957): swap for a real mutation call once the client lands (Phase 1 remainder); the
+   * activity type reused below (`item_completed`) is a placeholder — PR B's activity reconciliation
+   * (gap 4) adds a dedicated accept/reject/reopen vocabulary.
+   */
+  public async acceptFormationItem(req: Request, projectUid: string, itemKey: string, note?: unknown): Promise<FormationItem> {
+    if (note !== undefined) this.assertValidNotes(note, req, 'accept_formation_item');
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
+    if (item.status !== 'awaiting_acceptance') {
+      throw ServiceValidationError.forField('status', 'Only an item awaiting acceptance can be accepted', {
+        operation: 'accept_formation_item',
+        service: 'formation_service',
+        path: req.path,
+      });
+    }
+    await this.assertItemProjectWriteAccess(req, projectUid);
+    await this.assertCanComplete(req, item, 'accept_formation_item');
+
+    if (isFormationServiceLive()) {
+      const raw = await this.actLiveItem(req, projectUid, itemKey, 'accept', item.version, note !== undefined ? { note } : {}, 'accept_formation_item');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'accept_formation_item', 'Formation item accepted', { item_uid: updated.uid });
+      return this.enrichSingle(req, updated);
+    }
+
+    const updated: FormationItem = { ...item, status: 'done', notes: note ?? item.notes, updated_at: new Date().toISOString() };
+    putStoredItem(updated);
+    this.recordActivity(req, updated, 'item_completed', `accepted "${updated.title}"`, note !== undefined ? { note } : null);
+    this.refreshFormationReadiness(updated.formation_uid);
+
+    logger.info(req, 'accept_formation_item', 'Formation item accepted', { item_uid: item.uid });
+    return this.enrichSingle(req, updated);
+  }
+
+  /**
+   * New in GH-2267 Phase 2 — mirrors the upstream `reject` action (design.go item 5), which requires
+   * a non-empty note upstream; sends an `awaiting_acceptance` item back to the submitter as
+   * `in_progress` rather than closing it. Same fixture-era `gate_writer` substitution as
+   * {@link acceptFormationItem}. TODO(#1957): see that method's TODO — applies here too.
+   */
+  public async rejectFormationItem(req: Request, projectUid: string, itemKey: string, note: unknown): Promise<FormationItem> {
+    this.assertValidReason(note, 'A note is required to reject an item', req, 'reject_formation_item');
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
+    if (item.status !== 'awaiting_acceptance') {
+      throw ServiceValidationError.forField('status', 'Only an item awaiting acceptance can be rejected', {
+        operation: 'reject_formation_item',
+        service: 'formation_service',
+        path: req.path,
+      });
+    }
+    await this.assertItemProjectWriteAccess(req, projectUid);
+    await this.assertCanComplete(req, item, 'reject_formation_item');
+
+    if (isFormationServiceLive()) {
+      const raw = await this.actLiveItem(req, projectUid, itemKey, 'reject', item.version, { note }, 'reject_formation_item');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'reject_formation_item', 'Formation item rejected', { item_uid: updated.uid });
+      return this.enrichSingle(req, updated);
+    }
+
+    const updated: FormationItem = { ...item, status: 'in_progress', updated_at: new Date().toISOString() };
+    putStoredItem(updated);
+    this.recordActivity(req, updated, 'item_reopened', `rejected "${updated.title}"`, { rejected: true, note });
+    this.refreshFormationReadiness(updated.formation_uid);
+
+    logger.info(req, 'reject_formation_item', 'Formation item rejected', { item_uid: item.uid });
+    return this.enrichSingle(req, updated);
+  }
+
+  /**
+   * New in GH-2267 Phase 2 — mirrors the upstream `reopen` action (design.go item 6). Reversing a
+   * `done`/`skipped`/`awaiting_acceptance` item undoes a prior gate decision, so this reuses
+   * `assertCanComplete` the same way `updateFormationItemStatus` does for the equivalent reversal.
+   * TODO(#1957): see {@link acceptFormationItem}'s TODO — applies here too.
+   */
+  public async reopenFormationItem(req: Request, projectUid: string, itemKey: string, note?: unknown): Promise<FormationItem> {
+    if (note !== undefined) this.assertValidNotes(note, req, 'reopen_formation_item');
+    const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
+    if (item.status !== 'done' && item.status !== 'skipped' && item.status !== 'awaiting_acceptance') {
+      throw ServiceValidationError.forField('status', 'Only a done, skipped, or awaiting-acceptance item can be reopened', {
+        operation: 'reopen_formation_item',
+        service: 'formation_service',
+        path: req.path,
+      });
+    }
+    await this.assertItemProjectWriteAccess(req, projectUid);
+    await this.assertCanComplete(req, item, 'reopen_formation_item');
+
+    if (isFormationServiceLive()) {
+      const raw = await this.actLiveItem(req, projectUid, itemKey, 'reopen', item.version, note !== undefined ? { note } : {}, 'reopen_formation_item');
+      const updated = await this.mapLiveItem(req, projectUid, raw);
+      logger.info(req, 'reopen_formation_item', 'Formation item reopened', { item_uid: updated.uid });
+      return this.enrichSingle(req, updated);
+    }
+
+    const updated: FormationItem = { ...item, status: 'in_progress', skip_reason: null, updated_at: new Date().toISOString() };
+    putStoredItem(updated);
+    this.recordActivity(req, updated, 'item_reopened', `reopened "${updated.title}"`, note !== undefined ? { note } : null);
+    this.refreshFormationReadiness(updated.formation_uid);
+
+    logger.info(req, 'reopen_formation_item', 'Formation item reopened', { item_uid: item.uid });
     return this.enrichSingle(req, updated);
   }
 
   public async getFormationsQueue(req: Request, subStage?: FormationSubStage, search?: string): Promise<FormationsQueueResponse> {
     logger.debug(req, 'get_formations_queue', 'Fetching Formations queue', { subStage, search });
 
+    if (isFormationServiceLive()) {
+      return this.getFormationsQueueLive(req, subStage, search);
+    }
+
     // TODO(#1957): swap for a real query-service read once lfx-v2-formation-service ships;
-    // STATIC_QUEUE_FORMATIONS's shape already matches Formation[]. Each row is read through the
-    // write store first, so a completed/skipped item's readiness rollup (refreshFormationReadiness)
-    // is reflected here too, not just on the project-page checklist response.
-    let rows = STATIC_QUEUE_FORMATIONS.map((row) => getStoredFormation(row.uid) ?? row);
+    // the real projection already serves FormationQueueRow's exact shape (gap 2), so this fixture
+    // branch has to build one from the Formation fixture + its items instead of returning the
+    // Formation itself. Each row is read through the write store first, so a completed/skipped
+    // item's readiness rollup (refreshFormationReadiness) is reflected here too, not just on the
+    // project-page checklist response.
+    let formations = STATIC_QUEUE_FORMATIONS.map((row) => getStoredFormation(row.uid) ?? row);
+    if (subStage) {
+      formations = formations.filter((row) => row.sub_stage === subStage);
+    }
+    if (search && search.trim()) {
+      const term = search.trim().toLowerCase();
+      formations = formations.filter((row) => row.parent_project_name.toLowerCase().includes(term));
+    }
+
+    // Resolved once per request, not per row — root-project.helper.ts's cache already amortizes
+    // the NATS lookup across requests, but there's no reason to await it N times per response.
+    const rootUid = await resolveRootProjectUid(req, this.natsService);
+    const rows = formations.map((formation) => this.toQueueRow(formation, rootUid));
+    const tiles = this.buildQueueTiles();
+
+    return { tiles, rows, data_source: 'fixture' };
+  }
+
+  /**
+   * Live branch of {@link getFormationsQueue} — the indexer's `formation` projection already
+   * matches `FormationQueueRow`'s shape verbatim (GH-2267 plan gap 2), so no per-row mapper is
+   * needed, only ROOT collapse and the subStage/search filters the fixture branch also applies.
+   * `search` matches on `project_name`, mirroring the fixture branch's `parent_project_name` match.
+   * Rows the caller can't read are simply absent from `/query/resources` (per-row `auditor`
+   * enforcement upstream), so no additional access filtering is needed here.
+   */
+  private async getFormationsQueueLive(req: Request, subStage?: FormationSubStage, search?: string): Promise<FormationsQueueResponse> {
+    // subStage/search are applied client-side below, not as query-service params — the contract
+    // (GH-2267 plan §7's `getFormationsQueue` row) only documents `type=formation` and an
+    // `assignee:<username>` tag for "Mine"; there's no confirmed server-side sub_stage/name filter.
+    const rawRows = await fetchAllQueryResources<FormationQueueRow>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<FormationQueueRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'formation',
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    const rootUid = await resolveRootProjectUid(req, this.natsService);
+    let rows = rawRows.map((row) => ({ ...row, parent_uid: collapseRootParentUid(row.parent_uid, rootUid) ?? null }));
+
     if (subStage) {
       rows = rows.filter((row) => row.sub_stage === subStage);
     }
     if (search && search.trim()) {
       const term = search.trim().toLowerCase();
-      rows = rows.filter((row) => row.parent_project_name.toLowerCase().includes(term));
+      rows = rows.filter((row) => row.project_name.toLowerCase().includes(term));
     }
 
-    const tiles = this.buildQueueTiles();
+    const tiles = this.buildQueueTilesFromRows(rawRows);
 
-    return { tiles, rows, data_source: 'fixture' };
+    return { tiles, rows, data_source: 'live' };
+  }
+
+  /**
+   * Live-mode pre-read for a mutation's project-visibility + item-existence check, and the source of
+   * the item's current `version` for `If-Match` (GH-2267 Phase 1). Mirrors `assertItemProjectAccess`'s
+   * masking invariant: a 403/404 from the auditor-gated `GET /formations/{project_uid}` is
+   * indistinguishable from "no such formation" to the caller — this pre-read doubles as that access
+   * check for the live path, so mutation methods don't call `assertItemProjectAccess` separately.
+   */
+  private async fetchLiveChecklistOrDenyNotFound(req: Request, projectUid: string, itemAddress: string): Promise<UpstreamFormationChecklist> {
+    try {
+      return await this.microserviceProxy.proxyRequest<UpstreamFormationChecklist>(req, 'LFX_V2_FORMATION_SERVICE', `/formations/${projectUid}`, 'GET');
+    } catch (error) {
+      if (isMicroserviceError(error) && (error.statusCode === 403 || error.statusCode === 404)) {
+        logger.debug(req, 'get_formation_item', 'Denying formation-item access', { item_address: itemAddress, err: error });
+        throw new ResourceNotFoundError('FormationItem', itemAddress, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Maps one live checklist item onto `FormationItem`. `formation_uid` has no upstream source on
+   * this path (gap 3) — synthesized deterministically from `projectUid`, mirroring the fixture
+   * generator's own `formation:<project_uid>` convention so both backends agree on the shape.
+   */
+  private async mapLiveItem(req: Request, projectUid: string, raw: UpstreamFormationItem): Promise<FormationItem> {
+    const project = await this.projectService.getProjectById(req, projectUid, false);
+    const ctx: FormationItemMapContext = { formationUid: `formation:${projectUid}`, projectUid, projectSlug: project.slug };
+    return mapUpstreamFormationItem(raw, ctx);
+  }
+
+  /**
+   * Shared PATCH transport for complete/skip/request/status/update (design.go item 3) — `If-Match:
+   * <version>` enforces the optimistic lock. Only the 412 case is mapped to a dedicated error class
+   * here; the fuller 409/400 `reason`-based mapping is deferred (GH-2267 plan's Phase 3 scope note) —
+   * everything else passes through as the generic `MicroserviceError`.
+   */
+  private async mutateLiveItem(
+    req: Request,
+    projectUid: string,
+    itemKey: string,
+    version: number,
+    body: Record<string, unknown>,
+    operation: string
+  ): Promise<UpstreamFormationItem> {
+    try {
+      return await this.microserviceProxy.proxyRequest<UpstreamFormationItem>(
+        req,
+        'LFX_V2_FORMATION_SERVICE',
+        `/formations/${projectUid}/items/${itemKey}`,
+        'PATCH',
+        undefined,
+        body,
+        { 'If-Match': String(version) }
+      );
+    } catch (error) {
+      throw this.mapLivePreconditionError(error, req, operation);
+    }
+  }
+
+  /** Shared POST transport for accept/reject/reopen (design.go items 4-6) — same `If-Match`/412 handling as {@link mutateLiveItem}. */
+  private async actLiveItem(
+    req: Request,
+    projectUid: string,
+    itemKey: string,
+    action: 'accept' | 'reject' | 'reopen',
+    version: number,
+    body: Record<string, unknown>,
+    operation: string
+  ): Promise<UpstreamFormationItem> {
+    try {
+      return await this.microserviceProxy.proxyRequest<UpstreamFormationItem>(
+        req,
+        'LFX_V2_FORMATION_SERVICE',
+        `/formations/${projectUid}/items/${itemKey}/${action}`,
+        'POST',
+        undefined,
+        body,
+        { 'If-Match': String(version) }
+      );
+    } catch (error) {
+      throw this.mapLivePreconditionError(error, req, operation);
+    }
+  }
+
+  private mapLivePreconditionError(error: unknown, req: Request, operation: string): unknown {
+    if (isMicroserviceError(error) && error.statusCode === 412) {
+      return new PreconditionFailedError(error.errorBody?.message, { operation, service: 'formation_service', path: req.path });
+    }
+    return error;
+  }
+
+  /**
+   * Fixture-only address→uid bridge (GH-2267 Phase 2) — the store's flat item map is still keyed by
+   * the fixture uid (`formation-item:<project_uid>:<item_key>`, see `generateMockFormation`'s seed
+   * in `formation-fixture.helper.ts`), but every route/controller/client call above this service now
+   * addresses items by `(project_uid, item_key)`, matching the real service's contract. TODO(#1957):
+   * the real client drops this entirely — items are addressed by `(project_uid, item_key)` all the
+   * way down, with no uid reconstruction needed.
+   */
+  private static itemUidFor(projectUid: string, itemKey: string): string {
+    return `formation-item:${projectUid}:${itemKey}`;
+  }
+
+  /**
+   * Fixture-only adapter from {@link Formation} + its stored items to {@link FormationQueueRow} —
+   * the real client won't need this once `getFormationsQueue`'s live branch reads the indexer's
+   * projection directly (that document already carries this exact shape; see gap 2 in the GH-2267
+   * plan). `lifecycle` has no fixture source (it's a project-service concept the Formation fixture
+   * never modeled) — `'formation'` is a stand-in for every queue row, all of which are pre-Activation.
+   */
+  private toQueueRow(formation: Formation, rootUid: string | null): FormationQueueRow {
+    // Formation.uid is optional only because the checklist read can't source it (see its doc
+    // comment) — every queue-fixture row (STATIC_QUEUE_FORMATIONS, and anything seeded over it in
+    // the write store) sets it explicitly, so it's always present on this path.
+    const formationUid = formation.uid as string;
+    const items = getStoredItemsForFormation(formationUid);
+    const gatingItems = items.filter((item) => item.is_gating);
+    const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
+
+    const progress: Record<FormationItemStatus, number> = {
+      not_started: 0,
+      in_progress: 0,
+      blocked: 0,
+      awaiting_acceptance: 0,
+      done: 0,
+      skipped: 0,
+    };
+    for (const item of items) {
+      progress[item.status] += 1;
+    }
+
+    const assigneesByUsername = new Map<string, FormationUser>();
+    for (const item of items) {
+      if (item.owner) {
+        assigneesByUsername.set(item.owner.username, item.owner);
+      }
+    }
+
+    return {
+      formation_uid: formationUid,
+      project_uid: formation.parent_project_uid,
+      project_name: formation.parent_project_name,
+      project_slug: formation.parent_project_slug,
+      is_foundation: formation.is_foundation,
+      // ROOT collapse (GH-2267 Phase 4) — see root-project.helper.ts. Fixture rows already store
+      // null/a real parent, so this is a no-op for them; it matters once the live projection (which
+      // copies the project service's parent_uid verbatim) is wired in.
+      parent_uid: collapseRootParentUid(formation.parent_uid, rootUid) ?? null,
+      sub_stage: formation.sub_stage,
+      lifecycle: 'formation',
+      gates_cleared: gatingItems.length > 0 && blockedGatingItems.length === 0 && formation.gating_items_open === 0,
+      is_activating: formation.is_activating,
+      announcement_date: formation.announcement_date,
+      progress,
+      blocked_item_titles: blockedGatingItems.map((item) => item.title),
+      assignees: Array.from(assigneesByUsername.values()),
+    };
   }
 
   private buildQueueTiles(): FormationsQueueResponse['tiles'] {
@@ -350,6 +766,26 @@ export class FormationService {
     // The tile subLine only has room for a foundations/projects split — a bare 'project' entity (no
     // foundation/child_project formation ceremony) rolls into the projects count so it isn't
     // silently dropped from the breakdown while still counting toward `total`.
+    return {
+      ...bySubStage,
+      total: rows.length,
+      foundations: rows.filter((row) => deriveFormationEntityType(row) === 'foundation').length,
+      projects: rows.filter((row) => deriveFormationEntityType(row) !== 'foundation').length,
+    };
+  }
+
+  /**
+   * Live counterpart of {@link buildQueueTiles} — tiles are computed from the full unfiltered
+   * `FormationQueueRow[]` (pre-ROOT-collapse, since `deriveFormationEntityType` only needs
+   * `is_foundation`/whether `parent_uid` is set, and collapsing null→null is a no-op either way),
+   * matching the fixture branch's own "tiles reflect the whole queue, not the filtered view" contract.
+   */
+  private buildQueueTilesFromRows(rows: FormationQueueRow[]): FormationsQueueResponse['tiles'] {
+    const bySubStage = Object.fromEntries(FORMATION_QUEUE_SUB_STAGES.map((stage) => [stage, 0])) as Record<FormationSubStage, number>;
+    for (const row of rows) {
+      bySubStage[row.sub_stage] = (bySubStage[row.sub_stage] ?? 0) + 1;
+    }
+
     return {
       ...bySubStage,
       total: rows.length,
@@ -405,6 +841,9 @@ export class FormationService {
 
     putStoredFormation({
       ...formation,
+      // Anything the store hands back was written keyed by uid, so it's always present here even
+      // though `getStoredFormation`'s declared return type doesn't narrow that.
+      uid: formationUid,
       gating_items_open: openGatingItems.length,
       gating_items_total: gatingItems.length,
       is_activating: isActivating,
@@ -421,27 +860,22 @@ export class FormationService {
    * can't see throws here (404/403 from the upstream project service) before any item data or
    * mutation is returned.
    */
-  private async assertItemProjectAccess(req: Request, item: Pick<FormationItem, 'formation_uid'>, itemUid: string): Promise<void> {
-    // Always throws the same "FormationItem not found" shape as the missing-uid branch above,
-    // regardless of which check actually failed (dangling formation reference vs. an upstream
-    // project-visibility denial) — a differentiated error would let a caller distinguish "this
-    // item doesn't exist" from "it exists and you can't see it", an account/resource enumeration
-    // oracle. The real cause is still logged for operators.
-    const denyNotFound = (cause: unknown): never => {
-      logger.debug(req, 'assert_item_project_access', 'Denying formation-item access', { item_uid: itemUid, err: cause });
-      throw new ResourceNotFoundError('FormationItem', itemUid, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
-    };
-
-    const formation = getStoredFormation(item.formation_uid) ?? STATIC_QUEUE_FORMATIONS.find((row) => row.uid === item.formation_uid);
-    if (!formation) {
-      denyNotFound(new Error(`no formation record for formation_uid ${item.formation_uid}`));
-      return;
-    }
-
+  private async assertItemProjectAccess(req: Request, projectUid: string, itemAddress: string): Promise<void> {
+    // Always throws the same "FormationItem not found" shape as the missing-address branch above
+    // (getFormationItemOrThrow), keyed by the same public `${projectUid}/${itemKey}` address rather
+    // than the internal fixture uid — regardless of which check actually failed, a differentiated
+    // error would let a caller distinguish "this item doesn't exist" from "it exists and you can't
+    // see it", an account/resource enumeration oracle. The real cause is still logged for operators.
+    //
+    // Takes `projectUid` directly (GH-2267 Phase 1) rather than resolving it via a formation-record
+    // lookup keyed by `item.formation_uid` — that lookup (`getStoredFormation`/
+    // `STATIC_QUEUE_FORMATIONS`) is fixture-only and has no live equivalent, while every caller
+    // already has `projectUid` in hand. Works identically for both backends.
     try {
-      await this.projectService.getProjectById(req, formation.parent_project_uid, false);
+      await this.projectService.getProjectById(req, projectUid, false);
     } catch (error) {
-      denyNotFound(error);
+      logger.debug(req, 'assert_item_project_access', 'Denying formation-item access', { item_address: itemAddress, err: error });
+      throw new ResourceNotFoundError('FormationItem', itemAddress, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
     }
   }
 
@@ -453,17 +887,9 @@ export class FormationService {
    * masking `assertItemProjectAccess` uses — the caller already legitimately knows this item
    * exists, so there is no existence-oracle risk in saying so.
    */
-  private async assertItemProjectWriteAccess(req: Request, item: Pick<FormationItem, 'formation_uid'>): Promise<void> {
-    const formation = getStoredFormation(item.formation_uid) ?? STATIC_QUEUE_FORMATIONS.find((row) => row.uid === item.formation_uid);
-    if (!formation) {
-      throw new ResourceNotFoundError('Formation', item.formation_uid, {
-        operation: 'assert_item_project_write_access',
-        service: 'formation_service',
-        path: req.path,
-      });
-    }
-
-    const project = await this.projectService.getProjectById(req, formation.parent_project_uid, true);
+  private async assertItemProjectWriteAccess(req: Request, projectUid: string): Promise<void> {
+    // Takes `projectUid` directly, same rationale as `assertItemProjectAccess` above.
+    const project = await this.projectService.getProjectById(req, projectUid, true);
     if (!project.writer) {
       throw new AuthorizationError('Write access required for this project', {
         operation: 'assert_item_project_write_access',

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -373,8 +373,12 @@ export class FormationService {
         path: req.path,
       });
     }
-    if (patch.due_date !== undefined && patch.due_date !== null && (typeof patch.due_date !== 'string' || Number.isNaN(Date.parse(patch.due_date)))) {
-      throw ServiceValidationError.forField('due_date', 'due_date must be a valid ISO date string or null', {
+    if (
+      patch.due_date !== undefined &&
+      patch.due_date !== null &&
+      (typeof patch.due_date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(patch.due_date) || Number.isNaN(Date.parse(patch.due_date)))
+    ) {
+      throw ServiceValidationError.forField('due_date', 'due_date must be a YYYY-MM-DD date string or null', {
         operation: 'update_formation_item',
         service: 'formation_service',
         path: req.path,
@@ -399,11 +403,13 @@ export class FormationService {
       // empty string rather than `null` (a JSON `null` unmarshals into a nil `*string`, indistinguishable
       // from omission, and a clear-only PATCH would then 409 `no_fields_to_update` instead of clearing).
       // `due_date` additionally must be `YYYY-MM-DD` — upstream parses with that exact layout and
-      // 400s `due_date_invalid` on a full ISO datetime, which is what the drawer's `toISOString()` sends.
+      // 400s `due_date_invalid` on a full ISO datetime. The validation above already rejects
+      // anything but that shape (or `null`), so `patch.due_date` is safe to send as-is — no `slice`
+      // needed, and no risk of the calendar day shifting a UTC-instant truncation would introduce.
       const body: Record<string, unknown> = {};
       if (notesChanged) body['note'] = nextNotes ?? '';
       if (ownerChanged) body['assignee'] = nextOwnerUsername ?? '';
-      if (dueDateChanged) body['due_date'] = patch.due_date ? patch.due_date.slice(0, 10) : '';
+      if (dueDateChanged) body['due_date'] = patch.due_date ?? '';
       const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, body, 'update_formation_item');
       const updated = await this.mapLiveItem(req, projectUid, raw);
       logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: updated.uid });
@@ -453,7 +459,19 @@ export class FormationService {
     await this.assertCanComplete(req, item, 'accept_formation_item');
 
     if (isFormationServiceLive()) {
-      const raw = await this.actLiveItem(req, projectUid, itemKey, 'accept', item.version, note !== undefined ? { note } : {}, 'accept_formation_item');
+      // Unlike PATCH, upstream's accept/reject/reopen always overwrite the note column — omitting
+      // it means "the note is now empty", not "leave unchanged" (`acceptance.go`: "Written whether
+      // or not one was supplied, so the column means 'the note on this row now'"). Pass the item's
+      // current note through when the caller didn't supply one, matching the fixture branch below.
+      const raw = await this.actLiveItem(
+        req,
+        projectUid,
+        itemKey,
+        'accept',
+        item.version,
+        { note: note !== undefined ? note : (item.notes ?? '') },
+        'accept_formation_item'
+      );
       const updated = await this.mapLiveItem(req, projectUid, raw);
       logger.info(req, 'accept_formation_item', 'Formation item accepted', { item_uid: updated.uid });
       return this.enrichSingle(req, updated);
@@ -523,7 +541,16 @@ export class FormationService {
     await this.assertCanComplete(req, item, 'reopen_formation_item');
 
     if (isFormationServiceLive()) {
-      const raw = await this.actLiveItem(req, projectUid, itemKey, 'reopen', item.version, note !== undefined ? { note } : {}, 'reopen_formation_item');
+      // Same note-preservation contract as acceptFormationItem — see its comment.
+      const raw = await this.actLiveItem(
+        req,
+        projectUid,
+        itemKey,
+        'reopen',
+        item.version,
+        { note: note !== undefined ? note : (item.notes ?? '') },
+        'reopen_formation_item'
+      );
       const updated = await this.mapLiveItem(req, projectUid, raw);
       logger.info(req, 'reopen_formation_item', 'Formation item reopened', { item_uid: updated.uid });
       return this.enrichSingle(req, updated);
@@ -602,7 +629,7 @@ export class FormationService {
       ...row,
       parent_uid: collapseRootParentUid(row.parent_uid || null, rootUid) ?? null,
       announcement_date: row.announcement_date ?? null,
-      progress: row.progress ?? ({} as FormationQueueRow['progress']),
+      progress: row.progress ?? {},
       blocked_item_titles: row.blocked_item_titles ?? [],
       assignees: row.assignees ?? [],
     }));

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -825,9 +825,20 @@ export class FormationService {
       done: 0,
       skipped: 0,
     };
-    for (const item of items) {
-      progress[item.status] += 1;
+    if (items.length > 0) {
+      for (const item of items) {
+        progress[item.status] += 1;
+      }
+    } else {
+      // STATIC_QUEUE_FORMATIONS rows are never seeded into the per-item write store — only visiting
+      // a project's own checklist (getProjectFormation) does that. Without this fallback, every
+      // never-visited demo row would recompute as "0 of 0" from an empty item list, discarding the
+      // formation's own precomputed gating aggregate (which STATIC_QUEUE_FORMATIONS bakes in and
+      // refreshFormationReadiness keeps current for any row a mutation has touched).
+      progress.done = formation.gating_items_total - formation.gating_items_open;
+      progress.not_started = formation.gating_items_open;
     }
+    const blockedItemTitles = items.length > 0 ? blockedGatingItems.map((item) => item.title) : (formation.blocking_item_title?.split(', ') ?? []);
 
     // FormationQueueRow.assignees is bare usernames (matching the live indexer projection) — a
     // Set, not a Map keyed by FormationUser, since the fixture has no separate display-name source.
@@ -850,11 +861,14 @@ export class FormationService {
       parent_uid: collapseRootParentUid(formation.parent_uid, rootUid) ?? null,
       sub_stage: formation.sub_stage,
       lifecycle: 'formation',
-      gates_cleared: gatingItems.length > 0 && blockedGatingItems.length === 0 && formation.gating_items_open === 0,
+      // Sourced from the formation's own precomputed rollup, not re-derived from `items` here — that
+      // rollup (STATIC_QUEUE_FORMATIONS's baked-in defaults, kept current by refreshFormationReadiness
+      // on every mutation) is correct even for a never-visited demo row with no tracked items.
+      gates_cleared: formation.gating_items_total > 0 && formation.gating_items_open === 0,
       is_activating: formation.is_activating,
       announcement_date: formation.announcement_date,
       progress,
-      blocked_item_titles: blockedGatingItems.map((item) => item.title),
+      blocked_item_titles: blockedItemTitles,
       assignees: Array.from(assigneeUsernames),
     };
   }

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -11,6 +11,7 @@ import type {
   FormationQueueRow,
   FormationsQueueResponse,
   FormationSubStage,
+  Project,
   UpstreamFormationChecklist,
   UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
@@ -19,7 +20,7 @@ import { QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType, isFormationStageGate } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError } from '../errors';
+import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError, ConflictError } from '../errors';
 import { isFormationServiceLive } from '../helpers/formation-backend.helper';
 import { generateMockFormation, SEEDED_FORMATION_TEMPLATE, STATIC_QUEUE_FORMATIONS } from '../helpers/formation-fixture.helper';
 import { mapUpstreamFormationItem } from '../helpers/formation-mapper.helper';
@@ -59,6 +60,11 @@ export class FormationService {
   private readonly natsService = new NatsService();
   private readonly microserviceProxy = new MicroserviceProxyService();
   private static readonly plainStatusTransitions: ReadonlySet<FormationItemStatus> = new Set(['not_started', 'in_progress', 'blocked']);
+  // Per-request cache, keyed off the request object itself so it never outlives one HTTP call.
+  // {@link mapLiveItem} is invoked at least twice per live mutation (the pre-read via
+  // getFormationItemOrThrow, then the mutation result) purely to read project.slug — this avoids
+  // fanning that into two-plus NATS project reads for one user action.
+  private readonly projectByRequestCache = new WeakMap<Request, Map<string, Project>>();
 
   public async getProjectFormation(req: Request, projectSlug: string): Promise<FormationChecklistResponse> {
     logger.debug(req, 'get_project_formation', 'Fetching formation checklist', { projectSlug });
@@ -410,6 +416,13 @@ export class FormationService {
       if (notesChanged) body['note'] = nextNotes ?? '';
       if (ownerChanged) body['assignee'] = nextOwnerUsername ?? '';
       if (dueDateChanged) body['due_date'] = patch.due_date ?? '';
+      if (Object.keys(body).length === 0) {
+        // Upstream 409s an empty PATCH body (`no_fields_to_update`) — a no-op save is a reachable
+        // path (open the drawer, hit Save without editing), so match the fixture branch below and
+        // return the item unchanged rather than issuing a request upstream can only reject.
+        logger.debug(req, 'update_formation_item', 'No-op update, skipping upstream call', { item_uid: item.uid });
+        return this.enrichSingle(req, item);
+      }
       const raw = await this.mutateLiveItem(req, projectUid, itemKey, item.version, body, 'update_formation_item');
       const updated = await this.mapLiveItem(req, projectUid, raw);
       logger.debug(req, 'update_formation_item', 'Formation item updated', { item_uid: updated.uid });
@@ -678,9 +691,24 @@ export class FormationService {
    * generator's own `formation:<project_uid>` convention so both backends agree on the shape.
    */
   private async mapLiveItem(req: Request, projectUid: string, raw: UpstreamFormationItem): Promise<FormationItem> {
-    const project = await this.projectService.getProjectById(req, projectUid, false);
+    const project = await this.getProjectByIdCached(req, projectUid);
     const ctx: FormationItemMapContext = { formationUid: `formation:${projectUid}`, projectUid, projectSlug: project.slug };
     return mapUpstreamFormationItem(raw, ctx);
+  }
+
+  /** Request-scoped memoization of {@link ProjectService.getProjectById} — see {@link projectByRequestCache}. */
+  private async getProjectByIdCached(req: Request, projectUid: string): Promise<Project> {
+    let byUid = this.projectByRequestCache.get(req);
+    if (!byUid) {
+      byUid = new Map<string, Project>();
+      this.projectByRequestCache.set(req, byUid);
+    }
+    let project = byUid.get(projectUid);
+    if (!project) {
+      project = await this.projectService.getProjectById(req, projectUid, false);
+      byUid.set(projectUid, project);
+    }
+    return project;
   }
 
   /**
@@ -737,9 +765,26 @@ export class FormationService {
     }
   }
 
+  /**
+   * `acceptFormationItem`/`rejectFormationItem`/`reopenFormationItem`'s local status guards
+   * intentionally permit a superset of upstream's own preconditions (e.g. reopen allows
+   * `skipped`/`awaiting_acceptance` in addition to `done`, matching the fixture-era behavior
+   * documented on {@link reopenFormationItem}) — so the live path must still be prepared for
+   * upstream's own 409 `Conflict` (`internal/service/acceptance.go`'s `wrongStatusReason`) on a
+   * status this BFF's guard let through. Mapped the same shape as the fixture branch's own
+   * conflict errors, not left as a raw `MicroserviceError`.
+   */
   private mapLivePreconditionError(error: unknown, req: Request, operation: string): unknown {
     if (isMicroserviceError(error) && error.statusCode === 412) {
       return new PreconditionFailedError(error.errorBody?.message, { operation, service: 'formation_service', path: req.path });
+    }
+    if (isMicroserviceError(error) && error.statusCode === 409) {
+      const reason = typeof error.errorBody?.reason === 'string' ? error.errorBody.reason : 'conflict';
+      return new ConflictError(error.errorBody?.message ?? "The requested change conflicts with the item's current state", reason.toUpperCase(), {
+        operation,
+        service: 'formation_service',
+        path: req.path,
+      });
     }
     return error;
   }

--- a/apps/lfx-one/src/server/services/microservice-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/microservice-proxy.service.ts
@@ -154,14 +154,15 @@ export class MicroserviceProxyService {
   }
 
   // Single source of truth for per-service base URLs. LFX_V2_MEMBER_SERVICE,
-  // LFX_V2_COMMITTEE_SERVICE and LFX_V2_CAMPAIGN_SERVICE fall back to LFX_V2_SERVICE
-  // (the gateway) when unset.
+  // LFX_V2_COMMITTEE_SERVICE, LFX_V2_CAMPAIGN_SERVICE and LFX_V2_FORMATION_SERVICE fall back to
+  // LFX_V2_SERVICE (the gateway) when unset.
   private resolveBaseUrl(service: keyof MicroserviceUrls): string {
     const urls: MicroserviceUrls = {
       LFX_V2_SERVICE: process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
       LFX_V2_MEMBER_SERVICE: process.env['LFX_V2_MEMBER_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
       LFX_V2_COMMITTEE_SERVICE: process.env['LFX_V2_COMMITTEE_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
       LFX_V2_CAMPAIGN_SERVICE: process.env['LFX_V2_CAMPAIGN_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
+      LFX_V2_FORMATION_SERVICE: process.env['LFX_V2_FORMATION_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
     };
     // Strip trailing slashes so a config value like `https://host/` can't produce `host//path`.
     return urls[service].replace(/\/+$/, '');

--- a/apps/lfx-one/src/server/services/persona-detection.service.spec.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.spec.ts
@@ -38,6 +38,7 @@ vi.mock('./nats.service', () => ({
 
 vi.mock('./logger.service', () => ({ logger }));
 
+import { resetRootProjectUidCacheForTests } from '../helpers/root-project.helper';
 import { ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { PersonaDetectionService } from './persona-detection.service';
 
@@ -59,6 +60,9 @@ describe('PersonaDetectionService', () => {
     // "marketing auditor / campaign access OR path" tests below need it on to exercise checkMarketingAuditorAccess
     // / checkCampaignManagerAccess at all.
     process.env[ServerFeatureFlag.MarketingOpsFga] = 'true';
+    // resolveRootProjectUid's cache is module-level (shared across every consumer by design — see
+    // root-project.helper.ts) and would otherwise leak a resolved/failed ROOT uid across `it()` blocks.
+    resetRootProjectUidCacheForTests();
     service = new PersonaDetectionService();
   });
 

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -8,7 +8,6 @@ import {
   PERSONA_PRIORITY,
   PERSONAS_CACHE_TTL_MS,
   ROOT_PROJECT_SLUG,
-  ROOT_PROJECT_UID_CACHE_TTL_MS,
   VALID_PERSONAS,
 } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
@@ -25,6 +24,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
+import { resolveRootProjectUid } from '../helpers/root-project.helper';
 import { ServerFeatureFlag, isServerFeatureEnabled } from '../helpers/server-feature-flag.helper';
 import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
@@ -52,7 +52,6 @@ export class PersonaDetectionService {
   // Dedupes the projectSlug -> uid NATS lookup within a single request — checkMarketingAuditorAccess
   // and checkCampaignManagerAccess both resolve the same slug in the same getPersonas Promise.all.
   private readonly projectSlugRequestCache = new WeakMap<Request, Map<string, Promise<{ uid: string; exists: boolean }>>>();
-  private rootProjectUidCache: { uid: string | null; expiresAt: number } | null = null;
 
   public constructor() {
     this.natsService = new NatsService();
@@ -184,7 +183,7 @@ export class PersonaDetectionService {
     if (cached) return cached;
 
     // Degrade to false on failure so transient access-check errors don't 500 callers that rely on this as a bypass hint.
-    const promise = this.resolveRootUid(req)
+    const promise = resolveRootProjectUid(req, this.natsService)
       .then((rootUid) => {
         if (!rootUid) return false;
         return this.accessCheckService.checkSingleAccess(req, { resource: 'project', id: rootUid, access: 'writer' });
@@ -305,7 +304,7 @@ export class PersonaDetectionService {
     const cached = cache.get(req);
     if (cached) return cached;
 
-    const promise = this.resolveRootUid(req)
+    const promise = resolveRootProjectUid(req, this.natsService)
       .then((rootUid) => {
         if (!rootUid) return false;
         return this.accessCheckService.checkSingleAccess(req, { resource: 'project', id: rootUid, access });
@@ -347,28 +346,6 @@ export class PersonaDetectionService {
     );
 
     return promise;
-  }
-
-  private async resolveRootUid(req: Request): Promise<string | null> {
-    if (this.rootProjectUidCache && Date.now() < this.rootProjectUidCache.expiresAt) {
-      return this.rootProjectUidCache.uid;
-    }
-
-    try {
-      const codec = this.natsService.getCodec();
-      const response = await this.natsService.request(NatsSubjects.PROJECT_SLUG_TO_UID, codec.encode(ROOT_PROJECT_SLUG), { timeout: 5000 });
-      const uid = codec.decode(response.data).trim();
-      if (!uid) {
-        // Don't cache empty responses — a transient glitch would disable bypass for ROOT_PROJECT_UID_CACHE_TTL_MS.
-        logger.warning(req, 'resolve_root_uid', 'ROOT slug resolved to empty UID', { slug: ROOT_PROJECT_SLUG });
-        return null;
-      }
-      this.rootProjectUidCache = { uid, expiresAt: Date.now() + ROOT_PROJECT_UID_CACHE_TTL_MS };
-      return uid;
-    } catch (error) {
-      logger.warning(req, 'resolve_root_uid', 'ROOT slug→UID NATS lookup failed', { err: error, slug: ROOT_PROJECT_SLUG });
-      return null;
-    }
   }
 
   private async computePersonaDetections(req: Request, username: string, email: string): Promise<PersonaDetections> {

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -510,7 +510,8 @@ read "flag on, no errors" from this pre-CREATE era as a verified cutover.
 Campaign traffic reaches campaign-service **through the gateway**, at `environment.LFX_V2_SERVICE`.
 There is deliberately no chart parameter for a campaign-service base URL. The application does read
 `LFX_V2_CAMPAIGN_SERVICE` and falls back to `LFX_V2_SERVICE` when it is unset — the same shape as
-`LFX_V2_MEMBER_SERVICE` and `LFX_V2_COMMITTEE_SERVICE`, neither of which this chart declares either.
+`LFX_V2_MEMBER_SERVICE`, `LFX_V2_COMMITTEE_SERVICE` and `LFX_V2_FORMATION_SERVICE`, none of which
+this chart declares either.
 The fallback is what makes the gateway the default, and the gateway is where the authorization
 lives: Heimdall and OpenFGA enforce `campaign_manager` on the project in front of campaign-service,
 while the service's own token check authenticates the caller without authorizing them for that
@@ -519,7 +520,7 @@ act on a project it holds no grant for, given a job id.
 
 Omitting the key from `values.yaml` does not by itself close that path — `templates/deployment.yaml`
 emits every entry in `.Values.environment`, so an override adds the variable without touching this
-chart. All three variables are therefore rejected at render time by
+chart. All four variables are therefore rejected at render time by
 `lfx-self-serve.environment.gatewayOnlyValidate`, and `helm template` fails with the reason rather
 than producing a pod that silently bypasses the gateway. Declaring the key with an empty value is
 still fine: the container treats it as unset and the application resolves it to `LFX_V2_SERVICE`. A

--- a/charts/lfx-self-serve/templates/_helpers.tpl
+++ b/charts/lfx-self-serve/templates/_helpers.tpl
@@ -231,7 +231,7 @@ Args (dict):
 Reject a per-service base URL that would route traffic around the gateway.
 
 `microservice-proxy.service.ts` resolves each of LFX_V2_CAMPAIGN_SERVICE,
-LFX_V2_MEMBER_SERVICE and LFX_V2_COMMITTEE_SERVICE to its own value when set
+LFX_V2_MEMBER_SERVICE, LFX_V2_COMMITTEE_SERVICE and LFX_V2_FORMATION_SERVICE to its own value when set
 and to LFX_V2_SERVICE otherwise. The fallback is what makes the gateway the
 default, and the gateway is where the authorization lives: Heimdall and
 OpenFGA enforce the per-project grant in front of these services, while a
@@ -260,7 +260,7 @@ Call once at the top of any template that renders .Values.environment:
 */}}
 {{- define "lfx-self-serve.environment.gatewayOnlyValidate" -}}
 {{- $env := .Values.environment | default dict -}}
-{{- range $name := (list "LFX_V2_CAMPAIGN_SERVICE" "LFX_V2_MEMBER_SERVICE" "LFX_V2_COMMITTEE_SERVICE") -}}
+{{- range $name := (list "LFX_V2_CAMPAIGN_SERVICE" "LFX_V2_MEMBER_SERVICE" "LFX_V2_COMMITTEE_SERVICE" "LFX_V2_FORMATION_SERVICE") -}}
 {{- $cfg := index $env $name -}}
 {{- if kindIs "map" $cfg -}}
 {{- if or (and (hasKey $cfg "value") $cfg.value) (hasKey $cfg "valueFrom") -}}

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -350,17 +350,18 @@ environment:
   LFX_V2_SERVICE:
     value:
 
-  # `LFX_V2_CAMPAIGN_SERVICE` is deliberately NOT declared here, and neither are the sibling
-  # `LFX_V2_MEMBER_SERVICE` / `LFX_V2_COMMITTEE_SERVICE`. Each one falls back in code to
-  # `LFX_V2_SERVICE`, so leaving it unset routes campaign traffic through the gateway — and
-  # the gateway is where the authorization lives. Heimdall and OpenFGA enforce
-  # `campaign_manager` on the project in front of campaign-service; the service's own token
-  # check is an authentication check, not a project-scoped authorization one, so a base URL
-  # pointing straight at a service instance would let any caller holding a valid token act on
-  # a project it has no grant for, by knowing a job id.
+  # `LFX_V2_CAMPAIGN_SERVICE` is deliberately NOT declared here, and neither are the siblings
+  # `LFX_V2_MEMBER_SERVICE` / `LFX_V2_COMMITTEE_SERVICE` / `LFX_V2_FORMATION_SERVICE`. Each one
+  # falls back in code to `LFX_V2_SERVICE`, so leaving it unset routes traffic through the
+  # gateway — and the gateway is where the authorization lives. Heimdall and OpenFGA enforce
+  # the per-project/per-team grant (e.g. `campaign_manager` for campaign-service,
+  # `team:formation` membership for accept/reject/reopen) in front of each service; the
+  # service's own token check is an authentication check, not a project-scoped authorization
+  # one, so a base URL pointing straight at a service instance would let any caller holding a
+  # valid token act on a project or item it has no grant for.
   #
   # Omitting them here is not the enforcement, though — `templates/deployment.yaml` emits every
-  # entry in this map, so an override adds the variable without touching the chart. All three
+  # entry in this map, so an override adds the variable without touching the chart. All four
   # are rejected at render time by `lfx-self-serve.environment.gatewayOnlyValidate`; a
   # deployment that genuinely needs a direct address drops one from that list in a reviewed
   # chart commit. None of this is needed for the cutover flag below, a separate variable.

--- a/docs/architecture/backend/server-helpers.md
+++ b/docs/architecture/backend/server-helpers.md
@@ -13,17 +13,19 @@ All helpers follow consistent patterns: stateless functions, request parameter f
 
 The helpers directory contains files organized by responsibility:
 
-| File                      | Purpose                                                                           |
-| ------------------------- | --------------------------------------------------------------------------------- |
-| `api-gateway.helper.ts`   | API Gateway base URL resolution (`getApiGatewayBaseUrl`, `getUserServiceBaseUrl`) |
-| `error-serializer.ts`     | Pino error serializer configuration                                               |
-| `http-status.helper.ts`   | HTTP status code to message/code mappings                                         |
-| `ics.helper.ts`           | iCalendar (`.ics`) generation for meeting invites                                 |
-| `meeting.helper.ts`       | Meeting invitation checks with M2M tokens                                         |
-| `poll-endpoint.helper.ts` | Generic retry/polling with callback injection                                     |
-| `query-service.helper.ts` | Cursor-based pagination with automatic page following                             |
-| `url-validation.ts`       | URL and cookie domain validation with allowlists                                  |
-| `validation.helper.ts`    | TypeScript type guard validators for request parameters                           |
+| File                         | Purpose                                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `api-gateway.helper.ts`      | API Gateway base URL resolution (`getApiGatewayBaseUrl`, `getUserServiceBaseUrl`)                                               |
+| `error-serializer.ts`        | Pino error serializer configuration                                                                                             |
+| `formation-mapper.helper.ts` | Maps upstream `lfx-v2-formation-service` shapes (checklist, items, queue rows) onto the BFF's `@lfx-one/shared` formation types |
+| `http-status.helper.ts`      | HTTP status code to message/code mappings                                                                                       |
+| `ics.helper.ts`              | iCalendar (`.ics`) generation for meeting invites                                                                               |
+| `meeting.helper.ts`          | Meeting invitation checks with M2M tokens                                                                                       |
+| `poll-endpoint.helper.ts`    | Generic retry/polling with callback injection                                                                                   |
+| `query-service.helper.ts`    | Cursor-based pagination with automatic page following                                                                           |
+| `root-project.helper.ts`     | TTL-cached ROOT-project uid resolution and `parent_uid` collapse for top-level projects                                         |
+| `url-validation.ts`          | URL and cookie domain validation with allowlists                                                                                |
+| `validation.helper.ts`       | TypeScript type guard validators for request parameters                                                                         |
 
 ## Common Patterns
 
@@ -177,7 +179,7 @@ function isRetryableError(error: unknown): boolean {
 
 ## Validation Helper Reference
 
-The validation helper provides four type guard functions sharing a common interface:
+The validation helper provides five type guard functions sharing a common interface:
 
 ```typescript
 interface ValidationOptions {
@@ -187,12 +189,13 @@ interface ValidationOptions {
 }
 ```
 
-| Function                       | Validates                      | Type Predicate  |
-| ------------------------------ | ------------------------------ | --------------- |
-| `validateUidParameter`         | Non-empty string UID           | `uid is string` |
-| `validateRequiredParameter<T>` | Non-null/undefined/empty value | `value is T`    |
-| `validateArrayParameter<T>`    | Non-empty array                | `array is T[]`  |
-| `validateRequestBody<T>`       | Non-empty request body         | `body is T`     |
+| Function                       | Validates                                         | Type Predicate      |
+| ------------------------------ | ------------------------------------------------- | ------------------- |
+| `validateUidParameter`         | Non-empty string UID                              | `uid is string`     |
+| `validateItemKeyParameter`     | Formation `item_key` shape (lowercase snake_case) | `itemKey is string` |
+| `validateRequiredParameter<T>` | Non-null/undefined/empty value                    | `value is T`        |
+| `validateArrayParameter<T>`    | Non-empty array                                   | `array is T[]`      |
+| `validateRequestBody<T>`       | Non-empty request body                            | `body is T`         |
 
 All validators:
 

--- a/docs/architecture/backend/server-helpers.md
+++ b/docs/architecture/backend/server-helpers.md
@@ -204,7 +204,11 @@ All validators:
 ## Guidelines
 
 - **Use `logger` service** — never import `serverLogger` directly
-- **Keep helpers pure** — no shared mutable state
+- **Keep helpers pure** — no shared mutable state. Narrow exception: `root-project.helper.ts`'s
+  module-level TTL cache for the ROOT project's uid — there is exactly one such value per
+  environment, losing it costs one extra NATS round-trip rather than any correctness, and a test
+  reset hook (`resetRootProjectUidCacheForTests`) keeps specs isolated. Don't extend this exception
+  to helpers caching per-request or per-entity data.
 - **Accept `req` for correlation** — pass it through from controllers
 - **Return defaults on error** — prefer graceful degradation over throwing
 - **Use generics** — make helpers reusable across different data types

--- a/packages/shared/src/constants/index.spec.ts
+++ b/packages/shared/src/constants/index.spec.ts
@@ -12,8 +12,9 @@
 // apps/lfx-one's tailwind.config.js loads `@lfx-one/shared/constants` — with a JIT-compiler error
 // that surfaces far from its real cause (e.g. as an unrelated sass error on the global styles
 // entry). The sanctioned constants->utils edges today are dashboard-metrics.constants.ts
-// (color.utils, number.utils), committees.constants.ts (committee.utils), and
-// mentorship-enroll.constants.ts (date-time.utils) — all Angular-free.
+// (color.utils, number.utils), committees.constants.ts (committee.utils),
+// mentorship-enroll.constants.ts (date-time.utils), and org-lens-roi.constants.ts
+// (color.utils) — all Angular-free.
 //
 // This only covers the `/constants` subpath: the package root barrel (`packages/shared/src/index.ts`)
 // still does `export * from './utils'` and is plain-Node-hostile by design — so is the `/utils`

--- a/packages/shared/src/constants/index.spec.ts
+++ b/packages/shared/src/constants/index.spec.ts
@@ -11,8 +11,9 @@
 // crashes any plain-Node evaluation of this barrel — Vitest here, but also jiti, since
 // apps/lfx-one's tailwind.config.js loads `@lfx-one/shared/constants` — with a JIT-compiler error
 // that surfaces far from its real cause (e.g. as an unrelated sass error on the global styles
-// entry). The two sanctioned constants->utils edges today are dashboard-metrics.constants.ts
-// (color.utils, number.utils) and committees.constants.ts (committee.utils) — both Angular-free.
+// entry). The sanctioned constants->utils edges today are dashboard-metrics.constants.ts
+// (color.utils, number.utils), committees.constants.ts (committee.utils), and
+// mentorship-enroll.constants.ts (date-time.utils) — all Angular-free.
 //
 // This only covers the `/constants` subpath: the package root barrel (`packages/shared/src/index.ts`)
 // still does `export * from './utils'` and is plain-Node-hostile by design — so is the `/utils`

--- a/packages/shared/src/constants/mentorship-enroll.constants.ts
+++ b/packages/shared/src/constants/mentorship-enroll.constants.ts
@@ -10,6 +10,7 @@ import type {
   MentorshipProgramTerm,
 } from '../interfaces/mentorship.interface';
 import { mentorshipArtworkIconUrl } from './mentorship.constants';
+import { toLocalDateOnlyString } from '../utils/date-time.utils';
 
 export const MENTORSHIP_ENROLL_STEPS_ORDER: MentorshipEnrollStep[] = ['details', 'setup', 'prerequisites'];
 
@@ -323,10 +324,6 @@ export const MENTORSHIP_SKILL_OPTIONS: readonly string[] = [
   'XML',
 ];
 
-function toIsoDateOnly(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
-}
-
 /**
  * A term whose application window and start month stay valid on `today` and on a
  * UTC host one civil day ahead. Application start is tomorrow so an untouched
@@ -341,10 +338,10 @@ export function createDefaultMentorshipTerm(today = new Date()): MentorshipProgr
   return {
     id: `term-1-${year}`,
     name: `Term 1 - ${year}`,
-    startDate: toIsoDateOnly(start),
-    endDate: toIsoDateOnly(end),
-    applicationStartDate: toIsoDateOnly(applicationStart),
-    applicationEndDate: toIsoDateOnly(applicationEnd),
+    startDate: toLocalDateOnlyString(start),
+    endDate: toLocalDateOnlyString(end),
+    applicationStartDate: toLocalDateOnlyString(applicationStart),
+    applicationEndDate: toLocalDateOnlyString(applicationEnd),
   };
 }
 

--- a/packages/shared/src/interfaces/api.interface.ts
+++ b/packages/shared/src/interfaces/api.interface.ts
@@ -59,6 +59,8 @@ export interface MicroserviceUrls {
   LFX_V2_COMMITTEE_SERVICE: string;
   /** Campaign-service base URL; defaults to LFX_V2_SERVICE. Override to route only the project-scoped briefs, campaigns and jobs calls elsewhere (e.g. a locally-run campaign-service). */
   LFX_V2_CAMPAIGN_SERVICE: string;
+  /** Formation-service base URL; defaults to LFX_V2_SERVICE. Override to route only `/formations/*` calls elsewhere (e.g. a locally-run formation-service, or dev while the BFF otherwise talks to prod). */
+  LFX_V2_FORMATION_SERVICE: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/formation-checklist.interface.ts
+++ b/packages/shared/src/interfaces/formation-checklist.interface.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import type { ButtonSeverity, TagSeverity } from './components.interface';
-import type { Formation, FormationActivity, FormationItem, FormationItemStatus, FormationSubStage, FormationTemplateSection } from './formation.interface';
+import type {
+  FormationActivity,
+  FormationItem,
+  FormationItemStatus,
+  FormationQueueRow,
+  FormationSubStage,
+  FormationTemplateSection,
+} from './formation.interface';
 
 /**
  * Client-derived stand-in for the readiness strip. TODO(#1957): once the backend returns a
@@ -70,16 +77,27 @@ export interface FormationLinkRowActionConfig {
 }
 
 /**
- * `FormationsTableComponent`'s render row — `Formation` plus the pre-resolved stage chip
- * label/severity, so the `#body` template (where PrimeNG types the row context `any`) does a plain
- * property read instead of a method call that re-executes on every change-detection pass.
+ * `FormationsTableComponent`'s render row — {@link FormationQueueRow} plus the pre-resolved stage
+ * chip label/severity/gating summary, so the `#body` template (where PrimeNG types the row context
+ * `any`) does a plain property read instead of a method call that re-executes on every
+ * change-detection pass.
+ *
+ * GH-2267 gap 2: previously extended `Formation` (which carried `gating_items_open`/
+ * `gating_items_total`/`parent_formation_name`/`subtitle`) — the real indexed queue projection
+ * doesn't publish any of those, so this now extends {@link FormationQueueRow} instead and derives
+ * the gating "N of M" summary from `progress` + `gates_cleared`. The one-level indentation this
+ * used to drive off `parent_formation_name` has no data source upstream and is dropped with it —
+ * the Type column (from `deriveFormationEntityType`, unaffected by this gap) still distinguishes a
+ * `child_project` row, just without visual indentation.
  */
-export interface FormationTableRow extends Formation {
+export interface FormationTableRow extends FormationQueueRow {
   stageLabel: string;
   stageSeverity: TagSeverity;
   entityTypeLabel: string;
-  /** True when `parent_formation_name` matches another row's `parent_project_name` in the current result — drives the queue's one-level indented display (GH-1958 review). */
-  isChildRow: boolean;
+  /** `progress.done` — the completed count for the "N of M" gating summary. */
+  doneCount: number;
+  /** Sum of every `progress` bucket — the "M" in the "N of M" gating summary. */
+  totalCount: number;
 }
 
 /**

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -49,7 +49,14 @@ export interface FormationUser {
 }
 
 export interface Formation {
-  uid: string;
+  /**
+   * Absent on the checklist read (`GET /formations/{project_uid}` doesn't echo the formation's own
+   * uid today — raised upstream on #1957/GH-2267 as a one-line additive fix) — present on the queue
+   * projection ({@link FormationQueueRow.formation_uid}, copied here on that read path). Nothing in
+   * this repo cross-references a checklist-read `Formation` against a queue-read one by uid today,
+   * so the absence is safe to leave as-is until the upstream field lands.
+   */
+  uid?: string;
   /** The project this formation is FOR — not that project's parent; see {@link Formation.parent_uid} for that. */
   parent_project_uid: string;
   parent_project_slug: string;
@@ -95,8 +102,9 @@ export interface Formation {
   /** First not-done gating item's title, precomputed for the queue's "Blocking" column. */
   blocking_item_title: string | null;
   subtitle: string | null;
-  created_at: string;
-  updated_at: string;
+  /** Absent on the checklist read (`GET /formations/{project_uid}` doesn't return either timestamp) — raised upstream on #1957/GH-2267. */
+  created_at?: string;
+  updated_at?: string;
 }
 
 /**
@@ -180,6 +188,14 @@ export interface FormationItem {
   can_complete: boolean;
   created_at: string;
   updated_at: string;
+  /**
+   * Optimistic-locking token (#1957/GH-2267 gap 1). Echoed on every read, sent back as `If-Match`
+   * on every mutation; a stale value 412s upstream (mapped to `PreconditionFailedError` in the BFF)
+   * rather than silently overwriting a concurrent edit. Not present on any fixture-era item created
+   * before this field existed — callers reading an older stored item must treat a missing value as
+   * "unknown", never as "0" or "no lock".
+   */
+  version: number;
 }
 
 export interface FormationItemLink {
@@ -283,9 +299,38 @@ export type FormationQueueTiles = Record<FormationSubStage, number> & {
   projects: number;
 };
 
+/**
+ * One queue row, shaped to exactly what the `formation` indexed document carries
+ * (`internal/infrastructure/nats/indexer_publisher.go`'s hand-written allowlist) — not a subset of
+ * {@link Formation}. The indexer doesn't publish `template_uid`/`template_version`/`created_at`/
+ * `updated_at`/`gating_items_open`/`gating_items_total` (#1957/GH-2267 gap 2, raised upstream), so
+ * this is a deliberately separate shape rather than `Partial<Formation>` or an extension of it.
+ * `gates_cleared` replaces the checklist read's open/total pair — the queue's gating column reads
+ * off `gates_cleared` + `progress`, not `gating_items_open`/`gating_items_total`.
+ */
+export interface FormationQueueRow {
+  formation_uid: string;
+  project_uid: string;
+  project_name: string;
+  project_slug: string;
+  is_foundation: boolean;
+  /** Same ROOT-collapse contract as {@link Formation.parent_uid} — `null` for a top-level project. */
+  parent_uid: string | null;
+  sub_stage: FormationSubStage;
+  lifecycle: string;
+  /** Every gating item done — the projection's own boolean, not derived client-side (unlike {@link Formation.is_activating}, which is #1957-computed on the checklist read but not yet mirrored into the indexed document). */
+  gates_cleared: boolean;
+  is_activating: boolean;
+  announcement_date: string | null;
+  /** Six named progress counters (e.g. per-section or per-status breakdown) as published by the indexer — kept as a loose record until the projection's exact key set is confirmed upstream. */
+  progress: Record<string, number>;
+  blocked_item_titles: string[];
+  assignees: FormationUser[];
+}
+
 /** Response body for `GET /api/formations`. */
 export interface FormationsQueueResponse {
   tiles: FormationQueueTiles;
-  rows: Formation[];
+  rows: FormationQueueRow[];
   data_source: 'fixture' | 'live';
 }

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -324,8 +324,13 @@ export interface FormationQueueRow {
   gates_cleared: boolean;
   is_activating: boolean;
   announcement_date: string | null;
-  /** Six named progress counters (e.g. per-section or per-status breakdown) as published by the indexer — kept as a loose record until the projection's exact key set is confirmed upstream. */
-  progress: Record<string, number>;
+  /**
+   * Per-status item counts published by the indexer (`indexer_publisher.go`'s `projectionData`
+   * always emits all six {@link FormationItemStatus} keys). Still `Record<...>` rather than a
+   * required-keys type, and defaulted defensively where consumed, as protection against a
+   * malformed document rather than an open contract question.
+   */
+  progress: Record<FormationItemStatus, number>;
   blocked_item_titles: string[];
   /** Bare usernames, as published by the indexer (`internal/domain/port/ports.go`'s `Assignees []string`) — not `FormationUser` objects. */
   assignees: string[];

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -326,11 +326,13 @@ export interface FormationQueueRow {
   announcement_date: string | null;
   /**
    * Per-status item counts published by the indexer (`indexer_publisher.go`'s `projectionData`
-   * always emits all six {@link FormationItemStatus} keys). Still `Record<...>` rather than a
-   * required-keys type, and defaulted defensively where consumed, as protection against a
-   * malformed document rather than an open contract question.
+   * always emits all six {@link FormationItemStatus} keys). Typed `Partial<...>` rather than a
+   * required-keys `Record`, and defaulted defensively where consumed (`formation.service.ts`'s
+   * `??` default, `formations-table.component.ts`'s `?? 0`), as protection against a malformed
+   * document rather than an open contract question — the confirmed six-key shape doesn't need an
+   * unsound cast to express a `{}` fallback.
    */
-  progress: Record<FormationItemStatus, number>;
+  progress: Partial<Record<FormationItemStatus, number>>;
   blocked_item_titles: string[];
   /** Bare usernames, as published by the indexer (`internal/domain/port/ports.go`'s `Assignees []string`) — not `FormationUser` objects. */
   assignees: string[];

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -126,7 +126,10 @@ export type FormationItemStatus = 'not_started' | 'in_progress' | 'blocked' | 'a
  * `request` type is #1957/Epic 2). `status_only` items never expose how the underlying tooling was
  * set up (manual vs automated) — only Done/pending + an optional link.
  */
-export type FormationItemAction = 'manual' | 'link' | 'provisionable' | 'request' | 'status_only';
+// Derived from `FormationActionType` rather than its own literal union — the two must always agree
+// (the seeded template's `action` field is `FormationActionType`; a live checklist item's `action`
+// is one of these same values), and deriving it removes the need to cast between them.
+export type FormationItemAction = `${FormationActionType}`;
 
 export interface FormationSubItem {
   uid: string;
@@ -191,9 +194,8 @@ export interface FormationItem {
   /**
    * Optimistic-locking token (#1957/GH-2267 gap 1). Echoed on every read, sent back as `If-Match`
    * on every mutation; a stale value 412s upstream (mapped to `PreconditionFailedError` in the BFF)
-   * rather than silently overwriting a concurrent edit. Not present on any fixture-era item created
-   * before this field existed — callers reading an older stored item must treat a missing value as
-   * "unknown", never as "0" or "no lock".
+   * rather than silently overwriting a concurrent edit. Always populated — the fixture generator
+   * seeds `1` for every item, and the live mapper echoes the upstream `version` verbatim.
    */
   version: number;
 }
@@ -325,7 +327,8 @@ export interface FormationQueueRow {
   /** Six named progress counters (e.g. per-section or per-status breakdown) as published by the indexer — kept as a loose record until the projection's exact key set is confirmed upstream. */
   progress: Record<string, number>;
   blocked_item_titles: string[];
-  assignees: FormationUser[];
+  /** Bare usernames, as published by the indexer (`internal/domain/port/ports.go`'s `Assignees []string`) — not `FormationUser` objects. */
+  assignees: string[];
 }
 
 /** Response body for `GET /api/formations`. */
@@ -333,4 +336,53 @@ export interface FormationsQueueResponse {
   tiles: FormationQueueTiles;
   rows: FormationQueueRow[];
   data_source: 'fixture' | 'live';
+}
+
+/**
+ * Raw item shape from `GET /formations/{project_uid}` / a mutation response — one entry of
+ * {@link UpstreamFormationChecklist}'s `items[]`. Server-only (`formation-mapper.helper.ts` maps it
+ * onto {@link FormationItem}), kept here per this package's "no local interface in apps/lfx-one"
+ * convention rather than declared next to its sole consumer.
+ */
+export interface UpstreamFormationItem {
+  uid: string;
+  item_key: string;
+  section_key: string;
+  position: number;
+  title: string;
+  owner_team?: string | null;
+  gate: boolean;
+  requires_writer: boolean;
+  status_source: 'manual' | 'platform';
+  is_required: boolean;
+  checklist_type: string;
+  platform_check?: { min_count: number; resource_type: string } | null;
+  action_link?: string | null;
+  evidence_link?: string | null;
+  status: FormationItemStatus;
+  assignee?: string | null;
+  due_date?: string | null;
+  note?: string | null;
+  skip_reason?: string | null;
+  resolved_ref?: { type: string; uid: string } | null;
+  sub_items?: { key: string; title: string; status: FormationItemStatus }[];
+  version: number;
+}
+
+/** Raw response shape from `GET /formations/{project_uid}?v=1` — the GH-2267 plan's gap 3 (no `formation_uid`/timestamps). */
+export interface UpstreamFormationChecklist {
+  project_uid: string;
+  template_uid: string;
+  template_version: number;
+  lifecycle: string;
+  sections: { key: string; title: string; position: number }[];
+  items: UpstreamFormationItem[];
+  is_activating: boolean;
+}
+
+/** Everything `mapUpstreamFormationItem` needs beyond the raw item itself — none of it is on the wire. */
+export interface FormationItemMapContext {
+  formationUid: string;
+  projectUid: string;
+  projectSlug: string;
 }

--- a/packages/shared/src/utils/date-time.utils.spec.ts
+++ b/packages/shared/src/utils/date-time.utils.spec.ts
@@ -11,6 +11,7 @@ import {
   parseLocalDateString,
   timeAgo,
   toLocalDateOnlyString,
+  tryParseLocalDateString,
 } from './date-time.utils';
 
 /**
@@ -184,5 +185,19 @@ describe('toLocalDateOnlyString', () => {
 
   it('round-trips with parseLocalDateString', () => {
     expect(toLocalDateOnlyString(parseLocalDateString('2026-01-31'))).toBe('2026-01-31');
+  });
+});
+
+describe('tryParseLocalDateString', () => {
+  it('parses a valid YYYY-MM-DD string', () => {
+    expect(tryParseLocalDateString('2026-01-31')).toEqual(parseLocalDateString('2026-01-31'));
+  });
+
+  it('returns null instead of throwing for null, undefined, empty, or malformed input', () => {
+    expect(tryParseLocalDateString(null)).toBeNull();
+    expect(tryParseLocalDateString(undefined)).toBeNull();
+    expect(tryParseLocalDateString('')).toBeNull();
+    expect(tryParseLocalDateString('not-a-date')).toBeNull();
+    expect(tryParseLocalDateString('2026-1-5')).toBeNull();
   });
 });

--- a/packages/shared/src/utils/date-time.utils.spec.ts
+++ b/packages/shared/src/utils/date-time.utils.spec.ts
@@ -3,7 +3,15 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { formatIsoDateLabel, localDateStamp, normalizeSnowflakeTimestamp, parseIsoDateAsUtcMidnight, timeAgo } from './date-time.utils';
+import {
+  formatIsoDateLabel,
+  localDateStamp,
+  normalizeSnowflakeTimestamp,
+  parseIsoDateAsUtcMidnight,
+  parseLocalDateString,
+  timeAgo,
+  toLocalDateOnlyString,
+} from './date-time.utils';
 
 /**
  * The fallback contract is the whole point of this helper: anything that is not a real
@@ -166,5 +174,15 @@ describe('localDateStamp', () => {
     vi.setSystemTime(new Date('2026-01-05T20:00:00Z'));
 
     expect(localDateStamp()).toBe('20260105');
+  });
+});
+
+describe('toLocalDateOnlyString', () => {
+  it('formats a local-calendar date with zero-padded month and day', () => {
+    expect(toLocalDateOnlyString(new Date(2026, 0, 5))).toBe('2026-01-05');
+  });
+
+  it('round-trips with parseLocalDateString', () => {
+    expect(toLocalDateOnlyString(parseLocalDateString('2026-01-31'))).toBe('2026-01-31');
   });
 });

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -91,6 +91,17 @@ export const parseLocalDateString = (dateString: string): Date => {
 };
 
 /**
+ * Nullable counterpart to {@link parseLocalDateString} for callers reading a date-only field they
+ * cannot fail on — a malformed value comes back as `null` instead of throwing.
+ */
+export function tryParseLocalDateString(dateString: string | null | undefined): Date | null {
+  if (!dateString || !/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+    return null;
+  }
+  return parseLocalDateString(dateString);
+}
+
+/**
  * Formats a `Date` as a local-calendar `YYYY-MM-DD` string — the write-side counterpart to
  * {@link parseLocalDateString}. Built from local getters rather than `toISOString().slice(0, 10)`,
  * which reports the UTC calendar day and is a different day than the one a date picker showed for

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -91,6 +91,18 @@ export const parseLocalDateString = (dateString: string): Date => {
 };
 
 /**
+ * Formats a `Date` as a local-calendar `YYYY-MM-DD` string — the write-side counterpart to
+ * {@link parseLocalDateString}. Built from local getters rather than `toISOString().slice(0, 10)`,
+ * which reports the UTC calendar day and is a different day than the one a date picker showed for
+ * any viewer not at UTC+0.
+ */
+export function toLocalDateOnlyString(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/**
  * Combines a date and time string into an ISO string in the specified timezone
  * @param date The date object
  * @param time The time string in 12-hour format (e.g., "12:45 AM")

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -4,10 +4,12 @@
 import { fromZonedTime, getTimezoneOffset, toZonedTime } from 'date-fns-tz';
 
 // Direct file imports (not the '../constants' barrel): unlike activity-feed.utils.ts (see its
-// comment, and constants/index.spec.ts for the invariant), this isn't just defensive — a live path
-// already reaches this file from constants (constants/index.ts -> committees.constants.ts ->
-// '../utils/committee.utils' -> './date-time.utils'), so importing the constants barrel here would
-// close an actual cycle today. The two underlying constant files sidestep that entirely.
+// comment, and constants/index.spec.ts for the invariant), this isn't just defensive — live paths
+// already reach this file from constants, both indirectly (constants/index.ts ->
+// committees.constants.ts -> '../utils/committee.utils' -> './date-time.utils') and directly
+// (constants/index.ts -> mentorship-enroll.constants.ts -> './date-time.utils'), so importing the
+// constants barrel here would close an actual cycle today. The two underlying constant files
+// sidestep that entirely.
 import { DAYS_IN_WEEK, DEFAULT_REPEAT_INTERVAL, MINUTES_IN_HOUR, MS_IN_DAY, TIME_ROUNDING_MINUTES, WEEKDAY_CODES } from '../constants/meeting.constants';
 import { TIMEZONES } from '../constants/timezones.constants';
 import { RecurrenceType } from '../enums';
@@ -68,6 +70,9 @@ export const parseISODateString = (dateString: string | null | undefined): Date 
   return new Date(dateString);
 };
 
+/** Shape guard shared by {@link parseLocalDateString} and {@link tryParseLocalDateString} — keep the two in sync by referencing this rather than restating the pattern. */
+const LOCAL_DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 /**
  * Parse a date string in YYYY-MM-DD format as a local date (not UTC)
  * This avoids timezone shifting issues when displaying dates from analytics data
@@ -76,7 +81,7 @@ export const parseISODateString = (dateString: string | null | undefined): Date 
  * @throws Error if the date string is not in the expected format or is invalid
  */
 export const parseLocalDateString = (dateString: string): Date => {
-  if (!dateString || !/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+  if (!dateString || !LOCAL_DATE_ONLY_PATTERN.test(dateString)) {
     throw new Error(`Invalid date string format. Expected YYYY-MM-DD, got: ${dateString}`);
   }
 
@@ -95,7 +100,7 @@ export const parseLocalDateString = (dateString: string): Date => {
  * cannot fail on — a malformed value comes back as `null` instead of throwing.
  */
 export function tryParseLocalDateString(dateString: string | null | undefined): Date | null {
-  if (!dateString || !/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+  if (!dateString || !LOCAL_DATE_ONLY_PATTERN.test(dateString)) {
     return null;
   }
   return parseLocalDateString(dateString);

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -584,10 +584,7 @@ export function formatShortDate(date: Date): string {
  * tomorrow's date for any viewer west of UTC exporting in the evening).
  */
 export function localDateStamp(): string {
-  const now = new Date();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  return `${now.getFullYear()}${month}${day}`;
+  return toLocalDateOnlyString(new Date()).replace(/-/g, '');
 }
 
 /**

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
+import { toLocalDateOnlyString } from './date-time.utils';
 import { sanitizeFilename } from './file.utils';
 
 /**
@@ -75,9 +76,7 @@ function toDateStamp(value: Date | string | null | undefined): string {
   if (!value) return '';
   const date = new Date(value);
   if (isNaN(date.getTime())) return '';
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${date.getFullYear()}-${month}-${day}`;
+  return toLocalDateOnlyString(date);
 }
 
 /**

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -45,7 +45,7 @@ import type {
   MentorshipRowAction,
   MentorshipTermDateErrors,
 } from '../interfaces/mentorship.interface';
-import { formatIsoDateLabel, monthYearToIsoDate } from './date-time.utils';
+import { formatIsoDateLabel, monthYearToIsoDate, toLocalDateOnlyString } from './date-time.utils';
 import { stripHtml } from './html-utils';
 import { normalizeToUrl } from './url.utils';
 
@@ -283,10 +283,7 @@ export function parseMentorshipDateOnly(value: string): Date | null {
 }
 
 export function toMentorshipDateOnly(value: Date): string {
-  const year = value.getFullYear();
-  const month = String(value.getMonth() + 1).padStart(2, '0');
-  const day = String(value.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  return toLocalDateOnlyString(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the Formation Checklist / Formations Queue BFF's fixture layer with a real client
against `lfx-v2-formation-service`, now live on dev. Covers PR A of the GH-2267 plan: transport,
route re-addressing to `(project_uid, item_key)`, upstream error mapping (including a new
`PreconditionFailedError` for 412 `version_mismatch`), and ROOT-project `parent_uid` collapse.

Builds on `#1958`/`#2033` (Formation Checklist + Formations queue, Epic 1 scope), already merged
into `main`.

## Protected files

`/lfx-self-serve-pr-readiness` flagged 2 infrastructure-guarded files touched by this PR:

- `apps/lfx-one/src/server/server.ts` — mount-point docstring update only (reflects the new
  `(project_uid, item_key)` addressing for the formations router).
- `apps/lfx-one/src/server/services/microservice-proxy.service.ts` — adds `LFX_V2_FORMATION_SERVICE`
  to `resolveBaseUrl`, falling back to `LFX_V2_SERVICE`, the same pattern already used for
  `LFX_V2_MEMBER_SERVICE` / `LFX_V2_COMMITTEE_SERVICE` / `LFX_V2_CAMPAIGN_SERVICE`.

Requesting a code owner review on these two specifically.

## Deployment changes

- New env var `LFX_V2_FORMATION_SERVICE` (optional) — a formation-only dev override so the BFF can
  point at the service's dev gateway while everything else still talks to prod. Falls back to
  `LFX_V2_SERVICE` when unset, so no deployment config is required to keep current behavior.
- `isFormationServiceLive()` now also honors `FORMATION_BACKEND=live` in addition to the new env
  var being set, and gates `getFormationsQueue` plus all mutation methods (previously only
  `getProjectFormation` branched on it).

## What is / isn't verified

Dev is not usable end-to-end yet (template never seeded on dev, `team:formation` has zero members
there, an upstream project-service dependency was still open at last check) — see the GH-2267 plan
for details. Every path here is contract-verified only: built against the Goa design
(`lfx-v2-formation-service`'s `design/design.go`), with the transport (`MicroserviceProxyService.proxyRequest`)
mocked in tests. No live end-to-end check has been performed.

- **Drawer history is empty in live mode.** `getFormationItemDetail` still sources `history` from
  the process-local fixture activity store (`getActivityForItem`) regardless of `isFormationServiceLive()`,
  because none of the live mutation methods call `recordActivity` — there is no live equivalent yet.
  The upstream activity feed (`GET /formations/{project_uid}/activity`) and the shared-type rework
  it needs are gap 4 of the GH-2267 plan, explicitly deferred to PR B. Until PR B lands, the item
  drawer's "History" panel will render empty for any item mutated in live mode.

## Upstream items to raise on #1957 (not blockers)

- Add `formation_uid` to the checklist response — the checklist read has no unified identity with
  the queue projection today.
- Whether `created_at` / `updated_at` should appear on either read path.
- Whether the queue projection should carry `gating_items_open` / `gating_items_total`, since the
  queue UI already renders that pair.
- Confirm whether a `team:formation` member without project `auditor` is expected to be able to
  accept/reject/reopen — the BFF's read-gate-first ordering (masking a read denial as 404 before any
  mutation) would currently block such a caller; that's an upstream authz question, not something
  papered over here.
- Add a dedicated block-reason field to `update_item`, distinct from the general `note` field. Today
  a `blocked`-status transition's reason has nowhere upstream to live except `note`, which is also
  the drawer's persistent free-text field — writing the reason there would clobber it on the next
  plain note edit. The BFF currently drops the reason in live mode rather than overwrite `note` (see
  the code comment at `formation.service.ts`'s `updateFormationItemStatus`); a dedicated field (or an
  activity-log write from the service itself) would let the BFF preserve it without that conflict.

## Test plan

- [x] `yarn lint && yarn format && yarn check-types && yarn test && yarn build` — all green
- [x] Rewritten `formation.service.spec.ts` with `MicroserviceProxyService.proxyRequest` mocked —
      one case per endpoint, one per error mapping, ROOT-collapse case
- [x] New `root-project.helper.spec.ts` (TTL cache, fail-closed behavior)
- [x] New `validateItemKeyParameter` cases in `validation.helper.spec.ts`
- [ ] Live smoke test against dev (blocked — see "What is / isn't verified" above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZvfDc7yvuCsNB9DRD5dhQ
