### PR TITLE
fix(meetings): correct registrant writes and board access defaults

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -5,7 +5,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import { MEETING_ATTACHMENT_WRITE_CONCURRENCY, MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
-import { CommitteeMemberRole, CommitteeMemberVotingStatus, MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
+import { CancelOnCommitteeRemoval, CommitteeMemberRole, CommitteeMemberVotingStatus, MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import type {
   CommitteeMember,
   Meeting,
@@ -994,5 +994,186 @@ describe('MeetingComposerFormService — group reconciliation after a failed gue
 
     expect(service.guests()[0]).toMatchObject({ uid: 'registrant-1', state: 'deleted' });
     expect(service.registrantUpdates().toDelete).toEqual(['registrant-1']);
+  });
+});
+
+/**
+ * Covers the organizer picker's contribution to the save payload. Upstream has no owner-removal path
+ * and defaults a create's owner to the creator, so what matters is not what the three controls hold
+ * but whether `owner` is on the payload at all: sending it when nothing was picked would name the
+ * wrong organizer, and sending it on an untouched edit would blank the `profile_picture` this form
+ * never carries.
+ */
+describe('MeetingComposerFormService \u2014 organizer picker payload', () => {
+  let service: MeetingComposerFormService;
+  let createMeeting: ReturnType<typeof vi.fn>;
+  let updateMeeting: ReturnType<typeof vi.fn>;
+
+  const SAVED_OWNER = { username: 'alovelace', name: 'Ada Lovelace', email: 'ada@example.com' };
+
+  /** The payload the save actually sent, from whichever of the two write paths ran. */
+  const sentPayload = (): Record<string, unknown> => (createMeeting.mock.calls[0]?.[0] ?? updateMeeting.mock.calls[0]?.[1]) as Record<string, unknown>;
+
+  beforeEach(() => {
+    createMeeting = vi.fn().mockReturnValue(of({ id: 'meeting-1' } as Meeting));
+    updateMeeting = vi.fn().mockReturnValue(of({ id: 'meeting-1' } as Meeting));
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        { provide: MeetingService, useValue: { createMeeting, updateMeeting } },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+  });
+
+  it('leaves the owner key off entirely when the picker was never touched', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    service.submit().subscribe();
+
+    // Not `owner: undefined` \u2014 the key is absent, which is what lets upstream default the organizer
+    // to whoever created the meeting.
+    expect(sentPayload()).not.toHaveProperty('owner');
+  });
+
+  it('sends only the parts of the organizer that were filled in', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.switchToOwnerManualEntry();
+    service.form().patchValue({ ownerName: '  Ada Lovelace  ', ownerEmail: 'ada@example.com' });
+
+    service.submit().subscribe();
+
+    expect(sentPayload()['owner']).toEqual({ name: 'Ada Lovelace', email: 'ada@example.com' });
+  });
+
+  it('leaves the owner key off when an edit still holds the saved organizer', () => {
+    service.initialize({ mode: 'edit', projectUid: 'project-1' });
+    service.meetingId.set('meeting-1');
+    service.hydratedOwner.set(SAVED_OWNER);
+    service.form().patchValue({ ownerUsername: SAVED_OWNER.username, ownerName: SAVED_OWNER.name, ownerEmail: SAVED_OWNER.email });
+
+    service.submit().subscribe();
+
+    expect(updateMeeting).toHaveBeenCalled();
+    expect(sentPayload()).not.toHaveProperty('owner');
+  });
+
+  it('sends the organizer once an edit moves it off the saved one', () => {
+    service.initialize({ mode: 'edit', projectUid: 'project-1' });
+    service.meetingId.set('meeting-1');
+    service.hydratedOwner.set(SAVED_OWNER);
+    service.form().patchValue({ ownerUsername: 'ghopper', ownerName: 'Grace Hopper', ownerEmail: 'grace@example.com' });
+
+    service.submit().subscribe();
+
+    expect(sentPayload()['owner']).toEqual({ username: 'ghopper', name: 'Grace Hopper', email: 'grace@example.com' });
+  });
+
+  it('drops a picked LFID once the hand-typed organizer diverges from it', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.form().patchValue({ ownerUsername: SAVED_OWNER.username, ownerName: SAVED_OWNER.name, ownerEmail: SAVED_OWNER.email });
+
+    service.switchToOwnerManualEntry();
+    service.form().get('ownerEmail')?.setValue('ada@contractor.example');
+
+    // The LFID belonged to the directory entry, so carrying it alongside a hand-typed address would
+    // attribute the meeting to an account the organizer is no longer describing.
+    expect(service.form().get('ownerUsername')?.value).toBeNull();
+
+    service.submit().subscribe();
+
+    expect(sentPayload()['owner']).toEqual({ name: SAVED_OWNER.name, email: 'ada@contractor.example' });
+  });
+
+  it('keeps the restored LFID when the picker reverts to the saved organizer', () => {
+    service.initialize({ mode: 'edit', projectUid: 'project-1' });
+    service.hydratedOwner.set(SAVED_OWNER);
+    service.switchToOwnerManualEntry();
+    service.form().patchValue({ ownerName: 'Someone Else', ownerEmail: 'else@example.com' });
+
+    service.revertOwnerToSaved();
+
+    // The revert writes all three controls, so leaving manual mode on would have the hand-edit guard
+    // wipe the username the revert had just put back.
+    expect(service.ownerManualEntry()).toBe(false);
+    expect(service.form().get('ownerUsername')?.value).toBe(SAVED_OWNER.username);
+    expect(service.form().get('ownerEmail')?.value).toBe(SAVED_OWNER.email);
+  });
+
+  it('discards an invalid hand-typed email on the way back to search', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.switchToOwnerManualEntry();
+    service.form().patchValue({ ownerName: 'Ada Lovelace', ownerEmail: 'not-an-address' });
+
+    service.backToOwnerSearch();
+
+    // Its error message only renders in manual mode, so left in place it would gate the section with
+    // nothing on screen to explain why. A name-only organizer is valid upstream, so the name stays.
+    expect(service.form().get('ownerEmail')?.value).toBeNull();
+    expect(service.form().get('ownerName')?.value).toBe('Ada Lovelace');
+  });
+});
+
+/**
+ * Covers the per-meeting cancel-on-group-removal override. Upstream reads it only for a public meeting
+ * with linked groups, so the composer resolves the other cases to `inherit` rather than letting a value
+ * chosen under different settings ride along invisibly.
+ */
+describe('MeetingComposerFormService \u2014 cancel on committee removal', () => {
+  let service: MeetingComposerFormService;
+  let createMeeting: ReturnType<typeof vi.fn>;
+
+  const GROUP = [{ uid: 'committee-board', allowed_voting_statuses: [] }];
+
+  const sentOverride = (): unknown => (createMeeting.mock.calls[0][0] as Record<string, unknown>)['cancel_on_committee_removal'];
+
+  beforeEach(() => {
+    createMeeting = vi.fn().mockReturnValue(of({ id: 'meeting-1' } as Meeting));
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        { provide: MeetingService, useValue: { createMeeting } },
+      ],
+    });
+
+    service = TestBed.inject(MeetingComposerFormService);
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+  });
+
+  it('sends the override for a public meeting with a linked group', () => {
+    service.form().patchValue({ visibility: MeetingVisibility.PUBLIC, committees: GROUP, cancel_on_committee_removal: CancelOnCommitteeRemoval.CANCEL });
+
+    service.submit().subscribe();
+
+    expect(sentOverride()).toBe(CancelOnCommitteeRemoval.CANCEL);
+  });
+
+  it('falls back to inherit once the meeting is made private', () => {
+    service.form().patchValue({ visibility: MeetingVisibility.PUBLIC, committees: GROUP, cancel_on_committee_removal: CancelOnCommitteeRemoval.KEEP });
+
+    service.form().get('visibility')?.setValue(MeetingVisibility.PRIVATE);
+    service.submit().subscribe();
+
+    // The override has nothing to act on here, and a private meeting later reopened to the public
+    // should not silently inherit a rule chosen while nobody could see it.
+    expect(sentOverride()).toBe(CancelOnCommitteeRemoval.INHERIT);
+  });
+
+  it('falls back to inherit once the last group is unlinked', () => {
+    service.form().patchValue({ visibility: MeetingVisibility.PUBLIC, committees: GROUP, cancel_on_committee_removal: CancelOnCommitteeRemoval.KEEP });
+
+    service.form().get('committees')?.setValue([]);
+    service.submit().subscribe();
+
+    expect(sentOverride()).toBe(CancelOnCommitteeRemoval.INHERIT);
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -702,104 +702,66 @@ describe('MeetingComposerFormService — save gate', () => {
 });
 
 /**
- * Covers the re-wire that "Switch to advanced mode" performs on the form the organizer is already
- * typing into. Quick create wires one subscription the drawer must not have — the Board type's
- * visibility/restriction default — and the only way to drop it without discarding the entered values
- * is to rebuild the subscriptions against the same FormGroup instance, which is what these assert.
+ * Covers the meeting type's access defaults, which belong to create mode rather than to one surface:
+ * a board meeting opens private and invite-only whether the organizer used the quick dialog or walked
+ * the drawer, so switching between the two mid-fill changes nothing about them.
  */
-describe('MeetingComposerFormService — switch to advanced', () => {
+describe('MeetingComposerFormService \u2014 meeting type access defaults', () => {
   let service: MeetingComposerFormService;
-  let createMeeting: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    createMeeting = vi.fn();
-
     TestBed.configureTestingModule({
       providers: [
         MeetingComposerFormService,
         { provide: MessageService, useValue: { add: vi.fn() } },
         { provide: CommitteeService, useValue: {} },
         { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
-        { provide: MeetingService, useValue: { createMeeting } },
+        { provide: MeetingService, useValue: {} },
       ],
     });
 
     service = TestBed.inject(MeetingComposerFormService);
-    service.initialize({ mode: 'create', variant: 'quick', projectUid: 'project-1' });
   });
 
-  it('keeps the same form instance and everything entered into it', () => {
-    const form = service.form();
-    form.patchValue({ title: 'Quarterly sync', description: 'Roll call' });
+  it('turns a board meeting private and invite-only in the drawer', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
 
-    service.dropQuickCreateDefaults();
-
-    // Identity as well as values: the dialog's sections and the drawer's sections both read
-    // `formService.form()`, so a replacement would blank the drawer even with the values copied over.
-    expect(service.form()).toBe(form);
-    expect(service.form().get('title')?.value).toBe('Quarterly sync');
-    expect(service.form().get('description')?.value).toBe('Roll call');
-  });
-
-  it('stops the meeting type from rewriting visibility and join restriction', () => {
-    service.form().patchValue({ visibility: MeetingVisibility.PUBLIC, restricted: false });
-
-    service.dropQuickCreateDefaults();
     service.form().get('meeting_type')?.setValue(MeetingType.BOARD);
 
-    // The drawer walks every field explicitly, so it must not move one the organizer hasn't reached.
-    expect(service.form().get('visibility')?.value).toBe(MeetingVisibility.PUBLIC);
-    expect(service.form().get('restricted')?.value).toBe(false);
-  });
-
-  it('leaves a Board default already applied in the dialog in place', () => {
-    service.form().get('meeting_type')?.setValue(MeetingType.BOARD);
-
-    service.dropQuickCreateDefaults();
-
-    // Dropping the subscription is not undoing it: the organizer saw Private/Invited-only in the
-    // dialog, so the drawer has to open showing the same thing.
     expect(service.form().get('visibility')?.value).toBe(MeetingVisibility.PRIVATE);
     expect(service.form().get('restricted')?.value).toBe(true);
   });
 
-  it('keeps the subscriptions both surfaces need', () => {
-    service.dropQuickCreateDefaults();
-    const revision = service.revision();
+  it('applies the same default in the quick dialog', () => {
+    service.initialize({ mode: 'create', variant: 'quick', projectUid: 'project-1' });
 
-    service.form().get('title')?.setValue('Re-wired');
+    service.form().get('meeting_type')?.setValue(MeetingType.BOARD);
 
-    // `revision` is what makes FormGroup value/validity reactive for every computed in both surfaces —
-    // the chip selections, the agenda counter, the save gate. Rebuilding the subscription set has to
-    // rebuild that one too.
-    expect(service.revision()).toBeGreaterThan(revision);
+    expect(service.form().get('visibility')?.value).toBe(MeetingVisibility.PRIVATE);
+    expect(service.form().get('restricted')?.value).toBe(true);
   });
 
-  it('re-applies the custom-duration validators against the current value', () => {
-    service.setDuration(37);
+  it('hands the access settings back when the type moves off Board', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.form().get('meeting_type')?.setValue(MeetingType.BOARD);
 
-    service.dropQuickCreateDefaults();
-    service.form().get('customDuration')?.setValue(null);
+    service.form().get('meeting_type')?.setValue(MeetingType.TECHNICAL);
 
-    // Wired from `duration`'s current value on every re-wire, not only on a later change: a switch made
-    // while Custom is selected would otherwise leave the minutes input unvalidated for the rest of the open.
-    expect(service.form().get('customDuration')?.valid).toBe(false);
+    // Otherwise one mis-click on Board leaves a technical meeting silently invite-only.
+    expect(service.form().get('visibility')?.value).toBe(MeetingVisibility.PUBLIC);
+    expect(service.form().get('restricted')?.value).toBe(false);
   });
 
-  it('does not disown a save already in flight for this open', () => {
-    const created = new Subject<Meeting>();
-    createMeeting.mockReturnValue(created);
-    service.form().patchValue({ title: 'Quarterly sync', meeting_type: MeetingType.TECHNICAL });
-    const emissions: (Meeting | null)[] = [];
-    service.submit().subscribe((meeting) => emissions.push(meeting));
+  it('leaves the saved access settings alone in edit mode', () => {
+    service.initialize({ mode: 'edit', projectUid: 'project-1' });
 
-    service.dropQuickCreateDefaults();
-    created.next({ id: 'meeting-1' } as Meeting);
-    created.complete();
+    // Hydration writes `meeting_type` like any other field, so a wired subscription would fire
+    // mid-patch and overwrite what the meeting was actually saved with. The type is patched last here
+    // precisely so that overwrite would be visible rather than patched back over.
+    service.form().patchValue({ visibility: MeetingVisibility.PUBLIC, restricted: false, meeting_type: MeetingType.BOARD });
 
-    // The same open continuing, not a new one: the submit pipeline drops anything whose generation
-    // moved under it, so bumping it here would make the organizer's own save land silently.
-    expect(emissions).toEqual([{ id: 'meeting-1' }]);
+    expect(service.form().get('visibility')?.value).toBe(MeetingVisibility.PUBLIC);
+    expect(service.form().get('restricted')?.value).toBe(false);
   });
 });
 /**

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -261,7 +261,7 @@ export class MeetingComposerFormService {
     this.loading.set(false);
     this.form.set(this.createMeetingFormGroup());
     this.revision.set(0);
-    this.wireFormSubscriptions(context.variant === 'quick');
+    this.wireFormSubscriptions(context.mode === 'create');
 
     // Create only: the group context pre-fills and locks the committees field. In edit mode the saved
     // meeting owns that field, and locking it to a single committee would drop the others on save.
@@ -274,25 +274,10 @@ export class MeetingComposerFormService {
       this.loadGuests(context.meetingUid);
     }
 
-    // Set after the subscriptions are wired so quick create's visibility/restriction defaults still apply.
+    // Set after the subscriptions are wired so the type's visibility/restriction defaults still apply.
     if (context.mode === 'create' && context.meetingType) {
       this.form().get('meeting_type')?.setValue(context.meetingType);
     }
-  }
-
-  /**
-   * Re-wires the form for the advanced drawer, leaving every value already entered in place.
-   * @description The counterpart to `MeetingComposerService.switchToAdvanced()`. Quick create wires one
-   * subscription the drawer must not have — the Board type's visibility/restriction default — and the
-   * form instance the organizer has been typing into is the one carrying it, so the subscriptions are
-   * rebuilt against that same instance rather than through `initialize()`, which would replace the form.
-   * Deliberately does not touch `reset$` or `generation`: this is the same open continuing, so an
-   * in-flight committee-context load still belongs to it.
-   */
-  public dropQuickCreateDefaults(): void {
-    this.formSubscriptions.unsubscribe();
-    this.formSubscriptions = new Subscription();
-    this.wireFormSubscriptions(false);
   }
 
   /**
@@ -959,8 +944,9 @@ export class MeetingComposerFormService {
     // user isn't left with Board-level settings silently applied to a non-Board meeting.
     // The user can freely override visibility and restriction after the default is applied.
     //
-    // Quick create only: prefilling from the meeting type is that dialog's whole premise, whereas the
-    // drawer walks every field explicitly and must not move one the organizer hasn't reached yet.
+    // Both create surfaces, so a board meeting is private whichever one the organizer used. Not edit
+    // mode: hydration writes `meeting_type` like any other field, so the subscription would fire
+    // mid-patch and overwrite the access settings the meeting was actually saved with.
     const meetingTypeControl = appliesTypeDefaults ? form.get('meeting_type') : null;
     if (meetingTypeControl) {
       let previousType = meetingTypeControl.value as string;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
@@ -31,7 +31,6 @@ describe('MeetingComposerHostComponent', () => {
   let composer: MeetingComposerService;
   let formService: MeetingComposerFormService;
   let messageService: { add: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn> };
-  let canWrite: WritableSignal<boolean>;
   let canWriteMeetings: WritableSignal<boolean>;
   let meetingWriteAccessFor: ReturnType<typeof vi.fn>;
 
@@ -70,7 +69,6 @@ describe('MeetingComposerHostComponent', () => {
 
   beforeEach(async () => {
     messageService = { add: vi.fn(), clear: vi.fn() };
-    canWrite = signal(false);
     canWriteMeetings = signal(true);
     meetingWriteAccessFor = vi.fn().mockReturnValue(of(true));
 
@@ -87,8 +85,9 @@ describe('MeetingComposerHostComponent', () => {
             getMeetingDetail: vi.fn(() => of(null)),
           },
         },
-        // `canWrite` is fed to `toObservable`, so it has to be a real signal rather than a plain getter.
-        { provide: ProjectContextService, useValue: { canWrite, canWriteMeetings, activeContextUid: () => 'project-1', meetingWriteAccessFor } },
+        // `canWriteMeetings` is fed to `toObservable`, so it has to be a real signal rather than a plain
+        // getter. The host reads no other write-access signal off this service.
+        { provide: ProjectContextService, useValue: { canWriteMeetings, activeContextUid: () => 'project-1', meetingWriteAccessFor } },
         // Only reached by the project-context fallback, which never runs while no meeting is loaded.
         { provide: ProjectService, useValue: {} },
         { provide: Router, useValue: { events: new Subject(), url: '/meetings', parseUrl: () => ({ queryParams: {} }) } },
@@ -189,22 +188,23 @@ describe('MeetingComposerHostComponent', () => {
     });
 
     it('closes an open composer when write access is lost', async () => {
-      canWrite.set(true);
-      await flush();
       await openCreate();
 
-      canWrite.set(false);
+      canWriteMeetings.set(false);
       await flush();
 
       expect(composer.isOpen()).toBe(false);
     });
 
     it('leaves the composer open when write access only resolves late', async () => {
+      // `canWriteMeetings` starts false in production and stays false while the grants request is
+      // unresolved, so a deep-linked open would be closed under the organizer if any false counted
+      // rather than only a true -> false. Drop to false before opening to reach that state.
+      canWriteMeetings.set(false);
+      await flush();
       await openCreate();
 
-      // `canWrite` starts false and stays false while the grants request is unresolved, so a deep-linked
-      // open would be closed under the organizer if any false counted rather than only a true -> false.
-      canWrite.set(true);
+      canWriteMeetings.set(true);
       await flush();
 
       expect(composer.isOpen()).toBe(true);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
@@ -430,17 +430,20 @@ describe('MeetingComposerHostComponent', () => {
   });
 
   describe('switching a quick create to the drawer', () => {
-    it('drops the quick-create defaults before moving surfaces', async () => {
+    it('moves the surface without touching what was already entered', async () => {
       composer.open({ mode: 'create', projectUid: 'project-1', variant: 'quick' });
       await flush();
-      const dropDefaults = vi.spyOn(formService, 'dropQuickCreateDefaults');
+      const form = formService.form();
+      form.patchValue({ title: 'Quarterly sync' });
 
       component['onSwitchToAdvanced']();
+      await flush();
 
-      // Order matters only in that both run: the drawer must stop rewriting fields the organizer
-      // already answered in the dialog.
-      expect(dropDefaults).toHaveBeenCalledOnce();
+      // One form service instance feeds both surfaces, so the handoff has nothing to copy \u2014 what it
+      // must not do is re-initialize, which would hand the organizer back an empty drawer.
       expect(composer.isQuickCreate()).toBe(false);
+      expect(formService.form()).toBe(form);
+      expect(formService.form().get('title')?.value).toBe('Quarterly sync');
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -164,10 +164,14 @@ export class MeetingComposerHostComponent {
       .subscribe((context) => this.formService.initialize(context));
 
     // Losing write access while the composer is open would make submit fail upstream; close it instead
-    // of evicting the user from the page underneath. Only a true -> false transition counts: `canWrite`
-    // starts false and reports false while the project grants request is unresolved, so reacting to any
-    // false would close a composer opened from a deep link before write access ever resolved.
-    toObservable(this.projectContextService.canWrite)
+    // of evicting the user from the page underneath. `canWriteMeetings`, not `canWrite`: the latter is
+    // writer-only, so a meeting coordinator — who may open this composer and whose submit upstream
+    // accepts — reads as false on it throughout and would never produce the transition below anyway.
+    // Only a true -> false transition counts: it starts false and reports false while the grants
+    // request is unresolved, so reacting to any false would close a composer opened from a deep link
+    // before access ever resolved. A project switch holds the previous value rather than emitting a
+    // transient false, so the guard doesn't fire on navigation either.
+    toObservable(this.projectContextService.canWriteMeetings)
       .pipe(
         pairwise(),
         filter(([hadWriteAccess, canWrite]) => hadWriteAccess && !canWrite && this.composer.isOpen()),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -202,14 +202,12 @@ export class MeetingComposerHostComponent {
 
   /**
    * Continues a quick create in the drawer, carrying the answers over.
-   * @description The pairing lives here because this is the only place that holds both services: the
-   * composer service moves the surface, the form service drops the quick dialog's type-driven defaults
-   * so the drawer stops rewriting fields the organizer has already answered. Neither touches the form,
-   * which is why the values survive. The active section is left where the open put it — a quick open
-   * never leaves the first one — so the drawer lands on Details & Access with the rest still to visit.
+   * @description Only the surface moves: both are fed by the one form service instance, and nothing
+   * here touches the form, which is why every answer survives. The active section is left where the
+   * open put it — a quick open never leaves the first one — so the drawer lands on Details & Access
+   * with the rest still to visit.
    */
   protected onSwitchToAdvanced(): void {
-    this.formService.dropQuickCreateDefaults();
     this.composer.switchToAdvanced();
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -70,10 +70,9 @@ export class MeetingComposerService {
    * Moves an open quick create dialog into the full drawer, keeping the form exactly as it stands.
    * @description The two surfaces are fed by one `MeetingComposerFormService` instance, so the values
    * already entered need no copying — what they need is for nothing to reset them, which is why this
-   * writes the surface alone and leaves `context` untouched. Pair it with
-   * `MeetingComposerFormService.dropQuickCreateDefaults()`, which the drawer needs so a later type
-   * change stops rewriting fields; `MeetingComposerHostComponent` owns that pairing, being the only
-   * place that holds both services.
+   * writes the surface alone and leaves `context` untouched. The form needs nothing done to it either:
+   * the meeting type's access defaults belong to create mode rather than to the dialog, so the drawer
+   * carries on with the same subscriptions.
    *
    * The dialog's sections carry over as visited. `visitedSections` means "the organizer has seen this",
    * and they have — the drawer is only a second view of a fill already in progress. Left unset, the

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -115,9 +115,9 @@ vi.mock('../services/logger.service', () => ({
     info: vi.fn(),
   },
 }));
-// `stripAuthPrefix` is kept real rather than stubbed: the controller's prefix stripping only matters
-// because it has to agree with what the read paths do, and a stand-in here would assert agreement with
-// the stand-in instead.
+// Only the two session accessors are stubbed — they are what these tests steer. `stripAuthPrefix` is
+// passed through real so anything else the module graph pulls in keeps its actual behaviour rather
+// than a stand-in's.
 vi.mock('../utils/auth-helper', async () => {
   const actual = await vi.importActual<typeof import('../utils/auth-helper')>('../utils/auth-helper');
 
@@ -751,9 +751,6 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     generateM2MTokenMock.mockResolvedValue('m2m-token');
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.addMeetingRegistrantSelf.mockResolvedValue({ uid: 'reg-1' });
-    // `clearAllMocks` leaves return values from earlier suites in place, so pin the session username
-    // rather than inherit one.
-    getEffectiveUsernameMock.mockReturnValue(null);
   });
 
   it('calls addMeetingRegistrantSelf with user token and returns 201', async () => {
@@ -1007,10 +1004,22 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].occurrence_id).toBe('1666848600');
   });
 
-  // Derived from the session, never from the body. The provider prefix is stripped because a
-  // registrant record stores the plain LFID — every read path strips before matching, so a prefixed
-  // row would be invisible to the join-URL lookup.
-  it('takes username from the session, strips its provider prefix, and ignores the body', async () => {
+  // The address is narrowed here even though upstream reads the real one off the caller's JWT: the
+  // over-length guard measures this value and the shared request type requires it, so a padded,
+  // differently-cased submission must still normalise rather than reach the guard as typed.
+  it('trims and lowercases the submitted email', async () => {
+    const { req, res, next } = buildRegisterReq(true, { email: '  A@Example.COM  ' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].email).toBe('a@example.com');
+  });
+
+  // Identity belongs to the `self` endpoint, which takes it off the caller's token. Forwarding a
+  // username would be this handler asserting an identity on the registrant's behalf — the exact
+  // thing that endpoint exists to prevent — and `addMeetingRegistrantSelf` drops it regardless.
+  it('never forwards a username, whoever the session belongs to', async () => {
     getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
     getEffectiveEmailMock.mockReturnValue('a@example.com');
     const { req, res, next } = buildRegisterReq(true, { email: 'a@example.com', username: 'someone-else' });
@@ -1018,37 +1027,6 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2].username).toBe('realuser');
-  });
-
-  // The LFID is what makes a row *this* person's, so it may only be stamped on a row that carries an
-  // address the session owns. Without this, one signed-in visitor could register a colleague's email
-  // and silently own the resulting RSVP.
-  it('omits the session username when the submitted email is not the session email', async () => {
-    getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
-    getEffectiveEmailMock.mockReturnValue('someone-else@example.com');
-    const { req, res, next } = buildRegisterReq(true, { email: 'a@example.com' });
-
-    await controller.registerForPublicMeeting(req, res, next);
-
-    expect(next).not.toHaveBeenCalled();
     expect(meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2]).not.toHaveProperty('username');
-  });
-
-  // Ownership is an address comparison, not a string comparison: the IdP hands back a lowercased
-  // address and the registrant types whatever they type.
-  it('treats a differently-cased and padded submitted email as the session email', async () => {
-    getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
-    getEffectiveEmailMock.mockReturnValue('a@example.com');
-    const { req, res, next } = buildRegisterReq(true, { email: '  A@Example.COM  ' });
-
-    await controller.registerForPublicMeeting(req, res, next);
-
-    expect(next).not.toHaveBeenCalled();
-
-    const forwarded = meetingSvc.addMeetingRegistrantSelf.mock.calls[0][2];
-
-    expect(forwarded.username).toBe('realuser');
-    expect(forwarded.email).toBe('a@example.com');
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -29,7 +29,7 @@ import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
-import { getEffectiveEmail, getEffectiveUsername, stripAuthPrefix } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { ProjectService } from '../services/project.service';
 import { generateM2MToken } from '../utils/m2m-token.util';
 import { validatePassword } from '../utils/security.util';
@@ -482,7 +482,7 @@ export class PublicMeetingController {
    * requests receive 401.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const registrantData = this.toSelfRegistration(req, req.body);
+    const registrantData = this.toSelfRegistration(req.body);
     const meetingId = registrantData.meeting_id;
 
     // Reject an over-length identifier rather than truncating it. `toSelfRegistration` caps the
@@ -653,9 +653,10 @@ export class PublicMeetingController {
   /**
    * Narrows a self-registration request body to the fields a person may state about themselves.
    *
-   * `/public/api` is `auth: 'optional'`, so this runs both with and without a session — but it always
-   * forwards upstream under an M2M token, so whatever survives this function is written with
-   * application-level credentials. The body used to be assigned wholesale, which let a caller set
+   * `/public/api` is `auth: 'optional'`, but `registerForPublicMeeting` requires a session of its own
+   * and sends the write under the registrant's *own* bearer token — the M2M token it mints covers the
+   * meeting lookup and is swapped back before the write. So what survives this function is written as
+   * the caller, not as the application. The body used to be assigned wholesale, which let a caller set
    * `host: true` — upstream documents that as "access to host key for the meeting" — or claim
    * membership of a committee by passing `committee_uid`. Neither is the caller's to decide, so both
    * are dropped here rather than left to upstream's discretion.
@@ -668,53 +669,40 @@ export class PublicMeetingController {
    * shape nothing produced. Anything that isn't a string is dropped, which is what stops an object or
    * array from clearing the caller's `if (!registrantData.email …)` gate and reaching upstream.
    *
-   * `username` is taken from the session and never from the body, and only when the submitted email
-   * is the one that session belongs to. That second condition is what keeps LFID attribution honest:
-   * the row is written with application credentials, so upstream applies no ownership check of its
-   * own, and `getMeetingRegistrantsForUser` matches on email OR username. A row carrying one person's
-   * LFID against another person's address would therefore match both of them, and `createMeetingRsvp`
-   * takes `registrants[0]` from an unordered result — so either party's RSVP could land on it. Only
-   * stamping self-registrations removes that ambiguity at the source. It's stripped of any provider
-   * prefix because a registrant record stores the plain LFID: every read path strips before matching
-   * (`getMeetingRegistrantsByUsername`), so an `auth0|`-prefixed row would be invisible to the
-   * join-URL lookup that the username is stamped for in the first place. `email` is lowercased for the
-   * same reason, since query-service matching is case-sensitive and every read path lowercases.
+   * Identity is not this function's to set. The write lands on `/itx/meetings/:id/registrants/self`,
+   * and `addMeetingRegistrantSelf` sends neither `email` nor `username` — the meeting service reads
+   * both off the caller's JWT, which is the only reason a route reachable this way can attribute a
+   * row at all. This helper used to derive a prefix-stripped LFID from the session and hand it over;
+   * the service dropped it on the way out, so attribution was decided twice and applied once. Deriving
+   * it here is gone rather than plumbed through: a payload field would be the caller asserting an
+   * identity, which is exactly what the `self` endpoint exists to stop. `email` is still narrowed and
+   * lowercased because the caller's length guard measures it and the shared request type requires it.
    *
    * The three identifiers — `meeting_id`, `email` and `occurrence_id` — are trimmed but not truncated,
    * unlike the free-text fields, because truncating one would turn an unusable value into a different,
    * valid-looking one. The caller rejects an over-length one by name instead, so the response says
    * what was actually wrong.
    *
-   * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
-   * still register a third party's address for a public meeting and trigger an invite to it.
-   * `publicApiRateLimiter` caps the volume, not the primitive. Such a row is now unattributed, so it
-   * no longer collides with that person's own registration — the invite is the whole of the abuse.
-   * Nothing here checks `email_verified` either, so an IdP that admits an unverified address would
-   * still let an attacker who set their own account email to the victim's earn the stamp.
+   * Registering someone else's address is not reachable through this route: the handler rejects an
+   * anonymous caller, and the row upstream stores carries the session's address whatever the body
+   * said. A paragraph describing that abuse used to sit here, from when the endpoint accepted the
+   * submitted address as the registrant's.
    *
-   * What it costs: the registration form prefills the session email but leaves it editable, and
-   * ownership is decided against the session's single primary address. A signed-in user who registers
-   * with a secondary address of theirs now gets an unattributed row, so `createMeetingRsvp` — which
-   * resolves on session-email-OR-username — won't find it, and the RSVP controls read as
-   * "not invited". Closing that means comparing against the user's *verified* address set rather than
-   * the primary, which is an Auth0 Management round trip on an anonymous-capable route; deliberately
-   * left for its own change rather than bolted onto the identity fix.
+   * What it costs: the registration form still prefills the session address and still lets it be
+   * edited, and a registrant who types a second address of theirs is registered under their primary
+   * one with nothing saying the field was overridden. That belongs to the form, which has a value to
+   * stop offering; this helper has no address to honour.
    */
-  private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
+  private toSelfRegistration(body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string =>
       typeof raw[key] === 'string' ? truncateToUtf16Units((raw[key] as string).trim(), PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '';
     // Identifiers are narrowed and trimmed but never truncated — see the length branch in
     // `registerForPublicMeeting`, which rejects them by name instead.
     const identity = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim() : '');
+    // Normalised for the caller's over-length guard and because the shared request type requires the
+    // field, not because upstream reads it — `/registrants/self` takes the address off the JWT.
     const submittedEmail = identity('email').toLowerCase();
-    // The LFID is only stamped when the caller is registering the address their own session is for.
-    // Registering a third party's address stays allowed, but it produces an unattributed row rather
-    // than one that a downstream email-OR-username lookup would match for two different people.
-    const sessionUsername = getEffectiveUsername(req);
-    const sessionEmail = getEffectiveEmail(req)?.trim().toLowerCase() || '';
-    const ownsSubmittedEmail = !!sessionEmail && sessionEmail === submittedEmail;
-    const username = sessionUsername && ownsSubmittedEmail ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
     const orgName = text('org_name');
     const occurrenceId = identity('occurrence_id');
@@ -730,7 +718,6 @@ export class PublicMeetingController {
       // Which occurrences the registration covers is part of what a registrant states about their own
       // attendance, so it stays allowlisted even though no in-app caller sends it yet.
       ...(occurrenceId ? { occurrence_id: occurrenceId } : {}),
-      ...(username ? { username } : {}),
     };
   }
 

--- a/apps/lfx-one/src/server/routes/public-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/public-meetings.route.ts
@@ -8,8 +8,9 @@ import { PublicMeetingController } from '../controllers/public-meeting.controlle
 const router = Router();
 const publicMeetingController = new PublicMeetingController();
 
-// POST /public/api/meetings/register - register for a public, non-restricted meeting (optional auth:
-// no session required, but the handler reads the registrant's username off one when it exists)
+// POST /public/api/meetings/register - register for a public, non-restricted meeting. The router is
+// mounted with optional auth, but this handler requires a session: it registers the caller as
+// themselves, and upstream reads their identity off their own token.
 router.post('/register', (req, res, next) => publicMeetingController.registerForPublicMeeting(req, res, next));
 
 // GET /public/api/meetings/past/:id - get a past meeting with tiered access (public access, no authentication required)

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -132,7 +132,9 @@ export class AiService {
       return result;
     } catch (error) {
       logger.error(req, 'generate_meeting_agenda', startTime, error);
-      throw new Error('Failed to generate meeting agenda');
+      // The upstream failure is logged above and the message stays generic for the caller; the cause
+      // rides along so a handler that inspects `error.cause` still reaches the original stack.
+      throw new Error('Failed to generate meeting agenda', { cause: error });
     }
   }
 
@@ -204,7 +206,7 @@ export class AiService {
       return result;
     } catch (error) {
       logger.error(req, 'generate_newsletter', startTime, error);
-      throw new Error('Failed to generate newsletter');
+      throw new Error('Failed to generate newsletter', { cause: error });
     }
   }
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1109,7 +1109,9 @@ describe('MeetingService registrant write payloads', () => {
   // Same reasoning as the update fallback above, on the two create paths: `ApiClientService` maps an
   // empty response body to `null`, and a 201 carrying a literal `{}` is truthy — so both were mapped
   // straight through and reported a created registrant with every field missing. The submitted payload
-  // is the closest description of what upstream now holds; `uid` is the one thing it can't supply.
+  // is the closest description of what upstream now holds; `uid` is the one thing it can't supply, so
+  // it is stated as `''` — falsy, so a caller's `if (uid)` still routes to a read-back, and present,
+  // so the `MeetingRegistrant` cast isn't claiming a required field the object lacks.
   it.each([
     ['null', null],
     ['an empty object', {}],
@@ -1124,13 +1126,13 @@ describe('MeetingService registrant write payloads', () => {
     });
 
     expect(result).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
-    expect(result.uid).toBeUndefined();
+    expect(result.uid).toBe('');
   });
 
   // Self-registration is the path a registrant drives from the public meeting page, so the same
   // unusable body used to surface to them as a `{}` "created" record. Its success line has to say
-  // which branch produced the result — without `has_upstream_body` and an explicit `null` uid, Pino
-  // drops the undefined `uid` and the line is indistinguishable from a create whose log shape changed.
+  // which branch produced the result — without `has_upstream_body` and an explicit `null` uid, the
+  // fallback's placeholder would log as an empty UID rather than as one upstream never minted.
   it('logs which branch the self-registration create returned from when upstream sends no body', async () => {
     proxyRequest.mockResolvedValue(null);
 

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -984,7 +984,11 @@ export class MeetingService {
     // hands the result back to the client as the updated row. The submitted payload is the closest available
     // description of what upstream now stores. It inherits the two caveats above: a cleared
     // organization and a `linkedin_profile` both echo back as if they had been written.
-    return { ...updateData } as MeetingRegistrant;
+    // `uid` is required on `MeetingRegistrant` and is not part of the update body, so the cast would
+    // otherwise promise a field the object doesn't have. It is already known here — it addressed the
+    // request — so it is stated rather than asserted. `meeting_id` is in the body, but the meeting the
+    // request routed on is the authoritative one, so both are written after the spread.
+    return { ...updateData, uid: registrantUid, meeting_id: meetingUid } as MeetingRegistrant;
   }
 
   /**
@@ -2030,10 +2034,12 @@ export class MeetingService {
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {
       meeting_id: meetingId,
-      // `?? null` rather than leaving it `undefined`: Pino drops undefined values, so a create whose
+      // `|| null` rather than leaving it as it comes: Pino drops undefined values, so a create whose
       // upstream body carried no UID logged as a success line with no `registrant_uid` field at all,
-      // indistinguishable from a log-shape change. `has_upstream_body` says which branch produced it.
-      registrant_uid: newRegistrant.uid ?? null,
+      // indistinguishable from a log-shape change — and the fallback's own placeholder `''` would read
+      // as a UID that is empty rather than one upstream never minted. `has_upstream_body` says which
+      // branch produced it.
+      registrant_uid: newRegistrant.uid || null,
       has_upstream_body: hasUpstreamBody,
     });
 
@@ -2376,8 +2382,13 @@ export class MeetingService {
    * `{}` with no fields at all, and the M2M path's success log says which branch it came from.
    * Deliberately not thrown: the write already succeeded, and throwing here would report a created
    * registrant as a failure. Callers that need the UID have to read the registrant back.
+   *
+   * `uid` is stated as `''` rather than left off. `MeetingRegistrant` declares it required, so the cast
+   * would otherwise claim a field the object doesn't carry; an empty string is falsy, so a caller's
+   * `if (registrant.uid)` still routes to the read-back, whereas an absent one would reach a template
+   * or a URL segment as the literal `"undefined"`.
    */
   private static registrantFromSubmittedPayload(registrantData: CreateMeetingRegistrantRequest): MeetingRegistrant {
-    return { ...registrantData } as MeetingRegistrant;
+    return { uid: '', ...registrantData } as MeetingRegistrant;
   }
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -768,11 +768,11 @@ export interface ComposerGuestRow {
   trackId: string;
   /** Avatar initials, from the name when known and the email otherwise. */
   initials: string;
-  /** `first last`, as typed — no fallback, since both are required to add a guest. */
+  /** `first last` with empty parts dropped; `''` for a hydrated registrant that has neither name. */
   displayName: string;
   /** `email · org`, collapsing to just the email when the org is unknown. */
   secondaryLine: string;
-  /** The remove button's accessible name, which always identifies *which* guest it removes. */
+  /** The remove button's accessible name: the display name, or the email when there is no name. */
   removeLabel: string;
 }
 


### PR DESCRIPTION
> **Stack 19 of 20.** Based on PR 18 (`refactor/issue-1451-composer-signals`). Followed by PR 20 (`fix/issue-1451-recurrence-and-access`).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip.

## What

Last of three review-closeout PRs. Corrects the public registration write, the error causes and the docstrings that described the opposite of the code, applies the Board access default on both create surfaces, and pins the two save-payload branches that had gone across untested.

## How

- Stops `/public/api/meetings/register` deriving a `username` from the session: `addMeetingRegistrantSelf` never sends one and `/registrants/self` reads identity off the caller's own token, so the stripped LFID was a no-op that read like an identity assertion.
- Corrects the `toSelfRegistration` docstring, which reversed what the code does about credentials, and the route comment that claimed no session was required.
- Carries the upstream error as `cause` on the agenda and newsletter generator throws.
- Gives the two registrant fallbacks the `uid` their type promises — an explicit empty string on the create fallback (still falsy, so a caller's read-back branch runs) and the addressed ids on the update fallback.
- Points the composer's write-access eviction at `canWriteMeetings` instead of the writer-only `canWrite`, which a meeting coordinator reads false on throughout and so could never produce the transition the guard needs.
- Applies the Board meeting type's private + invite-only default across create mode rather than in the quick dialog alone, and removes `dropQuickCreateDefaults()`, which existed only to strip it on handoff.
- Adds 10 specs pinning what the organizer picker contributes to the payload and when the cancel-on-group-removal override is sent as chosen rather than as `inherit`.

## Notes for reviewers

- Edit mode stays unwired for the Board default on purpose: `FormGroup.patchValue` emits each child control's `valueChanges` during the patch, so hydrating a saved Board meeting would fire the subscription mid-patch and overwrite the access settings that meeting was actually saved with.
- Each new spec was checked against a mutated service to confirm it fails when the branch it names is removed.

## Protected files

This PR touches files flagged by `.claude/hooks/guard-protected-files.sh`. Requesting code-owner review from @linuxfoundation/lfx-platform.

| File | Why it is protected | What this PR changes |
| --- | --- | --- |
| `apps/lfx-one/src/server/services/ai.service.ts` | AI integration service. Changes affect AI-powered features. | Attaches the upstream error as `cause` on the two generator throws that already log it, so a handler inspecting `error.cause` reaches the original stack. The thrown messages, the prompts and the proxy call are unchanged. |

## Commits

3 commit(s), 12 files changed, 318 insertions(+), 204 deletions(-).

- `fix(meetings): correct registrant writes, causes and comments`
- `fix(meetings): apply board access defaults on both create surfaces`
- `test(meetings): pin the composer's owner and group-cancel payload`

## Related

- Refs #1452
- Refs #1453
- Refs #1457
- Refs #1460
- Refs #1463
- Refs #1464
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale
