### PR TITLE
feat(org-lens): explain an unsigned agreement on its overview tab

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
@@ -172,6 +172,51 @@
             </ng-template>
           </lfx-message>
         }
+        <!--
+          The body for an agreement the organization has not signed. Reached from the list, not
+          only from the signing flow: a row's status comes from the producer's `signed` flag, so an
+          unsigned agreement is an ordinary list entry. Without this the tab rendered its heading
+          and then stopped, which reads as a page that failed to load rather than as a state.
+        -->
+        @if (notStarted()) {
+          <div class="flex flex-col gap-3" data-testid="org-easycla-detail-not-started">
+            @if (notStartedLead()) {
+              <p class="text-sm text-gray-700" data-testid="org-easycla-detail-not-started-lead">{{ notStartedLead() }}</p>
+            }
+            <p class="font-semibold text-sm text-gray-900">{{ notStartedCopy.stepsHeading }}</p>
+            <!--
+              An ordered list, not three paragraphs as the prototype draws them. The steps are a
+              sequence and are numbered in their own text, so the markup that says so is what lets
+              assistive technology announce the position and count. The prototype's numbering is
+              kept in the visible text rather than generated, so the wording stays verbatim.
+            -->
+            <ol class="flex list-none flex-col gap-2 p-0">
+              @for (step of notStartedCopy.steps; track step.label) {
+                <li class="text-sm text-gray-700">
+                  <span class="font-semibold text-gray-900">{{ step.label }}</span> {{ step.body }}
+                </li>
+              }
+            </ol>
+            <!--
+              Inoperable for now, exactly as the list header's Sign CLA control ships: enabling it
+              belongs to the signing feature, and there is deliberately no click handler to leave
+              behind. The reason is in the accessible name as well as the tooltip, because the
+              tooltip sits on the non-focusable host while the button inside is disabled, so it
+              opens on hover and never on focus — without it, assistive technology announces only
+              "Start the CLA process, disabled" and the viewer cannot tell whether the control is
+              unavailable to them or to everyone.
+            -->
+            <div>
+              <lfx-button
+                [label]="notStartedCopy.startLabel"
+                icon="fa-light fa-file-signature"
+                [disabled]="true"
+                [ariaLabel]="notStartedCopy.startLabel + ' — signing a new CLA from the Organization Lens is coming soon.'"
+                tooltip="Signing a new CLA from the Organization Lens is coming soon."
+                data-testid="org-easycla-detail-start-cla" />
+            </div>
+          </div>
+        }
         @if (canDownload()) {
           <!--
             `severity="secondary"` with `outlined`, the pairing the survey-preview and profile

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -7,6 +7,7 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { ORG_CLA_NOT_STARTED_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -183,6 +184,73 @@ describe('OrgEasyclaDetailComponent', () => {
     const fixture = await render();
 
     expect(byTestId(fixture, 'org-easycla-detail-ccla-hint')?.textContent?.trim()).toBe("Covers Cascade for Acme's employees.");
+  });
+
+  describe('an agreement the organization has not signed', () => {
+    const notStarted = { status: 'not-started' as const, signed: false, signedOn: undefined };
+
+    it('explains the process instead of leaving the tab empty', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      const panel = byTestId(fixture, 'org-easycla-detail-not-started');
+      expect(panel).not.toBeNull();
+      // All three steps, not merely the heading: the steps are where the consequence of signing —
+      // that the signer becomes the initial CLA Manager — is stated before it happens.
+      expect(panel?.querySelectorAll('li').length).toBe(3);
+      expect(panel?.textContent).toContain(ORG_CLA_NOT_STARTED_COPY.stepsHeading);
+      for (const step of ORG_CLA_NOT_STARTED_COPY.steps) {
+        expect(panel?.textContent).toContain(step.body);
+      }
+    });
+
+    it('names the organization and the agreement it has not signed', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ ...notStarted, claGroupName: 'Cascade CLA' })] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started-lead')?.textContent?.trim()).toBe('Acme has not yet signed a CLA for Cascade CLA.');
+    });
+
+    it('numbers the steps as a list, so their order and count are announced', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')?.querySelector('ol')).not.toBeNull();
+    });
+
+    it('offers the start control, and says why it does nothing yet', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      // The reason has to be in the accessible name, not the tooltip alone: the tooltip host is
+      // not focusable while the button is disabled, so it never opens on focus.
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla');
+      expect(start).not.toBeNull();
+      expect(start?.querySelector('button')?.disabled).toBe(true);
+      expect(start?.querySelector('button')?.getAttribute('aria-label')).toContain('coming soon');
+    });
+
+    it('does not explain the process on a signed agreement', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
+
+    it('does not walk a sanctioned agreement through how to start signing', async () => {
+      // Sanctions take the same status slot, and that viewer's obstacle is not a missing signature
+      // — telling them how to begin would talk past the reason they cannot.
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ status: 'sanctioned', signed: false, signedOn: undefined })] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
   });
 
   it('withholds the download from an agreement that was never signed', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import type { OrgClaCoverageChip, OrgClaDetailTab, OrgClaDetailTabView, OrgClaGroup, OrgClaGroupList, OrgClaStatusDisplay } from '@lfx-one/shared/interfaces';
-import { ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
+import { ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
 import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -123,6 +123,18 @@ export class OrgEasyclaDetailComponent {
   // gives the viewer a control that can only fail.
   protected readonly canDownload = computed(() => this.claGroup()?.signed === true);
 
+  protected readonly notStartedCopy = ORG_CLA_NOT_STARTED_COPY;
+
+  /**
+   * Read from the status rather than from `signed` being false, unlike `canDownload` above.
+   * Sanctions occupy the same status slot, and a sanctioned agreement carries its own explanatory
+   * body in the design — walking that viewer through how to start signing would talk past the
+   * reason they cannot.
+   */
+  protected readonly notStarted = computed(() => this.claGroup()?.status === 'not-started');
+
+  protected readonly notStartedLead = computed(() => this.initNotStartedLead());
+
   protected readonly signedOnLabel = computed(() => this.initSignedOnLabel());
 
   protected readonly signedByName = computed(() => this.initSignedByName());
@@ -223,6 +235,17 @@ export class OrgEasyclaDetailComponent {
     const summary = orgClaCoverageSummary(group);
     const company = this.companyName();
     return summary && company ? `Covers ${summary} for ${company}'s employees.` : '';
+  }
+
+  /**
+   * Withheld until both names are known rather than filled with a placeholder. The sentence names
+   * the organization being bound and the agreement it would be bound to, so a gap in either is the
+   * part that carries the meaning, and "— has not yet signed a CLA for —" states nothing.
+   */
+  private initNotStartedLead(): string {
+    const group = this.claGroup();
+    const company = this.companyName();
+    return group && company ? this.notStartedCopy.lead(company, group.claGroupName) : '';
   }
 
   private initSignedOnLabel(): string {

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -185,6 +185,33 @@ export const CLA_MANAGER_MODAL_COPY = {
 } as const;
 
 /**
+ * The Overview body for an agreement the organization has not signed.
+ *
+ * The list is not exclusively signed agreements — a row's status is read from the producer's
+ * `signed` flag — so this state is reached from the list itself, without going near the signing
+ * flow. Before this copy existed the tab rendered a heading and then nothing.
+ *
+ * Taken verbatim from the M3 prototype, steps and all. The three steps are the only place the
+ * consequence of signing is spelled out before it happens: that whoever signs becomes the initial
+ * CLA Manager, and what that role then controls. Paraphrasing them would quietly change what the
+ * organization is told it is agreeing to arrange.
+ */
+export const ORG_CLA_NOT_STARTED_COPY = {
+  /** `company` and `claGroup` are the organization's and the agreement's names. */
+  lead: (company: string, claGroup: string): string => `${company} has not yet signed a CLA for ${claGroup}.`,
+  stepsHeading: "Here's what the process looks like:",
+  steps: [
+    {
+      label: 'Step 1:',
+      body: 'You will identify who should be the initial CLA Manager. The CLA Manager is the person who manages the list of approved contributors. This might be you, or might be someone else at your company.',
+    },
+    { label: 'Step 2:', body: 'That person will be able to sign the CLA (or send it to someone else for signature).' },
+    { label: 'Step 3:', body: 'Finally, the CLA Manager will be able to start approving contributors and adding other CLA Managers.' },
+  ],
+  startLabel: 'Start the CLA process',
+} as const;
+
+/**
  * Tab order of the Organization Lens CLA Group detail page. `OrgClaDetailTab` is derived from
  * this, so the set exists once: a tab added here is a compile error everywhere that switches on
  * the union until it is handled.


### PR DESCRIPTION
The CLA agreement Overview only rendered the signed case, so an agreement the
organization has not signed showed its heading and then nothing — a state that
reads as a page which failed to load. It is reached from the list rather than
from the signing flow: a row's status comes from the producer's `signed` flag,
and that flag is not always true.

The tab now carries the M3 prototype's body for that state, verbatim: who has
not signed what, and the three steps of the process. The steps are quoted
rather than paraphrased because they are the only place the consequence of
signing is stated before it happens — that whoever signs becomes the initial
CLA Manager, and what that role goes on to control — and they are marked up as
an ordered list so their order and count are announced rather than merely drawn.

The **Start the CLA process** control ships inoperable, with its reason in the
accessible name as well as the tooltip, exactly as the list header's Sign CLA
control does. Wiring it belongs to #1983.

Refs #1978