### PR TITLE
feat(org-cla): open a corporate signing session with EasyCLA

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@lfx-one/shared/constants';
 import type { OrgCanonicalRecord, OrgProfileEditableFields, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
 import { httpsUrlValidator } from '@lfx-one/shared/validators';
-import { extractErrorMessage } from '@shared/utils/http-error.utils';
+import { serverAuthoredMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -338,40 +338,14 @@ export class OrgProfileEditComponent implements OnInit {
       return {
         severity: 'error',
         summary: 'Logo rejected',
-        detail: this.logoErrorDetail(error, 'This image could not be used. Try a different file.'),
+        detail: serverAuthoredMessage(error, 'This image could not be used. Try a different file.'),
         life: 8000,
       };
     }
     if (status === 404 || status === 409) {
-      return { severity: 'error', summary: 'Upload failed', detail: this.logoErrorDetail(error, 'Unable to upload logo. Please try again.'), life: 5000 };
+      return { severity: 'error', summary: 'Upload failed', detail: serverAuthoredMessage(error, 'Unable to upload logo. Please try again.'), life: 5000 };
     }
     return { severity: 'error', summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.', life: 5000 };
-  }
-
-  /**
-   * Server-authored reason for a failed upload, or the caller's fallback.
-   *
-   * `extractErrorMessage` ends with `error.message || fallback`, and Angular always synthesizes a
-   * non-empty `error.message` ("Http failure response for …"), so its fallback is unreachable for a
-   * body-less response. Checking for a server-authored body first keeps that HTTP debugging string
-   * out of the toast.
-   */
-  private logoErrorDetail(error: unknown, fallback: string): string {
-    return this.hasServerMessage(error) ? extractErrorMessage(error, fallback) : fallback;
-  }
-
-  /** Whether the response body carries a message the server wrote, in any shape the BFF emits. */
-  private hasServerMessage(error: unknown): boolean {
-    const body = error instanceof HttpErrorResponse ? error.error : null;
-    if (typeof body === 'string') return body.trim().length > 0;
-    if (!body || typeof body !== 'object') return false;
-
-    const { message, error: errorText, errors } = body as { message?: unknown; error?: unknown; errors?: unknown };
-    const hasTopLevel = [message, errorText].some((value) => typeof value === 'string' && value.trim().length > 0);
-    const hasFieldDetail =
-      Array.isArray(errors) &&
-      errors.some((entry) => typeof (entry as { message?: unknown })?.message === 'string' && (entry as { message: string }).message.trim().length > 0);
-    return hasTopLevel || hasFieldDetail;
   }
 
   private refreshFieldFlags(): void {

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,7 +5,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { extractErrorMessage, isTransientHttpError, retryTransientHttpError } from './http-error.utils';
+import { extractErrorMessage, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });
@@ -145,5 +145,49 @@ describe('extractErrorMessage', () => {
   it('handles a plain Error and an unknown value', () => {
     expect(extractErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
     expect(extractErrorMessage('not an error', 'fallback')).toBe('fallback');
+  });
+});
+
+/**
+ * The composition for anywhere the fallback is user-facing copy rather than a debugging default.
+ * `extractErrorMessage` alone cannot serve that case: it ends with `error.message || fallback`,
+ * and Angular synthesizes a non-empty `.message` for every failure, so its fallback is unreachable
+ * and "Http failure response for /api/…" reaches the screen instead.
+ */
+describe('serverAuthoredMessage', () => {
+  // Two spellings because the server has two paths: `BaseApiError#toResponse` answers with the
+  // message under `error`, and a controller that validates and replies directly uses `message`. A
+  // reader that knows only one silently loses half the server's replies.
+  it.each([
+    ['error', { error: 'This organization requires additional review' }],
+    ['message', { message: 'This organization requires additional review' }],
+  ])('reads the message the server sent under %s', (_key, body) => {
+    expect(serverAuthoredMessage(httpErrorWithBody(403, body), 'fallback')).toBe('This organization requires additional review');
+  });
+
+  it('prefers a field-level detail, exactly as extractErrorMessage does', () => {
+    const error = httpErrorWithBody(400, { error: 'Validation failed', errors: [{ message: 'The real detail' }] });
+
+    expect(serverAuthoredMessage(error, 'fallback')).toBe('The real detail');
+  });
+
+  it('returns a plain string body directly', () => {
+    expect(serverAuthoredMessage(httpErrorWithBody(502, 'upstream down'), 'fallback')).toBe('upstream down');
+  });
+
+  // The whole reason this exists, and the case `extractErrorMessage` gets wrong.
+  it.each([[{}], [null], [{ code: 'FORBIDDEN' }], [{ message: '   ' }], [{ errors: 'not an array' }], ['   ']])(
+    'answers the fallback, not Angular’s synthesized message, for %p',
+    (body) => {
+      const shown = serverAuthoredMessage(httpErrorWithBody(403, body), 'fallback');
+
+      expect(shown).toBe('fallback');
+      expect(shown).not.toContain('Http failure response');
+    }
+  );
+
+  it('answers the fallback for anything that is not an HTTP failure', () => {
+    expect(serverAuthoredMessage(new Error('boom'), 'fallback')).toBe('fallback');
+    expect(serverAuthoredMessage(undefined, 'fallback')).toBe('fallback');
   });
 });

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -60,6 +60,46 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
 }
 
 /**
+ * The message the server wrote, or `fallback` when it wrote none.
+ *
+ * `extractErrorMessage` ends with `error.message || fallback`, and Angular always synthesizes a
+ * non-empty `HttpErrorResponse.message` ("Http failure response for …"), so its own fallback is
+ * unreachable for a body-less response — the HTTP debugging string reaches the screen instead.
+ * Anywhere the fallback is user-facing copy, this is the composition that is actually wanted.
+ */
+export function serverAuthoredMessage(error: unknown, fallback: string): string {
+  return hasServerAuthoredMessage(error) ? extractErrorMessage(error, fallback) : fallback;
+}
+
+/**
+ * Whether the response body carries a message the server wrote, in any shape this BFF emits.
+ *
+ * There are two, because the server has two paths: `BaseApiError#toResponse` answers with the
+ * message under `error`, while a controller that answers `res.status(...).json({ message })`
+ * directly answers with it under `message`. A reader that knows only one of them silently loses
+ * half the server's replies.
+ *
+ * **Both are still live and this must stay tolerant of both.** The org-lens sign route was moved
+ * onto the error-class path so it emits only the first, and the temptation is then to narrow this
+ * to `error`. Don't: the second shape is emitted by roughly two dozen surviving call sites across
+ * `clas`, `crowdfunding`, `profile` and `org-lens-project-detail`, including the sibling Me-lens
+ * CLA controller. Narrowing would turn every one of their messages into the generic fallback.
+ * Converting them is worth doing and is not this feature's to do.
+ */
+function hasServerAuthoredMessage(error: unknown): boolean {
+  const body = error instanceof HttpErrorResponse ? error.error : null;
+  if (typeof body === 'string') return body.trim().length > 0;
+  if (!body || typeof body !== 'object') return false;
+
+  const { message, error: errorText, errors } = body as { message?: unknown; error?: unknown; errors?: unknown };
+  const hasTopLevel = [message, errorText].some((value) => typeof value === 'string' && value.trim().length > 0);
+  const hasFieldDetail =
+    Array.isArray(errors) &&
+    errors.some((entry) => typeof (entry as { message?: unknown })?.message === 'string' && (entry as { message: string }).message.trim().length > 0);
+  return hasTopLevel || hasFieldDetail;
+}
+
+/**
  * Whether an error is worth retrying — a beat of time could plausibly fix a network drop (0),
  * rate limit (429), request timeout (408), or upstream 5xx, but not a client error like an
  * expired session (401) or a permission/not-found response (403/404).

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -7,7 +7,7 @@
 // EasyCLA re-verifies each key belongs to the caller and owns the signature, so the
 // upstream endpoint — not this controller — is the ownership authorization boundary.
 
-import { CLA_GROUP_SEARCH_MIN_CHARS, CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
+import { CLA_GROUP_ID_PATTERN, CLA_GROUP_SEARCH_MIN_CHARS, CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
 import type { ClaManagerRequestType } from '@lfx-one/shared/interfaces';
 import { codePointLength, sanitizePlainText } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
@@ -17,10 +17,6 @@ import { getStringQueryParam } from '../helpers/validation.helper';
 import { ClaService } from '../services/cla.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
-
-// A CLA Group UUID, hyphenated or not — the two spellings the producer's own pattern accepts.
-// Anchored with fixed-length runs, so it cannot backtrack.
-const CLA_GROUP_ID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 
 /**
  * Every recipient must already be a non-empty string. Coercing mixed arrays would turn

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.spec.ts
@@ -6,20 +6,28 @@ import '@angular/compiler';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { getUsernameFromAuth } = vi.hoisted(() => ({ getUsernameFromAuth: vi.fn<() => Promise<string | null>>() }));
-const { listClaGroups, getPdfUrl } = vi.hoisted(() => ({ listClaGroups: vi.fn(), getPdfUrl: vi.fn() }));
+const { listClaGroups, getPdfUrl, getSignOptions, requestCorporateSignature } = vi.hoisted(() => ({
+  listClaGroups: vi.fn(),
+  getPdfUrl: vi.fn(),
+  getSignOptions: vi.fn(),
+  requestCorporateSignature: vi.fn(),
+}));
 
 vi.mock('../utils/auth-helper', () => ({ getUsernameFromAuth }));
 vi.mock('../services/org-cla.service', () => ({
   OrgClaService: class {
     public listClaGroups = listClaGroups;
     public getPdfUrl = getPdfUrl;
+    public getSignOptions = getSignOptions;
+    public requestCorporateSignature = requestCorporateSignature;
   },
 }));
-vi.mock('../services/logger.service', () => ({
-  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
+vi.mock('../services/logger.service', () => ({ logger: loggerMock }));
 
-import { AuthenticationError } from '../errors';
+import { AuthenticationError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { OrgClasController } from './org-clas.controller';
 
@@ -124,5 +132,249 @@ describe('OrgClasController.getPdfUrl', () => {
     expect(getPdfUrl).toHaveBeenCalledWith(req, '0014100000Te2ovAAB', 'signature-uuid-1');
     expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     expect(res.json).toHaveBeenCalledWith({ url: 'https://s3.example.org/ccla.pdf', expiresInSeconds: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corporate signing hand-off (#1983)
+// ---------------------------------------------------------------------------
+
+const ORG_UID = '0014100000Te2ovAAB';
+const CLA_GROUP_ID = '7f3a1c22-9d51-4a8e-b0c6-2e4f81d9a733';
+const PROJECT_SFID = 'a09410000182dD3AAI';
+
+/** A request whose attestations are both genuinely affirmed. Cases override only what they test. */
+function signReq(body: Record<string, unknown> = {}) {
+  return {
+    params: { orgUid: ORG_UID },
+    query: {},
+    body: { projectSfid: PROJECT_SFID, claGroupId: CLA_GROUP_ID, authorityAcked: true, embargoAcked: true, ...body },
+  } as any;
+}
+
+/**
+ * Runs the sign controller and returns what it rejected with.
+ *
+ * The rejections go to `next(error)` rather than to `res.status(400).json(...)`, so the shared
+ * error handler owns the envelope and the severity — client input that fails validation is a
+ * WARN, and logging it as an ERROR inflates the signal this service is watched by. Asserting
+ * through `next` rather than through `res` is what keeps that true: a branch that answered
+ * directly would leave `next` uncalled and fail here.
+ */
+async function rejectionOf(body: Record<string, unknown>): Promise<{ statusCode: number; code: string; response: Record<string, any> }> {
+  const next = vi.fn();
+  await new OrgClasController().requestCorporateSignature(signReq(body), buildRes(), next);
+
+  const error = next.mock.calls[0]?.[0] as ServiceValidationError | undefined;
+  expect(error, 'expected the controller to reject via next(error)').toBeInstanceOf(ServiceValidationError);
+
+  return { statusCode: error!.statusCode, code: error!.code, response: error!.toResponse() };
+}
+
+describe('OrgClasController.getSignOptions', () => {
+  it('returns 401 (via next) when there is no authenticated user', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: 'nimbus' }, body: {} } as any, res, next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+    expect(getSignOptions).not.toHaveBeenCalled();
+  });
+
+  it('answers a term below the minimum with an empty set rather than an error', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: 'ni' }, body: {} } as any, res, vi.fn());
+
+    expect(getSignOptions).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ searchTerm: 'ni', resultCount: 0, truncated: false, results: [] });
+  });
+
+  it('trims the term before measuring it, so whitespace cannot buy the minimum', async () => {
+    const res = buildRes();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: '  n  ' }, body: {} } as any, res, vi.fn());
+
+    expect(getSignOptions).not.toHaveBeenCalled();
+  });
+
+  it('passes a searchable term through and answers with the envelope', async () => {
+    getSignOptions.mockResolvedValue({ searchTerm: 'nimbus', resultCount: 1, truncated: false, results: [] });
+    const res = buildRes();
+
+    await new OrgClasController().getSignOptions({ params: { orgUid: ORG_UID }, query: { search: 'nimbus' }, body: {} } as any, res, vi.fn());
+
+    expect(getSignOptions).toHaveBeenCalledWith(expect.anything(), 'nimbus');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+});
+
+/**
+ * The attestation gate.
+ *
+ * These are the highest-value assertions in this feature. Every other failure it can have is
+ * visible — a wrong URL, a missing field, a broken layout. This one is not: a request that
+ * transmits an affirmation the signatory did not make succeeds at every layer and produces a
+ * legally binding document, and nothing downstream can tell it apart from a genuine one.
+ *
+ * So the tests are written from the negative side. `false` surviving as `false` matters more
+ * than `true` surviving as `true`, because the code that would break the first is the same
+ * plausible-looking code — a literal, a default, a `??`, a truthiness check — that would let the
+ * second keep passing.
+ */
+describe('OrgClasController.requestCorporateSignature — the attestations', () => {
+  it('refuses when the authorization confirmation is false, and never calls upstream', async () => {
+    expect((await rejectionOf({ authorityAcked: false })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the compliance confirmation is false, and never calls upstream', async () => {
+    expect((await rejectionOf({ embargoAcked: false })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  it('refuses when both are false', async () => {
+    expect((await rejectionOf({ authorityAcked: false, embargoAcked: false })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  it('refuses when either is absent', async () => {
+    expect((await rejectionOf({ authorityAcked: undefined })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  // The specific failure this guards: `Boolean(body.authorityAcked)` or `!!body.authorityAcked`
+  // would accept every one of these and record an attestation nobody made.
+  it.each([['true'], [1], [{}], [[]], ['yes']])('refuses the truthy non-boolean %p rather than coercing it', async (value) => {
+    expect((await rejectionOf({ authorityAcked: value })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  // An operation opened and never terminated reads on a dashboard as a request still in flight.
+  // The error handler is what terminates these now, so what this asserts is that the rejection
+  // actually reaches it — a branch that answered on `res` directly would strand the operation.
+  it.each([
+    ['a withdrawn confirmation', { embargoAcked: false }],
+    ['a missing project', { projectSfid: '' }],
+    ['a malformed CLA group id', { claGroupId: 'not-a-uuid' }],
+  ])('hands the rejection to the error handler when rejecting %s', async (_case, body) => {
+    expect((await rejectionOf(body)).statusCode).toBe(400);
+    expect(loggerMock.startOperation).toHaveBeenCalledTimes(1);
+    // Not logged here at all: bad client input is not an operational error, and the handler
+    // classifies a 400 as a warning. A `logger.error` on this path is the defect.
+    expect(loggerMock.error).not.toHaveBeenCalled();
+  });
+
+  // A log line — and a response — is not a place to record a legal assertion. Naming which of the
+  // two confirmations was withheld would record exactly that, so neither the value nor the field
+  // is reported: the rejection is about the pair.
+  it('says a confirmation is missing without saying which one, or what arrived instead', async () => {
+    const { code, response } = await rejectionOf({ embargoAcked: 'yes please' });
+
+    expect(code).toBe('VALIDATION_ERROR');
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain('yes please');
+    expect(serialized).not.toContain('embargoAcked');
+    expect(serialized).not.toContain('authorityAcked');
+    expect(response['error']).toBe('Both the authorization and compliance confirmations are required');
+  });
+
+  // The whole point of D: one envelope. Every rejection from this route carries the standard
+  // `error` + `code` shape rather than the bare `{ message }` a direct `res.json` produced.
+  it.each([
+    ['a missing project', { projectSfid: '' }],
+    ['a malformed CLA group id', { claGroupId: 'not-a-uuid' }],
+    ['a withdrawn confirmation', { embargoAcked: false }],
+  ])('answers %s in the standard error envelope', async (_case, body) => {
+    const { response } = await rejectionOf(body);
+
+    expect(response).toMatchObject({ code: 'VALIDATION_ERROR' });
+    expect(typeof response['error']).toBe('string');
+  });
+
+  it('passes both confirmations through as the booleans that arrived, not as literals', async () => {
+    requestCorporateSignature.mockResolvedValue({ signUrl: 'https://docusign.example.org/session/1' });
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, vi.fn());
+
+    // The whole request, not a subset: the service requires `projectSfid` and `claGroupId` too,
+    // and a subset matcher cannot see a field that is absent.
+    expect(requestCorporateSignature).toHaveBeenCalledWith(expect.anything(), ORG_UID, {
+      projectSfid: PROJECT_SFID,
+      claGroupId: CLA_GROUP_ID,
+      authorityAcked: true,
+      embargoAcked: true,
+    });
+  });
+});
+
+describe('OrgClasController.requestCorporateSignature', () => {
+  it('returns 401 (via next) when there is no authenticated user', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing project identifier before calling upstream', async () => {
+    expect((await rejectionOf({ projectSfid: '   ' })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  // Shape-checked, not just non-empty. A malformed identifier that only fails an emptiness test
+  // reaches EasyCLA's project-and-organization authorization check and returns as a 403 — which
+  // this route relays in the producer's words, so the signatory is told their signing authority
+  // was refused when the real fault was a bad request this boundary could have named.
+  it.each([['nimbus'], ['not a salesforce id'], ['a0941000002wBz2AAE-extra'], ['../../etc/passwd']])(
+    'rejects a malformed project identifier %p before calling upstream',
+    async (projectSfid) => {
+      expect((await rejectionOf({ projectSfid })).statusCode).toBe(400);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects a CLA group identifier that is not a UUID', async () => {
+    expect((await rejectionOf({ claGroupId: 'nimbus-foundation' })).statusCode).toBe(400);
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+  });
+
+  // The organization is the grant-checked path segment. A body that names a different one is
+  // ignored rather than honoured — otherwise the path parameter is decorative and any viewer with
+  // org-lens access anywhere could open a signing session against another company.
+  it('takes the organization from the path, ignoring one supplied in the body', async () => {
+    requestCorporateSignature.mockResolvedValue({ signUrl: 'https://docusign.example.org/session/1' });
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq({ companySfid: '0014100000OtherAAA', orgUid: '0014100000OtherAAA' }), res, vi.fn());
+
+    expect(requestCorporateSignature).toHaveBeenCalledWith(expect.anything(), ORG_UID, expect.anything());
+  });
+
+  it('answers with the signing session and forbids caching it', async () => {
+    requestCorporateSignature.mockResolvedValue({ signUrl: 'https://docusign.example.org/session/1' });
+    const res = buildRes();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, vi.fn());
+
+    expect(res.json).toHaveBeenCalledWith({ signUrl: 'https://docusign.example.org/session/1' });
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
+
+  it('passes an upstream failure to the error handler rather than answering', async () => {
+    requestCorporateSignature.mockRejectedValue(new Error('upstream refused'));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new OrgClasController().requestCorporateSignature(signReq(), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/org-clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-clas.controller.ts
@@ -1,9 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { CLA_GROUP_ID_PATTERN, CLA_GROUP_SEARCH_MIN_CHARS, SALESFORCE_ID_PATTERN } from '@lfx-one/shared/constants';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, ServiceValidationError } from '../errors';
+import { getStringQueryParam } from '../helpers/validation.helper';
 import { assertOrgUid } from '../helpers/org-uid.helper';
 import { OrgClaService } from '../services/org-cla.service';
 import { logger } from '../services/logger.service';
@@ -71,6 +73,119 @@ export class OrgClasController {
 
       logger.success(req, 'get_org_cla_pdf_url', startTime, { org_uid: orgUid, signature_id: signatureId, found: true });
       res.json(pdf);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // GET /api/orgs/:orgUid/lens/cla-groups/sign-options?search=<term>
+  // CLA Groups the organization could sign a corporate CLA for (#1983). A read: impersonation
+  // stays allowed, exactly as on the Me-lens picker. The write is next door.
+  public async getSignOptions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_org_cla_sign_options');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'get_org_cla_sign_options' });
+      }
+
+      const orgUid = req.params['orgUid'];
+      assertOrgUid(orgUid, 'get_org_cla_sign_options');
+
+      const searchTerm = (getStringQueryParam(req, 'search') ?? '').trim();
+
+      // Upstream requires three characters and 400s below that. The picker gates on the same
+      // length; this is the second line, so a caller that skips the picker gets an empty set
+      // rather than an error describing a mistake nobody made.
+      if (searchTerm.length < CLA_GROUP_SEARCH_MIN_CHARS) {
+        logger.success(req, 'get_org_cla_sign_options', startTime, { result_count: 0, term_too_short: true });
+        res.setHeader('Cache-Control', 'no-store');
+        res.json({ searchTerm, resultCount: 0, truncated: false, results: [] });
+        return;
+      }
+
+      const envelope = await this.orgClaService.getSignOptions(req, searchTerm);
+
+      logger.success(req, 'get_org_cla_sign_options', startTime, { org_uid: orgUid, result_count: envelope.resultCount });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(envelope);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // POST /api/orgs/:orgUid/lens/cla-groups/sign
+  // Opens the corporate signing session and answers with the address EasyCLA returned. Nothing
+  // here composes that address, and nothing here decides whether the caller may sign — the CLA
+  // service checks signing authority and trade compliance on every request, and its refusal is
+  // relayed in its own words rather than pre-empted.
+  //
+  // Blocked during impersonation at the route, so there is no impersonation branch here.
+  public async requestCorporateSignature(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'request_org_cla_corporate_signature');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'request_org_cla_corporate_signature' });
+      }
+
+      const orgUid = req.params['orgUid'];
+      assertOrgUid(orgUid, 'request_org_cla_corporate_signature');
+
+      // The chosen project and CLA group are the only things taken from the body besides the two
+      // attestations. The organization is the grant-checked path parameter, and the return
+      // address is derived from the request — EasyCLA stores that value and redirects to it
+      // verbatim, so a client-supplied one would turn the hand-off into an open redirect.
+      const body = req.body as { projectSfid?: unknown; claGroupId?: unknown; authorityAcked?: unknown; embargoAcked?: unknown } | undefined;
+
+      // Each rejection below throws rather than answering directly, so the shared error handler
+      // classifies it: one response envelope, WARN rather than ERROR (bad client input is not an
+      // operational fault, and logging it as one inflates the error signal this service is
+      // watched by), and the operation terminated on the same path as every other failure. The
+      // sibling `getPdfUrl` above already does this; these three were the outliers.
+      // Shape-checked, not merely non-empty. A malformed identifier that is only checked for
+      // emptiness travels upstream and comes back as a 403 from the project-and-organization
+      // authorization check — which relays to the signatory as a refusal about their signing
+      // authority, when the real fault is a bad request this boundary could have named.
+      const projectSfid = String(body?.projectSfid ?? '').trim();
+      if (!SALESFORCE_ID_PATTERN.test(projectSfid)) {
+        throw ServiceValidationError.fromFieldErrors({ projectSfid: 'A project identifier is required' }, 'A project identifier is required', {
+          operation: 'request_org_cla_corporate_signature',
+        });
+      }
+
+      const claGroupId = String(body?.claGroupId ?? '').trim();
+      if (!CLA_GROUP_ID_PATTERN.test(claGroupId)) {
+        throw ServiceValidationError.fromFieldErrors({ claGroupId: 'A CLA group identifier is required' }, 'A CLA group identifier is required', {
+          operation: 'request_org_cla_corporate_signature',
+        });
+      }
+
+      // Compared against the literal `true`, not coerced. These two carry the legal weight of the
+      // request: a truthy non-boolean accepted here would record an attestation the signatory
+      // never made, and the failure would be invisible everywhere downstream because upstream
+      // sees only the boolean that arrives. Upstream refuses a false as well; answering it here
+      // spends no round trip to learn that a signatory who withdrew a confirmation cannot sign.
+      //
+      // Reported against `attestations` rather than against whichever of the two failed. Naming
+      // the failing one would record, in a log line and in the response, that this signatory did
+      // not affirm that specific statement — which is the legal assertion itself, and the reason
+      // the values are not logged either.
+      if (body?.authorityAcked !== true || body?.embargoAcked !== true) {
+        const message = 'Both the authorization and compliance confirmations are required';
+        throw ServiceValidationError.fromFieldErrors({ attestations: message }, message, { operation: 'request_org_cla_corporate_signature' });
+      }
+
+      const result = await this.orgClaService.requestCorporateSignature(req, orgUid, {
+        projectSfid,
+        claGroupId,
+        authorityAcked: body.authorityAcked,
+        embargoAcked: body.embargoAcked,
+      });
+
+      logger.success(req, 'request_org_cla_corporate_signature', startTime, { org_uid: orgUid });
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(result);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/errors/base.error.ts
+++ b/apps/lfx-one/src/server/errors/base.error.ts
@@ -2,6 +2,22 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Where a client-visible message is kept, when it must differ from `message`.
+ *
+ * A symbol, not a string key, and that is the whole mechanism. Two log paths read an error by
+ * enumerating its string keys — `customErrorSerializer` copies everything `Object.keys` returns
+ * onto the log payload, and anything reached by `JSON.stringify` does the same — so a plain
+ * `public clientMessage` would be written into the log line by both, which is the thing this
+ * exists to prevent. Symbol-keyed properties are invisible to `Object.keys`, `JSON.stringify`
+ * and spread alike, so the value cannot reach a log through the generic paths at all.
+ *
+ * Non-enumerable would also work and would be one line shorter. It is rejected because it is a
+ * flag on a property that a later `Object.assign`, clone or refactor can silently drop, whereas
+ * a symbol key cannot be un-symboled by accident.
+ */
+const CLIENT_MESSAGE = Symbol('BaseApiError.clientMessage');
+
+/**
  * Base error class for all API errors with structured metadata
  */
 export abstract class BaseApiError extends Error {
@@ -26,6 +42,7 @@ export abstract class BaseApiError extends Error {
       metadata?: Record<string, any>;
       originalError?: Error;
       transportFailure?: boolean;
+      clientMessage?: string;
     } = {}
   ) {
     super(message);
@@ -40,9 +57,28 @@ export abstract class BaseApiError extends Error {
     this.originalError = options.originalError;
     this.transportFailure = options.transportFailure;
 
+    if (options.clientMessage) {
+      (this as Record<symbol, unknown>)[CLIENT_MESSAGE] = options.clientMessage;
+    }
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
+  }
+
+  /**
+   * The message written for the client, when that differs from `message`.
+   *
+   * A getter on the prototype rather than an own property, so it is doubly out of reach of the
+   * key-enumerating log paths described at CLIENT_MESSAGE: not an own key to begin with, and its
+   * backing store is keyed by a symbol.
+   *
+   * Set this whenever the sentence the client should read is not one that may be logged —
+   * an upstream refusal that names the caller or their organization's compliance standing being
+   * the case this was built for. `message` then stays generic and is what the log records.
+   */
+  public get clientMessage(): string | undefined {
+    return (this as Record<symbol, unknown>)[CLIENT_MESSAGE] as string | undefined;
   }
 
   /**
@@ -79,7 +115,9 @@ export abstract class BaseApiError extends Error {
    */
   public toResponse(): Record<string, any> {
     return {
-      error: this.message,
+      // `clientMessage` when the throwing site set one, `message` otherwise — so the only errors
+      // whose response text differs from their log text are the ones that asked for it.
+      error: this.clientMessage ?? this.message,
       code: this.code,
       // Whether the BFF raised this as a TRANSPORT failure, declared explicitly by the site that
       // threw it -- not inferred from `originalError`.

--- a/apps/lfx-one/src/server/errors/microservice.error.ts
+++ b/apps/lfx-one/src/server/errors/microservice.error.ts
@@ -24,6 +24,7 @@ export class MicroserviceError extends BaseApiError {
       originalMessage?: string;
       originalError?: Error;
       transportFailure?: boolean;
+      clientMessage?: string;
     } = {}
   ) {
     super(message, statusCode, code, {
@@ -32,6 +33,7 @@ export class MicroserviceError extends BaseApiError {
       path: options.path,
       originalError: options.originalError,
       transportFailure: options.transportFailure,
+      clientMessage: options.clientMessage,
     });
 
     this.errorBody = options.errorBody;

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.spec.ts
@@ -97,3 +97,146 @@ describe('gatewayFetch sensitive response redaction', () => {
     expect(JSON.stringify(logger.warning.mock.calls)).not.toContain('SECRET-COUPON');
   });
 });
+
+/**
+ * The narrower option, for callers whose upstream refusals are written for the user: the sentence
+ * only exists in the body, so discarding the body outright would discard the message with it.
+ *
+ * Keeping the body on the error is half a control, not a whole one — `MicroserviceError` puts
+ * `errorBody` in its log context, and the API error handler logs that. The caller owes a
+ * `withoutUpstreamBody` after taking the message out. Documented on the option, and the reason
+ * these two behaviours are pinned separately.
+ */
+describe('gatewayFetch log-only redaction', () => {
+  const req = { apiGatewayToken: 'gateway-token' } as Request;
+  const options = {
+    operation: 'org_cla_request_corporate_signature',
+    service: 'org_cla_service',
+    errorMessage: 'Failed to request the corporate CLA signature',
+    errorCode: 'UPSTREAM_ERROR',
+    method: 'POST' as const,
+    redactResponseBodyFromLogs: true,
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('keeps a non-OK body out of the log', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'refused', lf_username: 'SENSITIVE-HANDLE' }), { status: 403 }))
+    );
+
+    await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch(() => undefined);
+
+    expect(JSON.stringify(logger.warning.mock.calls)).not.toContain('SENSITIVE-HANDLE');
+    expect(logger.warning.mock.calls[0]?.[3]).toMatchObject({ status: 403, body_redacted: true });
+  });
+
+  it('still attaches the body to the error, so the refusal sentence can be relayed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'refused' }), { status: 403 }))
+    );
+
+    const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch((caught: unknown) => caught)) as MicroserviceError;
+
+    expect(error.errorBody).toContain('refused');
+  });
+
+  // Otherwise a caller that set both would quietly get the weaker of the two.
+  it('is superseded by full redaction rather than overriding it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ message: 'refused' }), { status: 403 }))
+    );
+
+    const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', { ...options, redactResponseBody: true }).catch(
+      (caught: unknown) => caught
+    )) as MicroserviceError;
+
+    expect(error.errorBody).toBeUndefined();
+  });
+
+  /**
+   * A 2xx whose body does not parse.
+   *
+   * The option was written for refusals and so was only ever consulted on the non-OK branch,
+   * which left it silently unhonoured on the one path where the *success* payload is the
+   * sensitive thing. On the corporate signing call that body is the signing address and the
+   * signature identifier, so a single malformed response wrote both to the logs of a caller that
+   * had explicitly opted out of exactly that.
+   *
+   * Both surfaces are asserted, because the body reaches the logs by two routes: the helper's own
+   * warning, and `getLogContext()` on the thrown error, which the API error handler logs. Closing
+   * only the first moves the leak one layer up instead of fixing it — which is how the same
+   * finding came back twice before.
+   */
+  describe('a 2xx whose body does not parse', () => {
+    const SIGN_URL = 'https://demo.docusign.example/signing/envelope-SENSITIVE-ADDRESS';
+    const SIGNATURE_ID = 'signature-SENSITIVE-IDENTIFIER';
+
+    function malformedSuccess(): void {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(`{"sign_url":"${SIGN_URL}","signature_id":"${SIGNATURE_ID}" <<truncated`, { status: 200 }))
+      );
+    }
+
+    it('keeps the unparsed body out of the log line', async () => {
+      malformedSuccess();
+
+      await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch(() => undefined);
+
+      const emitted = JSON.stringify(logger.warning.mock.calls);
+      expect(emitted).not.toContain('SENSITIVE-ADDRESS');
+      expect(emitted).not.toContain('SENSITIVE-IDENTIFIER');
+      expect(emitted).not.toContain('docusign');
+    });
+
+    /**
+     * The redaction must not cost the diagnosis — but the parse message cannot be what preserves
+     * it. V8 quotes the offending input (`Unexpected token 'S', "SECRET-COUPON" is not valid
+     * JSON`), so logging the message hands over the leading edge of the very body being withheld.
+     * The exception name carries the useful half without the payload.
+     */
+    it('still says what happened and on which operation, without quoting the body', async () => {
+      malformedSuccess();
+
+      await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch(() => undefined);
+
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'org_cla_request_corporate_signature',
+        'Upstream returned invalid JSON response',
+        expect.objectContaining({ status: 200, body_redacted: true, error_name: 'SyntaxError' })
+      );
+    });
+
+    // Nothing relays a producer sentence out of a malformed success, so unlike the non-OK branch
+    // there is nothing here to keep the body for — and keeping it would re-log it at the handler.
+    it('does not carry the body out on the thrown error either', async () => {
+      malformedSuccess();
+
+      const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', options).catch((caught: unknown) => caught)) as MicroserviceError;
+
+      expect(error.errorBody).toBeUndefined();
+      expect(JSON.stringify(error.getLogContext())).not.toContain('SENSITIVE-ADDRESS');
+      expect(JSON.stringify(error.getLogContext())).not.toContain('SENSITIVE-IDENTIFIER');
+    });
+
+    // The counterpart: a caller that has not opted out still gets the body, or this change would
+    // have quietly removed a diagnostic from every other consumer of the helper.
+    it('leaves the body in place for a caller that did not ask for redaction', async () => {
+      malformedSuccess();
+
+      const plain = { ...options, redactResponseBodyFromLogs: false };
+      const error = (await gatewayFetch(req, 'https://gateway.example.test/sign', plain).catch((caught: unknown) => caught)) as MicroserviceError;
+
+      expect(error.errorBody).toContain('SENSITIVE-ADDRESS');
+      expect(JSON.stringify(logger.warning.mock.calls)).toContain('SENSITIVE-ADDRESS');
+    });
+  });
+});

--- a/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
+++ b/apps/lfx-one/src/server/helpers/gateway-fetch.helper.ts
@@ -20,6 +20,25 @@ export interface GatewayFetchOptions {
   bearerToken?: string;
   /** Suppresses upstream response bodies from logs and client-visible error metadata. */
   redactResponseBody?: boolean;
+  /**
+   * Keeps a non-OK upstream body out of the log while still attaching it to the thrown error, for
+   * the callers that must relay a producer-authored refusal to the user — the body is the only
+   * place that sentence exists, so `redactResponseBody` would discard the message along with it.
+   *
+   * Attaching is not the end of the story: `MicroserviceError#getLogContext` puts `errorBody` in
+   * the error handler's own log line. A caller using this owes it to drop the body once it has
+   * taken the message out (`withoutUpstreamBody`), or the leak simply moves one layer up.
+   *
+   * Also covers a 2xx whose body does not parse. Nothing relays a refusal from that path — there
+   * is no producer sentence in a malformed success — so the body is dropped there rather than
+   * attached, from the log line and from the thrown error alike. It has to be both: leaving it on
+   * the error would put it back in the log through `getLogContext`. This matters most on the one
+   * call where the *success* payload is the sensitive thing, the corporate signing hand-off, whose
+   * body carries the signing address and the signature identifier.
+   *
+   * Ignored when `redactResponseBody` is set, which discards the body outright.
+   */
+  redactResponseBodyFromLogs?: boolean;
 }
 
 /**
@@ -84,10 +103,11 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
     const body = options.redactResponseBody
       ? await discardResponseBody(upstream.body)
       : (await upstream.text().catch(() => '')).slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+    const loggableBody = options.redactResponseBodyFromLogs ? undefined : body;
     const logContext = {
       status: upstream.status,
       status_text: upstream.statusText,
-      ...(body === undefined ? { body_redacted: true } : { body }),
+      ...(loggableBody === undefined ? { body_redacted: true } : { body: loggableBody }),
     };
 
     logger.warning(req, options.operation, 'Upstream returned non-OK response', logContext);
@@ -121,11 +141,22 @@ export async function gatewayFetch<T>(req: Request, url: string, options: Gatewa
     return JSON.parse(rawBody) as T;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    const truncatedBody = options.redactResponseBody ? undefined : rawBody.slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+    // Either option withholds the body here. `redactResponseBodyFromLogs` keeps a non-OK body on
+    // the error so a refusal can be relayed, but a malformed 2xx has no refusal in it and nothing
+    // reads this one — so it is dropped from the error as well, not merely from the line below.
+    // Kept on the error, `getLogContext` would log it at the handler and undo the redaction.
+    const withheldBody = options.redactResponseBody || options.redactResponseBodyFromLogs;
+    const truncatedBody = withheldBody ? undefined : rawBody.slice(0, UPSTREAM_ERROR_BODY_LIMIT);
     const logContext = {
       status: upstream.status,
       status_text: upstream.statusText,
-      ...(truncatedBody === undefined ? { body_redacted: true } : { body: truncatedBody, error: message }),
+      // Under redaction the parse message is withheld along with the body, because it quotes the
+      // body: V8 reports `Unexpected token 'S', "SECRET-COUPON" is not valid JSON`, so logging it
+      // would hand over the first of exactly the content being redacted. The exception name is
+      // safe — it is a class name — and still distinguishes a parse failure from anything else.
+      ...(truncatedBody === undefined
+        ? { body_redacted: true, error_name: error instanceof Error ? error.name : 'Error' }
+        : { body: truncatedBody, error: message }),
     };
 
     logger.warning(req, options.operation, 'Upstream returned invalid JSON response', logContext);

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -451,3 +451,44 @@ export function validateRequestBody<T>(body: T | undefined, req: Request, next: 
 
   return true;
 }
+
+/**
+ * Whether a string is an absolute `https:` URL.
+ *
+ * For destinations this application hands to the browser to navigate to. An address that arrives
+ * from upstream and is assigned to `location.href` is executable if its scheme says so — a
+ * `javascript:` value runs in this origin, with this session — so the scheme has to be checked
+ * before the value is passed on, not merely its presence.
+ *
+ * Parsed rather than matched against the text. The browser normalizes before it reads the scheme
+ * — it trims leading whitespace and C0 control characters, and the scheme is case-insensitive —
+ * so `" javascript:…"` and `"JaVaScRiPt:…"` both execute while failing a written-out comparison.
+ * Handing the same parser the value is how this stays in step with what will act on it.
+ */
+export function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The scheme of a URL for a log line, or a constant when there is no parseable one.
+ *
+ * The companion to `isHttpsUrl`: when a destination is refused, the scheme is the part worth
+ * recording, since `javascript:` and `http:` call for different responses. The value itself is not
+ * loggable — a signing address is a capability, and a hostile one belongs in a log even less.
+ *
+ * Parsed rather than cut at the first colon. A value with no colon has no scheme to take, and
+ * cutting yields the whole string, so the one input most likely to be an opaque token is the one
+ * that would print verbatim. The parser also rejects anything outside the scheme charset, which is
+ * what bounds the output here.
+ */
+export function urlSchemeForLog(value: string): string {
+  try {
+    return new URL(value).protocol.replace(/:$/, '');
+  } catch {
+    return 'unparseable';
+  }
+}

--- a/apps/lfx-one/src/server/middleware/error-handler.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/error-handler.middleware.spec.ts
@@ -1,0 +1,161 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * What the API error handler writes to the log, and what it writes to the client.
+ *
+ * These are separate questions for exactly one class of error, and this suite exists for that
+ * class: an upstream refusal whose sentence must be shown to the person who triggered it and must
+ * not be recorded anywhere. The CLA service answers a signing-scope refusal with a body naming the
+ * caller, and a trade-compliance refusal with a body naming the organization's standing. Both are
+ * 403s, both are relayed verbatim to the signatory by design (#1983), and neither may appear in a
+ * log line.
+ *
+ * The assertions below deliberately search the *whole* emitted payload rather than named fields.
+ * This leak has been reported fixed twice while still being live, both times because the fix was
+ * verified by inspecting the field that had been cleaned rather than the line that gets written —
+ * and the refusal was still arriving through a different one. Serializing the payload and
+ * searching it for the sentence is the only assertion that cannot pass while the leak is open.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/logger.service', () => ({
+  logger: { getLastOperation: vi.fn(() => undefined), info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { apiErrorHandler } = await import('./error-handler.middleware');
+const { logger } = await import('../services/logger.service');
+const { MicroserviceError } = await import('../errors');
+const { withoutUpstreamBody, withProducerRefusalMessage } = await import('../services/cla.service');
+const { customErrorSerializer } = await import('../helpers/error-serializer');
+
+/**
+ * Shaped like the real thing and synthetic in every part: a scope refusal names the caller, so a
+ * fixture copied from a real one would put a real person's LF username in this file.
+ */
+const REFUSAL = 'user contributor-xyz is not authorized for project acme-motors-example on behalf of Vendor Corp';
+
+/** The generic sentence `gatewayFetch` builds for a non-OK response, before any relay runs. */
+const GENERIC = 'Failed to request corporate signature: 403 Forbidden';
+
+/** The error the sign path throws: relay the refusal to the client, drop the body it came from. */
+function refusedSigningError(): unknown {
+  const upstream = new MicroserviceError(GENERIC, 403, 'FORBIDDEN', {
+    operation: 'org_cla_request_corporate_signature',
+    service: 'easycla',
+    errorBody: JSON.stringify({ message: REFUSAL }),
+  });
+
+  return withoutUpstreamBody(withProducerRefusalMessage(upstream, 'org_cla_request_corporate_signature', 'easycla'));
+}
+
+function buildReq(): Request {
+  return { id: 'req-1', path: '/api/orgs/acme/lens/cla-groups/sign', method: 'POST', get: () => 'vitest' } as unknown as Request;
+}
+
+function buildRes(): Response & { statusCode?: number; body?: Record<string, unknown> } {
+  const res = {
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body: Record<string, unknown>) {
+      res.body = body;
+      return res;
+    },
+  } as unknown as Response & { statusCode?: number; body?: Record<string, unknown> };
+
+  return res;
+}
+
+function handle(error: unknown): { res: ReturnType<typeof buildRes> } {
+  const res = buildRes();
+  apiErrorHandler(error as Error, buildReq(), res, vi.fn() as unknown as NextFunction);
+  return { res };
+}
+
+/**
+ * Everything the log line would contain, as one searchable string.
+ *
+ * `err` is run through the real Pino serializer rather than stringified directly, because that
+ * serializer is what turns an Error into loggable fields — and it is the component that would
+ * copy a plain public property back onto the payload the handler had just been careful about.
+ * Skipping it would test a payload nobody emits.
+ */
+function emittedLogText(): string {
+  const warning = vi.mocked(logger.warning).mock.calls.at(-1);
+  expect(warning, 'expected a warning to have been logged for a 4xx').toBeDefined();
+
+  const [, operation, message, metadata] = warning as [unknown, string, string, Record<string, unknown>];
+  const { err, ...rest } = metadata;
+
+  return JSON.stringify({ operation, message, err: customErrorSerializer(err), rest });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('apiErrorHandler — a relayed upstream refusal', () => {
+  it('shows the signatory the refusal in the CLA service’s own words', () => {
+    const { res } = handle(refusedSigningError());
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body?.['error']).toBe(REFUSAL);
+  });
+
+  it('writes none of the refusal to the log', () => {
+    handle(refusedSigningError());
+
+    expect(emittedLogText()).not.toContain(REFUSAL);
+  });
+
+  // The two identifiers inside the sentence, asserted on their own. A future refusal format that
+  // this suite's fixture does not predict would still have to get these two past the assertion.
+  it('writes neither the named caller nor the named organization to the log', () => {
+    handle(refusedSigningError());
+
+    const logged = emittedLogText();
+    expect(logged).not.toContain('contributor-xyz');
+    expect(logged).not.toContain('Vendor Corp');
+  });
+
+  it('logs the generic upstream sentence instead, so the failure is still diagnosable', () => {
+    handle(refusedSigningError());
+
+    const logged = emittedLogText();
+    expect(logged).toContain(GENERIC);
+    expect(logged).toContain('org_cla_request_corporate_signature');
+  });
+
+  // The raw body is a second copy of the same sentence, reached by a different route: the handler
+  // spreads `getLogContext()` (which returns `error_body`) and the serializer enumerates the
+  // error's own keys. Dropping the body closes both.
+  it('writes no upstream response body to the log', () => {
+    handle(refusedSigningError());
+
+    expect(emittedLogText()).not.toContain('errorBody');
+    expect(emittedLogText()).not.toContain('error_body":"{');
+  });
+});
+
+describe('apiErrorHandler — errors that set no client message', () => {
+  // The fallback the rest of the app relies on. `toResponse` serving `clientMessage` must not
+  // change what any error that never sets one puts on the wire.
+  it('answers with `message`, exactly as before', () => {
+    const { res } = handle(new MicroserviceError('Upstream is unavailable', 503, 'SERVICE_UNAVAILABLE', { operation: 'op', service: 'svc' }));
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body?.['error']).toBe('Upstream is unavailable');
+  });
+
+  // A 403 the CLA service refused without a usable body: there is nothing to relay, so the
+  // generic sentence is both logged and shown. Proves the relay is not silently swallowing text.
+  it('shows the generic sentence when the refusal carried no message to relay', () => {
+    const bare = new MicroserviceError(GENERIC, 403, 'FORBIDDEN', { operation: 'op', service: 'easycla', errorBody: '<html>gateway</html>' });
+    const { res } = handle(withoutUpstreamBody(withProducerRefusalMessage(bare, 'op', 'easycla')));
+
+    expect(res.body?.['error']).toBe(GENERIC);
+  });
+});

--- a/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.spec.ts
@@ -7,12 +7,19 @@ import express from 'express';
 import type { Server } from 'node:http';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { listClaGroups, getPdfUrl } = vi.hoisted(() => ({ listClaGroups: vi.fn(), getPdfUrl: vi.fn() }));
+const { listClaGroups, getPdfUrl, getSignOptions, requestCorporateSignature } = vi.hoisted(() => ({
+  listClaGroups: vi.fn(),
+  getPdfUrl: vi.fn(),
+  getSignOptions: vi.fn(),
+  requestCorporateSignature: vi.fn(),
+}));
 
 vi.mock('../controllers/org-clas.controller', () => ({
   OrgClasController: class {
     public listClaGroups = listClaGroups;
     public getPdfUrl = getPdfUrl;
+    public getSignOptions = getSignOptions;
+    public requestCorporateSignature = requestCorporateSignature;
   },
 }));
 
@@ -23,7 +30,10 @@ vi.mock('../services/org-role-grants.service', () => ({
     public getAccessAwareOrgs = getAccessAwareOrgs;
   },
 }));
-vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => 'alice', isImpersonating: () => false }));
+// `isImpersonating` is a spy rather than a literal so the write route's guard can be driven from
+// a test. `blockDuringImpersonation` reads it, and it is the only input that guard has.
+const isImpersonating = vi.fn(() => false);
+vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => 'alice', isImpersonating: () => isImpersonating() }));
 vi.mock('../services/logger.service', () => ({
   logger: {
     info: vi.fn(),
@@ -72,9 +82,22 @@ afterAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  isImpersonating.mockReturnValue(false);
   listClaGroups.mockImplementation(ok);
   getPdfUrl.mockImplementation((_req: express.Request, res: express.Response) => {
     res.json({ url: 'https://s3.example.org/ccla.pdf' });
+  });
+  getSignOptions.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ searchTerm: 'cascade', resultCount: 0, truncated: false, results: [] });
+  });
+  requestCorporateSignature.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ signUrl: 'https://signing.example.org/session/1' });
+  });
+  getSignOptions.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ searchTerm: 'cascade', resultCount: 0, truncated: false, results: [] });
+  });
+  requestCorporateSignature.mockImplementation((_req: express.Request, res: express.Response) => {
+    res.json({ signUrl: 'https://docusign.example.org/session/1' });
   });
   getAccessAwareOrgs.mockResolvedValue({ resolved: new Map([[GRANTED, { roleSource: 'direct-writer' }]]), upstreamFailed: false });
 });
