### PR TITLE
fix(meetings): keep recurrence intact and re-check edit access

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -65,6 +65,7 @@
             severity="secondary"
             data-testid="edit-meeting-button"
             tooltip="Edit Meeting"
+            [disabled]="checkingEditAccess()"
             (onClick)="onEditMeeting()"></lfx-button>
         }
         @if (meeting().organizer) {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.spec.ts
@@ -1,0 +1,136 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Meeting } from '@lfx-one/shared/interfaces';
+import { MeetingComposerService } from '@app/modules/meetings/meeting-composer/meeting-composer.service';
+import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { UserService } from '@services/user.service';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { Observable, of, Subject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingCardComponent } from './meeting-card.component';
+
+const MEETING = { id: 'meeting-1', project_uid: 'project-1', project_slug: 'acme', organizer: true } as Meeting;
+
+/**
+ * Covers the write-access probe the edit button runs before opening the composer.
+ * @description `meeting().organizer` is a snapshot of what the list payload said when the card
+ * rendered, so an organizer whose access was revoked since then still sees an edit button. Opening
+ * the composer on that stale flag walks the organizer through a whole edit that upstream will reject
+ * on save, so the card re-asks before opening.
+ */
+describe('MeetingCardComponent — edit-access re-check', () => {
+  let composerOpen: ReturnType<typeof vi.fn>;
+  let toastAdd: ReturnType<typeof vi.fn>;
+  let writeAccess: ReturnType<typeof vi.fn>;
+
+  /** Mounts the card over `meeting` with an empty template — this suite exercises the handler, not the markup. */
+  async function mount(meeting: Meeting = MEETING): Promise<MeetingCardComponent> {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserService, useValue: { user: signal(null), authenticated: signal(false) } },
+        { provide: ProjectService, useValue: { project: signal(null) } },
+        { provide: ProjectContextService, useValue: { meetingWriteAccessFor: writeAccess } },
+        { provide: MeetingComposerService, useValue: { open: composerOpen } },
+        { provide: MessageService, useValue: { add: toastAdd } },
+        { provide: ConfirmationService, useValue: {} },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+        {
+          provide: MeetingService,
+          useValue: {
+            getMeetingAttachments: vi.fn().mockReturnValue(of([])),
+            getPastMeetingAttachments: vi.fn().mockReturnValue(of([])),
+            getPublicMeetingJoinUrl: vi.fn().mockReturnValue(of({ link: '' })),
+          },
+        },
+      ],
+    });
+    // Empty template: the 512-line card markup mounts a dozen child components that have nothing to
+    // do with this handler. providers: [] drops the component's own ConfirmationService so the stub
+    // above is the one injected.
+    TestBed.overrideComponent(MeetingCardComponent, { set: { template: '', imports: [], providers: [] } });
+    await TestBed.compileComponents();
+
+    const fixture = TestBed.createComponent(MeetingCardComponent);
+    fixture.componentRef.setInput('meetingInput', meeting);
+    fixture.detectChanges();
+
+    return fixture.componentInstance;
+  }
+
+  beforeEach(() => {
+    composerOpen = vi.fn();
+    toastAdd = vi.fn();
+    writeAccess = vi.fn().mockReturnValue(of(true));
+  });
+
+  it('opens the composer once the probe confirms write access', async () => {
+    const component = await mount();
+
+    component.onEditMeeting();
+
+    expect(writeAccess).toHaveBeenCalledWith('acme');
+    expect(composerOpen).toHaveBeenCalledWith({ mode: 'edit', meetingUid: 'meeting-1', projectUid: 'project-1' });
+    expect(toastAdd).not.toHaveBeenCalled();
+  });
+
+  it('refuses to open the composer for an organizer whose access has since been revoked', async () => {
+    writeAccess.mockReturnValue(of(false));
+    const component = await mount();
+
+    component.onEditMeeting();
+
+    // The stale `organizer: true` on the card is exactly the case this exists for: the edit would be
+    // rejected on save, after the organizer had already redone the work.
+    expect(composerOpen).not.toHaveBeenCalled();
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn', summary: 'Editing unavailable' }));
+  });
+
+  it('does not probe at all when the meeting carries no project reference', async () => {
+    const component = await mount({ id: 'meeting-1', organizer: true } as Meeting);
+
+    component.onEditMeeting();
+
+    // `meetingWriteAccessFor` needs a slug or uid to ask about; without one there is nothing to check
+    // and the composer would open on an unverified flag.
+    expect(writeAccess).not.toHaveBeenCalled();
+    expect(composerOpen).not.toHaveBeenCalled();
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn' }));
+  });
+
+  it('holds the button disabled for the length of the probe and ignores a second click', async () => {
+    const probe = new Subject<boolean>();
+    writeAccess.mockReturnValue(probe as unknown as Observable<boolean>);
+    const component = await mount();
+
+    component.onEditMeeting();
+
+    expect(component.checkingEditAccess()).toBe(true);
+
+    // A second click while the first probe is in flight must not queue a second request — otherwise
+    // two composers race to open over the same meeting.
+    component.onEditMeeting();
+    expect(writeAccess).toHaveBeenCalledTimes(1);
+
+    probe.next(true);
+    probe.complete();
+
+    expect(component.checkingEditAccess()).toBe(false);
+    expect(composerOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the button after a denied probe so the organizer can retry', async () => {
+    writeAccess.mockReturnValue(of(false));
+    const component = await mount();
+
+    component.onEditMeeting();
+
+    expect(component.checkingEditAccess()).toBe(false);
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -73,6 +73,7 @@ import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { AnimateOnScrollModule } from 'primeng/animateonscroll';
@@ -81,7 +82,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, filter, map, of, pairwise, skip, switchMap, take, tap, timer } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, filter, finalize, map, of, pairwise, skip, switchMap, take, tap, timer } from 'rxjs';
 
 import { CancelOccurrenceConfirmationComponent } from '../../components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component';
 import { MeetingMaterialsDrawerComponent } from '../meeting-materials-drawer/meeting-materials-drawer.component';
@@ -121,6 +122,7 @@ export class MeetingCardComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly clipboard = inject(Clipboard);
   private readonly userService = inject(UserService);
+  private readonly projectContext = inject(ProjectContextService);
   private readonly composer = inject(MeetingComposerService);
 
   private readonly destroyRef = inject(DestroyRef);
@@ -150,6 +152,8 @@ export class MeetingCardComponent implements OnInit {
   public drawerHosts: WritableSignal<MeetingHostCandidate[]> = signal<MeetingHostCandidate[]>([]);
   public attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
   public materialsDrawerVisible = signal(false);
+  /** Set while the pre-open write-access probe is in flight, so the edit button cannot be double-fired. */
+  public checkingEditAccess: WritableSignal<boolean> = signal(false);
 
   // Computed values for template
   public readonly summaryContent: Signal<string | null> = this.initSummaryContent();
@@ -276,12 +280,46 @@ export class MeetingCardComponent implements OnInit {
       .subscribe(() => this.optimisticInvited.set(false));
   }
 
+  /**
+   * Re-checks meeting write access before opening the composer in edit mode.
+   * @description `meeting().organizer` is whatever the list payload said when the card first rendered,
+   * so an organizer whose access was revoked since then keeps an edit button until the page reloads.
+   * Same fresh writer -> meeting-coordinator probe the group meetings list makes before scheduling: the
+   * save would fail upstream regardless, but the composer should not open onto work that cannot land.
+   */
   public onEditMeeting(): void {
-    this.composer.open({
-      mode: 'edit',
-      meetingUid: this.meeting().id,
-      projectUid: this.meeting().project_uid,
-    });
+    if (this.checkingEditAccess()) {
+      return;
+    }
+
+    const meeting = this.meeting();
+    const projectRef = meeting.project_slug || meeting.project_uid;
+
+    if (!projectRef) {
+      this.denyEdit();
+      return;
+    }
+
+    this.checkingEditAccess.set(true);
+    // `meetingWriteAccessFor` already folds its own failures into `false`, so there is no error branch.
+    this.projectContext
+      .meetingWriteAccessFor(projectRef)
+      .pipe(
+        finalize(() => this.checkingEditAccess.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((canEdit) => {
+        if (!canEdit) {
+          this.denyEdit();
+          return;
+        }
+
+        this.composer.open({
+          mode: 'edit',
+          meetingUid: meeting.id,
+          projectUid: meeting.project_uid,
+        });
+      });
   }
 
   public ngOnInit(): void {
@@ -821,6 +859,14 @@ export class MeetingCardComponent implements OnInit {
       const occurrence = this.occurrence();
       const meeting = this.meeting();
       return occurrence?.title || meeting.title || '';
+    });
+  }
+
+  private denyEdit(): void {
+    this.messageService.add({
+      severity: 'warn',
+      summary: 'Editing unavailable',
+      detail: 'You no longer have permission to edit this meeting.',
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.spec.ts
@@ -1,0 +1,112 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { Committee, CommitteeMember, MeetingCommittee } from '@lfx-one/shared';
+import { CommitteeService } from '@services/committee.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { Observable, of, Subject, throwError } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MeetingCommitteeManagerComponent } from './meeting-committee-manager.component';
+
+const BOARD = { uid: 'committee-board', name: 'Board', category: 'Board', enable_voting: false, public: true, sso_group_enabled: false } as Committee;
+const LEGAL = { uid: 'committee-legal', name: 'Legal', category: 'Legal', enable_voting: false, public: true, sso_group_enabled: false } as Committee;
+
+/** A member of `committeeUid`, carrying only the fields this component reads or forwards. */
+function member(committeeUid: string, email: string): CommitteeMember {
+  return { uid: `member-${email}`, committee_uid: committeeUid, email } as CommitteeMember;
+}
+
+/**
+ * Mounts the manager over `saved` groups, with each committee's member fetch supplied by `members`.
+ * @returns the emissions of `committeeMembersChange`, in order, and the mounted component.
+ */
+async function mount(saved: MeetingCommittee[], members: Record<string, Observable<CommitteeMember[]>>, options: Committee[] = [BOARD]) {
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: ProjectContextService, useValue: { activeContextUid: () => 'project-1' } },
+      {
+        provide: CommitteeService,
+        useValue: {
+          getCommitteesByProject: vi.fn().mockReturnValue(of(options)),
+          getCommitteeMembers: vi.fn((uid: string) => members[uid] ?? of([])),
+        },
+      },
+    ],
+  });
+
+  const fixture = TestBed.createComponent(MeetingCommitteeManagerComponent);
+  const emissions: CommitteeMember[][] = [];
+
+  fixture.componentRef.setInput('selectedCommittees', saved);
+  fixture.componentRef.setInput(
+    'form',
+    new FormGroup({
+      visibility: new FormControl('private'),
+      committees: new FormControl([]),
+      show_meeting_attendees: new FormControl(false),
+    })
+  );
+  fixture.componentInstance.committeeMembersChange.subscribe((value) => emissions.push(value));
+
+  await fixture.whenStable();
+
+  return { component: fixture.componentInstance, emissions, fixture };
+}
+
+/**
+ * Covers the gate on `committeeMembersChange`.
+ * @description The consumer treats every emission as the complete membership of the selected groups
+ * and marks anyone absent from it for deletion. An emission is therefore only safe once the fetch it
+ * describes has actually settled: at mount the list is empty because nothing has been asked yet, and
+ * after a failed fetch it is empty because the answer never came. Both look identical to a consumer,
+ * and both would delete a saved roster.
+ */
+describe('MeetingCommitteeManagerComponent — committee member emissions', () => {
+  it('stays silent until the members of a saved group have landed', async () => {
+    const board = new Subject<CommitteeMember[]>();
+    const { emissions, fixture } = await mount([{ uid: BOARD.uid } as MeetingCommittee], { [BOARD.uid]: board });
+
+    // The mount-time empty list is an artifact of nothing having been fetched yet. Emitting it would
+    // tell the composer this meeting's board group has no members, and the saved guests would go.
+    expect(emissions).toEqual([]);
+
+    // `forkJoin` gathers the per-committee fetches, so the response only counts once it completes.
+    board.next([member(BOARD.uid, 'chair@example.com')]);
+    board.complete();
+    await fixture.whenStable();
+
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].map((entry) => entry.email)).toEqual(['chair@example.com']);
+  });
+
+  it('never emits when a member fetch fails', async () => {
+    const { component, emissions } = await mount([{ uid: BOARD.uid } as MeetingCommittee], { [BOARD.uid]: throwError(() => new Error('boom')) });
+
+    // "No members" and "we could not ask" arrive as the same empty array and mean opposite things.
+    expect(emissions).toEqual([]);
+    expect(component.membersFetchError()).toBe(true);
+  });
+
+  it('never emits when only one of several groups fails', async () => {
+    const { component, emissions } = await mount(
+      [{ uid: BOARD.uid } as MeetingCommittee, { uid: LEGAL.uid } as MeetingCommittee],
+      { [BOARD.uid]: of([member(BOARD.uid, 'chair@example.com')]), [LEGAL.uid]: throwError(() => new Error('boom')) },
+      [BOARD, LEGAL]
+    );
+
+    // A partial result reconciles as a complete one: the legal members would be read as removed.
+    expect(emissions).toEqual([]);
+    expect(component.membersFetchError()).toBe(true);
+  });
+
+  it('emits the empty list once the parent has told it there are no groups', async () => {
+    const { emissions } = await mount([], {});
+
+    // The mirror of the first case: an empty selection the parent actually applied is a truthful
+    // answer, and withholding it would strand group guests the organizer has just deselected.
+    expect(emissions).toEqual([[]]);
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
@@ -88,7 +88,8 @@
     [styleClass]="textareaClass()"
     [rows]="rows()"
     [maxlength]="agendaMaxLength"
-    [ariaDescribedBy]="hint() ? inputId() + '-hint' : undefined"
+    [ariaDescribedBy]="agendaDescribedBy()"
+    [attr.aria-invalid]="agendaTooLong() ? 'true' : null"
     [attr.data-testid]="inputId() + '-textarea'" />
 
   <div class="flex items-center justify-between gap-2">
@@ -97,4 +98,10 @@
     }
     <p class="ml-auto text-xs" [ngClass]="agendaCounterClass()">{{ agendaLength() }}/{{ agendaMaxLength }}</p>
   </div>
+
+  @if (agendaTooLong()) {
+    <p [id]="inputId() + '-maxlength-error'" role="alert" class="text-xs text-red-600" [attr.data-testid]="inputId() + '-maxlength-error'">
+      The agenda is over the {{ agendaMaxLength }}-character limit. Shorten it before saving.
+    </p>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.ts
@@ -17,6 +17,7 @@ import { MeetingType } from '@lfx-one/shared/enums';
 import type { GenerateAgendaRequest, MeetingTemplate } from '@lfx-one/shared/interfaces';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { controlErrorSignal } from '@shared/utils/form-control-signals.util';
 import { MessageService } from 'primeng/api';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { catchError, EMPTY, finalize, take, tap } from 'rxjs';
@@ -70,6 +71,16 @@ export class ComposerAgendaFieldComponent {
     this.formService.revision();
     return (this.form().get('description')?.value as string | null)?.length ?? 0;
   });
+  /**
+   * Whether the agenda is over the cap — ungated by `touched` on purpose.
+   * @description The textarea carries a native `maxlength`, so nobody can type past the cap: an
+   * over-length agenda can only arrive from edit-mode hydration of an older meeting or from an AI
+   * generation, and in both cases the control is never touched. Gating this on a blur the organizer
+   * has no reason to perform would leave the save silently blocked with a red counter and no reason.
+   */
+  protected readonly agendaTooLong: Signal<boolean> = controlErrorSignal(this.form, 'description', 'maxlength');
+  protected readonly agendaDescribedBy: Signal<string | undefined> = this.initAgendaDescribedBy();
+
   protected readonly agendaCounterClass: Signal<string> = computed(() => {
     const length = this.agendaLength();
 
@@ -177,6 +188,17 @@ export class ComposerAgendaFieldComponent {
    * generated agenda with nothing saying why. Asking for this content is a deliberate edit, so it is
    * marked like one.
    */
+  /** Names only the paragraphs the template is currently rendering, so no id ever dangles. */
+  private initAgendaDescribedBy(): Signal<string | undefined> {
+    return computed(() => {
+      const ids = [this.hint() ? `${this.inputId()}-hint` : null, this.agendaTooLong() ? `${this.inputId()}-maxlength-error` : null].filter(
+        (id): id is string => id !== null
+      );
+
+      return ids.length ? ids.join(' ') : undefined;
+    });
+  }
+
   private writeAgenda(agenda: string): void {
     const description = this.form().get('description');
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -18,7 +18,7 @@ import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-import { of, Subject, throwError } from 'rxjs';
+import { Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
@@ -133,6 +133,24 @@ describe('MeetingComposerFormService — submit generation guard', () => {
     );
     // The warning is about the previous open, so the queues the reopened composer is holding stay put.
     expect(service.registrantUpdates()).toBe(reopened);
+  });
+
+  it('warns about guest failures on a save the composer is still open for', () => {
+    createMeeting.mockReturnValue(of({ id: 'meeting-1' } as Meeting));
+    addMeetingRegistrants.mockReturnValue(of({ summary: { successful: 0, failed: 1 } }));
+    service.registrantUpdates.set({ toAdd: [REGISTRANT], toUpdate: [], toDelete: [] });
+
+    const emissions: (Meeting | null)[] = [];
+    service.submit().subscribe((meeting) => emissions.push(meeting));
+
+    // Nothing reopened, so the drawer on screen is still the one that saved: the warning points at a
+    // form the organizer can act on, which is what separates this wording from the stale one.
+    expect(emissions).toEqual([{ id: 'meeting-1' }]);
+    expect(messageAdd).toHaveBeenCalledWith({
+      severity: 'warn',
+      summary: 'Meeting Created',
+      detail: '1 guest(s) could not be saved. You can manage them later.',
+    });
   });
 
   it('stays silent about partial saves when nothing was queued to attach', () => {
@@ -607,6 +625,20 @@ describe('MeetingComposerFormService — save gate', () => {
     service.form().patchValue({ title: 'Composer meeting', meeting_type: 'Technical' });
   });
 
+  // `meeting_type` carries `Validators.required` and nothing else, and the control is never disabled,
+  // so the `?.value` clause below is the whole of the gate: a `?.valid` clause next to it could never
+  // be false. Nothing covered that clause, and losing it would walk an organizer who cleared the type
+  // past details-access into a save the validator is silently holding shut.
+  it('flags details-access when the meeting type is missing', () => {
+    service.form().patchValue({ meeting_type: '' });
+
+    expect(service.isSectionValid('details-access')).toBe(false);
+
+    service.form().patchValue({ meeting_type: 'Technical' });
+
+    expect(service.isSectionValid('details-access')).toBe(true);
+  });
+
   // The API, PCC and Zoom all accept early-join values outside [10, 60], and edit mode patches
   // whatever is stored verbatim — so this is a real state, not a typing-only one.
   it('flags date-schedule when the early-join value falls outside the allowed range', () => {
@@ -987,6 +1019,102 @@ describe('MeetingComposerFormService — group reconciliation after a failed gue
 
     expect(service.guests()[0]).toMatchObject({ uid: 'registrant-1', state: 'deleted' });
     expect(service.registrantUpdates().toDelete).toEqual(['registrant-1']);
+  });
+});
+
+/**
+ * Covers what an edit-mode open puts in the form: the stored meeting type, and the guest list a group
+ * emission can race. Both hydrate through `initialize({ mode: 'edit' })`, so each case configures its
+ * own upstream responses rather than sharing one `beforeEach`.
+ */
+describe('MeetingComposerFormService \u2014 edit-mode hydration', () => {
+  /** Opens an edit composer over the given saved meeting, with `registrants$` standing in for the guest fetch. */
+  function openEdit(meeting: Partial<Meeting>, registrants$: Observable<MeetingRegistrant[]>): MeetingComposerFormService {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        {
+          provide: MeetingService,
+          useValue: {
+            getMeeting: vi.fn().mockReturnValue(of({ id: 'meeting-1', title: 'Saved meeting', ...meeting } as Meeting)),
+            getMeetingAttachments: vi.fn().mockReturnValue(of([])),
+            getMeetingRegistrants: vi.fn().mockReturnValue(registrants$),
+            stripMetadata: (meetingUid: string, guest: MeetingRegistrantWithState) => ({ meeting_id: meetingUid, email: guest.email }),
+            getChangedFields: (guest: MeetingRegistrantWithState) => ({ email: guest.email }),
+          },
+        },
+      ],
+    });
+
+    const service = TestBed.inject(MeetingComposerFormService);
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    return service;
+  }
+
+  /** A group member carrying the attribution fields `syncCommitteeMembers` reads. */
+  const boardMember = (email: string): CommitteeMember => ({
+    uid: `member-${email}`,
+    committee_uid: 'committee-board',
+    committee_name: 'Board',
+    email,
+    first_name: 'Ada',
+    last_name: 'Lovelace',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  });
+
+  // `None` is what upstream stores for a meeting created before the type was required. Hydrating it
+  // verbatim would show a card nobody can pick and let the save through on a type the form rejects.
+  it('blanks the legacy None type so the field asks for a real one', () => {
+    const service = openEdit({ meeting_type: MeetingType.NONE }, of([]));
+
+    expect(service.form().get('meeting_type')?.value).toBe('');
+    expect(service.form().get('meeting_type')?.hasError('required')).toBe(true);
+    expect(service.isSectionValid('details-access')).toBe(false);
+  });
+
+  // Upstream types the field as a free-form string, so a stored value this build has no card for is
+  // possible. Blanking it would silently rewrite the organizer's meeting on the next save.
+  it('keeps a stored type the composer does not recognize', () => {
+    const service = openEdit({ meeting_type: 'Retrospective' }, of([]));
+
+    expect(service.form().get('meeting_type')?.value).toBe('Retrospective');
+    expect(service.isSectionValid('details-access')).toBe(true);
+  });
+
+  it('folds a group member added mid-load into the saved row that arrives for them', () => {
+    const registrants = new Subject<MeetingRegistrant[]>();
+    const service = openEdit({}, registrants);
+
+    // Selecting a group while the guest fetch is still open queues its members as `new`; the
+    // deliberate case mismatch is what an upstream row and a committee record actually differ by.
+    service.syncCommitteeMembers([boardMember('Chair@Example.com')]);
+    expect(service.guests()).toHaveLength(1);
+
+    registrants.next([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]);
+
+    // One person, one row: without the dedupe the save would invite an already-registered guest again.
+    expect(service.guests()).toHaveLength(1);
+    expect(service.guests()[0]).toMatchObject({ uid: 'registrant-1', state: 'existing' });
+    expect(service.registrantUpdates().toAdd).toEqual([]);
+  });
+
+  it('keeps a mid-load guest the fetch does not know about', () => {
+    const registrants = new Subject<MeetingRegistrant[]>();
+    const service = openEdit({}, registrants);
+
+    service.syncCommitteeMembers([boardMember('newcomer@example.com')]);
+
+    registrants.next([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]);
+
+    // The dedupe must not swallow work done during the fetch, and the pending row keeps its place
+    // ahead of the saved ones so the organizer can still see what they just added.
+    expect(service.guests().map((guest) => guest.email)).toEqual(['newcomer@example.com', 'chair@example.com']);
+    expect(service.guests()[0]).toMatchObject({ state: 'new' });
   });
 });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -28,6 +28,9 @@ import { MeetingComposerFormService } from './meeting-composer-form.service';
  * that resolves after a close+reopen must neither emit (the host would toast and close the new open)
  * nor warn when there was nothing queued to attach.
  */
+/** The real rail entry, now that `MeetingComposerSection` is derived from the constant. */
+const composerSection = (id: MeetingComposerSectionId): MeetingComposerSection => MEETING_COMPOSER_SECTIONS.filter((section) => section.id === id)[0];
+
 describe('MeetingComposerFormService — submit generation guard', () => {
   let service: MeetingComposerFormService;
   let createMeeting: ReturnType<typeof vi.fn>;
@@ -632,23 +635,13 @@ describe('MeetingComposerFormService — save gate', () => {
 
     expect(service.form().valid).toBe(false);
     expect(service.isSectionValid('platform-features')).toBe(false);
-    expect(
-      service.sectionNeedsAttention(
-        { id: 'platform-features', label: 'Platform & Features', required: false } as MeetingComposerSection,
-        new Set(['platform-features'])
-      )
-    ).toBe(true);
+    expect(service.sectionNeedsAttention(composerSection('platform-features'), new Set(['platform-features']))).toBe(true);
   });
 
   it('does not flag an unvisited section in create mode', () => {
     service.form().get('description')?.setValue('x'.repeat(2001));
 
-    expect(
-      service.sectionNeedsAttention(
-        { id: 'agenda-resources', label: 'Agenda & Resources', required: false } as MeetingComposerSection,
-        new Set<MeetingComposerSectionId>()
-      )
-    ).toBe(false);
+    expect(service.sectionNeedsAttention(composerSection('agenda-resources'), new Set<MeetingComposerSectionId>())).toBe(false);
   });
 
   it('routes an off-scale stored duration to Custom rather than leaving the chips unselected', () => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
@@ -266,6 +266,33 @@ describe('ComposerDateScheduleComponent', () => {
       expect(recurrence()?.get('monthly_week')?.value).toBe(-1);
     });
 
+    it('keeps the occurrence count when a monthly cadence is relabelled for a later date', () => {
+      control('startDate')?.setValue(SECOND_THURSDAY);
+      control('recurrenceType')?.setValue('monthly_nth');
+      recurrence()?.get('end_times')?.setValue(12);
+
+      control('startDate')?.setValue(LAST_THURSDAY);
+
+      // Relabelling monthly_nth -> monthly_last is the same cadence under a new name. Letting the
+      // recurrenceType subscription see it would rebuild the group and silently drop the organizer's
+      // end condition, turning a 12-occurrence series into one that never ends.
+      expect(control('recurrenceType')?.value).toBe('monthly_last');
+      expect(recurrence()?.get('end_times')?.value).toBe(12);
+    });
+
+    it('keeps the end date when a last-occurrence cadence is relabelled for an earlier date', () => {
+      const endsOn = new Date(2026, 11, 31);
+      control('startDate')?.setValue(LAST_THURSDAY);
+      control('recurrenceType')?.setValue('monthly_last');
+      recurrence()?.get('end_date_time')?.setValue(endsOn);
+
+      control('startDate')?.setValue(SECOND_THURSDAY);
+
+      expect(control('recurrenceType')?.value).toBe('monthly_nth');
+      expect(recurrence()?.get('end_date_time')?.value).toBe(endsOn);
+      expect(recurrence()?.get('monthly_week')?.value).toBe(2);
+    });
+
     it('leaves the cadence alone when the date is cleared', () => {
       control('startDate')?.setValue(SECOND_THURSDAY);
       control('recurrenceType')?.setValue('weekly');

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -302,9 +302,13 @@ export class ComposerDateScheduleComponent implements OnInit {
     const { weekOfMonth, isLastWeek } = getWeekOfMonth(newDate);
 
     if ((recurrenceType === 'monthly_nth' && isLastWeek) || (recurrenceType === 'monthly_last' && !isLastWeek)) {
+      // Relabelling the same monthly cadence for a new start date, so the recurrenceType
+      // subscription must not run: it would rebuild the recurrence group from scratch and
+      // discard the end condition the organizer chose. This method already writes
+      // monthly_week / monthly_week_day, and type / repeat_interval stay monthly either way.
       this.form()
         .get('recurrenceType')
-        ?.setValue(isLastWeek ? 'monthly_last' : 'monthly_nth');
+        ?.setValue(isLastWeek ? 'monthly_last' : 'monthly_nth', { emitEvent: false });
     }
 
     recurrence.patchValue({

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -22,6 +22,7 @@
       [maxlength]="titleMaxlength()"
       [describedBy]="titleDescribedBy()"
       [invalid]="titleInvalid()"
+      dataTest="composer-title-input"
       data-testid="composer-title-input" />
 
     @if (titleHint(); as hint) {
@@ -34,6 +35,8 @@
           The meeting date is appended to the YouTube video title on upload, so the title must be ≤ {{ youtubeTitleLimit }} characters.
         </p>
         <p
+          role="status"
+          aria-live="polite"
           class="text-xs"
           [ngClass]="{
             'text-gray-500': titleLength() < youtubeAmberThreshold,

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { YOUTUBE_MAX_MEETING_TITLE_LENGTH } from '@lfx-one/shared/constants';
+import { MAINTAINER_MEETING_TYPES, MEETING_TYPE_OPTIONS, YOUTUBE_MAX_MEETING_TITLE_LENGTH } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
+import { Meeting } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
@@ -30,6 +32,76 @@ function configure(): void {
     ],
   });
 }
+
+/**
+ * Covers the meeting-type card list a maintainer sees in edit mode.
+ * @description `getSelectableMeetingTypeOptions` narrows the list to `MAINTAINER_MEETING_TYPES` for
+ * this persona, so a meeting stored with any other type has to be threaded back in by hand or the
+ * select renders empty over a populated control. The persona and the stored meeting both have to be
+ * in place before the computed runs, so this describe builds its own TestBed rather than reusing
+ * `configure()`, which pins the persona to `null` and stubs `MeetingService` with `{}`.
+ */
+describe('ComposerDetailsAccessComponent \u2014 maintainer editing a stored type', () => {
+  /** Opens the section in edit mode over a meeting saved with `meetingType`, as a maintainer. */
+  async function openAsMaintainer(meetingType: string): Promise<ComposerDetailsAccessComponent> {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: SearchService, useValue: { searchUsers: () => of([]) } },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+        { provide: PersonaService, useValue: { currentPersona: () => 'maintainer' } },
+        {
+          provide: MeetingService,
+          useValue: {
+            getMeeting: vi.fn().mockReturnValue(of({ id: 'meeting-1', title: 'Saved meeting', meeting_type: meetingType } as Meeting)),
+            getMeetingAttachments: vi.fn().mockReturnValue(of([])),
+            getMeetingRegistrants: vi.fn().mockReturnValue(of([])),
+          },
+        },
+      ],
+    });
+
+    const formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    const fixture = TestBed.createComponent(ComposerDetailsAccessComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    return fixture.componentInstance;
+  }
+
+  it('keeps the stored Board card a maintainer cannot otherwise pick', async () => {
+    const component = await openAsMaintainer(MeetingType.BOARD);
+    const options = component['meetingTypeOptions']();
+    const values = options.map((option) => option.value);
+
+    // The whole card, not just the value: the unknown-type fallback below would also put `Board` in
+    // this list, as a generic `Existing meeting type` tile. Board is a type the app knows — the
+    // organizer has to keep seeing its real icon, colour and description.
+    expect(MAINTAINER_MEETING_TYPES).not.toContain(MeetingType.BOARD);
+    expect(options.filter((option) => option.value === MeetingType.BOARD)[0]).toEqual(
+      MEETING_TYPE_OPTIONS.filter((option) => option.value === MeetingType.BOARD)[0]
+    );
+    // The retention is scoped to the stored type, not a hole in the persona filter: every other type
+    // outside the maintainer set stays out of the list.
+    expect(values).not.toContain(MeetingType.MARKETING);
+    expect(values).not.toContain(MeetingType.LEGAL);
+  });
+
+  it('synthesizes a card for a stored type this build has none for', async () => {
+    const component = await openAsMaintainer('Retrospective');
+    const option = component['meetingTypeOptions']().filter((entry) => entry.value === ('Retrospective' as MeetingType))[0];
+
+    // Without the synthesized entry the select renders blank over a control holding `Retrospective`,
+    // and the first save quietly rewrites the organizer's meeting to whatever they pick instead.
+    expect(option).toBeDefined();
+    expect(option.label).toBe('Retrospective');
+  });
+});
 
 /**
  * Covers the title's `aria-describedby` list and `aria-invalid`, read off the rendered field.

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup } from '@angular/forms';
 import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggle.component';
 import { UserSearchComponent } from '@components/user-search/user-search.component';
-import { COMMITTEE_LABEL, SHOW_MEETING_ATTENDEES_FEATURE } from '@lfx-one/shared/constants';
+import { SHOW_MEETING_ATTENDEES_FEATURE } from '@lfx-one/shared/constants';
 import type { ComposerGuestRow, CommitteeMember, ManualGuestDialogResult, MeetingCommittee, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
 import { avatarInitials } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
@@ -41,7 +41,6 @@ export class ComposerGuestsComponent {
 
   protected readonly quickAddForm = this.meetingService.createRegistrantFormGroup();
 
-  protected readonly committeeLabel = COMMITTEE_LABEL;
   protected readonly showMeetingAttendeesFeature = SHOW_MEETING_ATTENDEES_FEATURE;
 
   /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1904,13 +1904,12 @@ export type MeetingComposerMode = 'create' | 'edit';
  */
 export type MeetingComposerSectionId = (typeof MEETING_COMPOSER_SECTIONS)[number]['id'];
 
-/** A single meeting composer section as rendered by the rail. */
-export interface MeetingComposerSection {
-  id: MeetingComposerSectionId;
-  label: string;
-  icon: string;
-  required: boolean;
-}
+/**
+ * A single meeting composer section as rendered by the rail.
+ * @description Derived from {@link MEETING_COMPOSER_SECTIONS} rather than restated, so adding a
+ * section or renaming one of its fields fails the build here instead of drifting silently.
+ */
+export type MeetingComposerSection = (typeof MEETING_COMPOSER_SECTIONS)[number];
 
 /**
  * A rail row's derived display state for one composer section.


### PR DESCRIPTION
> **Stack 20 of 21.** Based on PR 19 (`fix/issue-1451-registrants-and-defaults`). Followed by PR 21 (#2310).
> Review only this PR's own commits — GitHub shows the diff against its base branch, which is the previous PR in the stack.
>
> **CI note:** `quality-check.yml` runs on pull requests targeting `main`, so it will not report on this PR while its base is the previous branch in the stack. GitHub retargets it to `main` once that parent merges, and the checks run then. Every gate (`format:check`, `lint:check`, `check-types`, `build`, `test:server`, `test:app`) was run green locally against the full branch tip, and the workflow was additionally dispatched against this branch directly.

## What

Closes out @dealako's review of PRs 1–4. Fixes the blocking recurrence bug he found, re-checks meeting write access before the composer opens in edit mode, finishes the composer's screen-reader wiring, and backfills the four test surfaces his review named as uncovered.

The remaining 22 findings from that review were already repaired by later PRs in this same stack — each is answered in its own thread with the commit that fixed it. Three are rebutted in thread with evidence.

## How

**Blocking — recurrence end conditions were silently wiped.** Moving a monthly meeting's start date across a month boundary can flip which relative pattern describes it (the fourth Tuesday of one month is the last Tuesday of the next). The composer relabels the cadence for that, and the relabel went out with events enabled — firing the `recurrenceType` subscription, which rebuilds the recurrence group from scratch and discards the organizer's chosen end condition. A series capped at twelve occurrences quietly became one that never ends. The relabel now writes with `emitEvent: false`; it is the same monthly cadence under a different name, and this method already writes the two fields that actually differ.

**Stale edit permission.** A meeting card's edit button comes from `organizer` as the list payload reported it when the card rendered. An organizer whose access was revoked since then keeps that button until the page reloads, and the composer opens onto an edit upstream will reject on save — after the work is done. The card now runs the same writer → meeting-coordinator probe the group meetings list makes before scheduling, holds the button disabled while it is in flight, and says so plainly rather than opening.

**Accessibility.** The YouTube title counter and the agenda maxlength message were rendered silently, so a reader crossing either limit was told nothing; both are announced now, the counter politely and the agenda error assertively, with the agenda field pointing at its message through `aria-describedby`. The title input carried a test hook the wrapper does not forward, so it was reachable from neither the DOM nor Playwright — it now carries both.

**Type derivation and dead code.** `MeetingComposerSection` restated by hand what `MEETING_COMPOSER_SECTIONS` already declares, so a renamed field would have drifted silently; it is now derived from the constant. The guests section imported a committee label it stopped rendering several commits ago.

**Coverage.** Four surfaces whose failure mode is silent data loss:

- The committee manager emits what it believes is the complete membership of the selected groups, and the composer deletes anyone absent from an emission. "No members" and "we could not ask" arrive as the same empty array. It had no spec file at all; there is one now covering the mount-time silence, a failed fetch, one failure among several groups, and the genuinely-empty list.
- Edit-mode hydration gets the two races it was missing — a group member added while the saved roster is still in flight folding into the row that arrives for them, and a guest the fetch does not know about surviving — plus the legacy `None` type being blanked while a stored type this build has no card for is kept.
- The maintainer meeting-type list keeps the stored card whole rather than the generic unknown-type fallback.
- The meeting card's edit-access probe, in its first-ever spec file.

## Notes for reviewers

- Every new case was checked against a mutated source to confirm it fails when the branch it names is removed.
- No protected files are touched (`.claude/hooks/guard-protected-files.sh` reports clean across the diff).

## Commits

3 commit(s), 13 files changed, 580 insertions(+), 31 deletions(-).

- `fix(meetings): keep the recurrence end condition on a date change`
- `fix(meetings): re-check write access and finish composer a11y`
- `test(meetings): cover type hydration, guest dedupe and group emits`

## Related

- Refs #1452
- Refs #1453
- Refs #1454
- Refs #1456
- Refs #1457
- Refs #1458
- Refs #1451

## Checklist

- [x] License headers on new files (`./check-headers.sh`)
- [x] `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build` pass on the branch tip
- [x] Unit tests pass (`test:server`, `test:app`)
- [x] Commits are DCO signed-off and GPG signed
- [x] Docs updated where the change made them stale

