### PR TITLE
fix(meetings): correct the composer save paths and label every input

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/add-link-dialog/add-link-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/add-link-dialog/add-link-dialog.component.html
@@ -4,9 +4,17 @@
 <div class="flex flex-col gap-4" data-testid="composer-add-link-dialog">
   <div class="flex flex-col gap-2">
     <label for="composer-link-title" class="text-sm font-medium text-gray-900">Title</label>
-    <lfx-input-text [form]="form" control="title" id="composer-link-title" placeholder="Design doc" dataTest="composer-link-title-input" styleClass="w-full" />
+    <lfx-input-text
+      [form]="form"
+      control="title"
+      inputId="composer-link-title"
+      placeholder="Design doc"
+      dataTest="composer-link-title-input"
+      styleClass="w-full"
+      [describedBy]="form.controls.title.touched && form.controls.title.invalid ? 'composer-link-title-error' : null"
+      [invalid]="form.controls.title.touched && form.controls.title.invalid" />
     @if (form.controls.title.touched && form.controls.title.invalid) {
-      <p class="text-xs text-red-600" data-testid="composer-link-title-error">A title is required.</p>
+      <p id="composer-link-title-error" class="text-xs text-red-600" data-testid="composer-link-title-error">A title is required.</p>
     }
   </div>
 
@@ -15,13 +23,15 @@
     <lfx-input-text
       [form]="form"
       control="url"
-      id="composer-link-url"
+      inputId="composer-link-url"
       type="url"
       placeholder="https://example.com/doc"
       dataTest="composer-link-url-input"
-      styleClass="w-full" />
+      styleClass="w-full"
+      [describedBy]="form.controls.url.touched && form.controls.url.invalid ? 'composer-link-url-error' : null"
+      [invalid]="form.controls.url.touched && form.controls.url.invalid" />
     @if (form.controls.url.touched && form.controls.url.invalid) {
-      <p class="text-xs text-red-600" data-testid="composer-link-url-error">Enter a full URL starting with https://</p>
+      <p id="composer-link-url-error" class="text-xs text-red-600" data-testid="composer-link-url-error">Enter a full URL starting with https://</p>
     }
   </div>
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
@@ -10,7 +10,7 @@
         icon="fa-light fa-list"
         size="small"
         [text]="true"
-        [ariaPressed]="showTemplates()"
+        [ariaExpanded]="showTemplates()"
         (onClick)="onToggleTemplates($event, templatesPopover)"
         [attr.data-testid]="inputId() + '-templates-toggle'" />
       <lfx-button
@@ -18,7 +18,7 @@
         icon="fa-light fa-wand-magic-sparkles"
         size="small"
         [text]="true"
-        [ariaPressed]="showAiHelper()"
+        [ariaExpanded]="showAiHelper()"
         (onClick)="aiPopover.toggle($event)"
         [attr.data-testid]="inputId() + '-ai-toggle'" />
     </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.spec.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { AbstractControl } from '@angular/forms';
 import { MEETING_AGENDA_PROMPT_MAX_LENGTH } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