@@ -118,5 +141,105 @@ describe('org-clas router', () => {
     expect(res.status).toBe(200);
     expect(getPdfUrl).toHaveBeenCalled();
     expect(await res.json()).toEqual({ url: 'https://s3.example.org/ccla.pdf' });
+  });
+
+  /**
+   * The corporate signing routes (#1983), asserted at the layer where their guards are wired. A
+   * controller test cannot see any of this: it is handed a request that has already passed
+   * everything the router put in front of it, so a guard deleted from a route line would leave
+   * every controller test green.
+   *
+   * There is no environment gate to assert. The module's server-side flag was removed on the
+   * parent branch, leaving the LaunchDarkly `org-lens-cla-m3-enabled` flag as the only one — and
+   * that hides the route and the nav without closing the BFF. So what stands in front of these
+   * two routes is exactly what is asserted below: the Org Lens grant on both, the impersonation
+   * guard on the write, and the CLA service's own signing-authority check past them. A shorter
+   * list than it was, which makes each of these cases more load-bearing rather than less.
+   */
+
+  /**
+   * Choosing a CLA Group to sign for. A read, so impersonation stays allowed — exactly as on the
+   * Me-lens picker, and unlike the write next door.
+   *
+   * The literal `sign-options` segment also has to beat the `:signatureId` route declared after
+   * it; if the declaration order ever flipped, this would arrive at `getPdfUrl` instead.
+   */
+  describe('sign-options', () => {
+    it('refuses a search for an org the caller holds no grant on', async () => {
+      const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(403);
+      expect(getSignOptions).not.toHaveBeenCalled();
+    });
+
+    it('admits a search for a granted org, and not as a signature id', async () => {
+      const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(200);
+      expect(getSignOptions).toHaveBeenCalled();
+      expect(getPdfUrl).not.toHaveBeenCalled();
+    });
+
+    it('stays available while impersonating, because it reads nothing and writes nothing', async () => {
+      isImpersonating.mockReturnValue(true);
+
+      const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/cla-groups/sign-options?search=cascade`);
+
+      expect(res.status).toBe(200);
+      expect(getSignOptions).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Opening the signing session: the one write in this router, and the one that creates a
+   * signature record and a DocuSign envelope against a company's legal position.
+   *
+   * Each guard is asserted to run *before* the next thing, not merely to be present. The payload
+   * below is a valid one throughout, so nothing here can pass by being rejected for its shape.
+   */
+  describe('sign', () => {
+    const body = {
+      projectSfid: 'a09410000182dD2AAI',
+      claGroupId: '11111111-1111-4111-8111-111111111111',
+      authorityAcked: true,
+      embargoAcked: true,
+    };
+
+    function sign(orgUid: string): Promise<Response> {
+      return fetch(`${baseUrl}/api/orgs/${orgUid}/lens/cla-groups/sign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it('refuses a signing request for an org the caller holds no grant on', async () => {
+      const res = await sign(UNGRANTED);
+
+      expect(res.status).toBe(403);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+    });
+
+    it('admits a signing request for a granted org', async () => {
+      const res = await sign(GRANTED);
+
+      expect(res.status).toBe(200);
+      expect(requestCorporateSignature).toHaveBeenCalled();
+    });
+
+    /**
+     * The payload carries no caller identity — the signatory is whoever the gateway token names.
+     * Under impersonation that is the wrong person, on a corporate agreement, and there is nothing
+     * in the record afterwards to say so. Refused before the controller runs, so no part of the
+     * request is acted on.
+     */
+    it('refuses a signing request while impersonating, before the controller runs', async () => {
+      isImpersonating.mockReturnValue(true);
+
+      const res = await sign(GRANTED);
+
+      expect(res.status).toBe(403);
+      expect(requestCorporateSignature).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/lfx-one/src/server/routes/org-clas.route.ts
+++ b/apps/lfx-one/src/server/routes/org-clas.route.ts
@@ -4,12 +4,43 @@
 import { Router } from 'express';
 
 import { OrgClasController } from '../controllers/org-clas.controller';
+import { blockDuringImpersonation } from '../middleware/impersonation-readonly.middleware';
 import { requireOrgLensAccess } from '../middleware/require-org-lens-access.middleware';
 
 const router = Router();
 const orgClasController = new OrgClasController();
 
 router.get('/:orgUid/lens/cla-groups', requireOrgLensAccess, (req, res, next) => orgClasController.listClaGroups(req, res, next));
+
+// Corporate CLA signing hand-off (#1983). Declared ahead of the `:signatureId` routes below so
+// the literal segments are not captured as a signature id.
+//
+// Picking the CLA Group is a read and stays available while impersonating. Opening the signing
+// session is guarded, and for the plainest form of the reason the read-only rule exists: it
+// creates a signature record and a DocuSign envelope against a company's legal position, with no
+// caller identity in the payload — the signatory is whoever the token names, which under
+// impersonation is the wrong person and cannot be corrected afterwards.
+//
+// Neither route carries a server-side environment gate, including the write, and the LaunchDarkly
+// `org-lens-cla-m3-enabled` flag is not one either: it is an Angular `canMatch` guard, so it hides
+// the route and the nav in the browser and leaves the BFF mounted. These two are protected by the
+// session, the Org Lens grant on the organization, `blockDuringImpersonation` on the write, and
+// the CLA service's own signing-authority and trade-compliance checks.
+//
+// A server-side flag check on the write was considered when this landed and deliberately not
+// added. It is not an authorization boundary: the same corporate signature can be requested by the
+// same caller through the ACS-authorized EasyCLA v4 API and through the Corporate CLA Console, so
+// a check here withholds no capability — and it would cost a GitOps round-trip and a pod roll per
+// rollout, which is why the env gate was removed with the detail page in the first place.
+//
+// The consequence to know, because it is operational rather than theoretical: the flag is not a
+// complete kill switch for this path. Turning it off stops the UI reaching the route; it does not
+// stop a direct call. Only a deliberate caller who already holds the grant can make that matter.
+router.get('/:orgUid/lens/cla-groups/sign-options', requireOrgLensAccess, (req, res, next) => orgClasController.getSignOptions(req, res, next));
+router.post('/:orgUid/lens/cla-groups/sign', requireOrgLensAccess, blockDuringImpersonation, (req, res, next) =>
+  orgClasController.requestCorporateSignature(req, res, next)
+);
+
 router.get('/:orgUid/lens/cla-groups/:signatureId/pdf-url', requireOrgLensAccess, (req, res, next) => orgClasController.getPdfUrl(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -46,6 +46,7 @@ import {
   recordedGithubIdentity,
   toClaGroupSearchResponse,
   toMyClaAgreement,
+  withoutUpstreamBody,
 } from './cla.service';
 
 const req = {} as unknown as Request;
@@ -170,6 +171,36 @@ describe('claReturnUrl', () => {
 
   it('refuses a protocol that is neither http nor https', () => {
     expect(() => claReturnUrl(reqWithHost('app.lfx.dev', 'javascript'))).toThrow(MicroserviceError);
+  });
+
+  it('leaves the URL unchanged when no query is asked for', () => {
+    expect(claReturnUrl(reqWithHost('app.lfx.dev'), '/org/easycla')).toBe('https://app.lfx.dev/org/easycla');
+  });
+
+  it('names the organization on the address, so the page does not have to guess it', () => {
+    expect(claReturnUrl(reqWithHost('app.lfx.dev'), '/org/easycla', { org: '0014100000Te0OKAAZ' })).toBe(
+      'https://app.lfx.dev/org/easycla?org=0014100000Te0OKAAZ'
+    );
+  });
+
+  // The whole point of routing this through `searchParams` rather than concatenating: EasyCLA
+  // stores the value and later redirects to it verbatim, so a value that could close the query and
+  // append its own path would turn the hand-off into an open redirect a second way.
+  it.each([
+    ['0014100000Te0OKAAZ#@evil.example.com', 'evil.example.com'],
+    ['0014100000Te0OKAAZ&next=https://evil.example.com', 'evil.example.com'],
+    ['../../evil', 'evil'],
+  ])('encodes %p so it cannot break out of the query string', (value, smuggled) => {
+    const url = claReturnUrl(reqWithHost('app.lfx.dev'), '/org/easycla', { org: value });
+
+    expect(new URL(url).origin).toBe('https://app.lfx.dev');
+    expect(new URL(url).pathname).toBe('/org/easycla');
+    expect(new URL(url).searchParams.get('org')).toBe(value);
+    expect(url).not.toContain(`/${smuggled}`);
+  });
+
+  it('still refuses an untrusted host when a query is supplied', () => {
+    expect(() => claReturnUrl(reqWithHost('evil.example.com'), '/org/easycla', { org: '0014100000Te0OKAAZ' })).toThrow(MicroserviceError);
   });
 });
 
@@ -1189,7 +1220,32 @@ describe('ClaService.prepareSign', () => {
 
     // The endpoint ships no reason code, so its prose is the only thing there is to say. Relaying
     // "403 Forbidden" instead would tell the contributor nothing they can act on.
-    await expect(new ClaService().prepareSign(prepareReq, '12345', CLA_GROUP_ID)).rejects.toMatchObject({ statusCode: 403, message: refusal });
+    //
+    // It arrives as `clientMessage`, not `message`. The sentence is a statement about who the
+    // caller is, and `message` is what the API error handler formats into its log line — so the
+    // relay writes the part that is shown and leaves the part that is recorded generic.
+    await expect(new ClaService().prepareSign(prepareReq, '12345', CLA_GROUP_ID)).rejects.toMatchObject({
+      statusCode: 403,
+      clientMessage: refusal,
+    });
+  });
+
+  it('keeps the relayed refusal out of the message the log line is built from', async () => {
+    const refusal = 'the provided identity does not belong to the authenticated user';
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to prepare the CLA signing session: 403 Forbidden', 403, 'FORBIDDEN', {
+        service: 'cla_service',
+        errorBody: JSON.stringify({ code: '403', message: refusal }),
+      })
+    );
+
+    const thrown = await new ClaService()
+      .prepareSign(prepareReq, '12345', CLA_GROUP_ID)
+      .then(() => null)
+      .catch((error: unknown) => error as Error);
+
+    expect(thrown?.message).not.toContain(refusal);
+    expect(thrown?.message).toBe('Failed to prepare the CLA signing session: 403 Forbidden');
   });
 
   it('does not derive a reason code from the refusal prose', async () => {
@@ -1405,5 +1461,67 @@ describe('producerMessageFrom', () => {
     expect(producerMessageFrom(JSON.stringify({ code: '403' }))).toBeNull();
     expect(producerMessageFrom(JSON.stringify({ message: '   ' }))).toBeNull();
     expect(producerMessageFrom({ message: 'an object, not the raw text gatewayFetch carries' })).toBeNull();
+  });
+});
+
+/**
+ * The counterpart to reading a message out of an upstream body: getting rid of the body once the
+ * message has been taken out of it.
+ *
+ * It exists because `MicroserviceError#getLogContext` returns `error_body`, and the API error
+ * handler spreads that into the line it logs. An error that still carries an upstream body
+ * therefore logs it wherever it is finally handled, no matter how the fetch that produced it was
+ * configured — so the drop has to happen on the error, not only at the fetch.
+ */
+describe('withoutUpstreamBody', () => {
+  it('keeps the message, status and code while dropping the body', () => {
+    const error = new MicroserviceError('This organization requires additional review', 403, 'UPSTREAM_ERROR', {
+      operation: 'org_cla_request_corporate_signature',
+      service: 'org_cla_service',
+      path: '/v4/self-serve/request-corporate-signature',
+      originalMessage: 'HTTP 403: Forbidden',
+      errorBody: JSON.stringify({ message: 'This organization requires additional review', lf_username: 'SENSITIVE-HANDLE' }),
+    });
+
+    const scrubbed = withoutUpstreamBody(error) as MicroserviceError;
+
+    expect(scrubbed.message).toBe('This organization requires additional review');
+    expect(scrubbed.statusCode).toBe(403);
+    expect(scrubbed.code).toBe('UPSTREAM_ERROR');
+    expect(scrubbed.operation).toBe('org_cla_request_corporate_signature');
+    expect(scrubbed.service).toBe('org_cla_service');
+    expect(scrubbed.path).toBe('/v4/self-serve/request-corporate-signature');
+    expect(scrubbed.originalMessage).toBe('HTTP 403: Forbidden');
+    expect(scrubbed.errorBody).toBeUndefined();
+  });
+
+  // The log line the error handler emits is the thing this protects, so that is what is asserted —
+  // not merely the absence of the field.
+  it('leaves nothing from the body in the log context', () => {
+    const error = new MicroserviceError('Refused', 403, 'UPSTREAM_ERROR', {
+      errorBody: JSON.stringify({ sanction_status: 'pending_review' }),
+    });
+
+    expect(JSON.stringify(error.getLogContext())).toContain('pending_review');
+    expect(JSON.stringify((withoutUpstreamBody(error) as MicroserviceError).getLogContext())).not.toContain('pending_review');
+  });
+
+  // A transport failure is declared by the site that threw it and is read by the client as "our
+  // connection broke" — rebuilding the error must not silently reclassify that.
+  it('preserves a declared transport failure', () => {
+    const error = new MicroserviceError('Gateway unreachable', 502, 'NETWORK_ERROR', {
+      errorBody: 'connection reset',
+      transportFailure: true,
+    });
+
+    expect((withoutUpstreamBody(error) as MicroserviceError).toResponse()['transport']).toBe(true);
+  });
+
+  it('returns anything without a body untouched, rather than rebuilding it', () => {
+    const withoutBody = new MicroserviceError('Refused', 403, 'UPSTREAM_ERROR', { service: 'org_cla_service' });
+    const notOurs = new Error('boom');
+
+    expect(withoutUpstreamBody(withoutBody)).toBe(withoutBody);
+    expect(withoutUpstreamBody(notOurs)).toBe(notOurs);
   });
 });

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -76,8 +76,15 @@ export { claServiceBaseUrl };
 const KNOWN_MATCH_TYPES = new Set<string>(['claGroup', 'project', 'organization', 'repository']);
 const KNOWN_ORG_SOURCES = new Set<string>(['github', 'gitlab', 'gerrit']);
 
-/** Maps one upstream search result onto the option the picker and the hand-off consume. */
-function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
+/**
+ * Maps one upstream search result onto the option the picker and the hand-off consume.
+ *
+ * Exported for the Org Lens sign-options route (#1983), which wraps rather than replaces it: it
+ * calls this for the shared shape and appends `projectSfid` afterwards, so the Me-lens response
+ * stays byte-identical. Do not add an Org-Lens-only field here — see the note on Salesforce ids
+ * in `toClaGroupSearchResponse` below.
+ */
+export function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
   return {
     claGroupId: result.claGroupID ?? '',
     projectName: result.projectName || undefined,
@@ -103,8 +110,14 @@ function toClaGroupOption(result: EasyClaSearchResult): ClaGroupOption {
  * The envelope is mirrored rather than flattened to an array because `truncated` describes the
  * result *set* — a cap cannot ride inside one of the results. The one field renamed is the
  * identifier (`claGroupID` → `claGroupId`), so Angular is not made to carry two spellings of the
- * same UUID. Salesforce ids are deliberately not carried across. ICLA/CCLA enablement flags are
- * forwarded for Gerrit contract-type routing (#2066); the GitHub prepare-sign path does not branch on them.
+ * same UUID. ICLA/CCLA enablement flags are forwarded for Gerrit contract-type routing (#2066);
+ * the GitHub prepare-sign path does not branch on them.
+ *
+ * Salesforce ids are not carried across *here*, because this envelope's consumer — the Me-lens
+ * picker and its hand-off — is keyed on `claGroupId` alone, and an unread field still ships to
+ * the browser inside the transferred state. The corporate hand-off does need the project id, and
+ * carries it on its own path: `OrgClaService.getSignOptions` appends `projectSfid` after calling
+ * `toClaGroupOption`. Moving it in here would put it in this response too, for no consumer.
  *
  * `searchTerm` falls back to the term the BFF actually sent, so the client can always tell which
  * query a set belongs to even if the producer echoes nothing.
@@ -143,8 +156,21 @@ const PREVIEW_RETURN_HOSTNAME = /^ui-pr-\d{1,10}\.dev\.v2\.cluster\.linuxfound\.
  * Because that makes the origin request-controlled, the host is checked against our own origins
  * before it is handed onward: EasyCLA stores this value and later redirects to it verbatim, so an
  * unchecked forged Host would turn a trusted hand-off into an open redirect.
+ *
+ * `path` selects where the signer lands: the contributor's own CLAs by default, or the Org Lens
+ * EasyCLA page for the corporate hand-off (#1983). A parameter rather than a second function
+ * because the host check above is the security-critical part, and it must exist exactly once.
+ * Callers pass a shared path constant, never a request-derived value.
+ *
+ * `query` is the one place a request-derived value may enter, and it is kept out of `path`
+ * deliberately: the corporate hand-off has to name the organization it was opened for, because the
+ * signer comes back through a cross-site navigation and the selected organization survives only in
+ * a `SameSite=Lax` cookie. A bare path leaves the page to guess, and it guesses the first
+ * organization in the viewer's list. Written through `searchParams`, so a value cannot break out of
+ * the query string and append a path or a second origin to a URL that EasyCLA stores and later
+ * redirects to verbatim.
  */
-export function claReturnUrl(req: Request): string {
+export function claReturnUrl(req: Request, path: string = MY_CLAS_PATH, query?: Readonly<Record<string, string>>): string {
   const host = req.get('host');
   if (!host) {
     throw new MicroserviceError('Cannot derive the CLA return URL: request has no Host header', 500, 'RETURN_URL_UNRESOLVABLE', { service: SERVICE });
@@ -167,7 +193,12 @@ export function claReturnUrl(req: Request): string {
     throw new MicroserviceError('Cannot derive the CLA return URL: untrusted Host header', 500, 'RETURN_URL_UNTRUSTED', { service: SERVICE });
   }
 
-  return `${req.protocol}://${host}${MY_CLAS_PATH}`;
+  const url = new URL(`${req.protocol}://${host}${path}`);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  return url.toString();
 }
 
 // Identity keys the CLA service reports as `"<type>:<value>"`, both in the verified `identity`
@@ -371,23 +402,66 @@ export function producerMessageFrom(errorBody: unknown): string | null {
 }
 
 /**
- * Re-labels an ownership refusal with the message the CLA service sent, so that message —
- * rather than "403 Forbidden" — is what the contributor is shown.
+ * Carries the CLA service's refusal to the client as `clientMessage`, so that sentence — rather
+ * than "403 Forbidden" — is what the contributor is shown.
  *
  * Scoped to 403 on purpose. That is the one status whose body is a statement about the
  * contributor's own identity and therefore worth repeating verbatim; relaying the prose of a
  * 500 would put upstream internals on screen for something they can do nothing about.
+ *
+ * **`message` is deliberately left alone**, and that is the point of the field. The refusal is
+ * exactly the text that must not be logged — a scope refusal names the caller, a trade-compliance
+ * refusal names the organization's standing — and `message` is logged three ways over: the error
+ * handler formats `API error: ${error.message}`, passes the error itself as `err`, and Pino's
+ * serializer reads `.message` off it. Writing the refusal into `message` therefore published it
+ * to the log line no matter what was done to the body afterwards. `clientMessage` reaches
+ * `toResponse` and nothing else; see `BaseApiError`.
+ *
+ * Exported for the corporate hand-off (#1983), which lands in the same window: the CLA service
+ * answers a trade-compliance refusal with a 403 whose body names the reason and the support
+ * route, and answers a missing signing authority with a 403 too. `operation` and `service` are
+ * parameters so the relabelled error keeps the caller's own log identity.
  */
-function withProducerRefusalMessage(error: unknown): unknown {
+export function withProducerRefusalMessage(error: unknown, operation = 'cla_prepare_sign', service = SERVICE): unknown {
   if (!(error instanceof MicroserviceError) || error.statusCode !== 403) return error;
 
   const message = producerMessageFrom(error.errorBody);
   if (!message) return error;
 
-  return new MicroserviceError(message, error.statusCode, error.code, {
-    operation: 'cla_prepare_sign',
-    service: SERVICE,
+  return new MicroserviceError(error.message, error.statusCode, error.code, {
+    operation,
+    service,
     errorBody: error.errorBody,
+    clientMessage: message,
+  });
+}
+
+/**
+ * The same error with the raw upstream body dropped, keeping its status, code and client message.
+ *
+ * `MicroserviceError#getLogContext` returns `error_body` and the API error handler spreads that
+ * into its log line; Pino's error serializer copies it a second time, since it enumerates the
+ * error's own string keys. So an error carrying an upstream body logs that body wherever it is
+ * finally handled, however carefully the fetch that produced it was configured. Compose this
+ * after anything that needed to read the body (`withProducerRefusalMessage`) and before the
+ * throw, on the paths whose upstream refusals name a person or an organization's standing.
+ *
+ * This drops the body only. It is not on its own sufficient to keep a refusal out of the logs,
+ * because the sentence extracted from the body is the sensitive part and dropping its container
+ * does nothing about it — `withProducerRefusalMessage` putting that sentence in `clientMessage`
+ * rather than `message` is the half that handles it. Both are needed: one for the record, one
+ * for the sentence.
+ */
+export function withoutUpstreamBody(error: unknown): unknown {
+  if (!(error instanceof MicroserviceError) || error.errorBody === undefined) return error;
+
+  return new MicroserviceError(error.message, error.statusCode, error.code, {
+    operation: error.operation,
+    service: error.service,
+    path: error.path,
+    originalMessage: error.originalMessage,
+    transportFailure: error.transportFailure,
+    clientMessage: error.clientMessage,
   });
 }
 

--- a/apps/lfx-one/src/server/services/org-cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.spec.ts
@@ -5,18 +5,34 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Request } from 'express';
 
+import type * as ClaIdentifierUtils from '../../../../../packages/shared/src/utils/cla-identifier.utils';
+import type { MicroserviceError as MicroserviceErrorType } from '../errors';
 import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList } from '../types/cla.types';
 
-const { gatewayFetch, isImpersonating } = vi.hoisted(() => ({ gatewayFetch: vi.fn(), isImpersonating: vi.fn(() => false) }));
+const { gatewayFetch, isImpersonating, loggerWarning } = vi.hoisted(() => ({
+  gatewayFetch: vi.fn(),
+  isImpersonating: vi.fn(() => false),
+  loggerWarning: vi.fn(),
+}));
+
+// The shared utils barrel reaches Angular through unrelated siblings (form/meeting/vote), which the
+// node test environment cannot compile. Only the real identifier helper is wanted here — pulled
+// from its own module via `importActual` rather than restated, so the comparison under test is the
+// one that ships. Same approach `rewards-subject.spec.ts` uses for the Salesforce pattern.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await vi.importActual<typeof ClaIdentifierUtils>('../../../../../packages/shared/src/utils/cla-identifier.utils');
+  return { isSameClaGroup: actual.isSameClaGroup, canonicalClaGroupId: actual.canonicalClaGroupId };
+});
 
 vi.mock('../helpers/gateway-fetch.helper', () => ({ gatewayFetch }));
 vi.mock('../helpers/cla-service-url.helper', () => ({ claServiceBaseUrl: () => 'https://gw.example.org/cla-service' }));
 vi.mock('../utils/auth-helper', () => ({ isImpersonating }));
 vi.mock('./logger.service', () => ({
-  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: loggerWarning, error: vi.fn(), debug: vi.fn(), info: vi.fn() },
 }));
 
 const { OrgClaService } = await import('./org-cla.service');
+const { MicroserviceError } = await import('../errors');
 
 const ORG_UID = '0014100000Te2ovAAB';
 
@@ -276,9 +292,10 @@ describe('OrgClaService.listClaGroups — status', () => {
     expect(row.status).toBe('signed');
   });
 
-  // The producer passes the signature's own signed flag through and its tests pin a returned
-  // row whose flag is false, so this list is not exclusively signed agreements. Calling one
-  // signed would state that an organization has signed something it has not.
+  // Upstream's query filters to signed signatures, so this payload is not one the live list
+  // produces — it pins the mapper's rule, not a reachable list state. Worth pinning anyway: the
+  // rule is what makes the same mapper safe for a producer that relaxes the filter, and calling
+  // an unsigned agreement signed would state that an organization has signed something it has not.
   it('maps an unsigned agreement to not-started rather than to signed', async () => {
     gatewayFetch.mockResolvedValue(upstreamList(upstreamEntry({ signed: false, sanctioned: false })));
 
@@ -636,5 +653,397 @@ describe('OrgClaService.getPdfUrl — the organization scope gate', () => {
       `https://gw.example.org/cla-service/v4/company/external/${ORG_UID}/cla-groups`,
       expect.objectContaining({ operation: 'org_cla_list_cla_groups' })
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Corporate signing hand-off (#1983)
+// ---------------------------------------------------------------------------
+
+const CLA_GROUP_ID = '7f3a1c22-9d51-4a8e-b0c6-2e4f81d9a733';
+const PROJECT_SFID = 'a09410000182dD3AAI';
+
+/** A request the CLA service would accept. Cases override only what they are about. */
+function signRequest(overrides: Record<string, unknown> = {}) {
+  return { projectSfid: PROJECT_SFID, claGroupId: CLA_GROUP_ID, authorityAcked: true, embargoAcked: true, ...overrides } as any;
+}
+
+/** A request carrying the Host the return address is derived from. */
+function signReq(): Request {
+  return { protocol: 'https', get: (header: string) => (header === 'host' ? 'app.lfx.dev' : undefined) } as unknown as Request;
+}
+
+describe('OrgClaService.getSignOptions', () => {
+  it('carries the project Salesforce id upstream sent, which is what the corporate request is keyed on', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      searchTerm: 'nimbus',
+      resultCount: 1,
+      results: [{ claGroupID: CLA_GROUP_ID, claGroupName: 'Nimbus Foundation CLA', projectName: 'Cascade', projectSFID: PROJECT_SFID, cclaEnabled: true }],
+    });
+
+    const envelope = await new OrgClaService().getSignOptions(req(), 'nimbus');
+
+    expect(envelope.results[0]).toMatchObject({ claGroupId: CLA_GROUP_ID, projectSfid: PROJECT_SFID, cclaEnabled: true });
+  });
+
+  // Upstream leaves the id unset for a CLA group spanning several projects with no
+  // foundation-level row. Defaulting it to an empty string would make the row look signable and
+  // produce a request that cannot succeed; the picker needs to see the absence.
+  it('omits the project id entirely when upstream resolved none, rather than defaulting it', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      searchTerm: 'nimbus',
+      resultCount: 1,
+      results: [{ claGroupID: CLA_GROUP_ID, claGroupName: 'Nimbus Foundation CLA', cclaEnabled: true }],
+    });
+
+    const envelope = await new OrgClaService().getSignOptions(req(), 'nimbus');
+
+    expect(envelope.results[0]).not.toHaveProperty('projectSfid');
+  });
+
+  it('treats a blank project id as no project id', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      searchTerm: 'nimbus',
+      resultCount: 1,
+      results: [{ claGroupID: CLA_GROUP_ID, projectSFID: '   ', cclaEnabled: true }],
+    });
+
+    expect(await new OrgClaService().getSignOptions(req(), 'nimbus')).toMatchObject({ results: [expect.not.objectContaining({ projectSfid: '   ' })] });
+  });
+
+  it('preserves the envelope fields the picker reads', async () => {
+    gatewayFetch.mockResolvedValueOnce({ searchTerm: 'nimbus', resultCount: 40, truncated: true, results: [] });
+
+    expect(await new OrgClaService().getSignOptions(req(), 'nimbus')).toMatchObject({ searchTerm: 'nimbus', resultCount: 40, truncated: true });
+  });
+});
+
+describe('OrgClaService.requestCorporateSignature', () => {
+  const upstreamOk = {
+    signature_id: 'signature-uuid-1',
+    sign_url: 'https://docusign.example.org/session/1',
+    cla_group_id: CLA_GROUP_ID,
+    project_sfid: PROJECT_SFID,
+    company_id: 'company-uuid-1',
+    company_sfid: ORG_UID,
+  };
+
+  // snake_case on this upstream, unlike the Me-lens prepare-sign next door, which is camelCase in
+  // both directions. Getting this wrong fails silently: go-swagger ignores unknown keys, so a
+  // camelCase body would arrive as a request with no project and no attestations.
+  it('sends the body in snake_case, with the organization from the grant-checked path', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      'https://gw.example.org/cla-service/v4/self-serve/request-corporate-signature',
+      expect.objectContaining({
+        method: 'POST',
+        // The whole body. A subset matcher would not notice a required field going missing, and
+        // would not notice a designee field being added either.
+        body: {
+          project_sfid: PROJECT_SFID,
+          company_sfid: ORG_UID,
+          return_url: `https://app.lfx.dev/org/easycla?org=${ORG_UID}`,
+          authority_acked: true,
+          embargo_acked: true,
+        },
+      })
+    );
+  });
+
+  // The counterpart to the controller's gate, one layer down: even reached directly, this method
+  // relays what it was given. A literal here would mean the controller's check was the only thing
+  // standing between a withdrawn confirmation and a signed agreement.
+  it('relays a withdrawn confirmation as withdrawn rather than substituting true', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest({ embargoAcked: false }));
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ authority_acked: true, embargo_acked: false }) })
+    );
+  });
+
+  it('derives the return address server-side, pointing at the Organization Lens rather than the profile CLAs', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ return_url: `https://app.lfx.dev/org/easycla?org=${ORG_UID}` }) })
+    );
+  });
+
+  // Without this the signatory returns through a cross-site navigation carrying only a
+  // `SameSite=Lax` cookie, and when it does not come back the page selects the first organization
+  // in their list — so signing for one company lands them looking at another.
+  it('names the organization on the return address rather than leaving the page to guess it', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    const body = gatewayFetch.mock.calls[0][2].body as { return_url: string };
+    const returned = new URL(body.return_url);
+
+    expect(returned.pathname).toBe('/org/easycla');
+    // The organization the grant check cleared and the request was made for, not a client value.
+    expect(returned.searchParams.get('org')).toBe(ORG_UID);
+  });
+
+  // The endpoint accepts these four for the send-by-email and designee paths. This feature
+  // implements neither, and `send_as_email` in particular changes what the response means.
+  it('sends none of the designee or send-by-email fields', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    const body = gatewayFetch.mock.calls[0][2].body;
+    expect(body).not.toHaveProperty('send_as_email');
+    expect(body).not.toHaveProperty('authority_name');
+    expect(body).not.toHaveProperty('authority_email');
+    expect(body).not.toHaveProperty('signing_entity_name');
+  });
+
+  it('maps the upstream response onto the shape the client consumes', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    // The address and the signature it belongs to, and nothing else. Upstream also returns the CLA
+    // group, project and company identifiers, and none of those has a client consumer. The signature
+    // id does: the return address is an input to this request and so cannot name the signature, which
+    // leaves the client as the only place the two are held together.
+    expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).toEqual({
+      signUrl: 'https://docusign.example.org/session/1',
+      signatureId: 'signature-uuid-1',
+    });
+  });
+
+  // An empty signing address is how upstream reports that it emailed a named signatory instead —
+  // a shape this route never asks for. Returning it as success would navigate the signatory to
+  // this application's own root and read as a completed hand-off.
+  it.each([[''], ['   '], [undefined]])('fails rather than succeeding when the signing address is %p', async (signUrl) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: signUrl });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/no usable corporate signing session/);
+  });
+
+  // The client assigns this value to `document.location.href`, so a scheme that executes rather
+  // than navigates would run in this origin at the moment the signatory expects to be sent away.
+  // The whitespace and mixed-case entries are the ones a written-out comparison misses: the
+  // browser trims and lowercases the scheme before acting on it, so both of those execute.
+  it.each([
+    ['javascript:alert(document.cookie)'],
+    ['  javascript:alert(1)'],
+    ['\tjavascript:alert(1)'],
+    ['JaVaScRiPt:alert(1)'],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['http://docusign.example.org/session/1'],
+    ['/session/1'],
+    ['not a url at all'],
+  ])('refuses a signing address of %p rather than handing it to the browser', async (signUrl) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: signUrl });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/unusable corporate signing address/);
+  });
+
+  // The address is a capability — it opens a named person's agreement — and a hostile one should
+  // not be written anywhere either. Only its scheme is recorded.
+  it('keeps the refused address out of the logs', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: 'javascript:alert(document.cookie)' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow();
+
+    const logged = JSON.stringify(loggerWarning.mock.calls);
+    expect(logged).not.toContain('alert(document.cookie)');
+    expect(logged).toContain('javascript');
+  });
+
+  // A refused address with no scheme at all is the one most likely to be an opaque token, so it is
+  // also the one that must not be echoed into the log while reaching for a scheme that isn't there.
+  it('records no fragment of a refused address that has no scheme', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, sign_url: 'Zm9yZ2VkLXNpZ25pbmctY2FwYWJpbGl0eS10b2tlbg' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow();
+
+    expect(JSON.stringify(loggerWarning.mock.calls)).not.toContain('Zm9yZ2Vk');
+  });
+
+  it('fails when upstream returned no signature identifier', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, signature_id: '' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/no usable corporate signing session/);
+  });
+
+  // The agreement is requested by project; the upstream input has no CLA Group field, so the group
+  // the signatory chose cannot be bound to the request and the echoed one is the only way to tell
+  // whether the session that came back is for the agreement they picked. Handing over a mismatched
+  // session would have them sign the wrong corporate agreement with nothing recording it.
+  it('refuses a session opened for a different CLA Group than the one chosen', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: 'a-different-cla-group-uuid' });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/different CLA Group/);
+  });
+
+  // The request boundary accepts hyphenated and unhyphenated spellings in either case; the producer
+  // answers in its own. Comparing raw refuses a perfectly valid session after the envelope exists,
+  // which is worse than not checking at all — so the accepted spellings are pinned here.
+  it.each([
+    ['unhyphenated request', CLA_GROUP_ID.replaceAll('-', '')],
+    ['upper-case request', CLA_GROUP_ID.toUpperCase()],
+  ])('accepts the canonical echo against an %s', async (_label, claGroupId) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: CLA_GROUP_ID });
+
+    expect(await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest({ claGroupId }))).toEqual({
+      signUrl: 'https://docusign.example.org/session/1',
+      signatureId: 'signature-uuid-1',
+    });
+  });
+
+  it('does not hand back the signing address when the CLA Group does not match', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: 'a-different-cla-group-uuid' });
+
+    const outcome = await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest()).catch((error: unknown) => error);
+
+    expect(JSON.stringify(outcome)).not.toContain('docusign.example.org');
+  });
+
+  // The echo is the whole check. An answer that carries no CLA Group cannot be shown to be the
+  // agreement the signatory chose, which from here is indistinguishable from one that is not — so
+  // it is refused on the same terms as a mismatch rather than accepted for lacking the evidence.
+  it.each([[''], ['   '], [undefined]])('refuses a session attributed to no CLA Group, given %p', async (claGroupId) => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: claGroupId });
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/attributed to no CLA Group/);
+  });
+
+  it('does not hand back the signing address when the session is attributed to no CLA Group', async () => {
+    gatewayFetch.mockResolvedValueOnce({ ...upstreamOk, cla_group_id: '' });
+
+    const outcome = await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest()).catch((error: unknown) => error);
+
+    expect(JSON.stringify(outcome)).not.toContain('docusign.example.org');
+  });
+
+  // The trade-compliance refusal is a 403 whose body is a sentence written for the signatory,
+  // naming the reason and the support route. Showing "403 Forbidden" instead discards it.
+  it("re-labels a 403 with the CLA service's own words", async () => {
+    const refusal = new MicroserviceError('Forbidden', 403, 'UPSTREAM_ERROR', {
+      service: 'org_cla_service',
+      errorBody: JSON.stringify({
+        message: 'We are sorry, but this organization requires additional trade compliance review, so the CLA cannot be completed at this time.',
+      }),
+    });
+    gatewayFetch.mockRejectedValueOnce(refusal);
+
+    const thrown = await new OrgClaService()
+      .requestCorporateSignature(signReq(), ORG_UID, signRequest())
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    // `clientMessage`, not `message`: the sentence is what the signatory reads and `toResponse`
+    // serves it, while `message` — the one the error handler formats into its log line — stays
+    // generic. Asserting `rejects.toThrow(/…/)` here would match on `message` and so would pass
+    // for the version of this code that logged the refusal.
+    expect((thrown as MicroserviceErrorType).clientMessage).toMatch(/trade compliance review/);
+    expect((thrown as MicroserviceErrorType).toResponse()['error']).toMatch(/trade compliance review/);
+    expect((thrown as MicroserviceErrorType).message).not.toMatch(/trade compliance review/);
+  });
+
+  /**
+   * A refusal from this endpoint names the caller's LF username when it is about scope, and the
+   * organization's trade-compliance standing when it is about sanctions. Neither belongs in an
+   * application log.
+   *
+   * Full redaction is not available here: `gatewayFetch` discards the body under that option, and
+   * the body is the only place the refusal sentence exists — the relay above would go with it. So
+   * the body is kept out of the log at the fetch, and dropped from the error afterwards, once its
+   * message has been taken out. Both halves are needed, and the second is the easier one to miss:
+   * without it the error reaches the API error handler still carrying the body, and that handler
+   * logs `getLogContext()`, which includes it.
+   */
+  it('keeps the upstream refusal body out of the logs', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledWith(expect.anything(), expect.any(String), expect.objectContaining({ redactResponseBodyFromLogs: true }));
+  });
+
+  it('relays the refusal sentence without carrying the body that held it', async () => {
+    const refusal = 'This organization requires additional trade compliance review. Contact support to review the determination.';
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Forbidden', 403, 'UPSTREAM_ERROR', {
+        service: 'org_cla_service',
+        // The shape upstream actually sends on a sanctions refusal: the sentence, alongside fields
+        // that identify the organization's standing and must not survive into a log line.
+        errorBody: JSON.stringify({ message: refusal, company_sfid: ORG_UID, sanction_status: 'pending_review' }),
+      })
+    );
+
+    const thrown = await new OrgClaService()
+      .requestCorporateSignature(signReq(), ORG_UID, signRequest())
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    expect((thrown as MicroserviceErrorType).clientMessage).toBe(refusal);
+    expect((thrown as MicroserviceErrorType).errorBody).toBeUndefined();
+    // The API error handler spreads this into its log line, so it is the thing that must be clean.
+    expect(JSON.stringify((thrown as MicroserviceErrorType).getLogContext())).not.toContain('sanction_status');
+    // And the sentence itself, which the log line carries separately as `API error: ${message}`.
+    expect((thrown as MicroserviceErrorType).message).not.toContain(refusal);
+    // The whole error as any key-enumerating serializer would see it — `customErrorSerializer`
+    // copies every own string key onto the log payload, so a client message held under one would
+    // be written straight back into the line the two assertions above just cleaned.
+    expect(JSON.stringify({ ...(thrown as object), message: (thrown as Error).message })).not.toContain(refusal);
+  });
+
+  // Nothing about the body-dropping is 403-specific: a 5xx body from this endpoint is no more
+  // loggable, and it is not relayed either, so it has no reason to survive the throw.
+  it('carries no upstream body on a failure it did not relay', async () => {
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to request the corporate CLA signature', 500, 'UPSTREAM_ERROR', {
+        service: 'org_cla_service',
+        errorBody: JSON.stringify({ message: 'panic in signature repository', lf_username: 'someone' }),
+      })
+    );
+
+    const thrown = await new OrgClaService()
+      .requestCorporateSignature(signReq(), ORG_UID, signRequest())
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    expect((thrown as MicroserviceErrorType).errorBody).toBeUndefined();
+    expect(JSON.stringify((thrown as MicroserviceErrorType).getLogContext())).not.toContain('lf_username');
+  });
+
+  // Scoped to 403 for the reason the helper documents: a 500's prose is about upstream internals,
+  // not about the caller, and putting it on screen helps nobody.
+  it('leaves a 500 with its own message rather than relaying upstream prose', async () => {
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to request the corporate CLA signature', 500, 'UPSTREAM_ERROR', {
+        service: 'org_cla_service',
+        errorBody: JSON.stringify({ message: 'panic: nil pointer dereference in signature repository' }),
+      })
+    );
+
+    await expect(new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest())).rejects.toThrow(/Failed to request the corporate CLA/);
+  });
+
+  // No pre-gate on the organization's compliance status: the CLA service screens on every
+  // request, and the status on an existing agreement row cannot answer for an organization that
+  // holds none — which is the population this flow exists for.
+  it('never reads the organization CLA list before requesting the signature', async () => {
+    gatewayFetch.mockResolvedValueOnce(upstreamOk);
+
+    await new OrgClaService().requestCorporateSignature(signReq(), ORG_UID, signRequest());
+
+    expect(gatewayFetch).toHaveBeenCalledTimes(1);
+    expect(gatewayFetch).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('/cla-groups'), expect.anything());
   });
 });

--- a/apps/lfx-one/src/server/services/org-cla.service.ts
+++ b/apps/lfx-one/src/server/services/org-cla.service.ts
@@ -8,13 +8,34 @@
 // One upstream call per page load, whatever the number of agreements. Searching and paging
 // happen client-side over the fetched set, so nothing on this path fans out per row.
 
-import type { OrgClaGroup, OrgClaGroupList, OrgClaGroupProject, OrgClaGroupStatus, PdfUrlResponse } from '@lfx-one/shared/interfaces';
+import { ORG_EASYCLA_PATH, ORG_EASYCLA_RETURN_ORG_PARAM } from '@lfx-one/shared/constants';
+import { isSameClaGroup } from '@lfx-one/shared/utils';
+import type {
+  ClaGroupOption,
+  ClaGroupSearchResponse,
+  OrgClaGroup,
+  OrgClaGroupList,
+  OrgClaGroupProject,
+  OrgClaGroupStatus,
+  OrgClaSignRequest,
+  OrgClaSignResponse,
+  PdfUrlResponse,
+} from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
-import type { EasyClaCompanyClaGroup, EasyClaCompanyClaGroupList, EasyClaSignedDocument } from '../types/cla.types';
+import type {
+  EasyClaCompanyClaGroup,
+  EasyClaCompanyClaGroupList,
+  EasyClaSearchList,
+  EasyClaSelfServeCorporateSignatureInput,
+  EasyClaSelfServeCorporateSignatureOutput,
+  EasyClaSignedDocument,
+} from '../types/cla.types';
 import { MicroserviceError } from '../errors';
 import { claServiceBaseUrl } from '../helpers/cla-service-url.helper';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