+import type { MeetingTemplate } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
@@ -97,5 +100,88 @@ describe('ComposerAgendaFieldComponent — AI helper guard', () => {
 
     expect(formService.form().get('aiPrompt')?.errors).toBeNull();
     expect(formService.form().get('aiPrompt')?.valid).toBe(true);
+  });
+});
+
+/**
+ * Covers what an applied template or a generated agenda leaves behind on the controls it writes.
+ *
+ * `setValue` alone leaves a control pristine, and two surfaces read pristine as "still an untouched
+ * default": the quick dialog's type-change prefill skips only dirty controls, and edit mode's Save is
+ * dirty-gated. So a template the organizer deliberately picked was free for the next type switch to
+ * overwrite, and a generated agenda in edit mode couldn't be saved.
+ */
+describe('ComposerAgendaFieldComponent — writes count as edits', () => {
+  let fixture: ComponentFixture<ComposerAgendaFieldComponent>;
+  let component: ComposerAgendaFieldComponent;
+  let formService: MeetingComposerFormService;
+
+  const popoverStub = { hide: vi.fn() } as unknown as Popover;
+  // A duration off the form's 60-minute default, so `applyEstimatedDuration` actually writes rather
+  // than short-circuiting on the no-op guard.
+  const template: MeetingTemplate = {
+    id: 'template-1',
+    title: 'Weekly sync',
+    content: '1. Roll call',
+    meetingType: MeetingType.BOARD,
+    estimatedDuration: 30,
+  };
+  const controlOf = (name: string): AbstractControl | null => formService.form().get(name);
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: { generateAgenda: vi.fn(() => of({ agenda: 'Roll call', estimatedDuration: 45 })) } },
+        { provide: ProjectContextService, useValue: { activeContext: () => null, activeContextUid: () => null } },
+        { provide: PersonaService, useValue: { currentPersona: () => null } },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerAgendaFieldComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerAgendaFieldComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('marks the agenda dirty when a template is applied', () => {
+    component['onApplyTemplate'](template, popoverStub);
+
+    expect(controlOf('description')?.value).toBe(template.content);
+    expect(controlOf('description')?.dirty).toBe(true);
+  });
+
+  it('marks the duration controls dirty when a template estimate is applied', () => {
+    component['onApplyTemplate'](template, popoverStub);
+
+    expect(controlOf('duration')?.value).toBe(30);
+    expect(controlOf('duration')?.dirty).toBe(true);
+    expect(controlOf('customDuration')?.dirty).toBe(true);
+  });
+
+  it('marks the agenda and duration dirty when the AI helper returns a draft', () => {
+    formService.form().get('title')?.setValue('Quarterly review');
+
+    component['onGenerateAgenda'](popoverStub);
+
+    expect(controlOf('description')?.value).toBe('Roll call');
+    expect(controlOf('description')?.dirty).toBe(true);
+    expect(controlOf('duration')?.dirty).toBe(true);
+  });
+
+  // The estimate is dropped with a warning when it falls outside the custom-duration range, and a
+  // dropped write must not claim the organizer touched the field — that would deaden the quick
+  // dialog's prefill for a duration nobody set.
+  it('leaves the duration pristine when the estimate is out of range and gets dropped', () => {
+    component['onApplyTemplate']({ ...template, estimatedDuration: 100000 }, popoverStub);
+
+    expect(controlOf('duration')?.dirty).toBe(false);
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.ts
@@ -101,7 +101,7 @@ export class ComposerAgendaFieldComponent {
   }
 
   protected onApplyTemplate(template: MeetingTemplate, popover: Popover): void {
-    this.form().get('description')?.setValue(template.content);
+    this.writeAgenda(template.content);
     this.applyEstimatedDuration(template.estimatedDuration);
     popover.hide();
   }
@@ -153,7 +153,7 @@ export class ComposerAgendaFieldComponent {
         take(1),
         tap({
           next: (response) => {
-            this.form().get('description')?.setValue(response.agenda);
+            this.writeAgenda(response.agenda);
             this.applyEstimatedDuration(response.estimatedDuration);
             popover.hide();
             this.messageService.add({ severity: 'success', summary: 'Agenda generated', detail: 'Review the draft and edit it as needed.' });
@@ -167,6 +167,21 @@ export class ComposerAgendaFieldComponent {
         finalize(() => this.isGeneratingAgenda.set(false))
       )
       .subscribe();
+  }
+
+  /**
+   * Writes an agenda the organizer asked for, and marks it as theirs.
+   * @description `setValue` alone leaves the control pristine, which two other surfaces read as "still
+   * an untouched default": the quick dialog's type-change prefill would overwrite a template the
+   * organizer deliberately picked, and edit mode's dirty-gated Save would stay disabled over a
+   * generated agenda with nothing saying why. Asking for this content is a deliberate edit, so it is
+   * marked like one.
+   */
+  private writeAgenda(agenda: string): void {
+    const description = this.form().get('description');
+
+    description?.setValue(agenda);
+    description?.markAsDirty();
   }
 
   /**
@@ -193,6 +208,11 @@ export class ComposerAgendaFieldComponent {
     if (this.formService.effectiveDuration() === estimatedDuration) {
       return;
     }
+
+    // Dirty for the same reason the agenda is: `setDuration` writes through `setValue`, and the quick
+    // dialog's prefill only skips controls it can see the organizer has moved.
+    this.form().get('duration')?.markAsDirty();
+    this.form().get('customDuration')?.markAsDirty();
 
     this.formService.setDuration(estimatedDuration);
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -3,8 +3,15 @@
 
 import { TestBed } from '@angular/core/testing';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
-import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
-import type { Meeting, MeetingComposerSection, MeetingComposerSectionId, MeetingRegistrant, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
+import { CommitteeMemberRole, CommitteeMemberVotingStatus, MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
+import type {
+  CommitteeMember,
+  Meeting,
+  MeetingComposerSection,
+  MeetingComposerSectionId,
+  MeetingRegistrant,
+  MeetingRegistrantWithState,
+} from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -676,5 +683,237 @@ describe('MeetingComposerFormService — switch to advanced', () => {
     // The same open continuing, not a new one: the submit pipeline drops anything whose generation
     // moved under it, so bumping it here would make the organizer's own save land silently.
     expect(emissions).toEqual([{ id: 'meeting-1' }]);
+  });
+});
+/**
+ * Covers the reconciliation pass the Guests section runs whenever the group multi-select emits.
+ *
+ * All three of these are save-path regressions rather than display bugs: what the pass writes into
+ * `guests()` is what `registrantUpdates()` derives the create/update/delete batches from, and a wrong
+ * row here is a wrong invitation, a lost removal, or an attribution the update endpoint cannot repair
+ * afterwards (`UpdateMeetingRegistrantRequest` declares no `committee_uid`).
+ */
+describe('MeetingComposerFormService — group reconciliation', () => {
+  let service: MeetingComposerFormService;
+
+  /** A member of `committee_uid`, with the attribution fields the "via [Group]" chip reads. */
+  const member = (committeeUid: string, committeeName: string, email = 'chair@example.com'): CommitteeMember => ({
+    uid: `member-${committeeUid}`,
+    committee_uid: committeeUid,
+    committee_name: committeeName,
+    email,
+    first_name: 'Ada',
+    last_name: 'Lovelace',
+    role: { name: CommitteeMemberRole.CHAIR },
+    voting: { status: CommitteeMemberVotingStatus.VOTING_REP },
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        {
+          provide: MeetingService,
+          useValue: {
+            stripMetadata: (meetingUid: string, guest: MeetingRegistrantWithState) => ({
+              meeting_id: meetingUid,
+              email: guest.email,
+              committee_uid: guest.committee_uid,
+            }),
+            getChangedFields: (guest: MeetingRegistrantWithState) => ({ email: guest.email }),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+  });
+
+  it('adds an uninvited group member with that group attribution', () => {
+    service.syncCommitteeMembers([member('committee-board', 'Board')]);
+
+    expect(service.guests()).toHaveLength(1);
+    expect(service.guests()[0]).toMatchObject({
+      email: 'chair@example.com',
+      state: 'new',
+      type: 'committee',
+      committee_uid: 'committee-board',
+      committee_name: 'Board',
+      committee_role: CommitteeMemberRole.CHAIR,
+      committee_voting_status: CommitteeMemberVotingStatus.VOTING_REP,
+    });
+  });
+
+  // GH-1463: someone who sits on two selected groups matches the existing row on the second pass, so
+  // deselecting the group that first added them used to leave that group's `committee_uid` on the row.
+  // The create write then hits `resolveRegistrantCommitteeUids`, which strips a UID no longer attached
+  // to the meeting — the guest lands as `direct` and loses attribution outright.
+  it('re-reads a matched guest attribution from the group still emitting them', () => {
+    service.syncCommitteeMembers([member('committee-board', 'Board')]);
+    service.syncCommitteeMembers([member('committee-tac', 'TAC')]);
+
+    expect(service.guests()).toHaveLength(1);
+    expect(service.guests()[0]).toMatchObject({
+      state: 'new',
+      committee_uid: 'committee-tac',
+      committee_name: 'TAC',
+    });
+    // The batch is what actually reaches the API, so assert the refresh survives `stripMetadata`.
+    expect(service.registrantUpdates().toAdd).toEqual([{ meeting_id: '', email: 'chair@example.com', committee_uid: 'committee-tac' }]);
+  });
+
+  // The refresh is deliberately client-side only. A saved row's attribution is repaired in place for
+  // the sake of a later re-add, but it queues no PUT — `registrantUpdates` keys on `state`, and the
+  // server strips `committee_uid` from update bodies anyway so `PUT` cannot route around the create
+  // path's meeting-scoped allowlist.
+  it('refreshes a saved guest attribution without queueing an update for it', () => {
+    service.setGuests([
+      {
+        uid: 'registrant-1',
+        email: 'chair@example.com',
+        state: 'existing',
+        type: 'committee',
+        committee_uid: 'committee-board',
+        committee_name: 'Board',
+      } as MeetingRegistrantWithState,
+    ]);
+
+    service.syncCommitteeMembers([member('committee-tac', 'TAC')]);
+
+    expect(service.guests()[0]).toMatchObject({ state: 'existing', committee_uid: 'committee-tac', committee_name: 'TAC' });
+    expect(service.registrantUpdates()).toEqual({ toAdd: [], toUpdate: [], toDelete: [] });
+  });
+
+  it('queues a guest for deletion once no selected group emits them', () => {
+    service.setGuests([
+      { uid: 'registrant-1', email: 'chair@example.com', state: 'existing', type: 'committee', committee_uid: 'committee-board' } as MeetingRegistrantWithState,
+    ]);
+
+    service.syncCommitteeMembers([]);
+
+    expect(service.guests()[0]).toMatchObject({ state: 'deleted' });
+    expect(service.registrantUpdates().toDelete).toEqual(['registrant-1']);
+  });
+
+  it('restores a guest a re-selected group emits again', () => {
+    service.setGuests([
+      { uid: 'registrant-1', email: 'chair@example.com', state: 'existing', type: 'committee', committee_uid: 'committee-board' } as MeetingRegistrantWithState,
+    ]);
+    service.syncCommitteeMembers([]);
+
+    service.syncCommitteeMembers([member('committee-board', 'Board')]);
+
+    expect(service.guests()[0]).toMatchObject({ state: 'existing' });
+    expect(service.registrantUpdates().toDelete).toEqual([]);
+  });
+
+  it('keeps a hand-removed guest removed when their group emits again', () => {
+    service.setGuests([
+      { uid: 'registrant-1', email: 'chair@example.com', state: 'deleted', type: 'committee', committee_uid: 'committee-board' } as MeetingRegistrantWithState,
+    ]);
+    service.suppressGuestEmail('Chair@Example.com');
+
+    service.syncCommitteeMembers([member('committee-board', 'Board')]);
+
+    expect(service.guests()[0]).toMatchObject({ state: 'deleted' });
+    expect(service.registrantUpdates().toDelete).toEqual(['registrant-1']);
+  });
+
+  it('leaves a directly-added guest untouched by the group pass', () => {
+    service.setGuests([{ email: 'direct@example.com', state: 'new', type: 'direct' } as MeetingRegistrantWithState]);
+
+    service.syncCommitteeMembers([]);
+
+    expect(service.guests()).toHaveLength(1);
+    expect(service.guests()[0]).toMatchObject({ email: 'direct@example.com', state: 'new' });
+  });
+});
+
+/**
+ * Covers what the group pass and a load retry do while the saved guest list is missing.
+ *
+ * Both are the same hazard from opposite ends: an empty `guests()` that means "not loaded" rather
+ * than "nobody invited". Reconciling against it re-invites people who are already registered, and
+ * re-hydrating over it un-removes people the organizer has already taken off the list.
+ */
+describe('MeetingComposerFormService — group reconciliation after a failed guest load', () => {
+  let service: MeetingComposerFormService;
+  let getMeetingRegistrants: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getMeetingRegistrants = vi.fn().mockReturnValue(throwError(() => new Error('boom')));
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        {
+          provide: MeetingService,
+          useValue: {
+            getMeeting: vi.fn().mockReturnValue(of({ id: 'meeting-1', title: 'Saved meeting' } as Meeting)),
+            getMeetingAttachments: vi.fn().mockReturnValue(of([])),
+            getMeetingRegistrants,
+            stripMetadata: (meetingUid: string, guest: MeetingRegistrantWithState) => ({ meeting_id: meetingUid, email: guest.email }),
+            getChangedFields: (guest: MeetingRegistrantWithState) => ({ email: guest.email }),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+  });
+
+  it('does not queue invitations for a group while the saved guests are unknown', () => {
+    expect(service.guestsLoadFailed()).toBe(true);
+
+    service.syncCommitteeMembers([
+      {
+        uid: 'member-1',
+        committee_uid: 'committee-board',
+        committee_name: 'Board',
+        email: 'chair@example.com',
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    // Everyone in the group is already registered upstream; the fetch just didn't come back. Queueing
+    // them as `new` would re-invite the whole group on save.
+    expect(service.guests()).toEqual([]);
+    expect(service.registrantUpdates().toAdd).toEqual([]);
+  });
+
+  it('hydrates the saved guests as already persisted once the retry succeeds', () => {
+    getMeetingRegistrants.mockReturnValue(of([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]));
+
+    service.retryLoadMeeting();
+
+    expect(service.guestsLoadFailed()).toBe(false);
+    expect(service.guests()[0]).toMatchObject({ uid: 'registrant-1', state: 'existing' });
+    expect(service.registrantUpdates()).toEqual({ toAdd: [], toUpdate: [], toDelete: [] });
+  });
+
+  // The retry re-fetches rows the organizer may have removed in the meantime. Hydrating those as
+  // `existing` drops the removal from the pending batch with nothing on screen saying so, so a
+  // suppressed email comes back queued for deletion rather than silently un-removed.
+  it('keeps a removal the organizer made before the retry', () => {
+    service.suppressGuestEmail('Chair@Example.com');
+    getMeetingRegistrants.mockReturnValue(of([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]));
+
+    service.retryLoadMeeting();
+
+    expect(service.guests()[0]).toMatchObject({ uid: 'registrant-1', state: 'deleted' });
+    expect(service.registrantUpdates().toDelete).toEqual(['registrant-1']);
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -54,7 +54,9 @@ import {
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
+  normalizeMeetingApiVotingStatuses,
   resolveMeetingOwner,
+  sanitizeMeetingCommittees,
 } from '@lfx-one/shared/utils';
 import { editModeDateTimeValidator, futureDateTimeValidator } from '@lfx-one/shared/validators';
 import { CommitteeService } from '@services/committee.service';
@@ -617,6 +619,15 @@ export class MeetingComposerFormService {
    * Lives here rather than in the Guests section because the quick create dialog selects groups too.
    */
   public syncCommitteeMembers(members: CommitteeMember[]): void {
+    // A failed guest load leaves `guests()` empty while the meeting still has saved registrants
+    // upstream. Reconciling against that empty list reads every group member as uninvited and queues
+    // them as `state: 'new'`, so saving would re-invite people who are already registered. Skip the
+    // pass entirely until a retry populates the list — the section already surfaces the failure and
+    // offers "Try again", and the group selection is re-applied once that succeeds.
+    if (this.guestsLoadFailed()) {
+      return;
+    }
+
     const memberByEmail = new Map<string, CommitteeMember>();
     members.forEach((member) => {
       if (member.email) {
@@ -634,13 +645,23 @@ export class MeetingComposerFormService {
         }
 
         const email = guest.email?.toLowerCase() ?? '';
-        if (memberByEmail.has(email)) {
+        const member = memberByEmail.get(email);
+        if (member) {
           memberByEmail.delete(email);
           // Reconciliation has to be idempotent: a guest queued for deletion because they left every
           // selected group is restored when they turn up in one again. A guest the organizer removed by
           // hand is suppressed, so their deletion survives re-emission.
           const restore = guest.state === 'deleted' && !suppressed.has(email);
-          kept.push(restore ? { ...guest, state: 'existing' } : guest);
+          // Re-read the attribution off the member the *current* selection emitted. Someone who belongs
+          // to two groups matches here after the group that first added them is deselected, and keeping
+          // the row verbatim would carry that group's `committee_uid` into the create write — where
+          // `resolveRegistrantCommitteeUids` strips a UID no longer attached to the meeting and the
+          // guest lands as `direct`, losing attribution outright.
+          kept.push({
+            ...guest,
+            ...this.groupAttribution(member),
+            ...(restore ? { state: 'existing' as const } : {}),
+          });
           return kept;
         }
 
@@ -720,6 +741,26 @@ export class MeetingComposerFormService {
       username: member.username || null,
       linkedin_profile: member.linkedin_profile || null,
       type: 'committee',
+      ...this.groupAttribution(member),
+    };
+  }
+
+  /**
+   * The four fields that say which group a guest came in through.
+   *
+   * Shared by the add path and the re-match path in `syncCommitteeMembers` so a guest who moves
+   * between two selected groups ends up with exactly the attribution a freshly added one would get.
+   *
+   * Note this repairs the *pending* write only. An already-saved registrant keeps whatever upstream
+   * stored, because the edit endpoint deliberately refuses to carry attribution:
+   * `UpdateMeetingRegistrantRequest` declares no `committee_uid` and `MeetingController` strips one
+   * that arrives anyway, so `PUT` cannot route around the meeting-scoped allowlist the create path
+   * enforces. Re-attributing a saved guest means removing and re-adding them.
+   */
+  private groupAttribution(
+    member: CommitteeMember
+  ): Pick<MeetingRegistrantWithState, 'committee_uid' | 'committee_name' | 'committee_role' | 'committee_voting_status'> {
+    return {
       committee_uid: member.committee_uid,
       committee_name: member.committee_name,
       committee_role: member.role?.name || null,
@@ -963,7 +1004,16 @@ export class MeetingComposerFormService {
         // Guests added while the fetch was in flight keep their place ahead of the saved rows, unless the
         // fetch turns out to have already returned them — a group emission can add someone mid-flight.
         const pending = this.guests().filter((guest) => guest.state === 'new' && !loadedEmails.has(guest.email?.toLowerCase() ?? ''));
-        this.setGuests([...pending, ...loaded.map((registrant) => ({ ...registrant, state: 'existing' as const, originalData: { ...registrant } }))]);
+        // A retry after a failed load re-fetches rows the organizer may have removed since. Hydrating
+        // those as `existing` would silently drop the removal from the pending changes, so a suppressed
+        // email comes back queued for deletion instead of un-removed.
+        const suppressed = this.suppressedGuestEmails();
+        const restored = loaded.map((registrant) => ({
+          ...registrant,
+          state: suppressed.has(registrant.email?.toLowerCase() ?? '') ? ('deleted' as const) : ('existing' as const),
+          originalData: { ...registrant },
+        }));
+        this.setGuests([...pending, ...restored]);
       });
   }
 
@@ -1029,7 +1079,12 @@ export class MeetingComposerFormService {
       auto_email_reminder_time: formValue.auto_email_reminder_enabled ? this.clampReminderTime(formValue.reminderHours, formValue.reminderMinutes) : undefined,
       recurrence: recurrenceObject,
       platform: formValue.platform || DEFAULT_MEETING_TOOL,
-      committees: formValue.committees || [],
+      // Canonicalize stored voting statuses at the save boundary: the form hydrates committees verbatim,
+      // so a legacy row would otherwise resubmit display values ('Voting Rep') on an unrelated edit (GH-1796).
+      committees: sanitizeMeetingCommittees(formValue.committees).map((committee) => ({
+        ...committee,
+        allowed_voting_statuses: normalizeMeetingApiVotingStatuses(committee.allowed_voting_statuses),
+      })),
       ...this.prepareOwnerData(formValue),
     };
   }
@@ -1180,7 +1235,7 @@ export class MeetingComposerFormService {
       reminderHours: reminderHours,
       reminderMinutes: reminderTotalMinutes % 60,
       recurrenceType: finalRecurrenceValue,
-      committees: meeting.committees || [],
+      committees: sanitizeMeetingCommittees(meeting.committees),
     });
 
     // Duration is set through `setDuration()` rather than patched, because it lives in two controls.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.spec.ts
@@ -56,6 +56,36 @@ describe('MeetingComposerService', () => {
     service.switchToAdvanced();
 
     expect(service.activeSection()).toBe('details-access');
+  });
+
+  // The preview hides `startDate` until Date & Schedule is visited, because that control opens
+  // pre-filled with a default and showing it unvisited would present a date nobody chose. After the
+  // handoff the organizer *has* chosen one — in the dialog — so leaving the section unvisited blanked
+  // the date they were looking at a second earlier.
+  it('marks the dialog own sections visited, so the drawer does not blank what it showed', () => {
+    service.open({ mode: 'create', variant: 'quick' });
+
+    service.switchToAdvanced();
+
+    expect(service.visitedSections()).toEqual(new Set(['details-access', 'date-schedule', 'guests', 'agenda-resources']));
+  });
+
+  // The one section the dialog has no column for. The preview gates its feature rows on this, so
+  // marking it visited would list defaults the organizer has never been shown.
+  it('leaves platform & features unvisited, since the dialog never puts it on screen', () => {
+    service.open({ mode: 'create', variant: 'quick' });
+
+    service.switchToAdvanced();
+
+    expect(service.visitedSections().has('platform-features')).toBe(false);
+  });
+
+  it('clears the carried-over sections on close, so the next open starts fresh', () => {
+    service.open({ mode: 'create', variant: 'quick' });
+    service.switchToAdvanced();
+
+    service.close();
+
     expect(service.visitedSections()).toEqual(new Set(['details-access']));
   });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { computed, Injectable, signal } from '@angular/core';
-import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
+import { MEETING_COMPOSER_SECTIONS, MEETING_QUICK_CREATE_SECTIONS } from '@lfx-one/shared/constants';
 import type { MeetingComposerContext, MeetingComposerSectionId, MeetingComposerVariant } from '@lfx-one/shared/interfaces';
 
 const FIRST_SECTION: MeetingComposerSectionId = MEETING_COMPOSER_SECTIONS[0].id;
@@ -74,9 +74,16 @@ export class MeetingComposerService {
    * `MeetingComposerFormService.dropQuickCreateDefaults()`, which the drawer needs so a later type
    * change stops rewriting fields; `MeetingComposerHostComponent` owns that pairing, being the only
    * place that holds both services.
+   *
+   * The dialog's sections carry over as visited. `visitedSections` means "the organizer has seen this",
+   * and they have — the drawer is only a second view of a fill already in progress. Left unset, the
+   * preview blanks the date the organizer just picked (it hides `startDate` until Date & Schedule is
+   * visited, since that control opens pre-filled with a default) and the rail shows four sections they
+   * have already been through as untouched.
    */
   public switchToAdvanced(): void {
     this._variant.set('drawer');
+    this._visitedSections.update((visited) => new Set([...visited, ...MEETING_QUICK_CREATE_SECTIONS]));
   }
 
   public notifySaved(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
@@ -70,14 +70,48 @@ describe('QuickCreateDialogComponent', () => {
     expect(valueOf('description')).toBe('');
   });
 
-  it('leaves an earlier prefill in place when the organizer switches to Other', () => {
+  // The counterpart to the test above. Leaving the previous type's prefill standing put a Board title
+  // and a Board agenda under a meeting typed `Other`, with the "Pre-filled for this meeting type" hint
+  // gone — so nothing on screen said where the text had come from or that it no longer matched.
+  it('takes the previous type prefill back out when the organizer switches to Other', () => {
     selectType(MeetingType.BOARD);
-    const boardAgenda = valueOf('description');
+    expect(valueOf('description')).toBeTruthy();
 
     selectType(MeetingType.OTHER);
 
-    // Clearing here would throw away an agenda the organizer may already have edited; the hint under the
-    // field is what goes quiet, and it reads `seededAgenda`, which the skip resets.
-    expect(valueOf('description')).toBe(boardAgenda);
+    expect(valueOf('title')).toBe('');
+    expect(valueOf('description')).toBe('');
+  });
+
+  // The reason the clear is guarded on `pristine` rather than run unconditionally: once the organizer
+  // has written in the field it is theirs, and switching type must not throw it away.
+  it('keeps an edited agenda when the organizer switches to Other', () => {
+    selectType(MeetingType.BOARD);
+    formService.form().get('description')?.setValue('My own agenda');
+    formService.form().get('description')?.markAsDirty();
+
+    selectType(MeetingType.OTHER);
+
+    expect(valueOf('description')).toBe('My own agenda');
+  });
+
+  it('keeps an edited title when the organizer switches to Other', () => {
+    selectType(MeetingType.BOARD);
+    formService.form().get('title')?.setValue('Q3 planning');
+    formService.form().get('title')?.markAsDirty();
+
+    selectType(MeetingType.OTHER);
+
+    expect(valueOf('title')).toBe('Q3 planning');
+  });
+
+  it('replaces the previous type prefill rather than layering the new one over it', () => {
+    selectType(MeetingType.BOARD);
+    const boardTitle = valueOf('title');
+
+    selectType(MeetingType.TECHNICAL);
+
+    expect(valueOf('title')).not.toBe(boardTitle);
+    expect(valueOf('title')).toBeTruthy();
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -5,7 +5,7 @@ import { NgClass } from '@angular/common';
 import { Component, computed, inject, output, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
-import { MEETING_DURATION_CHIP_OPTIONS, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
+import { DEFAULT_DURATION, MEETING_DURATION_CHIP_OPTIONS, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import type { CardSelectorOption, CommitteeMember, MeetingTemplate } from '@lfx-one/shared/interfaces';
 import { getSelectableMeetingTypeOptions } from '@lfx-one/shared/utils';
@@ -172,12 +172,14 @@ export class QuickCreateDialogComponent {
    * scale are skipped, since seeding one would drop this surface into the custom-minutes input.
    */
   private applyTypeTemplate(meetingType: MeetingType | null): void {
+    // Take the previous type's prefill back out first, so a type whose template omits a field — or has
+    // no template at all, which is `Other` — can't leave the last type's title and agenda standing
+    // under it with the "Pre-filled for this meeting type" hint gone.
+    this.clearSeededValues();
+
     const template = this.defaultTemplateFor(meetingType);
 
     if (!template) {
-      this.seededTitle.set(false);
-      this.seededDuration.set(false);
-      this.seededAgenda.set(false);
       return;
     }
 
@@ -207,6 +209,35 @@ export class QuickCreateDialogComponent {
     this.seededTitle.set(seededTitle);
     this.seededDuration.set(seededDuration);
     this.seededAgenda.set(seededAgenda);
+  }
+
+  /**
+   * Returns the controls this dialog seeded to their untouched state.
+   * @description Guarded on `pristine` exactly as the seeding is: a seeded value the organizer has since
+   * edited is theirs, and clearing it would throw the edit away. Nothing else needs guarding, because a
+   * control only reaches here if a previous pass through {@link applyTypeTemplate} wrote it.
+   */
+  private clearSeededValues(): void {
+    const form = this.formService.form();
+    const title = form.get('title');
+    const description = form.get('description');
+    const duration = form.get('duration');
+
+    if (this.seededTitle() && title?.pristine) {
+      title.setValue('');
+    }
+
+    if (this.seededDuration() && duration?.pristine) {
+      this.formService.setDuration(DEFAULT_DURATION);
+    }
+
+    if (this.seededAgenda() && description?.pristine) {
+      description.setValue('');
+    }
+
+    this.seededTitle.set(false);
+    this.seededDuration.set(false);
+    this.seededAgenda.set(false);
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -80,27 +80,38 @@
       <div class="flex flex-col gap-1.5">
         <div class="flex items-center gap-2">
           <!-- Visually hidden: the chip group's "Duration" label names the group, and the adjacent
-               "minutes" is a unit — neither gives this input an accessible name of its own. `id`
-               lands on the real <input> in `InputNumberComponent`, so `for` associates correctly. -->
+               "minutes" is a unit — neither gives this input an accessible name of its own. `inputId`
+               is what puts the id on the real <input>; a plain `id` would also stay on the
+               `lfx-input-number` host, and `for` resolves to that first. -->
           <label class="sr-only" for="composer-custom-duration">Custom duration in minutes</label>
           <lfx-input-number
             [form]="form()"
             control="customDuration"
             size="small"
-            id="composer-custom-duration"
+            inputId="composer-custom-duration"
             [placeholder]="minCustomDuration + '–' + maxCustomDuration"
             styleClass="w-[7.5rem]"
+            [describedBy]="customDurationDescribedBy()"
+            [invalid]="customDurationInvalid()"
             data-testid="composer-custom-duration" />
           <span class="text-sm text-gray-500">minutes</span>
         </div>
+        <!-- Each paragraph carries the id `customDurationDescribedBy` names for the same error, and the
+             same `error && touched` gate, so the attribute never points at something unrendered. -->
         @if (form().get('customDuration')?.errors?.['required'] && form().get('customDuration')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-custom-duration-required-error">Custom duration is required</p>
+          <p id="composer-custom-duration-required-error" class="text-sm text-red-600" data-testid="composer-custom-duration-required-error">
+            Custom duration is required
+          </p>
         }
         @if (form().get('customDuration')?.errors?.['min'] && form().get('customDuration')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-custom-duration-min-error">Custom duration must be at least {{ minCustomDuration }} minutes</p>
+          <p id="composer-custom-duration-min-error" class="text-sm text-red-600" data-testid="composer-custom-duration-min-error">
+            Custom duration must be at least {{ minCustomDuration }} minutes
+          </p>
         }
         @if (form().get('customDuration')?.errors?.['max'] && form().get('customDuration')?.touched) {
-          <p class="text-sm text-red-600" data-testid="composer-custom-duration-max-error">Custom duration cannot exceed {{ maxCustomDuration }} minutes</p>
+          <p id="composer-custom-duration-max-error" class="text-sm text-red-600" data-testid="composer-custom-duration-max-error">
+            Custom duration cannot exceed {{ maxCustomDuration }} minutes
+          </p>
         }
       </div>
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { WEEKDAY_CODES } from '@lfx-one/shared/constants';
+import { MAX_CUSTOM_DURATION, MIN_CUSTOM_DURATION, WEEKDAY_CODES } from '@lfx-one/shared/constants';
 import { RecurrenceType } from '@lfx-one/shared/enums';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
@@ -208,5 +208,111 @@ describe('ComposerDateScheduleComponent', () => {
       // and must not be blanked out under the organizer.
       expect(recurrence()?.get('weekly_days')?.value).toBe('5');
     });
+  });
+});
+
+/**
+ * Covers the custom-duration input's `aria-describedby` and `aria-invalid`, read off the rendered DOM.
+ * @description The chip group is labelled and the adjacent "minutes" is a unit, so this input's whole
+ * accessible story — its name, its validity, and which of three messages applies — is carried by
+ * attributes. All three error paragraphs are gated on `touched`, which `markAsTouched()` publishes on
+ * neither `valueChanges` nor `statusChanges`; the template is rendered here rather than stubbed so a
+ * gate that went stale on blur would show up as an attribute naming a paragraph that is not there.
+ */
+describe('ComposerDateScheduleComponent — custom duration description ids', () => {
+  let fixture: ComponentFixture<ComposerDateScheduleComponent>;
+  let formService: MeetingComposerFormService;
+
+  const durationInput = (): HTMLInputElement => fixture.nativeElement.querySelector('#composer-custom-duration') as HTMLInputElement;
+
+  /** The attribute a screen reader would find, with every id it names resolved against the page. */
+  const describedBy = (): string | null => {
+    fixture.detectChanges();
+    const value = durationInput().getAttribute('aria-describedby');
+
+    for (const id of value?.split(' ') ?? []) {
+      expect(fixture.nativeElement.querySelector(`#${id}`), `aria-describedby names "${id}", which is not on the page`).not.toBeNull();
+    }
+
+    return value;
+  };
+
+  const ariaInvalid = (): string | null => {
+    fixture.detectChanges();
+    return durationInput().getAttribute('aria-invalid');
+  };
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+      ],
+    });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerDateScheduleComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // The whole block is behind the custom chip; picking it is also what attaches the validators.
+    formService.form().get('duration')?.setValue('custom');
+    fixture.detectChanges();
+  });
+
+  it('carries the id a `<label for>` can target, on the real input rather than the wrapper host', () => {
+    // `inputId`, not `id`: a static `id` on the component would also stay on the `lfx-input-number`
+    // host, and `for` resolves to that first — a label pointing at an element nothing can focus.
+    expect(durationInput().tagName).toBe('INPUT');
+    expect(fixture.nativeElement.querySelector('label[for="composer-custom-duration"]')).not.toBeNull();
+  });
+
+  it('says nothing while the field is untouched', () => {
+    expect(describedBy()).toBeNull();
+    expect(ariaInvalid()).toBeNull();
+  });
+
+  it('names the required error once the empty field is blurred', () => {
+    expect(describedBy()).toBeNull();
+
+    formService.form().get('customDuration')?.markAsTouched();
+
+    expect(describedBy()).toBe('composer-custom-duration-required-error');
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('names the min error for a duration under the floor', () => {
+    const control = formService.form().get('customDuration');
+    control?.setValue(MIN_CUSTOM_DURATION - 1);
+    control?.markAsTouched();
+
+    expect(describedBy()).toBe('composer-custom-duration-min-error');
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('names the max error for a duration over the ceiling', () => {
+    const control = formService.form().get('customDuration');
+    control?.setValue(MAX_CUSTOM_DURATION + 1);
+    control?.markAsTouched();
+
+    expect(describedBy()).toBe('composer-custom-duration-max-error');
+    expect(ariaInvalid()).toBe('true');
+  });
+
+  it('drops both once the duration is in range', () => {
+    const control = formService.form().get('customDuration');
+    control?.markAsTouched();
+    expect(describedBy()).toBe('composer-custom-duration-required-error');
+
+    control?.setValue(MIN_CUSTOM_DURATION + 5);
+
+    expect(describedBy()).toBeNull();
+    expect(ariaInvalid()).toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -24,8 +24,10 @@ import {
 } from '@lfx-one/shared/constants';
 import { RecurrenceType } from '@lfx-one/shared/enums';
 import { getTimezoneUtcOffsetString, getWeekOfMonth } from '@lfx-one/shared/utils';
+import { controlTouchedSignal } from '@shared/utils/control-touched.util';
 import { TooltipModule } from 'primeng/tooltip';
 
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
 import { MeetingRecurrencePatternComponent } from '../../components/meeting-recurrence-pattern/meeting-recurrence-pattern.component';
 
 /**
@@ -52,6 +54,10 @@ import { MeetingRecurrencePatternComponent } from '../../components/meeting-recu
 })
 export class ComposerDateScheduleComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
+  // Only for `revision`: `FormGroup` validity is not reactive, so the two computeds below would
+  // latch their first value without it. Provided by the composer host, which is also this
+  // component's injector inside the quick create dialog.
+  private readonly formService = inject(MeetingComposerFormService);
 
   public readonly form = input.required<FormGroup>();
   /** Quick create renders these fields under its own dialog header, where a section heading only repeats it. */
@@ -117,6 +123,35 @@ export class ComposerDateScheduleComponent implements OnInit {
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(0, 0, 0, 0);
     return yesterday;
+  });
+
+  // `markAsTouched()` bumps neither `valueChanges` nor `statusChanges`, so `revision` cannot carry
+  // the blur these two gates turn on — see `controlTouchedSignal`.
+  private readonly customDurationTouched = controlTouchedSignal(this.form, 'customDuration');
+
+  /**
+   * Ids of the custom-duration errors on screen, for the input's `aria-describedby`.
+   * @description One list rather than one binding per message, because the attribute takes a single
+   * value. The `touched` half of each gate matches the paragraphs below in the template: an id here
+   * that named an unrendered paragraph would describe the field with nothing.
+   */
+  protected readonly customDurationDescribedBy = computed<string | null>(() => {
+    this.formService.revision();
+    if (!this.customDurationTouched()) return null;
+
+    const errors = this.form().get('customDuration')?.errors;
+    const ids = [
+      errors?.['required'] ? 'composer-custom-duration-required-error' : null,
+      errors?.['min'] ? 'composer-custom-duration-min-error' : null,
+      errors?.['max'] ? 'composer-custom-duration-max-error' : null,
+    ].filter((id): id is string => id !== null);
+
+    return ids.length ? ids.join(' ') : null;
+  });
+
+  protected readonly customDurationInvalid = computed<boolean>(() => {
+    this.formService.revision();
+    return this.customDurationTouched() && (this.form().get('customDuration')?.invalid ?? false);
   });
 
   public ngOnInit(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -16,10 +16,11 @@
       [form]="form()"
       size="small"
       control="title"
-      id="composer-meeting-title"
+      inputId="composer-meeting-title"
       placeholder="Enter meeting title"
       styleClass="w-full"
       [describedBy]="titleDescribedBy()"
+      [invalid]="titleInvalid()"
       data-testid="composer-title-input" />
 
     @if (titleHint(); as hint) {
@@ -46,7 +47,8 @@
     <!-- `aria-describedby` on the input reaches the two title errors below, so each is read the next time
          the field takes focus rather than when it appears — no composer error message is in a live region
          yet. Matters for both: `required` only shows after blur, and `maxlength` typically shows while the
-         field still has focus. -->
+         field still has focus. The `error && touched` gates here and the ones building the id list are the
+         same predicate on purpose — see `initTitleDescribedBy`. -->
     @if (form().get('title')?.errors?.['required'] && form().get('title')?.touched) {
       <p id="composer-title-required-error" class="text-sm text-red-600" data-testid="composer-title-required-error">Meeting title is required</p>
     }
@@ -148,7 +150,7 @@
               [form]="form()"
               size="small"
               control="ownerName"
-              id="composer-organizer-name"
+              inputId="composer-organizer-name"
               placeholder="Enter organizer name"
               styleClass="w-full"
               data-testid="composer-organizer-name-input" />
@@ -159,12 +161,16 @@
               [form]="form()"
               size="small"
               control="ownerEmail"
-              id="composer-organizer-email"
+              inputId="composer-organizer-email"
               placeholder="Enter organizer email"
               styleClass="w-full"
+              [describedBy]="ownerEmailInvalid() ? 'composer-organizer-email-error' : null"
+              [invalid]="ownerEmailInvalid()"
               data-testid="composer-organizer-email-input" />
-            @if (form().get('ownerEmail')?.errors?.['email'] && form().get('ownerEmail')?.touched) {
-              <p class="text-sm text-red-600" role="alert" data-testid="composer-organizer-email-error">Enter a valid email address</p>
+            @if (ownerEmailInvalid()) {
+              <p id="composer-organizer-email-error" class="text-sm text-red-600" role="alert" data-testid="composer-organizer-email-error">
+                Enter a valid email address
+              </p>
             }
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
@@ -7,36 +7,69 @@ import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { SearchService } from '@services/search.service';
 import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingComposerFormService } from '../meeting-composer-form.service';
 import { ComposerDetailsAccessComponent } from './composer-details-access.component';
 
+const HINT = 'Pre-filled for this meeting type — edit freely.';
+
+function configure(): void {
+  TestBed.configureTestingModule({
+    providers: [
+      MeetingComposerFormService,
+      { provide: MessageService, useValue: { add: vi.fn() } },
+      { provide: CommitteeService, useValue: {} },
+      { provide: MeetingService, useValue: {} },
+      { provide: SearchService, useValue: { searchUsers: () => of([]) } },
+      { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+      { provide: PersonaService, useValue: { currentPersona: () => null } },
+    ],
+  });
+}
+
 /**
- * Covers the title's `aria-describedby` list. The paragraphs it points at are gated on `touched`, which
- * emits on neither `valueChanges` nor `statusChanges` — so a list that gated on it too would go stale for
- * exactly the case the errors exist for.
+ * Covers the title's `aria-describedby` list and `aria-invalid`, read off the rendered field.
+ * @description Both are gated on `touched`, which emits on neither `valueChanges` nor `statusChanges`.
+ * That is the whole risk in this wiring: a blur is exactly when a required-field error appears, and a
+ * gate keyed on the form service's `revision` would go stale for it. The template is rendered rather
+ * than stubbed so every emitted id can be resolved against the DOM — an id naming a paragraph that is
+ * not on the page describes the field with nothing, which is worse than describing it with silence.
  */
 describe('ComposerDetailsAccessComponent — title description ids', () => {
   let fixture: ComponentFixture<ComposerDetailsAccessComponent>;
   let component: ComposerDetailsAccessComponent;
   let formService: MeetingComposerFormService;
 
-  const describedBy = (): string | null => component['titleDescribedBy']();
+  const titleInput = (): HTMLInputElement => fixture.nativeElement.querySelector('#composer-meeting-title') as HTMLInputElement;
+
+  /**
+   * The attribute as a screen reader would find it, checked against the page and against the signal.
+   * @description Every read goes through here so the two invariants hold everywhere rather than in one
+   * dedicated test: each id names an element that exists, and the DOM says what `titleDescribedBy` says.
+   */
+  const describedBy = (): string | null => {
+    fixture.detectChanges();
+    const value = titleInput().getAttribute('aria-describedby');
+
+    for (const id of value?.split(' ') ?? []) {
+      expect(fixture.nativeElement.querySelector(`#${id}`), `aria-describedby names "${id}", which is not on the page`).not.toBeNull();
+    }
+    expect(value).toBe(component['titleDescribedBy']());
+
+    return value;
+  };
+
+  const ariaInvalid = (): string | null => {
+    fixture.detectChanges();
+    return titleInput().getAttribute('aria-invalid');
+  };
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      providers: [
-        MeetingComposerFormService,
-        { provide: MessageService, useValue: { add: vi.fn() } },
-        { provide: CommitteeService, useValue: {} },
-        { provide: MeetingService, useValue: {} },
-        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
-        { provide: PersonaService, useValue: { currentPersona: () => null } },
-      ],
-    });
-    TestBed.overrideComponent(ComposerDetailsAccessComponent, { set: { template: '', imports: [] } });
+    configure();
 
     formService = TestBed.inject(MeetingComposerFormService);
     formService.initialize({ mode: 'create', projectUid: 'project-1' });
@@ -47,50 +80,120 @@ describe('ComposerDetailsAccessComponent — title description ids', () => {
     await fixture.whenStable();
   });
 
-  it('points at the required error on an empty title', () => {
-    expect(describedBy()).toBe('composer-title-required-error');
+  it('names nothing on an untouched empty title', () => {
+    // The error paragraph is gated on `touched` too, so there is nothing here to point at yet.
+    expect(describedBy()).toBeNull();
+    expect(ariaInvalid()).toBeNull();
   });
 
-  it('still points at the required error after a blur-only touch', () => {
-    // Primed first on purpose: the read is what caches the computed, and a `touched`-gated version could
-    // only be caught going stale from a cached value — nothing bumps `revision` on `markAsTouched()`.
-    expect(describedBy()).toBe('composer-title-required-error');
+  it('points at the required error as soon as the field is blurred', () => {
+    // Primed first on purpose: the read caches the computed, so a version keyed on `revision` alone
+    // could only be caught going stale from a cached value — `markAsTouched()` bumps `revision` on
+    // neither `valueChanges` nor `statusChanges`. `AbstractControl.events` is what closes that gap.
+    expect(describedBy()).toBeNull();
 
     formService.form().get('title')?.markAsTouched();
 
     expect(describedBy()).toBe('composer-title-required-error');
+    expect(ariaInvalid()).toBe('true');
   });
 
   it('drops the error once the title is filled', () => {
+    formService.form().get('title')?.markAsTouched();
     expect(describedBy()).toBe('composer-title-required-error');
 
     formService.form().get('title')?.setValue('Composer meeting');
 
     expect(describedBy()).toBeNull();
+    expect(ariaInvalid()).toBeNull();
+  });
+
+  it('lists the prefill hint before any blur, since the hint has no `touched` gate', () => {
+    fixture.componentRef.setInput('titleHint', HINT);
+
+    expect(describedBy()).toBe('composer-title-hint');
+    expect(ariaInvalid()).toBeNull();
   });
 
   it('lists the prefill hint alongside the error', () => {
-    fixture.componentRef.setInput('titleHint', 'Pre-filled for this meeting type — edit freely.');
+    fixture.componentRef.setInput('titleHint', HINT);
+    formService.form().get('title')?.markAsTouched();
 
     expect(describedBy()).toBe('composer-title-hint composer-title-required-error');
   });
 
   it('lists the prefill hint alone once the prefilled title validates', () => {
-    fixture.componentRef.setInput('titleHint', 'Pre-filled for this meeting type — edit freely.');
+    fixture.componentRef.setInput('titleHint', HINT);
     formService.form().get('title')?.setValue('Composer meeting');
 
     expect(describedBy()).toBe('composer-title-hint');
   });
 
   it('points at the maxlength error when the YouTube limit is exceeded', () => {
-    expect(describedBy()).toBe('composer-title-required-error');
-
     formService.form().get('youtube_upload_enabled')?.setValue(true);
     formService
       .form()
       .get('title')
       ?.setValue('a'.repeat(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1));
+    formService.form().get('title')?.markAsTouched();
 
     expect(describedBy()).toBe('composer-title-maxlength-error');
+    expect(ariaInvalid()).toBe('true');
+  });
+});
+
+/**
+ * Covers the hand-typed organizer email, whose error was previously visual only.
+ * @description One predicate now drives the paragraph, the id the input points at, and `aria-invalid`,
+ * so the three cannot drift: the attribute can never name a paragraph the template did not render.
+ */
+describe('ComposerDetailsAccessComponent — organizer email error', () => {
+  let fixture: ComponentFixture<ComposerDetailsAccessComponent>;
+  let formService: MeetingComposerFormService;
+
+  const emailInput = (): HTMLInputElement => fixture.nativeElement.querySelector('#composer-organizer-email') as HTMLInputElement;
+
+  beforeEach(async () => {
+    configure();
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+    formService.switchToOwnerManualEntry();
+
+    fixture = TestBed.createComponent(ComposerDetailsAccessComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('says nothing about an untouched email', () => {
+    expect(emailInput().getAttribute('aria-invalid')).toBeNull();
+    expect(emailInput().getAttribute('aria-describedby')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#composer-organizer-email-error')).toBeNull();
+  });
+
+  it('names the error paragraph once a malformed address has been blurred', () => {
+    const control = formService.form().get('ownerEmail');
+    control?.setValue('not-an-email');
+    control?.markAsTouched();
+    fixture.detectChanges();
+
+    expect(emailInput().getAttribute('aria-invalid')).toBe('true');
+    expect(emailInput().getAttribute('aria-describedby')).toBe('composer-organizer-email-error');
+    expect(fixture.nativeElement.querySelector('#composer-organizer-email-error')).not.toBeNull();
+  });
+
+  it('clears both once the address parses', () => {
+    const control = formService.form().get('ownerEmail');
+    control?.setValue('not-an-email');
+    control?.markAsTouched();
+    fixture.detectChanges();
+
+    control?.setValue('organizer@example.com');
+    fixture.detectChanges();
+
+    expect(emailInput().getAttribute('aria-invalid')).toBeNull();
+    expect(emailInput().getAttribute('aria-describedby')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#composer-organizer-email-error')).toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -20,6 +20,7 @@ import { MeetingType } from '@lfx-one/shared/enums';
 import type { CardSelectorOption, UserSearchResult } from '@lfx-one/shared/interfaces';
 import { getSelectableMeetingTypeOptions } from '@lfx-one/shared/utils';
 import { PersonaService } from '@services/persona.service';
+import { controlTouchedSignal } from '@shared/utils/control-touched.util';
 import { map, of, startWith, switchMap } from 'rxjs';
 
 import { MeetingComposerFormService } from '../meeting-composer-form.service';
@@ -91,6 +92,12 @@ export class ComposerDetailsAccessComponent {
    * into one list instead of overwriting each other.
    */
   protected readonly titleDescribedBy: Signal<string | null> = this.initTitleDescribedBy();
+  /** Drives `aria-invalid`, on the same `error && touched` terms as the visible error text. */
+  protected readonly titleInvalid: Signal<boolean> = this.initTitleInvalid();
+  /** Gates the manual organizer email error, its id, and `aria-invalid` from one predicate. */
+  protected readonly ownerEmailInvalid: Signal<boolean> = this.initOwnerEmailInvalid();
+  private readonly titleTouched: Signal<boolean> = controlTouchedSignal(this.form, 'title');
+  private readonly ownerEmailTouched: Signal<boolean> = controlTouchedSignal(this.form, 'ownerEmail');
   /** Feeds the picker's own display box, so it renders whatever is committed — hydrated or freshly picked. */
   protected readonly selectedOwnerLabel: Signal<string> = this.initSelectedOwnerLabel();
   protected readonly savedOwnerLabel: Signal<string> = this.initSavedOwnerLabel();
@@ -219,21 +226,32 @@ export class ComposerDetailsAccessComponent {
       this.formService.revision();
 
       const title = this.form().get('title');
-      // Deliberately not gated on `touched`, unlike the paragraphs themselves: a blur-driven
-      // `markAsTouched()` emits on neither `valueChanges` nor `statusChanges`, so this would keep a stale
-      // list through exactly the case the errors exist for — tabbing out of an empty title. An id whose
-      // element isn't rendered yet is ignored when the accessibility tree resolves the list, so listing it
-      // early is inert; the cost is that the attribute can name an id no element has yet, which linters
-      // like axe report even though assistive tech doesn't care. Keeping both sides gated would mean
-      // bumping `revision` on blur, and the form service owns that signal for the whole composer — a
-      // per-field blur writing to it is a wider change than the association it would buy.
+      // The two error ids carry the same `error && touched` gate as the paragraphs they name, so the
+      // attribute never points at an element the template has not rendered. `touched` comes from
+      // `initTouched` rather than from `revision`, which a blur does not bump. The hint has no such
+      // gate — it renders whenever there is one.
+      const touched = this.titleTouched();
       const ids = [
         this.titleHint() ? 'composer-title-hint' : null,
-        title?.errors?.['required'] ? 'composer-title-required-error' : null,
-        title?.errors?.['maxlength'] ? 'composer-title-maxlength-error' : null,
+        touched && title?.errors?.['required'] ? 'composer-title-required-error' : null,
+        touched && title?.errors?.['maxlength'] ? 'composer-title-maxlength-error' : null,
       ].filter((id): id is string => id !== null);
 
       return ids.length ? ids.join(' ') : null;
+    });
+  }
+
+  private initTitleInvalid(): Signal<boolean> {
+    return computed(() => {
+      this.formService.revision();
+      return this.titleTouched() && (this.form().get('title')?.invalid ?? false);
+    });
+  }
+
+  private initOwnerEmailInvalid(): Signal<boolean> {
+    return computed(() => {
+      this.formService.revision();
+      return this.ownerEmailTouched() && !!this.form().get('ownerEmail')?.errors?.['email'];
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
@@ -9,9 +9,10 @@
 
   <!-- Search and add -->
   <div class="flex flex-col gap-1.5">
-    <span class="text-sm font-medium text-gray-900">Search and add guests</span>
+    <label for="composer-guest-search" class="text-sm font-medium text-gray-900">Search and add guests</label>
     <lfx-user-search
       [form]="quickAddForm"
+      inputId="composer-guest-search"
       searchType="meeting_registrant"
       emailControl="email"
       firstNameControl="first_name"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.html
@@ -91,7 +91,7 @@
                   [form]="form()"
                   control="reminderHours"
                   size="small"
-                  id="composer-reminder-hours"
+                  inputId="composer-reminder-hours"
                   data-testid="composer-reminder-hours" />
                 <label for="composer-reminder-hours" class="text-sm text-gray-900">hours</label>
               </div>
@@ -101,7 +101,7 @@
                   [form]="form()"
                   control="reminderMinutes"
                   size="small"
-                  id="composer-reminder-minutes"
+                  inputId="composer-reminder-minutes"
                   data-testid="composer-reminder-minutes" />
                 <label for="composer-reminder-minutes" class="text-sm text-gray-900">minutes</label>
               </div>

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.spec.ts
@@ -5,7 +5,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { MEETING_INVITE_PRIMARY_SENTINEL } from '@lfx-one/shared/constants';
+import { ERROR_CODES, MEETING_INVITE_PRIMARY_SENTINEL } from '@lfx-one/shared/constants';
 import { EmailManagementData, MeetingInviteEmail, UserEmail } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -325,10 +325,44 @@ describe('AccountSettingsComponent — meeting-invite selection & delete guard (
     fixture.componentInstance.setMeetingInvite(ALT_EMAIL);
 
     expect(fixture.componentInstance.meetingInviteError()).toBeNull();
-    // The 503's own body is deliberately dropped in favour of the caller's fallback: `extractErrorMessage`
-    // stopped reading 5xx bodies because they are overwhelmingly the envelope's "Internal server error"
-    // or a Go-service string forwarded verbatim, neither of which names the action that failed.
+    // This 503 carries no advisory code, so its body is dropped in favour of the caller's fallback:
+    // `extractErrorMessage` skips 5xx bodies because they are overwhelmingly the envelope's "Internal
+    // server error" or a Go-service string forwarded verbatim, neither of which names the action that
+    // failed. The test below is the one exception.
     expect(messageServiceMock.add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Failed to update meeting invitation email' }));
+  });
+
+  // The other end of the advisory code. `profile.controller.ts` mints this 503 with copy telling the
+  // organizer to wait and retry — actionable, and true of nothing else the fallback could say. Without
+  // the code the blanket 5xx skip traded it for "Failed to update meeting invitation email", which reads
+  // as a permanent failure of a write that will succeed on its own in a minute.
+  it('shows the retry guidance a 503 wrote for the organizer, when it says so', async () => {
+    const guidance = 'This email was added recently and is not ready to use yet. Please try again in a few minutes.';
+    const messageServiceMock = { add: vi.fn() };
+    const userServiceMock = makeUserServiceMock({
+      invite: { email_id: null, email: null },
+      setMeetingInviteEmail: () => throwError(() => new HttpErrorResponse({ status: 503, error: { error: guidance, code: ERROR_CODES.SERVICE_ADVISORY } })),
+    });
+    TestBed.configureTestingModule({
+      imports: [AccountSettingsComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: ActivatedRoute, useValue: { snapshot: { data: {} }, fragment: of(null) } },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: ConfirmationService, useValue: { confirm: vi.fn() } },
+        { provide: MessageService, useValue: messageServiceMock },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+      ],
+    });
+    TestBed.overrideComponent(AccountSettingsComponent, { set: { template: '', imports: [], providers: [] } });
+    const fixture = TestBed.createComponent(AccountSettingsComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    fixture.componentInstance.setMeetingInvite(ALT_EMAIL);
+
+    expect(fixture.componentInstance.meetingInviteError()).toBeNull();
+    expect(messageServiceMock.add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: guidance }));
   });
 
   it('fails closed and skips the delete flow entirely when the invite lookup itself failed', async () => {

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.ts
@@ -417,8 +417,10 @@ export class AccountSettingsComponent {
             this.meetingInviteError.set(extractErrorMessage(err, 'This email is not an active, verified address on your account yet.'));
             return;
           }
-          // Retryable errors (503 sync_pending/unavailable, etc.) also carry copy under `error`, not
-          // `message` — use extractErrorMessage so the crafted retry guidance reaches the toast.
+          // Retryable errors (503 sync_pending/unavailable) carry their copy under `error`, not
+          // `message`, and under the code `SERVICE_ADVISORY` — which is what lets extractErrorMessage
+          // read a 5xx body at all. It discards every other one, so a 503 without that code shows the
+          // fallback below rather than the guidance the server wrote.
           this.messageService.add({ severity: 'error', summary: 'Error', detail: extractErrorMessage(err, 'Failed to update meeting invitation email') });
         },
       });

--- a/apps/lfx-one/src/app/shared/components/input-number/input-number.component.html
+++ b/apps/lfx-one/src/app/shared/components/input-number/input-number.component.html
@@ -1,6 +1,13 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!--
+  The id is written with `[attr.id]` rather than `[id]`. A property binding assigns whatever the
+  expression evaluates to, and `input<string>()` with no default is `undefined` for every caller
+  that passes neither `inputId` nor `id` — which the DOM stringifies, leaving those inputs sharing
+  a single `id="undefined"`. An attribute binding drops the attribute instead.
+-->
+
 <ng-container [formGroup]="form()">
   @if (icon()) {
     <p-iconfield>
@@ -8,26 +15,30 @@
       <input
         pInputText
         type="number"
-        [id]="id()"
+        [attr.id]="inputId() || id() || null"
         [formControlName]="control()"
         [pSize]="size()!"
         [placeholder]="placeholder() ?? ''"
         [class]="styleClass()"
         class="w-full"
         [autocomplete]="autocomplete()"
+        [attr.aria-describedby]="describedBy() || null"
+        [attr.aria-invalid]="invalid() ? true : null"
         [attr.data-test]="dataTest()" />
     </p-iconfield>
   } @else {
     <input
       pInputText
       type="number"
-      [id]="id()"
+      [attr.id]="inputId() || id() || null"
       [formControlName]="control()"
       [pSize]="size()!"
       [placeholder]="placeholder() ?? ''"
       [class]="styleClass()"
       class="w-full"
       [autocomplete]="autocomplete()"
+      [attr.aria-describedby]="describedBy() || null"
+      [attr.aria-invalid]="invalid() ? true : null"
       [attr.data-test]="dataTest()" />
   }
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/input-number/input-number.component.ts
+++ b/apps/lfx-one/src/app/shared/components/input-number/input-number.component.ts
@@ -17,10 +17,16 @@ export class InputNumberComponent {
   public form = input.required<FormGroup>();
   public control = input.required<string>();
   public id = input<string>();
+  /** Id applied to the focusable input — pair with an external `<label for>`. Prefer this over `id` so the host does not get a duplicate id. */
+  public inputId = input<string>();
   public size = input<'large' | 'small'>();
   public placeholder = input<string>();
   public autocomplete = input<string>();
   public dataTest = input<string>();
   public icon = input<string>();
   public styleClass = input<string>();
+  /** Id of the element describing this input (e.g. its error message) — wired to `aria-describedby`. */
+  public describedBy = input<string | null>();
+  /** Marks the control invalid for assistive tech; the visible error text is the caller's. */
+  public invalid = input<boolean>(false);
 }

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
@@ -8,6 +8,10 @@
   hint. Most call sites omit the attribute, so this showed a user "undefined" in the majority of
   the app's inputs. Coalescing here rather than defaulting the input keeps the signal's type honest
   about the attribute being optional.
+
+  The id is bound the same way for the same reason, as `[attr.id]`: assigning the `id` property
+  the `undefined` a caller who passes neither `inputId` nor `id` leaves behind would stringify
+  into `id="undefined"`, shared by every such input on the page.
 -->
 
 <ng-container [formGroup]="form()">
@@ -16,7 +20,7 @@
       <p-inputicon [class]="icon()" />
       <input
         pInputText
-        [id]="inputId() || id()"
+        [attr.id]="inputId() || id() || null"
         [formControlName]="control()"
         [pSize]="size()!"
         [type]="type()"
@@ -33,7 +37,7 @@
   } @else {
     <input
       pInputText
-      [id]="inputId() || id()"
+      [attr.id]="inputId() || id() || null"
       [formControlName]="control()"
       [pSize]="size()!"
       [type]="type()"

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
@@ -1,5 +1,13 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
+
+<!--
+  The id is written with `[attr.id]` rather than `[id]`. A property binding assigns whatever the
+  expression evaluates to, and both inputs are `undefined` for a caller that passes neither — which
+  the DOM stringifies, leaving every such textarea sharing a single `id="undefined"`. An attribute
+  binding drops the attribute instead.
+-->
+
 <ng-container [formGroup]="form()">
   <textarea
     pTextarea
@@ -8,7 +16,7 @@
     [rows]="rows()"
     [cols]="cols()"
     [placeholder]="placeholder() || ''"
-    [id]="inputId() || id()"
+    [attr.id]="inputId() || id() || null"
     [readonly]="readonly()"
     [class]="styleClass()"
     [autoResize]="autoResize()"

--- a/apps/lfx-one/src/app/shared/components/time-picker/time-picker.component.html
+++ b/apps/lfx-one/src/app/shared/components/time-picker/time-picker.component.html
@@ -1,9 +1,19 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!--
+  The id is written with `[attr.id]` rather than `[id]`. A property binding assigns whatever the
+  expression evaluates to, and `inputId` defaults to `undefined` — which the DOM stringifies,
+  leaving every picker whose caller omits it sharing a single `id="undefined"`. An attribute
+  binding drops the attribute instead.
+-->
+
 <ng-container [formGroup]="form()">
   @if (label()) {
-    <label [for]="control()" class="block text-sm font-medium text-gray-700 mb-1">
+    <!-- `for` names the inner input, which only has an id when the caller gave one. Pointing it at
+         the control name instead named nothing: the input is identified by `inputId`, not by the
+         control it is bound to. -->
+    <label [attr.for]="inputId() || null" class="block text-sm font-medium text-gray-700 mb-1">
       {{ label() }}
       @if (required()) {
         <span class="text-red-500">*</span>
@@ -14,7 +24,7 @@
   <div class="relative">
     <input
       pInputText
-      [id]="inputId()"
+      [attr.id]="inputId() || null"
       [formControlName]="control()"
       [placeholder]="placeholder()"
       [pSize]="size() || 'small'"

--- a/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
@@ -200,7 +200,7 @@ describe('ProjectContextService — canWriteMeetings', () => {
   /** Cache keys the stub actually went out for — one entry per HTTP round trip. */
   let fetchedKeys: string[];
 
-  const setup = (responses: { plain: Partial<Project> | null; coordinator?: Partial<Project> | null }): ProjectContextService => {
+  const setup = (responses: { plain: Partial<Project> | null; coordinator?: Partial<Project> | null }, authenticated = true): ProjectContextService => {
     fetchedKeys = [];
     // Memoized per cache key, the way `ProjectService.getProject` is (`shareReplay` behind a
     // `${slug}:${current}[:mc]` map). Without that, two gates reading the same key would look like two
@@ -233,9 +233,10 @@ describe('ProjectContextService — canWriteMeetings', () => {
       ],
     });
 
-    // The gate hangs off `activeContext`, which the auth gate holds closed until the session
-    // resolves — so an unauthenticated fixture would measure the gate's `null` branch, not its answer.
-    TestBed.inject(UserService).authenticated.set(true);
+    // The gate hangs off `activeContext` *and* the session, so the default here is a resolved one —
+    // an unauthenticated fixture would measure the gate's closed branch, not its answer. The two tests
+    // at the bottom pass `false` deliberately to measure exactly that.
+    TestBed.inject(UserService).authenticated.set(authenticated);
 
     const service = TestBed.inject(ProjectContextService);
     service.setRouteLensKind('project');
@@ -290,5 +291,28 @@ describe('ProjectContextService — canWriteMeetings', () => {
     // Both gates read the same cache key, which `projectQueryParamGuard` has already populated on
     // every navigation — so between them they add nothing.
     expect(fetchedKeys).toEqual([`${CONTEXT.slug}:false`]);
+  });
+
+  // `/api/projects/:slug` is session-authenticated, so with no session it answers 401 and the gate
+  // lands on `false` through its `catchError` — after paying for the round trip on the SSR critical
+  // path. The two sibling gates on this service already skip it for exactly that reason.
+  it('asks for nothing while the session is unresolved', () => {
+    const service = setup({ plain: { writer: true } }, false);
+
+    expect(service.canWriteMeetings()).toBe(false);
+    expect(fetchedKeys).toEqual([]);
+  });
+
+  // The half a `catchError` could never cover. Derived from the context alone, the gate resolved once
+  // per navigation and never again — so a session that settled after the context left every meeting
+  // surface reading a `false` computed before there was anyone to compute it for.
+  it('re-resolves once the session lands, rather than staying closed', () => {
+    const service = setup({ plain: { writer: true } }, false);
+    expect(service.canWriteMeetings()).toBe(false);
+
+    TestBed.inject(UserService).authenticated.set(true);
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(service.canWriteMeetings()).toBe(true);
   });
 });

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -383,9 +383,15 @@ export class ProjectContextService {
 
   private initCanWriteMeetings(): Signal<boolean> {
     return toSignal(
-      toObservable(this.activeContext).pipe(
-        switchMap((ctx) => {
-          if (!ctx?.slug) {
+      combineLatest([toObservable(this.activeContext), toObservable(this.userService.authenticated)]).pipe(
+        switchMap(([ctx, authenticated]) => {
+          // Anonymous/public routes have no session — /api/projects/:slug would just 401 (LFXV2-3266),
+          // same as the two siblings above. It also puts the recompute back: gated on the context
+          // alone this ran once per navigation and never again, so a session that settled after the
+          // context — or was lost mid-visit — left the answer computed against the wrong one. The
+          // unauthenticated result is `false` either way, via the `catchError` below; what changes is
+          // that it is no longer a wasted round trip, and that it re-evaluates when the session does.
+          if (!ctx?.slug || !authenticated) {
             return of(false);
           }
           // Two requests rather than one `?meeting_coordinator=true` fetch, and cheaper than it

--- a/apps/lfx-one/src/app/shared/utils/control-touched.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/control-touched.util.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormGroup } from '@angular/forms';
+import { map, of, startWith, switchMap } from 'rxjs';
+
+/**
+ * Tracks one control's `touched` flag as a signal.
+ *
+ * `touched` is what every blur-driven error message hangs off, and it is the one piece of form state
+ * that no value- or status-derived signal can stand in for: `markAsTouched()` emits on neither
+ * `valueChanges` nor `statusChanges`, so a `computed()` keyed on either keeps whatever it cached
+ * before the field was first left. Template expressions get away with reading `control.touched`
+ * directly because a blur marks the view dirty and every expression is re-evaluated; a `computed()`
+ * does not, which is how an `aria-describedby` assembled in TypeScript ends up naming errors the
+ * template has stopped rendering — or missing the one it has just started to.
+ *
+ * `AbstractControl.events` (Angular 18+) is the only stream that carries `TouchedChangeEvent`. The
+ * flag is read back off the control rather than off the event, so no event type has to be narrowed
+ * and a value or status change arriving on the same stream is reflected by the same read.
+ *
+ * The form is taken as a signal rather than as a value so a section handed a rebuilt `FormGroup`
+ * re-subscribes instead of holding a control that is no longer on screen. Must be called from an
+ * injection context — a field initializer or a constructor — since `toObservable` and `toSignal`
+ * both require one.
+ */
+export function controlTouchedSignal(form: Signal<FormGroup>, controlName: string): Signal<boolean> {
+  return toSignal(
+    toObservable(form).pipe(
+      switchMap((group) => {
+        const control = group.get(controlName);
+        if (!control) {
+          return of(false);
+        }
+
+        return control.events.pipe(
+          startWith(null),
+          map(() => control.touched)
+        );
+      })
+    ),
+    { initialValue: false }
+  );
+}

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { MAX_PLAIN_TEXT_BODY_LENGTH } from '@lfx-one/shared/constants';
+import { ERROR_CODES, MAX_PLAIN_TEXT_BODY_LENGTH } from '@lfx-one/shared/constants';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
@@ -98,6 +98,24 @@ describe('getHttpErrorDetail', () => {
   // the action that failed.
   it('ignores a 5xx body in favour of the caller fallback', () => {
     const error = new HttpErrorResponse({ status: 500, error: { error: 'Internal server error', code: 'INTERNAL_ERROR' } });
+
+    expect(getHttpErrorDetail(error, 'Could not save your changes.')).toBe('Could not save your changes.');
+  });
+
+  // The one 5xx that is read, and it is keyed on the code rather than the status because the code is
+  // the part an upstream pass-through cannot produce: `MicroserviceError.fromMicroserviceResponse`
+  // derives its code from the status, so a forwarded 503 is always `SERVICE_UNAVAILABLE`.
+  it('reads a 5xx body that carries the advisory code', () => {
+    const guidance = 'This email was added recently and is not ready to use yet. Please try again in a few minutes.';
+    const error = new HttpErrorResponse({ status: 503, error: { error: guidance, code: ERROR_CODES.SERVICE_ADVISORY } });
+
+    expect(getHttpErrorDetail(error, 'Could not save your changes.')).toBe(guidance);
+  });
+
+  // The other half of that: a 503 whose code came from its status is still discarded, so the
+  // exception cannot be reached by an upstream outage that happens to share the status.
+  it('still ignores a 5xx body whose code was derived from the status', () => {
+    const error = new HttpErrorResponse({ status: 503, error: { error: 'service unavailable', code: 'SERVICE_UNAVAILABLE' } });
 
     expect(getHttpErrorDetail(error, 'Could not save your changes.')).toBe('Could not save your changes.');
   });
@@ -223,6 +241,24 @@ describe('extractErrorMessage', () => {
 
     expect(extractErrorMessage(envelope, 'Could not save your changes.')).toBe('Could not save your changes.');
     expect(extractErrorMessage(upstreamText, 'Could not save your changes.')).toBe('Could not save your changes.');
+  });
+
+  // The live path for the exception: `profile.controller.ts` mints a 503 whose copy is retry guidance
+  // an organizer can act on, and `account-settings.component.ts` puts it straight in a toast. Before
+  // the code existed the blanket skip traded every one of those for the generic fallback.
+  it('reads a 5xx body that carries the advisory code', () => {
+    const guidance = 'The meeting service is temporarily unavailable. Please try again in a few minutes.';
+    const error = new HttpErrorResponse({ status: 503, error: { error: guidance, code: ERROR_CODES.SERVICE_ADVISORY } });
+
+    expect(extractErrorMessage(error, 'Failed to update meeting invitation email')).toBe(guidance);
+  });
+
+  // A plain-text 5xx carries no code to vouch for it, so the exception can never reach the case the
+  // skip exists for — a proxy's page returned in place of an envelope.
+  it('still ignores a plain-text 5xx body, which has no code to vouch for it', () => {
+    const error = new HttpErrorResponse({ status: 503, error: 'Service Temporarily Unavailable' });
+
+    expect(extractErrorMessage(error, 'Could not save your changes.')).toBe('Could not save your changes.');
   });
 
   it('reads a field reason when the top-level message carries a wire key', () => {

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -8,8 +8,9 @@ import { MonoTypeOperatorFunction, retry, throwError, timer } from 'rxjs';
 /**
  * The message an error body offers for display, or `undefined` when it offers none. Every policy the
  * two readers below share lives here rather than in each of them: which key wins, when a 5xx body is
- * discarded (see `getHttpErrorDetail` for why), and what a plain-text body is worth. The only thing
- * left to a caller is `plainString`, which is genuinely a per-caller call.
+ * discarded and the one code that overrides that (see `getHttpErrorDetail` for both), and what a
+ * plain-text body is worth. The only thing left to a caller is `plainString`, which is genuinely a
+ * per-caller call.
  *
  * `error` is read as well as `message` because `error` is the key the envelope actually sends —
  * `BaseApiError.toResponse()` emits `{ error, code }` and no `message`. A handful of controllers do
@@ -78,7 +79,11 @@ import { MonoTypeOperatorFunction, retry, throwError, timer } from 'rxjs';
  * is whatever the proxy in front of us decided to return rather than a key someone chose to fill.
  */
 function readErrorBodyMessage(body: unknown, status: number, plainString: 'read' | 'ignore'): string | undefined {
-  if (status >= 500) {
+  // The one code that survives the 5xx skip — see `getHttpErrorDetail` for why a code, and not a
+  // status, is what can prove the message was written for a reader.
+  const isAdvisory = !!body && typeof body === 'object' && !(body instanceof Error) && (body as { code?: unknown }).code === ERROR_CODES.SERVICE_ADVISORY;
+
+  if (status >= 500 && !isAdvisory) {
     return undefined;
   }
 
@@ -124,15 +129,23 @@ function readErrorBodyMessage(body: unknown, status: number, plainString: 'read'
  * Reading only `message` — a key the envelope does not send — left every branch below on its hard-coded
  * string, so a server reason never reached the committee call sites. See `readErrorBodyMessage`.
  *
- * A 5xx body is deliberately not read. Every 5xx body traced to these call sites is either the
- * envelope's own "Internal server error" or an upstream Go service message that `MicroserviceError`
- * passes through verbatim — neither tells the user anything, and both would displace the caller's
- * fallback, which at least names the action that failed ("Failed to remove member. Please try again.").
- * The skip is by status, not by provenance, so it also discards the hand-written 5xx messages this
- * server mints — including ones written for a person (`ACCESS_CHECK_UNAVAILABLE`,
- * `FORWARD_SET_FAILED`, and `ROLE_GRANTS_UNAVAILABLE` in `org-lens-access.service.ts`). None of those
- * reaches a call site of either reader today, but routing one here would silently trade it for the
- * fallback; a `code` allowlist would be the way to let a chosen few through.
+ * A 5xx body is not read unless it says it was written for a reader. Every 5xx body traced to these
+ * call sites is either the envelope's own "Internal server error" or an upstream Go service message
+ * that `MicroserviceError` passes through verbatim — neither tells the user anything, and both would
+ * displace the caller's fallback, which at least names the action that failed ("Failed to remove
+ * member. Please try again."). That is the default, and it stays.
+ *
+ * The exception is `ERROR_CODES.SERVICE_ADVISORY` — the `code` allowlist this note used to call for,
+ * narrowed to one code. Provenance is what the skip actually wants and a status cannot tell it, but a
+ * code can: `MicroserviceError.fromMicroserviceResponse` always derives its code from the status via
+ * `getCodeForStatus`, so a forwarded 503 is always `SERVICE_UNAVAILABLE` and can never arrive carrying
+ * `SERVICE_ADVISORY`. A body with that code is positive proof this server hand-wrote the message for
+ * the person reading it — the same reasoning `upstream-error.utils.ts` uses to tell a minted failure
+ * from a forwarded one. Setting it is a deliberate act at the throw site; the meeting-invite writes in
+ * `profile.controller.ts` are the first, and every other 5xx, minted or forwarded, is still discarded.
+ * The hand-written messages that stay silent for now (`ACCESS_CHECK_UNAVAILABLE`, `FORWARD_SET_FAILED`,
+ * `ROLE_GRANTS_UNAVAILABLE` in `org-lens-access.service.ts`) reach neither reader today; routing one
+ * here is a matter of setting the code at its throw site.
  *
  * Below 500 the body is usually a validation or permission reason written about the request, which is
  * worth showing. Not always: `MicroserviceError` forwards an upstream Go message verbatim at any
@@ -164,7 +177,9 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
  *
  * See `readErrorBodyMessage` for which key in the body is read, and why, and for the 5xx skip these two
  * share — "Internal server error" and a forwarded Go-service string tell a user nothing, and the
- * caller's fallback at least names the action that failed.
+ * caller's fallback at least names the action that failed. A body carrying `ERROR_CODES.SERVICE_ADVISORY`
+ * is the one 5xx that gets through, and this reader is where it lands today: the meeting-invite retry
+ * guidance shown by `account-settings.component.ts`.
  *
  * Unlike `getHttpErrorDetail` this one does read a plain-text body: it has no per-status hint layer, so
  * a 4xx sentence written about the request is the best thing on offer. `readErrorBodyMessage` still

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -16,7 +16,7 @@ const V1_COMMITTEE_SFID = 'a09v1SFIDaaaa';
 const USER_TOKEN = 'user-bearer-token';
 const M2M_TOKEN = 'm2m-bearer-token';
 
-const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock, generateM2MTokenMock } = vi.hoisted(() => ({
+const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock, resolveCommitteeV2UidMappingsMock, generateM2MTokenMock } = vi.hoisted(() => ({
   meetingSvc: {
     getMeetingById: vi.fn(),
     getMeetingRegistrants: vi.fn(),
@@ -28,6 +28,7 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock, gene
   aiSvc: { generateMeetingAgenda: vi.fn() },
   committeeSvc: { getCommitteeById: vi.fn(), getCommitteeMembers: vi.fn() },
   resolveCommitteeV2UidsToV1IdsMock: vi.fn(),
+  resolveCommitteeV2UidMappingsMock: vi.fn(),
   generateM2MTokenMock: vi.fn(),
 }));
 
@@ -71,6 +72,7 @@ vi.mock('../helpers/meeting.helper', () => ({
 }));
 vi.mock('../helpers/committee-v1-mapping.helper', () => ({
   resolveCommitteeV2UidsToV1Ids: resolveCommitteeV2UidsToV1IdsMock,
+  resolveCommitteeV2UidMappings: resolveCommitteeV2UidMappingsMock,
 }));
 vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(() => 'user@example.com') }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
@@ -120,7 +122,18 @@ class FakeValidationError extends Error {
     super(message);
   }
 }
+/** Only the fields the assertions read; the real class adds serialization the controller never touches. */
+class FakeMicroserviceError extends Error {
+  public constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly code: string
+  ) {
+    super(message);
+  }
+}
 vi.mock('../errors', () => ({
+  MicroserviceError: FakeMicroserviceError,
   ServiceValidationError: {
     forField: (field: string, message: string) =>
       new FakeValidationError(`Validation failed for ${field}`, [{ field, message, code: 'FIELD_VALIDATION_ERROR' }]),
@@ -304,7 +317,7 @@ describe('MeetingController', () => {
     // GH-1463: upstream stores a v1 SFID and derives type: 'committee' from it. Forwarding the v2
     // UID the picker works in would persist a bogus committee reference.
     it('rewrites a group guest committee_uid from the v2 UID to the v1 SFID', async () => {
-      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]));
+      resolveCommitteeV2UidMappingsMock.mockResolvedValue({ resolved: new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]), confirmedUnresolved: new Set() });
       const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
@@ -319,7 +332,7 @@ describe('MeetingController', () => {
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
-      expect(resolveCommitteeV2UidsToV1IdsMock).not.toHaveBeenCalled();
+      expect(resolveCommitteeV2UidMappingsMock).not.toHaveBeenCalled();
       const [, forwarded] = meetingSvc.addMeetingRegistrant.mock.calls[0];
       expect(forwarded).not.toHaveProperty('committee_uid');
     });
@@ -340,14 +353,28 @@ describe('MeetingController', () => {
 
     // The key is deleted, not nulled: upstream declares `committee_uid` a non-nullable optional
     // `string`, so omission is on-contract and an explicit `null` is not.
-    it('strips an unresolvable committee_uid rather than forwarding a v2 UID upstream', async () => {
-      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map());
+    it('strips a confirmed-unresolvable committee_uid rather than forwarding a v2 UID upstream', async () => {
+      resolveCommitteeV2UidMappingsMock.mockResolvedValue({ resolved: new Map(), confirmedUnresolved: new Set([V2_COMMITTEE_UID]) });
       const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
       const [, forwarded] = meetingSvc.addMeetingRegistrant.mock.calls[0];
       expect(forwarded).not.toHaveProperty('committee_uid');
+    });
+
+    // The counterpart to the test above, and the reason the two are told apart at all: "no v1
+    // counterpart exists" is permanent and degrades, while "the lookup didn't answer" is transient.
+    // Downgrading the second writes a `direct` row and answers 201, and the update contract declares
+    // no `committee_uid` to repair it with — so it has to fail before the first write instead.
+    it('fails the batch when an allowlisted committee_uid lookup is indeterminate', async () => {
+      resolveCommitteeV2UidMappingsMock.mockResolvedValue({ resolved: new Map(), confirmedUnresolved: new Set() });
+      const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(meetingSvc.addMeetingRegistrant).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 503 }));
     });
 
     it('drops a client-sent null committee_uid instead of proxying it upstream', async () => {
@@ -364,7 +391,7 @@ describe('MeetingController', () => {
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
-      expect(resolveCommitteeV2UidsToV1IdsMock).not.toHaveBeenCalled();
+      expect(resolveCommitteeV2UidMappingsMock).not.toHaveBeenCalled();
       expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ email: 'a@example.com' }));
     });
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -24,8 +24,8 @@ import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { NULLISH_DROPPED_REGISTRANT_KEYS, UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS } from '../constants';
-import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
-import { AuthorizationError, ServiceValidationError } from '../errors';
+import { resolveCommitteeV2UidMappings, resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
+import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
 import {
   addInvitedStatusToMeeting,
   applyOrganizerAndHostKeyResult,
@@ -2043,6 +2043,16 @@ export class MeetingController {
    * as a non-nullable optional `string`, so an explicit `null` is off-contract even though omission
    * is fine. A `null` arriving from the client is dropped for the same reason.
    *
+   * "Unresolvable" means *confirmed* unresolvable — the lookup answered, and this committee has no v1
+   * counterpart. An allowlisted UID the lookup could not answer for (a NATS timeout, an `error:`
+   * reply, the batch budget cutting the loop short) fails the whole request instead, for the same
+   * reason `getMeetingCommitteeUids` lets its own read error out: nothing has been written yet, so
+   * failing here is recoverable by a retry, whereas downgrading writes a `direct` row and answers
+   * 201, and `UpdateMeetingRegistrantRequest` declares no `committee_uid` to repair it with. Two
+   * outcomes that read identically as "absent from the map" are opposite decisions once a write
+   * depends on them, which is why this path reads the batch's `confirmedUnresolved` set rather than
+   * the map-only wrapper the read paths use.
+   *
    * `allowedV2Uids` is the meeting's own `committees[].uid` set, and a UID outside it is stripped
    * before any lookup. Without that gate the resolver would happily resolve any committee UID the
    * caller cared to send — `resolveCommitteeV2UidsToV1Ids` goes over NATS with the BFF's own
@@ -2073,10 +2083,29 @@ export class MeetingController {
 
     // Still fall through to the map when there's nothing to resolve — a client that sent an explicit
     // `committee_uid: null` needs the key dropped, and only the map below does that.
-    const v2ToV1Map = v2Uids.length > 0 ? await resolveCommitteeV2UidsToV1Ids(req, this.natsService, v2Uids) : new Map<string, string>();
+    const { resolved: v2ToV1Map, confirmedUnresolved } =
+      v2Uids.length > 0
+        ? await resolveCommitteeV2UidMappings(req, this.natsService, v2Uids)
+        : { resolved: new Map<string, string>(), confirmedUnresolved: new Set<string>() };
 
-    if (v2ToV1Map.size < v2Uids.length) {
-      logger.warning(req, 'resolve_registrant_committee_uids', 'Some committee UIDs could not be resolved to v1 SFIDs', {
+    const indeterminate = v2Uids.filter((uid) => !v2ToV1Map.has(uid) && !confirmedUnresolved.has(uid));
+
+    if (indeterminate.length > 0) {
+      logger.warning(req, 'resolve_registrant_committee_uids', 'Committee UID lookup did not answer; failing before any registrant write', {
+        requested: v2Uids.length,
+        resolved: v2ToV1Map.size,
+        // Counts only, for the same reason as the allowlist warning above.
+        indeterminate_count: indeterminate.length,
+      });
+
+      throw new MicroserviceError('Could not confirm group attribution for these guests. Please try again.', 503, 'SERVICE_UNAVAILABLE', {
+        operation: 'resolve_registrant_committee_uids',
+        service: 'committee-service',
+      });
+    }
+
+    if (confirmedUnresolved.size > 0) {
+      logger.warning(req, 'resolve_registrant_committee_uids', 'Some committee UIDs have no v1 SFID; adding those guests without attribution', {
         requested: v2Uids.length,
         resolved: v2ToV1Map.size,
       });

--- a/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
@@ -72,6 +72,9 @@ vi.mock('@lfx-one/shared/constants', () => ({
   CDP_TO_AUTH0_PROVIDER_MAP: {},
   EMAIL_ALREADY_LINKED_MESSAGE: 'already linked',
   EMAIL_REGEX: /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/,
+  // Only the member the write path sets. This factory replaces the module wholesale, so a name the
+  // controller reads and this list omits fails as an undefined export rather than a wrong value.
+  ERROR_CODES: { SERVICE_ADVISORY: 'SERVICE_ADVISORY' },
   PURCHASE_LINUX_URL: 'https://example.com',
   PROFILE_EMAIL_PATH: '/profile/email',
   PROFILE_EMAILS_PATH: '/profile/emails',
@@ -300,6 +303,9 @@ describe('ProfileController.getMeetingInviteEmail', () => {
     controller = new ProfileController();
   });
 
+  // Plain SERVICE_UNAVAILABLE, unlike the write path below. `extractErrorMessage` reads a 5xx body
+  // only under SERVICE_ADVISORY, and setting it here would buy nothing: the caller swallows this
+  // response into an `inviteLoadFailed` flag and renders its own copy, so the message reaches nobody.
   it('responds 503 without calling the meeting service when the v1 api-gateway token is missing', async () => {
     const next = vi.fn();
 
@@ -401,12 +407,15 @@ describe('ProfileController.setMeetingInviteEmail', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  // SERVICE_ADVISORY, not SERVICE_UNAVAILABLE — the code is what carries this message past the
+  // frontend's blanket 5xx skip and into the toast. All three write-path 503s below assert it for
+  // the same reason; a status alone could not, since a forwarded upstream 503 shares it.
   it('responds 503 without calling the meeting service when the v1 api-gateway token is missing', async () => {
     const next = vi.fn();
 
     await controller.setMeetingInviteEmail(buildSetReq({ email: 'invite@example.com' }, { apiGatewayToken: undefined }), buildRes(), next);
 
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'SERVICE_UNAVAILABLE', statusCode: 503 }));
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'SERVICE_ADVISORY', statusCode: 503 }));
     expect(meetingPrefSvc.setMeetingInviteEmail).not.toHaveBeenCalled();
   });
 
@@ -445,7 +454,7 @@ describe('ProfileController.setMeetingInviteEmail', () => {
 
     expect(next).toHaveBeenCalledWith(
       expect.objectContaining({
-        code: 'SERVICE_UNAVAILABLE',
+        code: 'SERVICE_ADVISORY',
         statusCode: 503,
         message: 'This email was added recently and is not ready to use yet. Please try again in a few minutes.',
       })
@@ -460,7 +469,7 @@ describe('ProfileController.setMeetingInviteEmail', () => {
 
     expect(next).toHaveBeenCalledWith(
       expect.objectContaining({
-        code: 'SERVICE_UNAVAILABLE',
+        code: 'SERVICE_ADVISORY',
         statusCode: 503,
         message: 'The meeting service is temporarily unavailable. Please try again in a few minutes.',
       })

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -10,6 +10,7 @@ import {
   CDP_TO_AUTH0_PROVIDER_MAP,
   EMAIL_ALREADY_LINKED_MESSAGE,
   EMAIL_REGEX,
+  ERROR_CODES,
   PROFILE_EMAIL_PATH,
   PROFILE_EMAILS_PATH,
   PROFILE_PASSWORD_PATH,
@@ -720,7 +721,10 @@ export class ProfileController {
           new MicroserviceError(
             'Meeting invitation email settings are temporarily unavailable. Please refresh the page and try again.',
             503,
-            'SERVICE_UNAVAILABLE',
+            // Written for the organizer, and the write path surfaces it: `extractErrorMessage` reads a
+            // 5xx body only under this code. The two GET-path 503s above keep SERVICE_UNAVAILABLE —
+            // that response is swallowed by an `inviteLoadFailed` catch, so their copy reaches nobody.
+            ERROR_CODES.SERVICE_ADVISORY,
             {
               operation: 'set_meeting_invite_email',
               service: 'profile_controller',
@@ -746,17 +750,22 @@ export class ProfileController {
         // SFDC sync from auth0 hasn't landed yet — the address is valid but not usable right now.
         if (result.reason === 'sync_pending') {
           return next(
-            new MicroserviceError('This email was added recently and is not ready to use yet. Please try again in a few minutes.', 503, 'SERVICE_UNAVAILABLE', {
-              operation: 'set_meeting_invite_email',
-              service: 'profile_controller',
-            })
+            new MicroserviceError(
+              'This email was added recently and is not ready to use yet. Please try again in a few minutes.',
+              503,
+              ERROR_CODES.SERVICE_ADVISORY,
+              {
+                operation: 'set_meeting_invite_email',
+                service: 'profile_controller',
+              }
+            )
           );
         }
 
         // The meeting service itself was unreachable (timeout/503) — transport failure, retryable.
         if (result.reason === 'unavailable') {
           return next(
-            new MicroserviceError('The meeting service is temporarily unavailable. Please try again in a few minutes.', 503, 'SERVICE_UNAVAILABLE', {
+            new MicroserviceError('The meeting service is temporarily unavailable. Please try again in a few minutes.', 503, ERROR_CODES.SERVICE_ADVISORY, {
               operation: 'set_meeting_invite_email',
               service: 'profile_controller',
             })

--- a/apps/lfx-one/src/server/helpers/committee-v1-mapping.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-v1-mapping.helper.ts
@@ -5,6 +5,7 @@ import type { Request } from 'express';
 
 import type { NatsService } from '../services/nats.service';
 import { resolveV1MappingBatch } from './v1-mapping-batch.helper';
+import type { V1MappingBatchResult } from './v1-mapping-batch.helper';
 
 /**
  * Resolves LFX v2 committee UUIDs to the v1 committee SFID via the platform's
@@ -36,7 +37,24 @@ import { resolveV1MappingBatch } from './v1-mapping-batch.helper';
  * know the batch was cut short. See `v1-mapping-batch.helper.ts` for the shared implementation.
  */
 export async function resolveCommitteeV2UidsToV1Ids(req: Request, natsService: NatsService, v2CommitteeUids: string[]): Promise<Map<string, string>> {
-  const { resolved } = await resolveV1MappingBatch(req, natsService, v2CommitteeUids, {
+  const { resolved } = await resolveCommitteeV2UidMappings(req, natsService, v2CommitteeUids);
+  return resolved;
+}
+
+/**
+ * The same lookup, keeping the `confirmedUnresolved` half of the batch result.
+ *
+ * `resolveCommitteeV2UidsToV1Ids` above collapses "this committee has no v1 counterpart" and "the
+ * lookup didn't answer" into the same absence, which is the right contract for a caller that
+ * degrades either way. A caller that *writes* needs them apart: a confirmed absence is permanent, so
+ * failing on it would leave the organizer with no way to save at all, while an indeterminate answer
+ * is a transient fault a retry can clear — and downgrading on it persists a wrong row that no later
+ * request can repair (`UpdateMeetingRegistrantRequest` carries no `committee_uid` by design).
+ *
+ * See `V1MappingBatchResult` for exactly which outcomes land in which bucket.
+ */
+export async function resolveCommitteeV2UidMappings(req: Request, natsService: NatsService, v2CommitteeUids: string[]): Promise<V1MappingBatchResult> {
+  return resolveV1MappingBatch(req, natsService, v2CommitteeUids, {
     buildLookupKey: (v2Uid) => `committee.uid.${v2Uid}`,
     parseResponse: (responseText) => {
       // Response format: "{project_sfid}:{committee_sfid}" — the committee SFID is the second segment.
@@ -46,5 +64,4 @@ export async function resolveCommitteeV2UidsToV1Ids(req: Request, natsService: N
     logOperation: 'resolve_committee_v1_mapping',
     entityLabel: 'committee',
   });
-  return resolved;
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -345,6 +345,15 @@ export const MEETING_COMPOSER_SECTIONS = [
 ] as const;
 
 /**
+ * Sections the quick create dialog puts in front of the organizer.
+ * @description Everything the dialog's two columns cover — platform and features are the one section
+ * it leaves entirely at its form defaults. "Switch to advanced mode" marks these visited in the drawer
+ * it hands off to, because the rail and the preview both read `visitedSections` as "has the organizer
+ * seen this yet", and the dialog is where they saw it.
+ */
+export const MEETING_QUICK_CREATE_SECTIONS = ['details-access', 'date-schedule', 'guests', 'agenda-resources'] as const;
+
+/**
  * Feature rows the composer preview lists, in display order.
  * @description Only the labels are the preview's own — shorter wording than the section's toggle
  * titles. Controls and icons come from {@link MEETING_FEATURE_BY_KEY}, so renaming a feature key

--- a/packages/shared/src/constants/server.constants.ts
+++ b/packages/shared/src/constants/server.constants.ts
@@ -65,4 +65,11 @@ export const ERROR_CODES = {
   FORBIDDEN: 'FORBIDDEN',
   CONFLICT: 'CONFLICT',
   INTERNAL_ERROR: 'INTERNAL_ERROR',
+  /**
+   * A 5xx this server minted whose message was written for the person reading it rather than for a
+   * log. `getCodeForStatus` never produces it, so a pass-through of an upstream 5xx cannot carry it —
+   * which is what lets the frontend's `readErrorBodyMessage` show the message instead of discarding
+   * the body. Set it only where the copy is retry guidance or an explanation a user can act on.
+   */
+  SERVICE_ADVISORY: 'SERVICE_ADVISORY',
 } as const;


### PR DESCRIPTION
> **Stack 17 of 20.** Based on PR 16 (`fix/issue-1451-review-and-specs`). Followed by PR 18 (`refactor/issue-1451-composer-signals`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

First of three PRs closing out the review threads raised across PRs 1-16. This one covers what the composer writes when the organizer saves, what survives the quick-create-to-drawer handoff, and the fields assistive technology could not name or hear.

## How

- Canonicalises committee voting statuses at both boundaries, waits for the saved guest list before reconciling groups, keeps removals across a retry, and re-reads a matched guest's attribution from the group still emitting them.
- Makes `resolveRegistrantCommitteeUids` distinguish a confirmed-missing v1 SFID from a lookup that did not answer — the indeterminate case now fails with 503 before the first write instead of silently downgrading the guest to `direct`.
- Carries the quick dialog's four sections over as visited, marks template and AI writes dirty so the dirty-gated Save and the prefill guard both see them, and takes the previous type's prefill back out when the meeting type changes.
- Derives `canWriteMeetings` from the session as well as the active context, so it stops resolving once per navigation against an anonymous 401 and re-evaluates when the session settles.
- Adds `ERROR_CODES.SERVICE_ADVISORY` as the one code that survives the frontend's blanket 5xx skip, and sets it on the three meeting-invite writes whose 503 copy is retry guidance rather than a failure.
- Fixes the accessibility findings: `[attr.id]` instead of `[id]` on four wrappers that were writing the literal string `undefined`, `inputId` instead of a static `id` on nine fields, `describedBy`/`invalid` on `input-number`, `role="alert"` on the error paragraphs, and `aria-expanded` on the two popover triggers.
- Adds `controlTouchedSignal` so a blur-gated `aria-describedby` assembled in TypeScript actually moves — `markAsTouched()` emits on neither `valueChanges` nor `statusChanges`, so the form service's `revision()` cannot see it.

## Notes for reviewers

- The section specs now render their real templates and resolve every id an `aria-describedby` emits against the rendered page — an id naming nothing is exactly the failure mode these findings describe, and it is invisible from the signal alone.
- The two GET-path 503s in `profile.controller.ts` deliberately keep `SERVICE_UNAVAILABLE`: their response is swallowed by an `inviteLoadFailed` catch, so the copy reaches nobody either way.

## Commits

4 commit(s), 37 files changed, 1234 insertions(+), 133 deletions(-).

- `fix(meetings): correct the composer guest save path`
- `fix(meetings): carry the quick create fill into the drawer`
- `fix(meetings): re-resolve write access and surface 503 guidance`
- `fix(meetings): label composer inputs and announce their errors`

## Related

- Refs #1452
- Refs #1453
- Refs #1454
- Refs #1456
- Refs #1457
- Refs #1458
- Refs #1459
- Refs #1460
- Refs #1463
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