+import { isHttpsUrl, urlSchemeForLog } from '../helpers/validation.helper';
+import { claReturnUrl, toClaGroupOption, withoutUpstreamBody, withProducerRefusalMessage } from './cla.service';
 import { logger } from './logger.service';
 import { isImpersonating } from '../utils/auth-helper';
 
@@ -45,8 +66,8 @@ const SERVICE = 'org_cla_service';
  * status. `status` remains the single slot the template reads, because sanctions outrank
  * signing there and a consumer forming its own opinion from the two booleans would present a
  * sanctioned entity's agreement as ordinarily signed. What `status` cannot answer is whether a
- * document exists to fetch, since a `sanctioned` row may be signed or unsigned, and that is the
- * one question `signed` is here for.
+ * document exists to fetch, since `sanctioned` describes the entity and not the agreement, and
+ * that is the one question `signed` is here for.
  */
 function toOrgClaGroup(entry: EasyClaCompanyClaGroup & { signatureID: string }, companyName: string): OrgClaGroup {
   const projects: OrgClaGroupProject[] = (entry.projects ?? [])
@@ -105,15 +126,18 @@ function toOrgClaGroup(entry: EasyClaCompanyClaGroup & { signatureID: string }, 
  * sanctioned entity's agreement as ordinarily signed is the more damaging of the two errors
  * available here.
  *
- * An unsigned agreement is a real case, and it is read from the flag rather than assumed
- * away. The producer sets each row's signed flag from the signature it was built from, and
- * its own tests pin a returned row whose flag is false, so the list is not exclusively
- * signed agreements. Defaulting to `signed` would state that an organization has signed
- * something it has not — the same class of false claim the precedence above avoids, and the
- * reason the flag is checked explicitly rather than treated as always true.
+ * `not-started` cannot come out of this endpoint. Upstream builds every row from a CCLA
+ * signature and copies that signature's own signed flag onto it, and the query it draws those
+ * signatures from appends `signature_signed == true` to its filter unconditionally, with no
+ * parameter to bypass it. So `entry.signed` is true on every row the list returns, and the two
+ * statuses reachable from here are `signed` and `sanctioned`.
  *
- * Sanctions still win over an unsigned agreement, for the same reason they win over a signed
- * one: the sanctions fact is the one a viewer must not miss.
+ * The branch stays, and is read from the flag rather than assumed away, because the status type
+ * is not this endpoint's alone: the pre-signing preview builds an `OrgClaGroup` for an agreement
+ * nobody has signed, and `not-started` is the whole of what that page renders. Defaulting to
+ * `signed` here would additionally mean that the day upstream relaxes that filter, the list
+ * states an organization has signed something it has not — the same class of false claim the
+ * precedence above avoids.
  */
 function toStatus(entry: EasyClaCompanyClaGroup): OrgClaGroupStatus {
   if (entry.sanctioned === true) return 'sanctioned';
@@ -216,10 +240,11 @@ export class OrgClaService {
       return null;
     }
 
-    // Membership is not signedness. A sanctioned row may be unsigned, and upstream presigns the
-    // expected S3 key without checking that anything was ever written there — so calling it for
-    // an unsigned agreement hands back a URL to a document that does not exist. Absent is the
-    // honest answer, and it is the one the caller already handles.
+    // Membership is not signedness, and this checks rather than assumes. Upstream's list filters
+    // to signed signatures, so no row reaching here should fail this — but the document endpoint
+    // presigns the expected S3 key without checking that anything was ever written there, so if
+    // that ever stopped holding the caller would get a URL to a file that does not exist rather
+    // than an error. Absent is the honest answer, and it is the one the caller already handles.
     if (!match.signed) {
       logger.warning(req, 'org_cla_get_pdf_url', 'agreement is not signed, so no document exists', { org_uid: orgUid, signature_id: signatureId });
       return null;
@@ -266,5 +291,235 @@ export class OrgClaService {
     // would be invented. The URL is presigned and short-lived, but its lifetime is upstream's to
     // state, and `0` would read to a consumer as already expired.
     return { url };
+  }
+
+  /**
+   * Searches CLA Groups the organization could sign a corporate CLA for (#1983).
+   *
+   * Wraps the Me-lens per-result mapper rather than reimplementing or amending it, and appends
+   * `projectSfid` afterwards. That id is what the corporate signature request is keyed on, and it
+   * has no consumer on the Me-lens path, so carrying it in the shared mapper would put an unread
+   * field into that response and into the state it ships with. Keeping the append here leaves the
+   * Me-lens envelope byte-identical.
+   *
+   * Upstream sets the id from a project-to-CLA-Group mapping row and deliberately leaves it unset
+   * when a CLA Group maps to several projects with none of them foundation-level. It is therefore
+   * carried only when upstream sent one, and its absence is what the picker renders as
+   * "cannot be signed from here" — a property of the CLA Group, not a failure.
+   *
+   * Runs on the default gateway token with no impersonation branch, same as the Me-lens search:
+   * the CLA Group catalogue is not organization-scoped upstream, so there is no ownership check
+   * for a token swap to satisfy. The gate on this route is `requireOrgLensAccess` alone; nothing
+   * about the caller's company reaches the query. The dark-launch flag is not part of it — that
+   * flag is an Angular route guard, so it hides the page without closing this endpoint.
+   */
+  public async getSignOptions(req: Request, searchTerm: string): Promise<ClaGroupSearchResponse> {
+    // No `startOperation` here, for the reason `getPdfUrl` above gives: the HTTP lifecycle is the
+    // controller's, and a second one double-counts the completion telemetry for one endpoint.
+    const params = new URLSearchParams({ searchTerm });
+    const list = await gatewayFetch<EasyClaSearchList>(req, `${claServiceBaseUrl(SERVICE)}/v4/cla-group/search?${params.toString()}`, {
+      operation: 'org_cla_sign_options',
+      service: SERVICE,
+      errorMessage: 'Failed to search CLA groups',
+      errorCode: 'UPSTREAM_ERROR',
+    });
+
+    const upstreamResults = list?.results ?? [];
+    const results: ClaGroupOption[] = upstreamResults.map((result) => {
+      const option = toClaGroupOption(result);
+      const projectSfid = result.projectSFID?.trim();
+      return projectSfid ? { ...option, projectSfid } : option;
+    });
+
+    const envelope: ClaGroupSearchResponse = {
+      searchTerm: list?.searchTerm ?? searchTerm,
+      resultCount: list?.resultCount ?? results.length,
+      truncated: list?.truncated === true,
+      results,
+    };
+
+    // A business event, not a request completion. How many of the matches are actually signable is
+    // the thing worth watching here: a search that returns rows the picker then greys out is how a
+    // project-to-CLA-Group mapping gap shows up in production.
+    logger.info(req, 'org_cla_sign_options', 'searched signable CLA groups', {
+      result_count: envelope.resultCount,
+      truncated: envelope.truncated,
+      signable_count: results.filter((option) => !!option.projectSfid && option.cclaEnabled === true).length,
+    });
+    return envelope;
+  }
+
+  /**
+   * Opens a corporate signing session for the organization and returns where the signatory
+   * completes it (#1983).
+   *
+   * Three values are deliberately not taken from the caller's body:
+   *
+   * - the organization, which is the grant-checked `orgUid` path parameter;
+   * - the return address, derived from the request Host and host-checked, because EasyCLA stores
+   *   it and later redirects to it verbatim — a client-supplied one would be an open redirect;
+   * - the caller's identity, which travels as the default gateway token. That token is the
+   *   signatory's own, exchanged for the gateway audience, and it is what makes the signature
+   *   attributable. There is no impersonation branch precisely because the route is blocked
+   *   during impersonation instead: a corporate agreement signed under an impersonated session
+   *   would bind a company on behalf of somebody who did not act.
+   *
+   * The two attestations are passed through exactly as received. They are not defaulted here and
+   * must not be: the client gates on both, so a request arriving with either false is either a
+   * signatory who withdrew a confirmation or a client that has regressed, and both must reach the
+   * refusal rather than be papered over. Upstream rejects the request ahead of any signing work
+   * for the same reason.
+   *
+   * Authorization is upstream's alone. It checks the caller's signing authority for the project
+   * and organization pair — refusing a platform-administrator token, which an org-lens read grant
+   * has no bearing on — and screens the company for trade compliance on every request. Neither is
+   * pre-empted here: the compliance status carried on an existing agreement row cannot answer for
+   * an organization that holds no agreements yet, which is the population this flow serves.
+   */
+  public async requestCorporateSignature(req: Request, orgUid: string, request: OrgClaSignRequest): Promise<OrgClaSignResponse> {
+    // No `startOperation` here, for the reason `getPdfUrl` above gives: the HTTP lifecycle is the
+    // controller's. The events below are business events on top of it, not a second request.
+    // Derived before the call: an unusable origin dead-ends the hand-off anyway, and failing
+    // afterwards would leave a real signing session behind with nowhere to return to.
+    // Named on the return address, not left to the cookie. The signatory comes back through a
+    // cross-site navigation, and which organization is selected survives that only in a
+    // `SameSite=Lax` cookie; without it the page falls to the first organization in their list, so
+    // signing for one company lands them looking at another. `orgUid` is the value the grant check
+    // already cleared and the same one sent as `company_sfid`, so the address describes the session
+    // that was actually opened.
+    const returnUrl = claReturnUrl(req, ORG_EASYCLA_PATH, { [ORG_EASYCLA_RETURN_ORG_PARAM]: orgUid });
+
+    // snake_case on the wire, unlike the Me-lens prepare-sign next door. Built as a typed object
+    // rather than spread from the request so every field crossing the spelling boundary is named.
+    const body: EasyClaSelfServeCorporateSignatureInput = {
+      project_sfid: request.projectSfid,
+      company_sfid: orgUid,
+      return_url: returnUrl,
+      authority_acked: request.authorityAcked,
+      embargo_acked: request.embargoAcked,
+    };
+
+    let result: EasyClaSelfServeCorporateSignatureOutput | null;
+    try {
+      result = await gatewayFetch<EasyClaSelfServeCorporateSignatureOutput>(req, `${claServiceBaseUrl(SERVICE)}/v4/self-serve/request-corporate-signature`, {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+        errorMessage: 'Failed to request the corporate CLA signature',
+        errorCode: 'UPSTREAM_ERROR',
+        method: 'POST',
+        body,
+        // A refusal from this endpoint names the caller's LF username when it is about scope, and
+        // the organization's trade-compliance standing when it is about sanctions. Neither belongs
+        // in an application log. Full redaction would take the refusal sentence with it — the body
+        // is the only place that sentence exists — so the body is kept out of the log here and
+        // dropped from the error below, once the message has been taken out of it.
+        redactResponseBodyFromLogs: true,
+      });
+    } catch (error) {
+      // A 403 here is a sentence written for the signatory — the trade-compliance refusal names
+      // the reason and the support route, and the authority refusal names the missing scope.
+      // Relabelling is what puts those words on screen instead of "403 Forbidden".
+      //
+      // Then the body goes, message already extracted. Without that second step the error reaches
+      // the API error handler still carrying it, and `getLogContext` writes it to the log line
+      // that handler emits — which is the same disclosure the fetch option just prevented.
+      throw withoutUpstreamBody(withProducerRefusalMessage(error, 'org_cla_request_corporate_signature', SERVICE));
+    }
+
+    const signUrl = result?.sign_url?.trim() ?? '';
+    const signatureId = result?.signature_id?.trim() ?? '';
+
+    // An empty signing address is how upstream signals that the agreement was emailed to a named
+    // signatory instead — a shape this route never requests, since it sends no `send_as_email`.
+    // Receiving one means the request was not fulfilled the way it was made, so it fails loudly.
+    // Navigating to an empty address would send the signatory to this application's own root and
+    // read as a successful hand-off that silently signed nothing.
+    // The scheme is checked, not just the presence of a string. The client assigns this value
+    // straight to `document.location.href`, so a `javascript:` address coming back from a
+    // malformed or compromised response would execute in this application's origin, with this
+    // application's session — and it would arrive at exactly the moment the signatory is
+    // expecting to be sent somewhere. Nothing downstream of here looks at it again.
+    //
+    // Scheme only, not a host allowlist. The signing addresses are EasyCLA's to choose and it has
+    // not published the set, so pinning hosts here would break the hand-off the first time one
+    // changed. The scheme is the part that carries the execution risk.
+    if (signUrl && !isHttpsUrl(signUrl)) {
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream returned a signing address that is not an https URL', {
+        // The address itself is deliberately not logged: it is a capability — anyone holding it can
+        // open a named person's agreement — and if it is hostile it does not belong in a log either.
+        sign_url_scheme: urlSchemeForLog(signUrl),
+      });
+      throw new MicroserviceError('Upstream returned an unusable corporate signing address', 502, 'CLA_SIGN_URL_INVALID', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
+    if (!signUrl || !signatureId) {
+      // The fields, not the severity: the throw below reaches the shared error handler, which logs
+      // the failure centrally. Duplicating that here as an error would double-count it.
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream returned no usable signing session', {
+        has_sign_url: !!signUrl,
+        has_signature_id: !!signatureId,
+      });
+      throw new MicroserviceError('Upstream opened no usable corporate signing session', 502, 'CLA_SIGN_SESSION_INCOMPLETE', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
+    // The agreement is requested by project, not by CLA Group: the upstream input takes
+    // `project_sfid` and has no field for a CLA Group, so the group the signatory chose cannot be
+    // bound to the request. It comes back on the response, and that echo is the only place the two
+    // can be compared. Without this check a project whose CLA Group mapping moved between the
+    // search and the confirmation — or a client that posted a mismatched pair — hands the signatory
+    // a session for an agreement they did not choose, and nothing anywhere would say so.
+    //
+    // This necessarily refuses after the envelope exists, leaving one abandoned upstream. That is
+    // the cheaper of the two outcomes by a wide margin: the alternative is a corporate agreement
+    // signed against the wrong CLA Group, which is a legal instrument that cannot be withdrawn by
+    // this application. Binding the group in the request instead needs an upstream field.
+    // Compared canonically, never as raw strings. The request boundary accepts the hyphenated and
+    // unhyphenated spellings in either case, because the producer does, and the producer answers in
+    // its own canonical one — so a request that spelled the id differently would fail a raw
+    // comparison and have a perfectly valid signing session refused out from under it.
+    //
+    // An absent echo is refused for the same reason a mismatched one is. The field is declared
+    // always-present upstream, so losing it means the check itself is gone — and a session that
+    // cannot be shown to be the chosen agreement is indistinguishable, from here, from one that is
+    // not. Proceeding would hand it over on the strength of the field being missing.
+    const returnedClaGroupId = result?.cla_group_id?.trim() ?? '';
+    if (!returnedClaGroupId) {
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream opened a session it attributed to no CLA Group', {
+        requested_cla_group_id: request.claGroupId,
+        project_sfid: request.projectSfid,
+      });
+      throw new MicroserviceError('Upstream opened a corporate signing session it attributed to no CLA Group', 502, 'CLA_SIGN_GROUP_UNVERIFIABLE', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
+    if (!isSameClaGroup(returnedClaGroupId, request.claGroupId)) {
+      logger.warning(req, 'org_cla_request_corporate_signature', 'upstream opened a session for a different CLA Group', {
+        requested_cla_group_id: request.claGroupId,
+        returned_cla_group_id: returnedClaGroupId,
+        project_sfid: request.projectSfid,
+      });
+      throw new MicroserviceError('Upstream opened a signing session for a different CLA Group', 502, 'CLA_SIGN_GROUP_MISMATCH', {
+        operation: 'org_cla_request_corporate_signature',
+        service: SERVICE,
+      });
+    }
+
+    // A corporate agreement was just opened — the notable business event on this path, and the only
+    // record tying this request to the signature it created.
+    logger.info(req, 'org_cla_request_corporate_signature', 'opened a corporate signing session', { org_uid: orgUid, signature_id: signatureId });
+
+    // The signature id goes back with the address because the address cannot carry it: `return_url`
+    // is an input to the request above and is therefore fixed before a signature exists, so the
+    // client is the only place the two are ever held together — and landing the signatory back on
+    // the agreement they signed needs both.
+    return { signUrl, signatureId };
   }
 }

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -354,3 +354,48 @@ export interface EasyClaSignedDocument {
   signatureID?: string;
   signedClaUrl?: string;
 }
+
+/**
+ * Request body for `POST /v4/self-serve/request-corporate-signature`
+ * (`#/definitions/self-serve-corporate-signature-input`).
+ *
+ * **snake_case in both directions**, unlike the sibling `prepare-sign` endpoint, which is
+ * camelCase in both. Mirrored exactly as it goes on the wire so the spelling boundary sits in
+ * one place — the mapping in `OrgClaService.requestCorporateSignature` — rather than leaking
+ * into the shared contract.
+ *
+ * Four properties the schema defines are deliberately absent: `signing_entity_name`,
+ * `send_as_email`, `authority_name` and `authority_email`. They belong to the send-by-email and
+ * designee paths, which are not implemented here; omitting them from the type is what stops one
+ * being set by accident.
+ */
+export interface EasyClaSelfServeCorporateSignatureInput {
+  project_sfid: string;
+  company_sfid: string;
+  /** Absolute https URL. EasyCLA stores it and later redirects to it verbatim. */
+  return_url: string;
+  /**
+   * Both attestations must be literally `true` or the CLA service refuses ahead of any signing
+   * work. Required as non-optional booleans here so the value has to be supplied by the caller
+   * and cannot default in.
+   */
+  authority_acked: boolean;
+  embargo_acked: boolean;
+}
+
+/**
+ * Response for `POST /v4/self-serve/request-corporate-signature`
+ * (`#/definitions/self-serve-corporate-signature-output`).
+ *
+ * Every field is `x-omitempty: false` upstream, so a present-but-empty string is what a missing
+ * value looks like — hence `sign_url` is checked for content, not for presence.
+ */
+export interface EasyClaSelfServeCorporateSignatureOutput {
+  signature_id?: string;
+  /** Empty when the request was sent as an email to a named signatory — never on this path. */
+  sign_url?: string;
+  cla_group_id?: string;
+  project_sfid?: string;
+  company_id?: string;
+  company_sfid?: string;
+}

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { OrgClaGroup, OrgClaStatusDisplay } from '../interfaces/cla.interface';
+import type { OrgClaDetailTab, OrgClaGroup, OrgClaStatusDisplay } from '../interfaces/cla.interface';
 
 /** Long enough to not query on every keystroke, short enough that the CLA-group list feels live. */
 export const CLA_GROUP_SEARCH_DEBOUNCE_MS = 250;
@@ -185,6 +185,171 @@ export const CLA_MANAGER_MODAL_COPY = {
 } as const;
 
 /**
+ * The Overview body for an agreement the organization has not signed.
+ *
+ * Reached only through the pre-signing preview, which builds its agreement from the picker's
+ * choice. The organization's own list cannot show this state: upstream draws every row from a
+ * signature its query has already filtered to signed. Before this copy existed the tab rendered a
+ * heading and then nothing.
+ *
+ * Taken verbatim from the M3 prototype, steps and all. The three steps are the only place the
+ * consequence of signing is spelled out before it happens: that whoever signs becomes the initial
+ * CLA Manager, and what that role then controls. Paraphrasing them would quietly change what the
+ * organization is told it is agreeing to arrange.
+ */
+export const ORG_CLA_NOT_STARTED_COPY = {
+  /** `company` and `claGroup` are the organization's and the agreement's names. */
+  lead: (company: string, claGroup: string): string => `${company} has not yet signed a CLA for ${claGroup}.`,
+  stepsHeading: "Here's what the process looks like:",
+  steps: [
+    {
+      label: 'Step 1:',
+      body: 'You will identify who should be the initial CLA Manager. The CLA Manager is the person who manages the list of approved contributors. This might be you, or might be someone else at your company.',
+    },
+    { label: 'Step 2:', body: 'That person will be able to sign the CLA (or send it to someone else for signature).' },
+    { label: 'Step 3:', body: 'Finally, the CLA Manager will be able to start approving contributors and adding other CLA Managers.' },
+  ],
+  startLabel: 'Start the CLA process',
+} as const;
+
+/**
+ * Where EasyCLA returns a signatory after signing a corporate CLA (#1983). Mirrors the `easycla`
+ * child route under /org in the org dashboard routes.
+ *
+ * Sibling of `MY_CLAS_PATH` for the same reason that one is shared: the BFF derives the return
+ * address from the request Host, and the two hand-offs must not disagree on where they land.
+ */
+export const ORG_EASYCLA_PATH = '/org/easycla';
+
+/**
+ * Child segment of `ORG_EASYCLA_PATH` holding the preview a signatory reads before starting a
+ * corporate CLA (#1983).
+ *
+ * Shared because the route declares it and the CLA picker navigates to it, and the two cannot be
+ * allowed to disagree: `:signatureId` is declared alongside it, so a segment spelled differently
+ * in one place matches as a signature id and renders the not-found state instead.
+ */
+export const ORG_EASYCLA_NEW_SEGMENT = 'new';
+
+/**
+ * Key the picker's chosen CLA Group travels under, in the router state of the navigation to
+ * `ORG_EASYCLA_NEW_SEGMENT` (#1983).
+ *
+ * State rather than the address, because there is nothing in the address to resolve: the CLA
+ * service exposes no fetch-a-CLA-group-by-id endpoint — `/cla-group/{id}` offers only PUT and
+ * DELETE, and the search takes a term — so ids in the URL would be decorative and the display
+ * names would have to ride along with them, leaving the page to render its heading from text
+ * taken out of the URL.
+ */
+export const ORG_CLA_SIGN_SELECTION_STATE = 'orgClaSignSelection';
+
+/**
+ * `sessionStorage` key holding the signature a corporate signing session just created, so the
+ * signatory returns to the agreement they signed rather than to the list (#1983).
+ *
+ * `sessionStorage` precisely because router state is not available: the return from DocuSign is a
+ * cross-site round trip, which no in-memory or history-bound value survives, and this does — in
+ * the one tab that made the request. The value is single-use and cleared on the way back.
+ */
+export const ORG_CLA_SIGNED_SIGNATURE_KEY = 'lfx.orgCla.signedSignatureId';
+
+/**
+ * Query parameter naming the organization a corporate signing session was opened for, carried on
+ * `ORG_EASYCLA_PATH` when EasyCLA returns the signatory (#1983).
+ *
+ * The return is a cross-site navigation, and which organization is selected survives only in a
+ * `SameSite=Lax` cookie. When that cookie does not come back the page falls to the first
+ * organization in the viewer's list, so a signatory who signed for one company returns looking at
+ * another — reading as though the signature landed on the wrong organization.
+ *
+ * Shared because the BFF writes it and the Org Lens page reads it. **It names an organization; it
+ * does not grant one.** The page resolves it against the viewer's own authorized organizations and
+ * ignores anything absent from that list, so a crafted link cannot select an organization the
+ * viewer does not hold.
+ */
+export const ORG_EASYCLA_RETURN_ORG_PARAM = 'org';
+
+/**
+ * Copy for the corporate signing flow (#1983), taken verbatim from the M3 prototype.
+ *
+ * Held here rather than inlined in the template because this is the first attestation the
+ * product renders itself — every earlier CLA surface handed off to another product before any
+ * attestation appeared. Wording that a signatory affirms under their own authority should not
+ * be reachable by a template edit that reads as a copy tweak, and keeping it in one file gives
+ * the legal review a single subject.
+ *
+ * Not paraphrased, not re-ordered, not shortened.
+ */
+export const CCLA_SIGN_COPY = {
+  attestation: {
+    header: 'Confirm Authorization to Sign the CLA',
+    authorityHeading: 'Authorization Confirmation',
+    authorityLabel: 'I am authorized to sign this Contributor License Agreement (CLA) on behalf of my company.',
+    embargoHeading: 'Compliance Confirmation',
+    embargoLabel: 'I hereby certify that I am not, and/or the organization I am representing is not:',
+    embargoConditions: [
+      'located in Cuba, Iran, North Korea, Syria, the Crimea Region of Ukraine, or the Russian-controlled areas of the Donetsk or Luhansk regions of Ukraine;',
+      'owned or controlled by, acting for or on behalf of, or an individual or entity that has in the past acted for or on behalf of the Government of Cuba, Iran, North Korea, Syria, or Venezuela;',
+    ],
+    /**
+     * The third condition carries a link mid-sentence, so it cannot sit in the array above
+     * without the template either rendering markup from a string or losing the link.
+     */
+    embargoSanctionsCondition: {
+      before: "listed as a blocked person by the U.S. Department of the Treasury's ",
+      linkText: 'Office of Foreign Assets Control (OFAC)',
+      linkUrl: 'https://ofac.treasury.gov/sanctions-programs-and-country-information',
+      after: ' or directly or indirectly owned 50 percent or more by such a listed person',
+    },
+    continueLabel: 'Continue',
+    cancelLabel: 'Cancel',
+  },
+  preparing: {
+    header: 'Configuring CLA Manager Settings…',
+    body: 'Please wait while we configure the initial CLA Manager settings for this CLA.',
+    /** Stated before the signatory commits, so the consequence is not first learned after signing. */
+    consequence: 'When this CLA is signed, you will be the initial CLA Manager.',
+  },
+  /**
+   * No cancel label, deliberately. By the time this state is on screen the agreement and its
+   * DocuSign envelope already exist upstream, and the address below is the only way anyone reaches
+   * them — so there is no exit here that does not abandon a real agreement. The one way on is
+   * forward, and the copy says the envelope is already waiting rather than implying it is not.
+   */
+  ready: {
+    header: 'Review CCLA',
+    body: 'Your CCLA is ready and waiting for signature. Continue to review and sign it. After the CCLA is signed, you will be the initial CLA Manager and authorized to approve contributors and add additional CLA Managers.',
+    continueLabel: 'Review and Sign CCLA',
+  },
+  failure: {
+    header: 'Unable to prepare CLA',
+    /**
+     * Only for a failure the CLA service did not explain. A refusal it *did* explain is shown in
+     * its own words — it names the reason and what to do next, and substituting this would
+     * discard both.
+     */
+    body: 'We could not prepare this CLA right now. Please try again, or contact support if the problem continues.',
+  },
+  picker: {
+    header: 'Sign a CLA',
+    body: 'Choose the project, CLA group, or repository source (GitHub, GitLab, or Gerrit), for which you want to sign a CLA.',
+    placeholder: 'Search projects, CLA groups, repo sources, or paste a repo link',
+    empty: 'Search for a project, CLA group, repo source, or paste a repo link.',
+    noMatch: 'No matching projects, CLA groups, or foundations.',
+    continueLabel: 'Continue to sign →',
+    cancelLabel: 'Cancel',
+    /** Why a row cannot be signed. Shown on the row, because the row stays visible. */
+    multiProjectDisabledReason: 'This CLA group covers several projects and cannot be signed from here.',
+    cclaDisabledReason: 'This CLA group does not offer a corporate CLA.',
+    /**
+     * Names the organization rather than the CLA group, because that is the true scope of the
+     * refusal: the group is not spent, this organization's corporate agreement for it exists.
+     */
+    alreadySignedDisabledReason: 'Your organization has already signed a corporate CLA for this CLA group.',
+  },
+} as const;
+
+/**
  * Tab order of the Organization Lens CLA Group detail page. `OrgClaDetailTab` is derived from
  * this, so the set exists once: a tab added here is a compile error everywhere that switches on
  * the union until it is handled.
@@ -213,4 +378,30 @@ export const ORG_CLA_HEADING_STATUS: Record<OrgClaGroup['status'], string> = {
   signed: 'Signed',
   'not-started': 'Not yet signed',
   sanctioned: 'Unavailable',
+};
+
+/**
+ * Why the CLA Managers and Approval List tabs hold nothing until the agreement is signed, taken
+ * verbatim from the M3 prototype's locked panels.
+ *
+ * Only these two tabs. Both describe a role and a rule set that come into existence *with* the
+ * signature — the signatory becomes the initial CLA Manager, and approval entries are what that
+ * manager then maintains — so on an unsigned agreement there is nothing to list rather than a list
+ * that failed to load. The remaining tabs are unbuilt for every agreement, signed or not, and
+ * saying "once this CLA is signed" on them would promise content signing does not produce.
+ *
+ * Reached only through the pre-signing preview, since upstream's list draws every row from a
+ * signature its query has already filtered to signed. That makes the preview the sole place these
+ * panels render — which is why they are copy rather than an empty section. This is the same gap
+ * the empty Overview had.
+ */
+export const ORG_CLA_LOCKED_TAB_COPY: Partial<Record<OrgClaDetailTab, { title: string; subtitle: string }>> = {
+  managers: {
+    title: 'CLA Managers become available once this CLA is signed',
+    subtitle: 'The person who coordinates signing becomes the initial CLA Manager once this CLA is signed. Additional managers can be added afterward.',
+  },
+  approval: {
+    title: 'The approval list becomes available once this CLA is signed',
+    subtitle: 'Sign this CLA first, then add approval list entries to automatically cover matching contributors.',
+  },
 };

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -27,11 +27,19 @@ export const ORG_LENS_ROI_ENABLED_FLAG = 'org-lens-roi-enabled';
  * module invisible. The route guard fails closed (unlike `myClasEnabledGuard`).
  *
  * Evaluated through `FeatureFlagService.getBooleanFlag`, which is the Web SDK and never runs
- * server-side, so this hides the route and nav without closing the BFF. That is deliberate and
- * matches M1/M2: the module's routes still require an Org Lens grant, and the data they read is
- * already reachable through the ACS-authorized EasyCLA APIs and the Corporate CLA Console, so a
- * second env-var gate would add a GitOps round-trip to every rollout without withholding
- * anything. Revisit if M3 write paths (sign, managers, approval list) land on these routes.
+ * server-side, so this hides the route and nav without closing the BFF. **Turning this flag off
+ * therefore stops the UI reaching the module; it does not stop a direct call to the BFF.** It is
+ * not a kill switch, and it is not an authorization boundary — the routes are protected by the
+ * Org Lens grant, by `blockDuringImpersonation` on the write, and by the CLA service's own
+ * signing-authority and trade-compliance checks.
+ *
+ * The first M3 write path has now landed on these routes: corporate CLA signing (#1983), which
+ * creates a signature record and a DocuSign envelope. A server-side gate was reconsidered at that
+ * point, as the note here previously said it should be, and still not added — the same corporate
+ * signature is requestable by the same caller through the ACS-authorized EasyCLA v4 API and the
+ * Corporate CLA Console, so a gate withholds no capability while costing a GitOps round-trip and
+ * a pod roll per rollout. What changed is that this is now written down as a decision about a
+ * write, rather than resting on the reads being harmless.
  */
 export const ORG_LENS_CLA_M3_ENABLED_FLAG = 'org-lens-cla-m3-enabled';
 /**

--- a/packages/shared/src/constants/regex.constants.ts
+++ b/packages/shared/src/constants/regex.constants.ts
@@ -10,6 +10,19 @@
  */
 export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * A CLA Group UUID as the EasyCLA producer spells it — 8-4-4-4-12 hex, hyphens optional, either
+ * case, because the producer's own pattern accepts all of those spellings. Deliberately looser
+ * than `UUID_REGEX`, which requires the hyphens.
+ *
+ * Because the accepted spellings differ from each other, **two identifiers that match this pattern
+ * can be the same CLA Group and still not be string-equal.** Never compare two of these directly;
+ * put both through `canonicalClaGroupId` first. Comparing raw is how a valid corporate signing
+ * session came to be refused as a mismatch: the request carried one spelling and the producer
+ * echoed the canonical one back.
+ */
+export const CLA_GROUP_ID_PATTERN = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
 /** Salesforce Account ID — "001" prefix + 12 (15-char form) or 15 (18-char form) alphanumeric chars. General Salesforce account-id validator (events, analytics). */
 export const SALESFORCE_ACCOUNT_ID_PATTERN = /^001[A-Za-z0-9]{12,15}$/;
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -219,6 +219,18 @@ export interface ClaGroupOption {
   /** Full repository name the term resolved to — set only when `matchTypes` includes `repository`. */
   matchedRepositoryName?: string;
   matchedRepositoryURL?: string;
+  /**
+   * Salesforce id of the project a corporate signature is requested against (#1983).
+   *
+   * **Set only by the Organization Lens sign-options route.** The Me-lens search omits it: that
+   * hand-off is keyed on `claGroupId` alone, and a field no template reads still ships to the
+   * browser inside the transferred state.
+   *
+   * Absent on the Org Lens path too when the CLA group maps to several projects with no
+   * foundation-level row — upstream declines to pick one arbitrarily. That is a real property of
+   * the CLA group, not a failure, and it makes the group unsignable from here.
+   */
+  projectSfid?: string;
 }
 
 /**
@@ -649,11 +661,16 @@ export interface OrgClaGroup {
   /**
    * Whether a signed CCLA actually exists, taken from upstream's own flag.
    *
-   * Deliberately separate from `status`, which cannot answer this: sanctions win the single
-   * status slot, so a `sanctioned` row may be signed or unsigned. Anything deciding whether
-   * there is a document to fetch must read this rather than infer from the status, and
-   * `signedOn` is not a stand-in either — it is additionally conditional on upstream sending
-   * a date, so a signed agreement can carry no date and still have a document.
+   * Deliberately separate from `status`, which asks a different question: `status` collapses a
+   * fact about the entity (sanctions) and a fact about the agreement (signing) into one slot, so
+   * `status !== 'signed'` cannot be read as "there is no document".
+   *
+   * The list endpoint cannot currently produce a row where the two disagree — it builds every row
+   * from a signature its own query has already filtered to signed — but this shape is not the
+   * list's alone. The pre-signing preview constructs one for an agreement nobody has signed, and
+   * the detail page's download gate serves both sources from this field. `signedOn` is not a
+   * stand-in for it either: that field is additionally conditional on upstream sending a date, so
+   * a signed agreement can carry no date and still have a document.
    */
   signed: boolean;
   status: OrgClaGroupStatus;
@@ -718,4 +735,127 @@ export interface OrgClaCoverageDialogData {
   claGroupName: string;
   foundationName?: string;
   projects: OrgClaGroupProject[];
+}
+
+/**
+ * One hand-off request for a corporate CLA (#1983).
+ *
+ * The organization is deliberately absent: it comes from the grant-checked `:orgUid` path
+ * segment. So is the return address, which the BFF derives from the request — EasyCLA stores it
+ * and later redirects to it verbatim, so a client-supplied one would be an open redirect.
+ */
+export interface OrgClaSignRequest {
+  /** From the chosen search result. Keys the corporate signature upstream. */
+  projectSfid: string;
+  claGroupId: string;
+  /**
+   * The signatory's own checkbox state at the moment they continued — never a literal, never
+   * inferred from having reached this step. The two attestations are the legally operative part
+   * of this request, and the value that matters is the one the signatory actually set.
+   */
+  authorityAcked: boolean;
+  embargoAcked: boolean;
+}
+
+/**
+ * The signing session EasyCLA opened, as the client consumes it (#1983).
+ *
+ * The address and the signature it belongs to, and nothing else. Upstream also returns the CLA
+ * group, project and company identifiers, none of which has a consumer here — the hand-off
+ * navigates and the page is replaced.
+ *
+ * The signature id is carried because the return address cannot name it. `return_url` is an
+ * *input* to the upstream request, fixed before a signature exists, so the only place the id and
+ * the address are ever held together is this response — and landing the signatory back on the
+ * agreement they just signed needs both.
+ */
+export interface OrgClaSignResponse {
+  /**
+   * Where the signatory completes the ceremony. Navigated to as returned, never composed.
+   *
+   * Never empty on this path: upstream leaves it empty only for a request sent as an email to a
+   * named signatory, which this route does not make, so an empty value is a failure rather than
+   * a state to render.
+   */
+  signUrl: string;
+  /**
+   * The corporate signature this session will complete — the id that keys its row on the
+   * organization's CLA list, so the return can land on that agreement.
+   *
+   * A pointer to a named organization's agreement, and held accordingly: the client stashes it
+   * for the length of the round trip, spends it once, and never puts it in an address.
+   */
+  signatureId: string;
+}
+
+/**
+ * The two confirmations the signatory gave, as they actually stood when they continued (#1983).
+ *
+ * A distinct type from the request so the attestation step can close with exactly this and
+ * nothing else — the step that collects them is the only place entitled to say what they were.
+ */
+export interface OrgClaSignAttestations {
+  authorityAcked: boolean;
+  embargoAcked: boolean;
+}
+
+/** What the Org Lens CLA group picker is given. */
+export interface OrgClaGroupSelectDialogData {
+  orgUid: string;
+  /**
+   * The organization's corporate CLAs, so the picker can refuse a CLA Group it already holds one
+   * for. The list is the one already loaded on the CLAs page the picker opens over — it is handed
+   * down rather than fetched again, mirroring `ClaGroupSelectDialogData`.
+   *
+   * Empty is a safe value and is what the page passes when its response belongs to a different
+   * organization: no row is refused, which is the behaviour before this check existed.
+   */
+  claGroups: OrgClaGroup[];
+}
+
+/** What the Org Lens CLA group picker closes with. */
+export interface OrgClaGroupPickerResult {
+  claGroupId: string;
+  projectSfid: string;
+  projectName: string;
+}
+
+/**
+ * The chosen CLA Group as it travels from the picker to the pre-signing preview page (#1983).
+ *
+ * A superset of what the signing request needs, because the preview has to *name* the agreement
+ * as well as key it. Nothing on the receiving page can look these names up: the CLA service has
+ * no fetch-a-CLA-group-by-id endpoint, so a page handed only ids could render a heading for an
+ * agreement it cannot describe.
+ */
+export interface OrgClaSignSelection extends OrgClaGroupPickerResult {
+  /**
+   * The CLA Group's own name, which the preview heads the page with — distinct from
+   * `projectName`, the covered project the corporate signature is keyed on. The two differ
+   * routinely ("Cascade CLA" over "Cascade"), and search names them separately.
+   */
+  claGroupName: string;
+}
+
+/**
+ * A picker row, plus why it cannot be chosen. `disabledReason` is null when the row is selectable.
+ *
+ * A row the organization cannot sign keeps its place and states its reason rather than being
+ * filtered out, so the reason is part of the row's shape rather than a lookup beside it.
+ */
+export interface OrgClaGroupOptionView extends ClaGroupOptionView {
+  disabledReason: string | null;
+}
+
+/**
+ * What the hand-off dialog is given: the chosen CLA group, and the confirmations behind it.
+ *
+ * The attestations travel as data rather than being re-collected here, because the step that
+ * collected them is the only one entitled to say what the signatory set.
+ */
+export interface OrgClaSignHandoffDialogData {
+  orgUid: string;
+  projectSfid: string;
+  claGroupId: string;
+  attestations: OrgClaSignAttestations;
 }

--- a/packages/shared/src/utils/cla-identifier.utils.spec.ts
+++ b/packages/shared/src/utils/cla-identifier.utils.spec.ts
@@ -1,0 +1,53 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { canonicalClaGroupId, isSameClaGroup } from './cla-identifier.utils';
+
+const HYPHENATED = '01234567-89ab-cdef-0123-456789abcdef';
+const BARE = '0123456789abcdef0123456789abcdef';
+
+describe('canonicalClaGroupId', () => {
+  it.each([
+    [HYPHENATED, BARE],
+    [HYPHENATED.toUpperCase(), BARE],
+    [BARE, BARE],
+    [`  ${HYPHENATED}  `, BARE],
+  ])('canonicalises %p', (input, expected) => {
+    expect(canonicalClaGroupId(input)).toBe(expected);
+  });
+
+  // An empty canonical form is the "no answer" value the comparison relies on, so anything that is
+  // not CLA-Group-shaped has to reach it rather than pass through as itself.
+  it.each([[''], ['   '], ['not-a-uuid'], ['0123456789abcdef0123456789abcde'], [null], [undefined], [42], [{}]])('rejects %p', (input) => {
+    expect(canonicalClaGroupId(input)).toBe('');
+  });
+});
+
+describe('isSameClaGroup', () => {
+  // The case this exists for: the request carries one accepted spelling and the producer answers in
+  // its own. Comparing raw is what made a valid signing session look like a mismatch.
+  it.each([
+    [HYPHENATED, BARE],
+    [HYPHENATED, HYPHENATED.toUpperCase()],
+    [BARE.toUpperCase(), HYPHENATED],
+  ])('treats %p and %p as the same group', (left, right) => {
+    expect(isSameClaGroup(left, right)).toBe(true);
+  });
+
+  it('distinguishes genuinely different groups', () => {
+    expect(isSameClaGroup(HYPHENATED, 'fedcba98-7654-3210-fedc-ba9876543210')).toBe(false);
+  });
+
+  // Two values that cannot be read are not evidence of a match. Folding them together would make
+  // the mismatch guard pass on exactly the input it is least able to vouch for.
+  it.each([
+    ['', ''],
+    ['nonsense', 'nonsense'],
+    [null, null],
+    [undefined, undefined],
+  ])('does not call %p and %p the same group', (left, right) => {
+    expect(isSameClaGroup(left, right)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/cla-identifier.utils.ts
+++ b/packages/shared/src/utils/cla-identifier.utils.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CLA_GROUP_ID_PATTERN } from '../constants/regex.constants';
+
+/**
+ * The one spelling of a CLA Group id that two values can be compared in.
+ *
+ * `CLA_GROUP_ID_PATTERN` accepts hyphenated and unhyphenated forms in either case, because the
+ * EasyCLA producer does. That means two strings can name the same CLA Group and still fail `===`,
+ * so any comparison has to canonicalise first — lower-cased, hyphens removed. Returns an empty
+ * string for anything that is not CLA-Group-shaped, so a malformed value can never canonicalise
+ * into an accidental match with another malformed one.
+ */
+export function canonicalClaGroupId(value: unknown): string {
+  if (typeof value !== 'string') return '';
+
+  const trimmed = value.trim();
+  if (!CLA_GROUP_ID_PATTERN.test(trimmed)) return '';
+
+  return trimmed.toLowerCase().replaceAll('-', '');
+}
+
+/**
+ * Whether two CLA Group identifiers name the same group, allowing for the spellings the producer
+ * accepts. Two unrecognizable values are never "the same": both canonicalise to empty, and an
+ * empty canonical form is treated as no answer rather than as a match.
+ */
+export function isSameClaGroup(left: unknown, right: unknown): boolean {
+  const a = canonicalClaGroupId(left);
+  return a !== '' && a === canonicalClaGroupId(right);
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -58,6 +58,7 @@ export * from './persona.utils';
 export * from './metric-trend.utils';
 export * from './org-meetings-insights.utils';
 export * from './cla-view.utils';
+export * from './cla-identifier.utils';
 export * from './cla-manager-actions.utils';
 export * from './org-cla-view.utils';
 export * from './committee-engagement-classifier.utils';

--- a/packages/shared/src/utils/org-cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/org-cla-view.utils.spec.ts
@@ -3,7 +3,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { orgClaCoverageChips, orgClaCoverageSummary, orgClaOpenLabel } from './org-cla-view.utils';
+import type { OrgClaSignSelection } from '../interfaces/cla.interface';
+import { orgClaCoverageChips, orgClaCoverageSummary, orgClaOpenLabel, orgClaPreviewGroup } from './org-cla-view.utils';
 
 describe('orgClaOpenLabel', () => {
   it('names the agreement alone when nothing else distinguishes it', () => {
@@ -86,5 +87,43 @@ describe('orgClaCoverageSummary', () => {
 
   it('summarises nothing when the agreement names no projects', () => {
     expect(orgClaCoverageSummary({ projects: [] })).toBe('');
+  });
+});
+
+describe('orgClaPreviewGroup', () => {
+  const selection: OrgClaSignSelection = {
+    claGroupId: 'cla-group-uuid-1',
+    claGroupName: 'Cascade CLA',
+    projectSfid: 'a09410000182dD2AAI',
+    projectName: 'Cascade',
+  };
+
+  it('heads the preview with the CLA Group the picker named, as an agreement nobody has signed', () => {
+    expect(orgClaPreviewGroup(selection)).toMatchObject({ claGroupName: 'Cascade CLA', signed: false, status: 'not-started' });
+  });
+
+  /**
+   * The two fields the signing scope is read from, and the reason this is a function rather than a
+   * spread.
+   *
+   * `projects` holding exactly the entry search named routes the scope through the single-covered-
+   * project branch, which returns the SFID search gave. `foundationSfid` staying unset matters
+   * because that branch is read *first*: setting it would assert a foundation where search may have
+   * named a project, changing the scope the corporate agreement is opened at rather than mislabelling
+   * it. Neither is observable from the preview page's own rendering, which is why they are pinned
+   * here.
+   */
+  it('names exactly the one project search resolved, and asserts no foundation', () => {
+    const group = orgClaPreviewGroup(selection);
+
+    expect(group.projects).toEqual([{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }]);
+    expect(group.foundationSfid).toBeUndefined();
+    expect(group.foundationName).toBeUndefined();
+  });
+
+  // 0, not absent. Absence means the deployment did not report a count; this agreement genuinely has
+  // none, because it has no signature for them to hang off.
+  it('reports no managers and no approval criteria, rather than reporting nothing', () => {
+    expect(orgClaPreviewGroup(selection)).toMatchObject({ claManagersCount: 0, approvalCriteriaCount: 0, needsClaManager: false });
   });
 });

--- a/packages/shared/src/utils/org-cla-view.utils.ts
+++ b/packages/shared/src/utils/org-cla-view.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { OrgClaCoverageChip, OrgClaGroup } from '../interfaces/cla.interface';
+import type { OrgClaCoverageChip, OrgClaGroup, OrgClaSignSelection } from '../interfaces/cla.interface';
 
 export function orgClaCoverageSummary(group: Pick<OrgClaGroup, 'projects'>): string {
   const { projects } = group;
@@ -47,4 +47,40 @@ export function orgClaCoverageChips(group: Pick<OrgClaGroup, 'projects' | 'found
 
   const projectsChip: OrgClaCoverageChip = { label: `Covers ${projects.length} projects`, opensCoverage: true };
   return foundationName ? [{ label: foundationName, opensCoverage: false }, projectsChip] : [projectsChip];
+}
+
+/**
+ * The row the pre-signing preview page renders, built from the picker's choice rather than fetched
+ * (#1983).
+ *
+ * The preview describes an agreement that does not exist yet, so there is no list row to find: the
+ * page is keyed on the CCLA signature id, and nobody has signed. Everything the detail page shows
+ * already works off an `OrgClaGroup`, so this is the one place the selection becomes that shape.
+ *
+ * Two fields carry the whole reason this is a function rather than a spread:
+ *
+ * - **`projects` holds exactly the one entry search named.** That single entry is what routes the
+ *   signing scope through the single-covered-project branch, which returns the SFID search gave.
+ * - **`foundationSfid` is left unset**, even though search resolves `projectSfid` to the foundation
+ *   for a foundation-level group. Setting it would *assert* a foundation where search may have
+ *   named a project, and the signing scope reads `foundationSfid` first — so the assertion would
+ *   change the scope the corporate agreement is opened at rather than merely mislabel it.
+ *
+ * `id` is empty because no signature exists. Nothing keys off it here: the document offer reads
+ * `signed`, and the list lookup is bypassed entirely.
+ */
+export function orgClaPreviewGroup(selection: OrgClaSignSelection): OrgClaGroup {
+  return {
+    id: '',
+    claGroupId: selection.claGroupId,
+    claGroupName: selection.claGroupName,
+    projects: [{ projectName: selection.projectName, projectSfid: selection.projectSfid }],
+    signed: false,
+    status: 'not-started',
+    needsClaManager: false,
+    claManagersCount: 0,
+    // 0, not absent. Absence means the deployment did not report a count; this agreement genuinely
+    // has no approval criteria, because it has no signature for them to hang off.
+    approvalCriteriaCount: 0,
+  };
 }


### PR DESCRIPTION
The server side of the corporate CLA hand-off (#1983): the route that asks EasyCLA to
open a signing session for an organization, the CLA Groups it offers to choose from,
and the shared contract both ends read.

**Nothing user-visible ships here.** No screen calls these endpoints yet, so this can
go to production on its own.

### What the service refuses, and why

- **A signing address whose scheme is not `https`.** The client assigns that value to
  `location.href`, so a `javascript:` address coming back from a malformed or
  compromised response would execute in this origin, with this session, at the moment
  the signatory expects to be sent away. Parsed rather than matched as text, because
  the browser trims and lowercases a scheme before acting on it.
- **A session attributed to a different CLA Group than the one chosen, or to none at
  all.** The upstream input is keyed on a project and has no field for a CLA Group, so
  the echo on the response is the only place the two can be compared. This necessarily
  refuses *after* the envelope exists; an abandoned envelope is much the cheaper
  outcome than a corporate agreement signed against the wrong one.

CLA Group ids are compared canonically — the request boundary accepts hyphenated and
unhyphenated spellings in either case because the producer does, and the producer
answers in its own, so a raw comparison would refuse a valid session out from under
the signatory.

A trade-compliance refusal arrives as a 403 whose body is a sentence written for the
signatory. That sentence reaches the client while the upstream body stays out of the
log line, which is why the error carries a client-facing message separately from the
one that gets logged.

### Reviewing

2,497 lines added, 54% of them tests. Worth a close look: the refusal branches in
`org-cla.service.ts` and the route-level middleware coverage.

First of three stacked PRs that together replace #2236. Refs #1983.
