### PR TITLE
feat(org-lens): sign a corporate CLA from the organization's agreements

### DIFF
--- a/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-easycla.helper.ts
@@ -168,6 +168,81 @@ export function searchInput(page: Page): Locator {
   return page.locator('[data-test="org-easycla-search"]');
 }
 
+// ---------------------------------------------------------------------------
+// The self-sign hand-off (GH-1983)
+// ---------------------------------------------------------------------------
+
+/** The CLA Group search behind the picker. */
+export const SIGN_OPTIONS_ROUTE = '**/api/orgs/*/lens/cla-groups/sign-options*';
+
+/** The write. Every spec below stubs it; none may ever let it reach a real CLA service. */
+export const SIGN_ROUTE = '**/api/orgs/*/lens/cla-groups/sign';
+
+/**
+ * Where the hand-off is told to send the signer.
+ *
+ * A synthetic address on a reserved domain, routed and fulfilled locally by `stubHandoff` so the
+ * browser never leaves the app under test. A real signing address here would create a real
+ * envelope against a real agreement on every run.
+ */
+export const STUB_SIGN_URL = 'https://signing.example.org/session/e2e-stub';
+
+/**
+ * The signature the stubbed hand-off says it opened.
+ *
+ * Deliberately the `id` of the default `claGroup()` row, because that is what makes the return
+ * landing observable: the page only navigates to an agreement it can see in the organization's own
+ * list, so a stub signature absent from the stubbed list would leave the signatory on it.
+ */
+export const STUB_SIGNATURE_ID = 'signature-uuid-1';
+
+/** A searchable CLA Group, corporate-signable unless a case says otherwise. */
+export function signOption(overrides: Record<string, unknown> = {}) {
+  return {
+    claGroupId: 'aaaaaaaa-1111-4111-8111-111111111111',
+    claGroupName: 'Cascade CLA',
+    projectName: 'Cascade',
+    projectSfid: 'a09410000182dD2AAI',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+    ...overrides,
+  };
+}
+
+export function signOptionsResponse(results: ReturnType<typeof signOption>[], truncated = false) {
+  return { searchTerm: 'cascade', resultCount: results.length, truncated, results };
+}
+
+/**
+ * Stubs the whole hand-off chain: the picker's search, the signature request, and the signing
+ * address the request answers with.
+ *
+ * The last one is the important one and is not optional. The component assigns the returned
+ * address to `location.href`, so without a route intercepting it the browser navigates away to
+ * whatever the fixture said — and a fixture that ever named a real signing host would drive a
+ * real DocuSign session from CI. Fulfilling it locally keeps the assertion (did we navigate to
+ * exactly the address the server returned?) while the navigation lands on a blank local page.
+ */
+export async function stubHandoff(page: Page, options: { search?: unknown; sign?: { status: number; body: unknown }; signUrl?: string } = {}): Promise<void> {
+  const signUrl = options.signUrl ?? STUB_SIGN_URL;
+
+  await fulfillJson(page, SIGN_OPTIONS_ROUTE, options.search ?? signOptionsResponse([signOption()]));
+
+  const sign = options.sign ?? { status: 200, body: { signUrl, signatureId: STUB_SIGNATURE_ID } };
+  await page.route(SIGN_ROUTE, (route) => route.fulfill({ status: sign.status, contentType: 'application/json', body: JSON.stringify(sign.body) }));
+
+  await page.route(`${signUrl}**`, (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body data-testid="stub-signing-service">stub signing service</body></html>' })
+  );
+}
+
+/** The picker's search box. Same `data-test` quirk as the list's, for the same reason. */
+export function groupSearchInput(page: Page): Locator {
+  return page.locator('[data-test="org-easycla-group-select-search"]');
+}
+
 /** Skips when the shared Playwright credentials are absent, as every authenticated spec does. */
 export function skipWithoutCredentials(): void {
   if (!process.env.TEST_USERNAME || !process.env.TEST_PASSWORD) {

--- a/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign-robust.spec.ts
@@ -1,0 +1,248 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Lens EasyCLA corporate self-sign — structural E2E (GH-1983).
+ *
+ * The structural half of the repository's dual E2E architecture; `org-easycla-sign.spec.ts` is the
+ * content half. This one asserts the `data-testid` contract, the dialog sequence, and the request
+ * that goes on the wire — not the copy — so the pair fails independently: reworded legal text
+ * breaks only the content spec, and a dialog rebuilt behind the same testids leaves this one green.
+ *
+ * The hand-off's three states are mutually exclusive by construction, so each is pinned together
+ * with the absence of the others. A regression that renders "preparing" alongside "ready" is
+ * otherwise invisible to a spec that only asserts presence — and on this flow that pairing would
+ * show a signatory a spinner above a button that opens a legal agreement.
+ *
+ * Same standing constraint as the content spec: the signing request is stubbed and the address it
+ * returns is intercepted, so no run creates a real agreement or a real envelope.
+ *
+ * Prerequisites: as `org-easycla-sign.spec.ts`.
+ */
+
+import { expect, Page, Request, test } from '@playwright/test';
+
+import {
+  claGroup,
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  fulfillJson,
+  gotoEasyclaList,
+  groupSearchInput,
+  PAGE_LOAD_TIMEOUT,
+  signOption,
+  skipWithoutCredentials,
+  stubHandoff,
+  STUB_SIGN_URL,
+} from './helpers/org-easycla.helper';
+
+const CASCADE = signOption();
+
+// The default budget is one authenticated boot; these cases are a boot plus a four-step chain. The
+// neighbouring Org Lens specs all raise it for the same reason, and the same figure.
+test.setTimeout(120_000);
+
+/** The dialogs, in the order the flow opens them. */
+const PICKER = 'org-easycla-group-select-dialog';
+const ATTESTATION = 'org-easycla-attestation-dialog';
+const HANDOFF = 'org-easycla-sign-handoff-dialog';
+
+/** Start, on the preview page the picker hands the choice to — the step between picker and dialogs. */
+const PREVIEW_START = 'org-easycla-detail-start-cla';
+
+const HANDOFF_STATES = ['org-easycla-sign-preparing', 'org-easycla-sign-ready', 'org-easycla-sign-failed'];
+
+function stubPage(page: Page) {
+  return fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList([claGroup()]));
+}
+
+/** Asserts exactly one hand-off state is on screen. */
+async function onlyState(page: Page, expected: string): Promise<void> {
+  await expect(page.getByTestId(expected)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  for (const other of HANDOFF_STATES.filter((state) => state !== expected)) {
+    await expect(page.getByTestId(other)).toHaveCount(0);
+  }
+}
+
+/**
+ * Picks the CLA Group, which now lands on the preview page rather than opening the attestation.
+ *
+ * The inner `button`, not the `lfx-button` host the test id sits on. Sign CLA is disabled until the
+ * organization context settles, and Playwright's actionability check reads the element it is given
+ * — a custom element, which is never "disabled" — so a click on the host lands on a dead control
+ * instead of waiting for a live one.
+ */
+async function reachPreview(page: Page): Promise<void> {
+  await page.getByTestId('org-easycla-sign-cla').locator('button').click();
+  await expect(page.getByTestId(PICKER)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  await groupSearchInput(page).fill('cascade');
+  await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
+  await page.getByTestId('org-easycla-group-continue').locator('button').click();
+
+  await expect(page.getByTestId(PREVIEW_START)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+async function reachAttestation(page: Page): Promise<void> {
+  await reachPreview(page);
+  await page.getByTestId(PREVIEW_START).locator('button').click();
+}
+
+async function reachHandoff(page: Page): Promise<void> {
+  await reachAttestation(page);
+  await page.locator('label[for="authorityAcked"]').click();
+  await page.locator('label[for="embargoAcked"]').click();
+  await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+}
+
+test.describe('Org Lens EasyCLA corporate self-sign — structure', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test.beforeEach(() => skipWithoutCredentials());
+
+  // One step at a time. The flow replaces each with the next rather than stacking them, so a
+  // regression that leaves the picker mounted behind the attestation would let a signatory change
+  // the CLA Group under a confirmation they have already given.
+  //
+  // The picker and the two dialogs are separated by a page: the choice is carried to the preview by
+  // a router navigation, and both dialogs are opened by that page rather than by the list.
+  test('opens the picker, the preview, then the two dialogs in sequence', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await page.getByTestId('org-easycla-sign-cla').locator('button').click();
+    await expect(page.getByTestId(PICKER)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
+    await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
+
+    await groupSearchInput(page).fill('cascade');
+    await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
+    await page.getByTestId('org-easycla-group-continue').locator('button').click();
+
+    await expect(page).toHaveURL(/\/org\/easycla\/new$/, { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId(PREVIEW_START)).toBeVisible();
+    // The picker does not survive the navigation, and neither dialog opens before Start is pressed —
+    // so nothing is confirmed by arriving here.
+    await expect(page.getByTestId(PICKER)).toHaveCount(0);
+    await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
+    await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
+
+    await page.getByTestId(PREVIEW_START).locator('button').click();
+
+    await expect(page.getByTestId(ATTESTATION)).toBeVisible();
+    await expect(page.getByTestId(HANDOFF)).toHaveCount(0);
+
+    await page.locator('label[for="authorityAcked"]').click();
+    await page.locator('label[for="embargoAcked"]').click();
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId(HANDOFF)).toBeVisible();
+    await expect(page.getByTestId(ATTESTATION)).toHaveCount(0);
+  });
+
+  test('settles the hand-off on exactly one state', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await reachHandoff(page);
+
+    await onlyState(page, 'org-easycla-sign-ready');
+    await expect(page.getByTestId('org-easycla-sign-review')).toBeVisible();
+    // No way out but forward: the agreement and its envelope exist by now, and the address behind
+    // this control is the only thing that reaches them.
+    await expect(page.getByTestId('org-easycla-sign-cancel')).toHaveCount(0);
+  });
+
+  test('settles on the failure state alone when the request is refused', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p, { sign: { status: 403, body: { error: 'Refused', code: 'FORBIDDEN' } } });
+    });
+
+    await reachHandoff(page);
+
+    await onlyState(page, 'org-easycla-sign-failed');
+    await expect(page.getByTestId('org-easycla-sign-failure-message')).toBeVisible();
+    await expect(page.getByTestId('org-easycla-sign-review')).toHaveCount(0);
+  });
+
+  /**
+   * What actually goes on the wire.
+   *
+   * Both confirmations must travel as the booleans the signatory gave, the organization must come
+   * from the path rather than the body, and no signing address may be composed by the client. A
+   * component test cannot see any of this: it asserts on the arguments handed to a stubbed
+   * service, one layer above the request that is the thing the CLA service reads.
+   */
+  test('sends both confirmations as booleans, keyed to the chosen CLA group', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    const signRequest = page.waitForRequest((request: Request) => request.url().includes('/lens/cla-groups/sign') && request.method() === 'POST');
+
+    await reachHandoff(page);
+
+    const body = (await (await signRequest).postDataJSON()) as Record<string, unknown>;
+
+    expect(body['authorityAcked']).toBe(true);
+    expect(body['embargoAcked']).toBe(true);
+    expect(body['claGroupId']).toBe(CASCADE.claGroupId);
+    expect(body['projectSfid']).toBe(CASCADE.projectSfid);
+    // The return address is the server's to derive: a client-supplied one turns the hand-off into
+    // an open redirect, since the CLA service stores it and redirects to it verbatim.
+    expect(body).not.toHaveProperty('claReturnUrl');
+    expect(body).not.toHaveProperty('returnUrl');
+  });
+
+  // The picker is a combobox and the focused element is the text box, so that is where the
+  // combobox state has to live. On the listbox — which nothing ever focuses — it is never
+  // announced, which looks identical on screen and is silent to a screen reader.
+  test('wires the combobox state onto the focused search input', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await page.getByTestId('org-easycla-sign-cla').locator('button').click();
+    const input = groupSearchInput(page);
+
+    await expect(input).toHaveAttribute('role', 'combobox');
+    await expect(input).toHaveAttribute('aria-controls', 'org-easycla-group-select-results');
+
+    await input.fill('cascade');
+    await expect(page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    await input.press('ArrowDown');
+    await expect(input).toHaveAttribute('aria-activedescendant', `org-easycla-group-option-${CASCADE.claGroupId}`);
+
+    // And the keyboard alone completes the choice, which is the reason the wiring exists.
+    await input.press('Enter');
+    await expect(page.getByTestId('org-easycla-group-continue').locator('button')).toBeEnabled();
+  });
+
+  // The hand-off is a full-page navigation in the same tab, not a popup and not an iframe: the
+  // signing service sets its own cookies and redirects back to the return address, neither of
+  // which survives being embedded.
+  test('leaves the app in the same tab, to the address the server returned', async ({ page, context }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubPage(p);
+      await stubHandoff(p);
+    });
+
+    await reachHandoff(page);
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    const pagesBefore = context.pages().length;
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+    expect(context.pages()).toHaveLength(pagesBefore);
+    await expect(page.locator('iframe')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-easycla-sign.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign.spec.ts
@@ -1,0 +1,265 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Lens EasyCLA corporate self-sign — content E2E (GH-1983).
+ *
+ * The content half of the repository's dual E2E architecture; `org-easycla-sign-robust.spec.ts` is
+ * the structural half. This one walks the chain a signatory walks — Sign CLA, choose a CLA Group,
+ * confirm both statements, hand off — and asserts on the words and the destination.
+ *
+ * The unit tests cover each dialog on its own, with the next one's inputs handed to it directly.
+ * What they cannot cover is the chain: three dialogs opened in sequence by a parent that passes
+ * each one's result into the next, an HTTP round trip in the middle, and a full-page navigation at
+ * the end. Every join in that sequence is real here and stubbed there.
+ *
+ * **Nothing in this file may reach a real signing service.** The request creates a corporate
+ * agreement and a *sent* envelope with no rehearsal mode, so the route that answers it is stubbed,
+ * and the address it answers with is a reserved-domain address that is itself routed and fulfilled
+ * locally. A run that navigated to a genuine address would leave an unsigned agreement behind on
+ * every execution, against a real organization.
+ *
+ * Prerequisites:
+ * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD
+ * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+import {
+  claGroup,
+  claGroupList,
+  CLA_GROUPS_ROUTE,
+  EASYCLA_URL,
+  fulfillJson,
+  gotoEasyclaList,
+  groupSearchInput,
+  PAGE_LOAD_TIMEOUT,
+  signOption,
+  signOptionsResponse,
+  skipWithoutCredentials,
+  stubHandoff,
+  STUB_SIGN_URL,
+} from './helpers/org-easycla.helper';
+
+// The default budget is one authenticated boot; these cases are a boot plus a four-step chain. The
+// neighbouring Org Lens specs all raise it for the same reason, and the same figure.
+test.setTimeout(120_000);
+
+const CASCADE = signOption();
+
+function stubList(page: Page) {
+  return fulfillJson(page, CLA_GROUPS_ROUTE, claGroupList([claGroup()]));
+}
+
+/**
+ * Opens the picker and chooses the one signable CLA Group, landing on the preview page.
+ *
+ * The inner `button`, not the `lfx-button` host the test id sits on. Sign CLA is disabled until the
+ * organization context settles, and Playwright's actionability check reads the element it is given
+ * — a custom element, which is never "disabled" — so a click on the host lands on a dead control
+ * instead of waiting for a live one. The whole file's other controls are already reached this way.
+ */
+async function chooseClaGroup(page: Page): Promise<void> {
+  await page.getByTestId('org-easycla-sign-cla').locator('button').click();
+  await expect(page.getByTestId('org-easycla-group-select-dialog')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  await groupSearchInput(page).fill('cascade');
+  await page.getByTestId(`org-easycla-group-select-${CASCADE.claGroupId}`).click();
+  await page.getByTestId('org-easycla-group-continue').locator('button').click();
+
+  await expect(page).toHaveURL(/\/org\/easycla\/new$/, { timeout: PAGE_LOAD_TIMEOUT });
+}
+
+/**
+ * Chooses the CLA Group and starts the process from the preview, leaving the attestation up.
+ *
+ * The preview between them is the part no unit test reaches: the choice crosses a router navigation
+ * as state, and the page it lands on has to read it back before Start can build a request from it.
+ */
+async function chooseThenStart(page: Page): Promise<void> {
+  await chooseClaGroup(page);
+
+  await page.getByTestId('org-easycla-detail-start-cla').locator('button').click();
+  await expect(page.getByTestId('org-easycla-attestation-dialog')).toBeVisible();
+}
+
+/** Ticks both confirmations. The labels are the accessible handles PrimeNG wires to the boxes. */
+async function confirmBoth(page: Page): Promise<void> {
+  await page.locator('label[for="authorityAcked"]').click();
+  await page.locator('label[for="embargoAcked"]').click();
+}
+
+test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test.beforeEach(() => skipWithoutCredentials());
+
+  test('walks the whole chain and hands off to the address the server returned', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+
+    // The whole point of the hand-off: the address is the server's, byte for byte, and the
+    // navigation is a full-page one in the same tab rather than a popup or an embedded frame.
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+  /**
+   * The preview page the picker now hands the choice to, and the reason it exists as a page rather
+   * than a fourth dialog: it names the agreement the two legally operative steps are about.
+   *
+   * Only reachable this way. There is no fetch-a-CLA-group-by-id endpoint, so the address carries
+   * nothing that could rebuild this page — which is also what the case below is about.
+   */
+  test('previews the chosen CLA Group before anything is confirmed', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseClaGroup(page);
+
+    await expect(page.getByTestId('org-easycla-detail-title')).toHaveText(CASCADE.claGroupName);
+    await expect(page.getByTestId('org-easycla-detail-not-started')).toBeVisible();
+    // The row-shaped states of a page that fetches a list. This one fetches none, and either of
+    // them here would tell a signatory the agreement they are about to sign does not exist.
+    await expect(page.getByTestId('org-easycla-detail-not-found-state')).toHaveCount(0);
+    await expect(page.getByTestId('org-easycla-detail-list-loading')).toHaveCount(0);
+  });
+
+  /**
+   * A pasted, bookmarked or linked preview address arrives on a fresh history entry, which carries
+   * no choice — and nothing on the page can rebuild one. Sent back to the list, which is where the
+   * picker is, rather than left on a page headed with a blank name and offering a Start that would
+   * build a request from nothing.
+   *
+   * A reload is *not* this case, which is why it is not the one exercised here: the browser keeps a
+   * history entry's state across a reload, and Angular copies it onto the navigation it synthesises
+   * for one, so a reloaded preview still has the choice it was opened with.
+   */
+  test('sends a preview address that carries no choice back to the list', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await page.goto(`${EASYCLA_URL}/new`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/org\/easycla$/, { timeout: PAGE_LOAD_TIMEOUT });
+  });
+
+
+  /**
+   * The attestation gate, driven the way a signatory would.
+   *
+   * This is the assertion the feature exists to make safe. Continuing without both confirmations
+   * would transmit an affirmation the signatory did not make, and produce a legally binding
+   * document that nothing downstream can distinguish from a genuine one.
+   */
+  test('will not continue until both confirmations are given', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    // No request may leave while the gate is shut, so any that does fails the test rather than
+    // being quietly answered by the stub.
+    let signRequests = 0;
+    page.on('request', (request) => {
+      if (request.url().includes('/lens/cla-groups/sign') && request.method() === 'POST') signRequests += 1;
+    });
+
+    await chooseThenStart(page);
+    const continueButton = page.getByTestId('org-easycla-attestation-continue').locator('button');
+
+    await expect(continueButton).toBeDisabled();
+
+    await page.locator('label[for="authorityAcked"]').click();
+    await expect(continueButton).toBeDisabled();
+
+    await page.locator('label[for="embargoAcked"]').click();
+    await expect(continueButton).toBeEnabled();
+
+    // Withdrawing one closes the gate again, rather than leaving it open on a stale check.
+    await page.locator('label[for="authorityAcked"]').click();
+    await expect(continueButton).toBeDisabled();
+
+    expect(signRequests).toBe(0);
+  });
+
+  /**
+   * A refusal reaches the signatory in the CLA service's own words.
+   *
+   * The trade-compliance refusal is the case this is for: it names the reason and the route to
+   * challenge it, and replacing it with generic copy would leave a signatory with no idea why
+   * their organization cannot sign or who to ask.
+   */
+  test('shows a refusal in the words the CLA service used, not generic failure copy', async ({ page }) => {
+    const refusal = 'This organization requires additional trade compliance review, so the CLA cannot be completed at this time. Contact EasyCLA Support.';
+
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      // The envelope the BFF's error class really serialises to: the sentence under `error`.
+      await stubHandoff(p, { sign: { status: 403, body: { error: refusal, code: 'FORBIDDEN' } } });
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-failed')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-sign-failure-message')).toHaveText(refusal);
+    await expect(page.getByTestId('org-easycla-sign-failure-message')).not.toContainText('We could not prepare this CLA');
+  });
+
+  // A response with no address is how the CLA service says it emailed a named signatory instead —
+  // a shape this flow never asks for. Navigating anyway would send the signer to an empty URL.
+  test('treats a response carrying no signing address as a failure', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p, { sign: { status: 200, body: { signUrl: '' } } });
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-failed')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/org\/easycla/);
+  });
+
+  // A CLA Group with no resolvable project cannot be signed corporately. It stays on screen with
+  // its reason — dropping it would leave the signatory hunting for something they can see in the
+  // legacy console — but it must never become the one a request is built from.
+  test('shows an unsignable CLA group with its reason and refuses to choose it', async ({ page }) => {
+    const multiProject = signOption({ claGroupId: 'bbbbbbbb-2222-4222-8222-222222222222', claGroupName: 'Driftwood Umbrella CLA', projectSfid: undefined });
+
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p, { search: signOptionsResponse([multiProject]) });
+    });
+
+    await page.getByTestId('org-easycla-sign-cla').locator('button').click();
+    await groupSearchInput(page).fill('driftwood');
+
+    await expect(page.getByTestId(`org-easycla-group-disabled-${multiProject.claGroupId}`)).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Forced past the actionability check, which reads `aria-disabled` and would simply refuse to
+    // click. Refusing is not the assertion: what has to be proven is that a click that does land —
+    // as one from a pointing device would — still selects nothing.
+    await page.getByTestId(`org-easycla-group-select-${multiProject.claGroupId}`).click({ force: true });
+
+    await expect(page.getByTestId('org-easycla-group-continue').locator('button')).toBeDisabled();
+    await expect(page.getByTestId('org-easycla-attestation-dialog')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-easycla-sign.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign.spec.ts
@@ -158,7 +158,6 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
     await expect(page).toHaveURL(/\/org\/easycla$/, { timeout: PAGE_LOAD_TIMEOUT });
   });
 
-
   /**
    * The attestation gate, driven the way a signatory would.
    *

--- a/apps/lfx-one/src/app/app.routes.server.ts
+++ b/apps/lfx-one/src/app/app.routes.server.ts
@@ -15,6 +15,16 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Server,
     status: 404,
   },
+  // The corporate CLA preview is defined entirely by a browser-only value: the choice the picker
+  // left on the history entry. The server cannot read it, so it cannot render this page — it would
+  // emit the skeleton, and the browser would then hydrate the preview over it, which is a
+  // structural mismatch rather than a slower first paint. Nothing here is deep-linked or indexed:
+  // the route is reached from the picker, and an address arriving without a choice leaves for the
+  // list.
+  {
+    path: 'org/easycla/new',
+    renderMode: RenderMode.Client,
+  },
   // Catch-all — the global 404 renders here in place (no /not-found redirect). The Express SSR
   // handler rewrites this to HTTP 404 when NotFoundComponent sets the render-context flag.
   {

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { MKTG_OS_AGENTS_ROUTE_SEGMENT } from '@lfx-one/shared/constants';
+import { MKTG_OS_AGENTS_ROUTE_SEGMENT, ORG_EASYCLA_NEW_SEGMENT } from '@lfx-one/shared/constants';
 import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
@@ -169,6 +169,15 @@ export const routes: Routes = [
               {
                 path: '',
                 loadComponent: () => import('./modules/dashboards/org/org-easycla/org-easycla.component').then((m) => m.OrgEasyclaComponent),
+              },
+              {
+                // Ahead of `:signatureId`, which would otherwise match this segment as a signature
+                // id and render the not-found state. The preview reuses the detail component,
+                // sourcing the agreement from the picker's choice in the router state.
+                path: ORG_EASYCLA_NEW_SEGMENT,
+                data: { title: 'Sign a CLA', description: 'Review a CLA before starting the corporate signing process.' },
+                loadComponent: () =>
+                  import('./modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component').then((m) => m.OrgEasyclaDetailComponent),
               },
               {
                 path: ':signatureId',

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.html
@@ -172,6 +172,48 @@
             </ng-template>
           </lfx-message>
         }
+        <!--
+          The body for an agreement the organization has not signed, which on this page means the
+          pre-signing preview: the organization's list draws every row from a signature upstream
+          has already filtered to signed, so it never reaches here. Without this the tab rendered
+          its heading and then stopped, which reads as a page that failed to load rather than as a
+          state.
+        -->
+        @if (notStarted()) {
+          <div class="flex flex-col gap-3" data-testid="org-easycla-detail-not-started">
+            @if (notStartedLead()) {
+              <p class="text-sm text-gray-700" data-testid="org-easycla-detail-not-started-lead">{{ notStartedLead() }}</p>
+            }
+            <p class="font-semibold text-sm text-gray-900">{{ notStartedCopy.stepsHeading }}</p>
+            <!--
+              An ordered list, not three paragraphs as the prototype draws them. The steps are a
+              sequence and are numbered in their own text, so the markup that says so is what lets
+              assistive technology announce the position and count. The prototype's numbering is
+              kept in the visible text rather than generated, so the wording stays verbatim.
+            -->
+            <ol class="flex list-none flex-col gap-2 p-0">
+              @for (step of notStartedCopy.steps; track step.label) {
+                <li class="text-sm text-gray-700">
+                  <span class="font-semibold text-gray-900">{{ step.label }}</span> {{ step.body }}
+                </li>
+              }
+            </ol>
+            <!--
+              Skips the picker: this page already named the CLA Group. The reason a start is
+              refused lives in the accessible name, not a tooltip — the tooltip host is not
+              focusable while the button is disabled, so it never opens on focus.
+            -->
+            <div>
+              <lfx-button
+                [label]="notStartedCopy.startLabel"
+                icon="fa-light fa-file-signature"
+                [disabled]="startDisabled()"
+                [ariaLabel]="startAriaLabel()"
+                (onClick)="startClaProcess()"
+                data-testid="org-easycla-detail-start-cla" />
+            </div>
+          </div>
+        }
         @if (canDownload()) {
           <!--
             `severity="secondary"` with `outlined`, the pairing the survey-preview and profile
@@ -196,7 +238,21 @@
         [id]="'org-easycla-detail-tab-panel-' + activeTab()"
         [attr.aria-labelledby]="'org-easycla-detail-tab-trigger-' + activeTab()"
         class="py-8"
-        data-testid="org-easycla-detail-tab-empty"></section>
+        data-testid="org-easycla-detail-tab-empty">
+        <!--
+          The CLA Managers and Approval List tabs on an unsigned agreement, where signing is what
+          creates the content: the signatory becomes the initial CLA Manager, and approval entries
+          are what that manager then maintains. Left bare, the panel reads as a page that failed to
+          load rather than as a state — the same gap the empty Overview had. One lock icon for both,
+          because "locked until signed" is what each panel is actually saying.
+
+          The remaining tabs stay bare. They are unbuilt for every agreement, signed or not, so
+          "once this CLA is signed" would promise content signing does not produce.
+        -->
+        @if (lockedTab(); as locked) {
+          <lfx-empty-state data-testid="org-easycla-detail-tab-locked" icon="fa-light fa-lock" [title]="locked.title" [subtitle]="locked.subtitle" />
+        }
+      </section>
     }
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -528,6 +528,41 @@ describe('OrgEasyclaDetailComponent', () => {
 
       expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
     });
+
+    /**
+     * The redirect that leaves the page is asynchronous, so the first render can present a Start
+     * button that is enabled and clickable against a selected organization the choice was not made
+     * for. Without the guard, a race click during that window would open the hand-off — for the
+     * wrong company. The disabled state at first render is what closes it.
+     */
+    it('disables Start when the preview organization does not match the selected one', async () => {
+      const fixture = await render(previewing({ orgUid: '0014100000OtherOrgAA' }));
+
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      expect(start?.disabled).toBe(true);
+    });
+
+    /**
+     * The action boundary is asserted separately from the disabled state, because a race click can
+     * arrive between the enabled paint and the async redirect. Refusing at `startClaProcess` is the
+     * belt to the disabled state's braces.
+     */
+    it('refuses the click even if the button somehow fires under a mismatched selection', async () => {
+      const opened: { component: unknown }[] = [];
+      openDialog.mockImplementation((component: unknown) => {
+        opened.push({ component });
+        return { onClose: of(null), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      const fixture = await render(previewing());
+      // The component is on-screen against SELECTED_ACCOUNT. Simulate the race window by switching
+      // the account after the guard has read a matching value, then calling the action directly.
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      const component = fixture.componentInstance as unknown as { startClaProcess: () => void };
+      component.startClaProcess();
+
+      expect(opened).toEqual([]);
+    });
   });
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -638,6 +638,39 @@ describe('OrgEasyclaDetailComponent', () => {
   });
 
   /**
+   * Angular reuses this component across `/org/easycla/new` and `/org/easycla/:signatureId`. When
+   * a signatory navigates from the preview onto the newly-signed agreement, the previous route's
+   * `history.state` is still what `Location.getState()` returns until Angular has written the new
+   * entry \u2014 so the constructor of the reused component instance can read a picker choice that
+   * has nothing to do with the URL it is being reused under.
+   *
+   * If that leftover state drives `previewing`, the page skips the list fetch, latches the stale
+   * selection, and renders the unsigned preview instead of the signed agreement in the URL. The
+   * agreement route is disqualified from the history fallback by the presence of `signatureId`
+   * in the route's parameter map, whether or not `extras.state` was carried by the navigation.
+   */
+  describe('a stale history entry from a previous /new visit', () => {
+    const CASCADE: OrgClaSignSelection = {
+      claGroupId: 'cla-group-uuid-1',
+      claGroupName: 'Cascade CLA',
+      projectSfid: 'a09410000182dD2AAI',
+      projectName: 'Cascade',
+      orgUid: SELECTED_ACCOUNT.uid,
+    };
+
+    it('does not drive the preview when the route is an agreement id', async () => {
+      // The paramMap default (`signatureId: 'signature-uuid-1'`) is the agreement route.
+      const fixture = await render(undefined, { [ORG_CLA_SIGN_SELECTION_STATE]: CASCADE });
+
+      // The list is what the agreement page reads, so the fetch is what pins that the guard held.
+      expect(getClaGroups).toHaveBeenCalled();
+      // And the preview page's own signal is off, so no side of it can render.
+      const component = fixture.componentInstance as unknown as { previewing: boolean };
+      expect(component.previewing).toBe(false);
+    });
+  });
+
+  /**
    * The two dialogs this page owns, driven with a harness whose closes the test controls.
    *
    * The shared `openDialog` stub closes synchronously, which is fine for asserting what gets passed

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -299,6 +299,78 @@ describe('OrgEasyclaDetailComponent', () => {
       expect(start()?.disabled).toBe(false);
     });
 
+    // The attestation panel closes on `onClose`, and the hand-off is opened on the ref's later
+    // `onDestroy` — the wait keeps a second dialog from stacking on top of the first while its
+    // leave animation is still running. That wait is also a window in which the organization or
+    // the CLA Group underneath the page can change: the attestation itself names neither, so the
+    // captured values from the click that opened it are no longer the ones the viewer confirms.
+    // These two tests pin the sync re-check inside the `onDestroy` callback that refuses to open
+    // the hand-off when either has moved.
+    it('refuses to open the hand-off when the organization changed during the attestation teardown', async () => {
+      const attestations = { authorityAcked: true, embargoAcked: true };
+      const attestationOnClose = new Subject<unknown>();
+      const attestationOnDestroy = new Subject<void>();
+      const opened: unknown[] = [];
+      openDialog.mockImplementation((component: unknown) => {
+        opened.push(component);
+        return { onClose: attestationOnClose, onDestroy: attestationOnDestroy, close: vi.fn() };
+      });
+
+      const signable = {
+        ...notStarted,
+        claGroupId: 'cla-group-uuid-1',
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+      fixture.detectChanges();
+
+      attestationOnClose.next(attestations);
+      // Between onClose and onDestroy, the viewer switches organizations. The click captured the
+      // Acme uid; opening the hand-off now would sign Acme's CCLA for a different company.
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      attestationOnDestroy.next();
+      fixture.detectChanges();
+
+      // The invariant is a negative: only the attestation was opened. Without the sync re-check
+      // in `openHandOffIfContextHeld`, the callback would run against the captured Acme uid and
+      // stack a `OrgEasyclaSignHandoffComponent` on the page under Other.
+      expect(opened).toEqual([OrgEasyclaAttestationComponent]);
+    });
+
+    it('refuses to open the hand-off when the CLA Group under the page changed during the attestation teardown', async () => {
+      const attestations = { authorityAcked: true, embargoAcked: true };
+      const attestationOnClose = new Subject<unknown>();
+      const attestationOnDestroy = new Subject<void>();
+      const opened: unknown[] = [];
+      openDialog.mockImplementation((component: unknown) => {
+        opened.push(component);
+        return { onClose: attestationOnClose, onDestroy: attestationOnDestroy, close: vi.fn() };
+      });
+
+      const initial = { ...notStarted, claGroupId: 'cla-group-uuid-1', projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }] };
+      const swapped = { ...notStarted, claGroupId: 'cla-group-uuid-2', projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }] };
+      const groups = new BehaviorSubject({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(initial)] });
+      getClaGroups.mockReturnValue(groups);
+
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+      fixture.detectChanges();
+
+      attestationOnClose.next(attestations);
+      // Between onClose and onDestroy, a fresh list arrives whose row for this signature id names
+      // a different CLA Group. Opening the hand-off with the captured claGroupId would sign the
+      // agreement the viewer is no longer looking at.
+      groups.next({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(swapped)] });
+      attestationOnDestroy.next();
+      fixture.detectChanges();
+
+      expect(opened).toEqual([OrgEasyclaAttestationComponent]);
+      expect(byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.disabled).toBe(false);
+    });
+
     it('hands the confirmations to the signing step for this agreement', async () => {
       const attestations = { authorityAcked: true, embargoAcked: true };
       const opened: { component: unknown; config: { data?: unknown; closable?: boolean } }[] = [];

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -3,6 +3,7 @@
 
 import '@angular/compiler';
 
+import { Location } from '@angular/common';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -66,7 +67,7 @@ describe('OrgEasyclaDetailComponent', () => {
    * reading it back out of the navigation is the part under test: the address holds nothing, so a
    * selection handed in directly would pass on a page that renders blank in the browser.
    */
-  async function render(previewState?: Record<string, unknown>): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
+  async function render(previewState?: Record<string, unknown>, restoredState?: Record<string, unknown>): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [OrgEasyclaDetailComponent],
@@ -95,6 +96,9 @@ describe('OrgEasyclaDetailComponent', () => {
     vi.spyOn(router, 'getCurrentNavigation').mockReturnValue(
       previewState === undefined ? null : ({ extras: { state: previewState } } as unknown as Navigation)
     );
+    // The history entry, which outlives the navigation that wrote it. Empty by default, as it is on
+    // an address nobody arrived at through the picker.
+    vi.spyOn(TestBed.inject(Location), 'getState').mockReturnValue(restoredState ?? {});
 
     const fixture = TestBed.createComponent(OrgEasyclaDetailComponent);
     fixture.detectChanges();
@@ -419,6 +423,19 @@ describe('OrgEasyclaDetailComponent', () => {
 
       expect(byTestId(fixture, 'org-easycla-detail-title')?.textContent).toContain('Cascade CLA');
       expect(byTestId(fixture, 'org-easycla-detail-status')?.textContent).toContain('Not started');
+    });
+
+    /**
+     * A reload, and any restore, arrives with no navigation in flight to carry the choice — but the
+     * history entry the picker wrote is still there. Reading only the navigation would answer a
+     * refresh by discarding the selection and sending the signatory back to the picker to make it
+     * again.
+     */
+    it('keeps the choice when the page is reloaded onto it', async () => {
+      const fixture = await render(undefined, previewing());
+
+      expect(byTestId(fixture, 'org-easycla-detail-title')?.textContent).toContain('Cascade CLA');
+      expect(navigate).not.toHaveBeenCalled();
     });
 
     // The row-shaped states of a page that fetches a list. Neither can be reached without a list in

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -6,8 +6,9 @@ import '@angular/compiler';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
-import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
+import { ActivatedRoute, convertToParamMap, Navigation, provideRouter, Router } from '@angular/router';
+import { CCLA_SIGN_COPY, ORG_CLA_LOCKED_TAB_COPY, ORG_CLA_NOT_STARTED_COPY, ORG_CLA_SIGN_SELECTION_STATE } from '@lfx-one/shared/constants';
+import type { OrgClaGroup, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
@@ -16,9 +17,11 @@ import { OrgNavigationService } from '@shared/services/org-navigation.service';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 
 import { OrgEasyclaCoverageDialogComponent } from '../org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
+import { OrgEasyclaAttestationComponent } from '../org-easycla-sign/org-easycla-attestation.component';
+import { OrgEasyclaSignHandoffComponent } from '../org-easycla-sign/org-easycla-sign-handoff.component';
 import { OrgEasyclaDetailComponent } from './org-easycla-detail.component';
 
 describe('OrgEasyclaDetailComponent', () => {
@@ -35,6 +38,9 @@ describe('OrgEasyclaDetailComponent', () => {
   const getPdfUrl = vi.fn();
   const addMessage = vi.fn();
   const openDialog = vi.fn();
+
+  /** Where the page tried to go. Installed by `render` on the real router; see the spy there. */
+  let navigate: MockInstance<Router['navigate']>;
 
   function claGroup(overrides: Partial<OrgClaGroup> = {}): OrgClaGroup {
     return {
@@ -53,7 +59,14 @@ describe('OrgEasyclaDetailComponent', () => {
     };
   }
 
-  async function render(): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
+  /**
+   * Renders the page, optionally as the preview the picker navigates to.
+   *
+   * The selection is installed on the navigation rather than passed to the component, because
+   * reading it back out of the navigation is the part under test: the address holds nothing, so a
+   * selection handed in directly would pass on a page that renders blank in the browser.
+   */
+  async function render(previewState?: Record<string, unknown>): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [OrgEasyclaDetailComponent],
@@ -73,6 +86,15 @@ describe('OrgEasyclaDetailComponent', () => {
     TestBed.overrideComponent(OrgEasyclaDetailComponent, {
       set: { providers: [{ provide: DialogService, useValue: { open: openDialog } }] },
     });
+
+    const router = TestBed.inject(Router);
+    // The test module declares no routes, so a real navigation would resolve to nothing and the
+    // assertion would be about the router's failure rather than about where the page tried to go.
+    navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    // Read in a field initializer, so the answer has to be in place before the component exists.
+    vi.spyOn(router, 'getCurrentNavigation').mockReturnValue(
+      previewState === undefined ? null : ({ extras: { state: previewState } } as unknown as Navigation)
+    );
 
     const fixture = TestBed.createComponent(OrgEasyclaDetailComponent);
     fixture.detectChanges();
@@ -183,6 +205,495 @@ describe('OrgEasyclaDetailComponent', () => {
     const fixture = await render();
 
     expect(byTestId(fixture, 'org-easycla-detail-ccla-hint')?.textContent?.trim()).toBe("Covers Cascade for Acme's employees.");
+  });
+
+  describe('an agreement the organization has not signed', () => {
+    const notStarted = { status: 'not-started' as const, signed: false, signedOn: undefined };
+
+    it('explains the process instead of leaving the tab empty', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      const panel = byTestId(fixture, 'org-easycla-detail-not-started');
+      expect(panel).not.toBeNull();
+      // All three steps, not merely the heading: the steps are where the consequence of signing —
+      // that the signer becomes the initial CLA Manager — is stated before it happens.
+      expect(panel?.querySelectorAll('li').length).toBe(3);
+      expect(panel?.textContent).toContain(ORG_CLA_NOT_STARTED_COPY.stepsHeading);
+      for (const step of ORG_CLA_NOT_STARTED_COPY.steps) {
+        expect(panel?.textContent).toContain(step.body);
+      }
+    });
+
+    it('names the organization and the agreement it has not signed', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ ...notStarted, claGroupName: 'Cascade CLA' })] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started-lead')?.textContent?.trim()).toBe('Acme has not yet signed a CLA for Cascade CLA.');
+    });
+
+    it('numbers the steps as a list, so their order and count are announced', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')?.querySelector('ol')).not.toBeNull();
+    });
+
+    it('does not start signing when the agreement has no project to sign against', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+
+      // Same reason the picker leaves a row visible but unselectable: the producer signs by
+      // project, and a row with no project SFID cannot be bound to a request.
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla');
+      expect(start).not.toBeNull();
+      expect(start?.querySelector('button')?.disabled).toBe(true);
+      expect(start?.querySelector('button')?.getAttribute('aria-label')).toContain(CCLA_SIGN_COPY.picker.multiProjectDisabledReason);
+    });
+
+    it('starts the confirmation for this agreement, without asking which CLA group', async () => {
+      openDialog.mockReturnValue({ onClose: of(null), onDestroy: of(undefined), close: vi.fn() });
+      const signable = {
+        ...notStarted,
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      expect(start?.disabled).toBe(false);
+
+      start?.click();
+
+      expect(openDialog).toHaveBeenCalledTimes(1);
+      expect(openDialog.mock.calls[0][0]).toBe(OrgEasyclaAttestationComponent);
+    });
+
+    it('offers Start again after the header close tears the dialog down without onClose', async () => {
+      const onClose = new Subject<unknown>();
+      const onDestroy = new Subject<void>();
+      openDialog.mockReturnValue({ onClose, onDestroy, close: vi.fn() });
+      const signable = {
+        ...notStarted,
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      const start = (): HTMLButtonElement | null | undefined => byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      start()?.click();
+      fixture.detectChanges();
+      expect(start()?.disabled).toBe(true);
+
+      onDestroy.next();
+      fixture.detectChanges();
+
+      expect(start()?.disabled).toBe(false);
+    });
+
+    it('hands the confirmations to the signing step for this agreement', async () => {
+      const attestations = { authorityAcked: true, embargoAcked: true };
+      const opened: { component: unknown; config: { data?: unknown; closable?: boolean } }[] = [];
+      openDialog.mockImplementation((component: unknown, config: { data?: unknown; closable?: boolean } = {}) => {
+        opened.push({ component, config });
+        const result = opened.length === 1 ? attestations : null;
+        return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      const signable = {
+        ...notStarted,
+        claGroupId: 'cla-group-uuid-1',
+        projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(signable)] }));
+
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+
+      expect(opened).toHaveLength(2);
+      expect(opened[1].component).toBe(OrgEasyclaSignHandoffComponent);
+      expect(opened[1].config.data).toEqual({
+        orgUid: SELECTED_ACCOUNT.uid,
+        projectSfid: 'a09410000182dD2AAI',
+        claGroupId: 'cla-group-uuid-1',
+        attestations,
+      });
+    });
+
+    it('signs a foundation-level agreement against the foundation, not one project it covers', async () => {
+      const opened: { config: { data?: unknown } }[] = [];
+      openDialog.mockImplementation((_component: unknown, config: { data?: unknown } = {}) => {
+        opened.push({ config });
+        return { onClose: of(opened.length === 1 ? { authorityAcked: true, embargoAcked: true } : null), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      // The ordinary shape of an unsigned agreement: one CLA Group covering several projects
+      // under a foundation, each project carrying its own SFID.
+      const foundationLevel = {
+        ...notStarted,
+        claGroupId: 'cla-group-uuid-1',
+        foundationSfid: 'a09410000182dFOUND',
+        projects: [
+          { projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' },
+          { projectName: 'Driftwood', projectSfid: 'a09410000182dD3AAI' },
+        ],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(foundationLevel)] }));
+
+      const fixture = await render();
+      expect(byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.disabled).toBe(false);
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+
+      // The first covered project's SFID would bind the agreement to that project alone, and
+      // nothing downstream would notice: it resolves back to this same CLA Group, so the
+      // response's group-mismatch check sees the id it asked for.
+      expect(opened[1].config.data).toMatchObject({ projectSfid: 'a09410000182dFOUND', claGroupId: 'cla-group-uuid-1' });
+    });
+
+    it('refuses to choose between several covered projects when there is no foundation', async () => {
+      const ambiguous = {
+        ...notStarted,
+        projects: [
+          { projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' },
+          { projectName: 'Driftwood', projectSfid: 'a09410000182dD3AAI' },
+        ],
+      };
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(ambiguous)] }));
+
+      const fixture = await render();
+
+      // Both projects carry an SFID, so a choice is available — and that is the reason to refuse
+      // it. Search declines to name a project for this shape and the picker greys the row out.
+      expect(byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.disabled).toBe(true);
+    });
+
+    it('does not explain the process on a signed agreement', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
+
+    it('does not walk a sanctioned agreement through how to start signing', async () => {
+      // Sanctions take the same status slot, and that viewer's obstacle is not a missing signature
+      // — telling them how to begin would talk past the reason they cannot.
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ status: 'sanctioned', signed: false, signedOn: undefined })] }));
+
+      const fixture = await render();
+
+      expect(byTestId(fixture, 'org-easycla-detail-not-started')).toBeNull();
+    });
+  });
+
+  /**
+   * The preview a signatory reads before starting a corporate CLA (#1983), reached from the picker.
+   *
+   * Nothing on this route is fetched. There is no fetch-a-CLA-group-by-id endpoint upstream, so the
+   * page is built entirely from the choice the navigation carried — which is why these cases pass no
+   * `signatureId` and assert that no list is requested.
+   */
+  describe('previewing a CLA Group the picker chose', () => {
+    const CASCADE: OrgClaSignSelection = {
+      claGroupId: 'cla-group-uuid-1',
+      claGroupName: 'Cascade CLA',
+      projectSfid: 'a09410000182dD2AAI',
+      projectName: 'Cascade',
+      orgUid: SELECTED_ACCOUNT.uid,
+    };
+
+    function previewing(selection: Partial<OrgClaSignSelection> = {}): Record<string, unknown> {
+      return { [ORG_CLA_SIGN_SELECTION_STATE]: { ...CASCADE, ...selection } };
+    }
+
+    beforeEach(() => {
+      paramMap.next(convertToParamMap({}));
+    });
+
+    it('heads the page with the CLA Group the picker chose', async () => {
+      const fixture = await render(previewing());
+
+      expect(byTestId(fixture, 'org-easycla-detail-title')?.textContent).toContain('Cascade CLA');
+      expect(byTestId(fixture, 'org-easycla-detail-status')?.textContent).toContain('Not started');
+    });
+
+    // The row-shaped states of a page that fetches a list. Neither can be reached without a list in
+    // hand, and `notFound` firing here would tell a signatory the agreement they are about to sign
+    // does not exist.
+    it('asks for no list, and shows neither a skeleton nor a missing agreement', async () => {
+      const fixture = await render(previewing());
+
+      expect(getClaGroups).not.toHaveBeenCalled();
+      expect(byTestId(fixture, 'org-easycla-detail-list-loading')).toBeNull();
+      expect(byTestId(fixture, 'org-easycla-detail-not-found-state')).toBeNull();
+    });
+
+    /**
+     * Start must reach the hand-off from the preview, and against the project the picker resolved.
+     *
+     * This is what the synthesized row is shaped for: one covered project and no foundation SFID, so
+     * `signingChoice` resolves to the picker's own SFID rather than inventing a foundation-level
+     * agreement out of a choice that was made at project level.
+     */
+    it('starts the confirmation against the project the picker resolved', async () => {
+      const opened: { component: unknown; config: { data?: unknown } }[] = [];
+      openDialog.mockImplementation((component: unknown, config: { data?: unknown } = {}) => {
+        opened.push({ component, config });
+        return { onClose: of(opened.length === 1 ? { authorityAcked: true, embargoAcked: true } : null), onDestroy: of(undefined), close: vi.fn() };
+      });
+
+      const fixture = await render(previewing());
+      const start = byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button');
+      expect(start?.disabled).toBe(false);
+
+      start?.click();
+
+      expect(opened[0].component).toBe(OrgEasyclaAttestationComponent);
+      expect(opened[1].config.data).toMatchObject({ claGroupId: CASCADE.claGroupId, projectSfid: CASCADE.projectSfid });
+    });
+
+    // A pasted, bookmarked or linked preview address arrives with nothing, and nothing here can
+    // rebuild it. The list is where the picker lives, so it is a redirect rather than an empty state.
+    it('leaves for the list when the address carries no selection', async () => {
+      await render();
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+
+    /**
+     * A truncated selection is treated as no selection at all.
+     *
+     * The value comes back out of a history entry, so it can have been written by an earlier
+     * deployment. Trusted, a partial one heads the page with an undefined name and still offers
+     * Start — a missing project SFID only disables signing once something reads it.
+     */
+    it.each([['claGroupId'], ['claGroupName'], ['projectSfid'], ['projectName'], ['orgUid']] as const)('leaves for the list when %s is missing', async (field) => {
+      await render(previewing({ [field]: '' }));
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+
+    /**
+     * An organization switch invalidates the preview, not merely an open dialog.
+     *
+     * The choice was made under the organization the viewer has just left, and Start would open a
+     * session against the one they arrived at. Nothing here can be re-derived for it either — the CLA
+     * Group named may not be one the new organization can sign.
+     */
+    it('leaves for the list when the viewer switches organization', async () => {
+      const fixture = await render(previewing());
+      expect(navigate).not.toHaveBeenCalled();
+
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+
+    /**
+     * The same mismatch arriving without a switch to witness.
+     *
+     * The choice lives in a history entry and the selected organization is a cookie another tab can
+     * change, so back or reload can render this page with the wrong company already in force. It is
+     * the *initial* value then, not a change — so the choice has to carry the organization it was
+     * made under for there to be anything to compare.
+     */
+    it('leaves for the list when the choice was made under another organization', async () => {
+      await render(previewing({ orgUid: '0014100000OtherOrgAA' }));
+
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+    });
+  });
+
+  /**
+   * The two dialogs this page owns, driven with a harness whose closes the test controls.
+   *
+   * The shared `openDialog` stub closes synchronously, which is fine for asserting what gets passed
+   * along and useless for asserting what happens while one is still standing.
+   */
+  describe('the signing dialogs this page owns', () => {
+    interface OpenDialog {
+      component: unknown;
+      config: { data?: unknown; closable?: boolean; closeOnEscape?: boolean; dismissableMask?: boolean };
+      close: ReturnType<typeof vi.fn>;
+      /** Emit to drive this dialog's own close, which is how the flow advances a step. */
+      onClose: Subject<unknown>;
+      /** Emit after `onClose` to finish the leave animation. The next step waits on this. */
+      onDestroy: Subject<void>;
+    }
+
+    const opened: OpenDialog[] = [];
+    const attestations = { authorityAcked: true, embargoAcked: true };
+
+    beforeEach(() => {
+      opened.length = 0;
+      openDialog.mockImplementation((component: unknown, config: OpenDialog['config'] = {}) => {
+        const dialog: OpenDialog = { component, config, close: vi.fn(), onClose: new Subject<unknown>(), onDestroy: new Subject<void>() };
+        opened.push(dialog);
+        return { onClose: dialog.onClose, onDestroy: dialog.onDestroy, close: dialog.close };
+      });
+      getClaGroups.mockReturnValue(
+        of({
+          orgUid: SELECTED_ACCOUNT.uid,
+          claGroups: [
+            claGroup({
+              status: 'not-started',
+              signed: false,
+              signedOn: undefined,
+              projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+            }),
+          ],
+        })
+      );
+    });
+
+    async function start(): Promise<ComponentFixture<OrgEasyclaDetailComponent>> {
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-start-cla')?.querySelector('button')?.click();
+      return fixture;
+    }
+
+    /**
+     * The hand-off opens locked by all three routes.
+     *
+     * The initial values belong here rather than in the hand-off's own suite, which supplies its own
+     * config and so cannot see what this call site passes. The signing request starts as that dialog
+     * appears and is the call that creates both the signature record and the DocuSign envelope:
+     * dismissed before the address comes back, it leaves an envelope nobody was handed.
+     */
+    it('opens the hand-off with no way to dismiss it', async () => {
+      await start();
+      opened[0].onClose.next(attestations);
+      opened[0].onDestroy.next();
+
+      expect(opened[1].component).toBe(OrgEasyclaSignHandoffComponent);
+      expect(opened[1].config).toMatchObject({ closable: false, closeOnEscape: false, dismissableMask: false });
+    });
+
+    // The step before it is freely dismissable: nothing has been created yet, and trapping someone
+    // in a legal confirmation they want to back out of would be its own problem.
+    it('leaves the attestation dismissable, because nothing exists yet to lose', async () => {
+      await start();
+
+      expect(opened[0].config.closable).toBe(true);
+    });
+
+    /**
+     * The hand-off waits for the attestation to be torn down, not merely closed.
+     *
+     * `close()` emits `onClose` synchronously and starts the leave animation from that same emission,
+     * and the end of that animation drops `p-overflow-hidden` from the body. A dialog opened from
+     * inside `onClose` therefore has its own scroll lock stripped a moment after it appears, and the
+     * page scrolls behind it. The Me-lens hand-off found this first (#2066).
+     */
+    it('opens no hand-off until the attestation has torn down', async () => {
+      await start();
+
+      opened[0].onClose.next(attestations);
+      expect(opened).toHaveLength(1);
+
+      opened[0].onDestroy.next();
+      expect(opened).toHaveLength(2);
+    });
+
+    // Nothing has been created at this point, and the confirmations are about a specific
+    // organization's authority and export position — they cannot carry over to another company.
+    it('closes the attestation on an organization switch, since no signature has been asked for yet', async () => {
+      const fixture = await start();
+      expect(opened).toHaveLength(1);
+
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(opened[0].close).toHaveBeenCalled();
+    });
+
+    // Angular reuses this component when only `:signatureId` changes, so an org-only stream never
+    // fires and the attestation would survive onto an agreement it was never about — confirming it
+    // then opens a session for the one the viewer navigated away from.
+    it('closes the attestation when the viewer moves to another agreement', async () => {
+      const fixture = await start();
+      expect(opened).toHaveLength(1);
+
+      paramMap.next(convertToParamMap({ signatureId: 'signature-uuid-2' }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(opened[0].close).toHaveBeenCalled();
+    });
+
+    /**
+     * The hand-off is deliberately not closed.
+     *
+     * By the time it is open the request has been issued and a signature record and DocuSign envelope
+     * exist for the organization that was selected when the viewer confirmed — which is the one they
+     * meant to sign for. The address that comes back is the only thing that reaches them, so closing
+     * this on a switch would orphan an envelope to save nothing. It is also why the field holding the
+     * closeable ref is named for the uncommitted half.
+     */
+    it('leaves the hand-off standing, because a signing session already exists behind it', async () => {
+      const fixture = await start();
+      opened[0].onClose.next(attestations);
+      opened[0].onDestroy.next();
+      expect(opened).toHaveLength(2);
+
+      selectedAccount.set({ uid: '0014100000OtherOrgAA', accountName: 'Other' });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(opened[1].close).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Why the open tab holds nothing on an agreement nobody has signed, when signing is what fills it.
+   */
+  describe('the tabs signing is what fills', () => {
+    const notStarted = { status: 'not-started' as const, signed: false, signedOn: undefined };
+
+    it.each([['managers'], ['approval']] as const)('explains that the %s tab is waiting on the signature', async (tab) => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+      byTestId(fixture, `org-easycla-detail-tab-${tab}`)?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-detail-tab-locked')?.textContent).toContain(ORG_CLA_LOCKED_TAB_COPY[tab]?.title);
+    });
+
+    // Unbuilt for every agreement, signed or not — so "once this CLA is signed" would promise
+    // content signing does not produce.
+    it.each([['acknowledgments'], ['activity']] as const)('leaves the %s tab bare, since signing does not fill it', async (tab) => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup(notStarted)] }));
+
+      const fixture = await render();
+      byTestId(fixture, `org-easycla-detail-tab-${tab}`)?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-detail-tab-empty')).not.toBeNull();
+      expect(byTestId(fixture, 'org-easycla-detail-tab-locked')).toBeNull();
+    });
+
+    /**
+     * Read from `signed` rather than the status, as the download is and for the same reason:
+     * sanctions occupy the single status slot, so a sanctioned agreement may be signed — and its CLA
+     * Managers are real people who would be told they do not exist yet.
+     */
+    it('does not lock the managers tab on a signed agreement that is also sanctioned', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup({ status: 'sanctioned' })] }));
+
+      const fixture = await render();
+      byTestId(fixture, 'org-easycla-detail-tab-managers')?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-detail-tab-locked')).toBeNull();
+    });
   });
 
   it('withholds the download from an agreement that was never signed', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -488,11 +488,14 @@ describe('OrgEasyclaDetailComponent', () => {
      * deployment. Trusted, a partial one heads the page with an undefined name and still offers
      * Start — a missing project SFID only disables signing once something reads it.
      */
-    it.each([['claGroupId'], ['claGroupName'], ['projectSfid'], ['projectName'], ['orgUid']] as const)('leaves for the list when %s is missing', async (field) => {
-      await render(previewing({ [field]: '' }));
+    it.each([['claGroupId'], ['claGroupName'], ['projectSfid'], ['projectName'], ['orgUid']] as const)(
+      'leaves for the list when %s is missing',
+      async (field) => {
+        await render(previewing({ [field]: '' }));
 
-      expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
-    });
+        expect(navigate).toHaveBeenCalledWith(['/org/easycla'], { replaceUrl: true });
+      }
+    );
 
     /**
      * An organization switch invalidates the preview, not merely an open dialog.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -4,15 +4,34 @@
 import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
-import type { OrgClaCoverageChip, OrgClaDetailTab, OrgClaDetailTabView, OrgClaGroup, OrgClaGroupList, OrgClaStatusDisplay } from '@lfx-one/shared/interfaces';
-import { ORG_CLA_DETAIL_TABS, ORG_CLA_HEADING_STATUS, ORG_CLA_STATUS_DISPLAY } from '@lfx-one/shared/constants';
-import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary } from '@lfx-one/shared/utils';
+import type {
+  OrgClaCoverageChip,
+  OrgClaDetailTab,
+  OrgClaDetailTabView,
+  OrgClaGroup,
+  OrgClaGroupList,
+  OrgClaGroupPickerResult,
+  OrgClaSignAttestations,
+  OrgClaSignSelection,
+  OrgClaStatusDisplay,
+} from '@lfx-one/shared/interfaces';
+import {
+  CCLA_SIGN_COPY,
+  ORG_CLA_DETAIL_TABS,
+  ORG_CLA_HEADING_STATUS,
+  ORG_CLA_LOCKED_TAB_COPY,
+  ORG_CLA_NOT_STARTED_COPY,
+  ORG_CLA_SIGN_SELECTION_STATE,
+  ORG_CLA_STATUS_DISPLAY,
+  ORG_EASYCLA_PATH,
+} from '@lfx-one/shared/constants';
+import { downloadFromUrl, formatClaSignedOnInstant, orgClaCoverageChips, orgClaCoverageSummary, orgClaPreviewGroup } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, distinctUntilChanged, filter, finalize, map, of, skip, switchMap, takeUntil, tap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, filter, finalize, map, of, skip, switchMap, take, takeUntil, tap } from 'rxjs';
 
 import { BreadcrumbComponent } from '@components/breadcrumb/breadcrumb.component';
 import { ButtonComponent } from '@components/button/button.component';
@@ -27,6 +46,8 @@ import { OpenIntercomDirective } from '@shared/directives/open-intercom.directiv
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 
 import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from '../org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
+import { OrgEasyclaAttestationComponent } from '../org-easycla-sign/org-easycla-attestation.component';
+import { OrgEasyclaSignHandoffComponent } from '../org-easycla-sign/org-easycla-sign-handoff.component';
 
 @Component({
   selector: 'lfx-org-easycla-detail',
@@ -37,6 +58,7 @@ import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from '.
 })
 export class OrgEasyclaDetailComponent {
   private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly accountContext = inject(AccountContextService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
@@ -51,6 +73,16 @@ export class OrgEasyclaDetailComponent {
   protected readonly downloading = signal(false);
   protected readonly fetchError = signal(false);
   private readonly claLoadingState = signal(false);
+
+  /** One hand-off at a time. Also what disables Start while a flow is open. */
+  protected readonly signingOpen = signal(false);
+
+  /**
+   * The attestation dialog, while it is open. Held so an organization switch can close it.
+   * Never holds the hand-off — by then a signing session exists for the organization that was
+   * selected when the viewer confirmed.
+   */
+  private uncommittedSigningDialog: DynamicDialogRef | null = null;
 
   protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
   protected readonly hasCompany = computed(() => !!this.accountContext.selectedAccount()?.uid);
@@ -70,6 +102,22 @@ export class OrgEasyclaDetailComponent {
     ),
     { initialValue: (this.route.snapshot.paramMap.get('signatureId') ?? '').trim() }
   );
+
+  /**
+   * The CLA Group the picker chose, when this page was opened as the preview a signatory reads
+   * before starting a corporate CLA (#1983). Null on an ordinary agreement route, and on the server.
+   *
+   * Carried by the navigation rather than by the address because an address holds nothing that
+   * could be resolved: the CLA service exposes no fetch-a-CLA-group-by-id endpoint, so ids in the
+   * URL could not be turned back into the agreement this page has to name, and the names would
+   * have to ride along in the URL for the heading to render at all. Angular copies the non-router
+   * keys of a restored `history.state` onto the navigation it synthesises, so in-app back and
+   * forward arrive here with the choice still attached.
+   */
+  private readonly previewSelection: OrgClaSignSelection | null = this.readPreviewSelection();
+
+  /** Previewing an agreement nobody has signed, so there is no list row to find and none is fetched. */
+  private readonly previewing = !!this.previewSelection;
 
   // Every selection the viewer makes, including clearing it.
   private readonly selectedOrgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(distinctUntilChanged());
@@ -102,8 +150,12 @@ export class OrgEasyclaDetailComponent {
     return !data || data.orgUid === this.accountContext.selectedAccount()?.uid;
   });
 
+  // `previewing` first: no list is requested in that mode, so `claData()` stays undefined for the
+  // life of the page and every other term here would hold the skeleton over a page that has
+  // everything it needs.
   protected readonly claLoading = computed(
-    () => this.hasCompany() && (this.claData() === undefined || this.claLoadingState() || !this.claDataIsForSelectedOrg()) && !this.fetchError()
+    () =>
+      !this.previewing && this.hasCompany() && (this.claData() === undefined || this.claLoadingState() || !this.claDataIsForSelectedOrg()) && !this.fetchError()
   );
 
   protected readonly claGroup: Signal<OrgClaGroup | undefined> = computed(() => this.initClaGroup());
@@ -118,10 +170,53 @@ export class OrgEasyclaDetailComponent {
 
   protected readonly coverageHint = computed(() => this.initCoverageHint());
 
-  // Read from `signed` rather than the status: sanctions win the single status slot, so a
-  // `sanctioned` row may be signed or unsigned, and offering the document on an unsigned one
-  // gives the viewer a control that can only fail.
+  // Read from `signed` rather than the status, because this component serves two sources and only
+  // the flag answers both: the preview builds an agreement nobody has signed, and `status` there
+  // is `not-started` while on a sanctioned list row it says nothing about whether a document
+  // exists. Offering the download on an agreement without one is a control that can only fail.
   protected readonly canDownload = computed(() => this.claGroup()?.signed === true);
+
+  protected readonly notStartedCopy = ORG_CLA_NOT_STARTED_COPY;
+
+  /**
+   * Read from the status rather than from `signed` being false, unlike `canDownload` above.
+   * Sanctions occupy the same status slot, and a sanctioned agreement carries its own explanatory
+   * body in the design — walking that viewer through how to start signing would talk past the
+   * reason they cannot.
+   */
+  protected readonly notStarted = computed(() => this.claGroup()?.status === 'not-started');
+
+  protected readonly notStartedLead = computed(() => this.initNotStartedLead());
+
+  /**
+   * The SFID and CLA Group this page already named, so Start can skip the picker.
+   *
+   * Foundation before covered project, and the order is the whole point. A CLA Group covering
+   * several projects is the ordinary case, not an edge one, and the corporate signature is keyed
+   * on the SFID sent with it — so taking the first covered project would open the agreement
+   * against one project of the several the CLA Group covers. That is not caught downstream
+   * either: the sub-project resolves back to this same CLA Group, so the mismatch guard on the
+   * response sees the id it asked for and passes.
+   *
+   * Absent a foundation, only a CLA Group covering a single project is unambiguous. Several
+   * covered projects with no foundation SFID is exactly the case search declines to name a
+   * project for, and the picker greys those rows out for the same reason.
+   */
+  protected readonly signingChoice = computed(() => this.signingChoiceFrom(this.claGroup()));
+
+  protected readonly startDisabled = computed(
+    () => !this.hasCompany() || this.signingOpen() || this.hasNoOrgAccess() || !this.orgContextLoaded() || !this.signingChoice()
+  );
+
+  protected readonly startAriaLabel = computed(() => {
+    const label = this.notStartedCopy.startLabel;
+    if (this.hasNoOrgAccess()) return `${label} — Organization Lens is not available for your account`;
+    if (!this.orgContextLoaded()) return `${label} — checking your organization access`;
+    if (!this.hasCompany()) return `${label} — select an organization first`;
+    if (this.signingOpen()) return `${label} — a signing request is already open`;
+    if (!this.signingChoice()) return `${label} — ${CCLA_SIGN_COPY.picker.multiProjectDisabledReason}`;
+    return label;
+  });
 
   protected readonly signedOnLabel = computed(() => this.initSignedOnLabel());
 
@@ -134,6 +229,36 @@ export class OrgEasyclaDetailComponent {
   protected readonly approvalBadge = computed(() => this.initApprovalBadge());
 
   protected readonly tabs = computed(() => this.initTabs());
+
+  protected readonly lockedTab = computed(() => this.initLockedTab());
+
+  public constructor() {
+    // Either arm of the context, because neither destroys this component: an organization switch
+    // re-drives the list fetch, and Angular reuses the component when `:signatureId` changes. So
+    // without this the attestation stays open over a page that has moved on, and confirming it
+    // would open a session for the agreement the viewer left rather than the one on screen.
+    this.contextChanged$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.uncommittedSigningDialog?.close());
+
+    // The organization alone, because only it invalidates the preview. The choice was made under
+    // the organization the viewer has just left, and Start would open a session against the one
+    // they arrived at; nothing here can be re-derived for it either, since the CLA Group named may
+    // not be one the new organization can sign. So the page leaves rather than re-render itself
+    // under a company the choice was never about.
+    //
+    // Compared against the choice's own organization rather than skipping the first value, because
+    // the mismatch is not always a switch this page witnesses. The choice survives history
+    // restoration and the selected organization is a cookie another tab can change, so back or
+    // reload can land here with the wrong company already in force — as the initial value, which a
+    // `skip(1)` guard is precisely blind to.
+    this.orgUid$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((uid) => {
+      if (this.previewing && this.previewSelection?.orgUid !== uid) this.leaveForList();
+    });
+
+    // A pasted or bookmarked preview address, or one whose selection did not survive the trip.
+    // Nothing can be rehydrated — see `previewSelection` — and the list is where the picker lives,
+    // so this is a redirect rather than an empty state offering to start again.
+    if (isPlatformBrowser(this.platformId) && !this.previewing && !this.signatureId()) this.leaveForList();
+  }
 
   protected selectTab(tab: OrgClaDetailTab): void {
     this.activeTab.set(tab);
@@ -162,6 +287,21 @@ export class OrgEasyclaDetailComponent {
     if (!group) return;
 
     this.dialogService.open(OrgEasyclaCoverageDialogComponent, orgClaCoverageDialogConfig(group));
+  }
+
+  /**
+   * Starts the corporate signing flow from this agreement, skipping the picker.
+   *
+   * The page already named the CLA Group. Asking again would be a second source of truth for
+   * which agreement the viewer is looking at, and a chance to hand off a different one.
+   */
+  protected startClaProcess(): void {
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    const chosen = this.signingChoice();
+    if (!orgUid || !chosen || this.signingOpen()) return;
+
+    this.signingOpen.set(true);
+    this.confirmThenHandOff(orgUid, chosen);
   }
 
   protected onDownload(): void {
@@ -193,7 +333,85 @@ export class OrgEasyclaDetailComponent {
       });
   }
 
+  private confirmThenHandOff(orgUid: string, chosen: OrgClaGroupPickerResult): void {
+    const attestationRef = this.dialogService.open(OrgEasyclaAttestationComponent, {
+      header: CCLA_SIGN_COPY.attestation.header,
+      width: '42rem',
+      style: { maxWidth: '90vw' },
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+    }) as DynamicDialogRef;
+
+    this.uncommittedSigningDialog = attestationRef;
+
+    this.whenSigningDialogEnds(attestationRef, (attestations: OrgClaSignAttestations) => {
+      this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
+    });
+  }
+
+  private afterDialogTornDown(dialogRef: DynamicDialogRef, next: () => void): void {
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => next());
+  }
+
+  private openHandOff(orgUid: string, chosen: OrgClaGroupPickerResult, attestations: OrgClaSignAttestations): void {
+    const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
+      header: CCLA_SIGN_COPY.preparing.header,
+      width: '40rem',
+      style: { maxWidth: '90vw' },
+      modal: true,
+      closable: false,
+      closeOnEscape: false,
+      dismissableMask: false,
+      data: { orgUid, projectSfid: chosen.projectSfid, claGroupId: chosen.claGroupId, attestations },
+    }) as DynamicDialogRef;
+
+    this.whenSigningDialogEnds(handoffRef);
+  }
+
+  /**
+   * Releases Start when a dialog ends, unless `onAdvance` is taking the lock to the next step.
+   *
+   * PrimeNG's header close and Escape go through `p-dialog` `onHide` → `DynamicDialogRef.destroy()`.
+   * That never emits `onClose`. A listener that only watches `onClose` therefore leaves
+   * `signingOpen` true after those dismissals, and the control stays disabled until reload.
+   */
+  private whenSigningDialogEnds<T>(dialogRef: DynamicDialogRef, onAdvance?: (value: T) => void): void {
+    let handedOff = false;
+
+    dialogRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: T | null | undefined) => {
+      if (this.uncommittedSigningDialog === dialogRef) this.uncommittedSigningDialog = null;
+      if (value && onAdvance) {
+        handedOff = true;
+        onAdvance(value);
+        return;
+      }
+      this.signingOpen.set(false);
+    });
+
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      if (!handedOff) this.signingOpen.set(false);
+    });
+  }
+
+  private signingChoiceFrom(group: OrgClaGroup | undefined): OrgClaGroupPickerResult | null {
+    const claGroupId = group?.claGroupId;
+    if (!group || !claGroupId) return null;
+
+    if (group.foundationSfid) {
+      return { claGroupId, projectSfid: group.foundationSfid, projectName: group.foundationName ?? group.claGroupName };
+    }
+
+    const [only] = group.projects;
+    if (group.projects.length !== 1 || !only?.projectSfid) return null;
+
+    return { claGroupId, projectSfid: only.projectSfid, projectName: only.projectName };
+  }
+
   private initClaGroup(): OrgClaGroup | undefined {
+    // The preview's agreement does not exist yet, so there is no row keyed by signature id to find.
+    if (this.previewSelection) return orgClaPreviewGroup(this.previewSelection);
+
     const id = this.signatureId();
     if (!id) return undefined;
     return this.claData()?.claGroups.find((group) => group.id === id);
@@ -225,6 +443,17 @@ export class OrgEasyclaDetailComponent {
     return summary && company ? `Covers ${summary} for ${company}'s employees.` : '';
   }
 
+  /**
+   * Withheld until both names are known rather than filled with a placeholder. The sentence names
+   * the organization being bound and the agreement it would be bound to, so a gap in either is the
+   * part that carries the meaning, and "— has not yet signed a CLA for —" states nothing.
+   */
+  private initNotStartedLead(): string {
+    const group = this.claGroup();
+    const company = this.companyName();
+    return group && company ? this.notStartedCopy.lead(company, group.claGroupName) : '';
+  }
+
   private initSignedOnLabel(): string {
     const signedOn = this.claGroup()?.signedOn;
     if (!signedOn) return '';
@@ -251,14 +480,61 @@ export class OrgEasyclaDetailComponent {
     return ORG_CLA_DETAIL_TABS.map((tab) => ({ ...tab, badge: this.tabBadge(tab.id) }));
   }
 
+  /**
+   * Why the open tab holds nothing, when signing is what would fill it. Null on every other tab
+   * and on a signed agreement, where the panel is simply unbuilt.
+   *
+   * Read from `signed` rather than the status, as `canDownload` is and for the same reason:
+   * sanctions occupy the single status slot, so a `sanctioned` agreement may be signed — and its
+   * CLA Managers are real people who would be told they do not exist yet.
+   */
+  private initLockedTab(): { title: string; subtitle: string } | null {
+    const group = this.claGroup();
+    if (!group || group.signed) return null;
+    return ORG_CLA_LOCKED_TAB_COPY[this.activeTab()] ?? null;
+  }
+
   private tabBadge(tab: OrgClaDetailTab): string {
     if (tab === 'managers') return this.managersBadge();
     if (tab === 'approval') return this.approvalBadge();
     return '';
   }
 
+  /**
+   * The picker's choice, validated, or null when this is not the preview route.
+   *
+   * Validated rather than trusted: the value comes back out of a history entry, so it can be a
+   * shape written by an earlier deployment or one truncated on the way. Left unchecked, a partial
+   * selection would head the page with an undefined name — and it would still offer Start, because
+   * a missing project SFID only disables signing once something reads it.
+   */
+  private readPreviewSelection(): OrgClaSignSelection | null {
+    if (!isPlatformBrowser(this.platformId)) return null;
+
+    const state = this.router.getCurrentNavigation()?.extras?.state;
+    const selection = state?.[ORG_CLA_SIGN_SELECTION_STATE] as OrgClaSignSelection | undefined;
+    if (!selection?.claGroupId || !selection.claGroupName || !selection.projectSfid || !selection.projectName || !selection.orgUid) return null;
+
+    return selection;
+  }
+
+  /**
+   * Leaves the preview for the list, replacing the address rather than pushing over it.
+   *
+   * Replacing is what actually closes the page: the choice lives in the history entry, so an entry
+   * left behind is one Back re-renders — under whichever organization is selected by then, which on
+   * the organization-switch path is precisely the wrong one.
+   */
+  private leaveForList(): void {
+    void this.router.navigate([ORG_EASYCLA_PATH], { replaceUrl: true });
+  }
+
   private initClaData(): Signal<OrgClaGroupList | null | undefined> {
-    if (!isPlatformBrowser(this.platformId)) {
+    // Not requested while previewing: `claGroup` comes from the selection, so the response would be
+    // fetched and never read. That absence is also what keeps `notFound` and `fetchError` off this
+    // page — neither can be reached without a list in hand — and `notFound` firing over a preview
+    // would tell a signatory the agreement they are about to sign does not exist.
+    if (this.previewing || !isPlatformBrowser(this.platformId)) {
       return signal<OrgClaGroupList | null | undefined>(undefined);
     }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -554,9 +554,21 @@ export class OrgEasyclaDetailComponent {
    * in-flight navigation exposes `extras.state`, and there is no in-flight navigation on a reload
    * or a restore — the entry itself survives both, so reading only the former would abandon a
    * choice the browser still holds and send the signatory back to the list for pressing refresh.
+   *
+   * Gated on the route so a leftover history entry cannot drive an agreement view. This component
+   * is reused across `/org/easycla/new` and `/org/easycla/:signatureId` — Angular re-runs the
+   * constructor on the switch, but the previous route's `history.state` is still what
+   * `location.getState()` returns until Angular has written the new entry, and the fallback would
+   * otherwise latch that stale selection under a signatureId that has nothing to do with it. The
+   * `/new` route matches `ORG_EASYCLA_NEW_SEGMENT` as its literal path and has no `signatureId`
+   * parameter, so the presence of a `signatureId` is a reliable this-is-an-agreement signal.
    */
   private readPreviewSelection(): OrgClaSignSelection | null {
     if (!isPlatformBrowser(this.platformId)) return null;
+    // The signatureId is set on the agreement route and absent on the preview route. Its
+    // presence is what disqualifies the history fallback, whether or not `extras.state` was
+    // carried by the in-flight navigation.
+    if (this.route.snapshot.paramMap.has('signatureId')) return null;
 
     const state = this.router.getCurrentNavigation()?.extras?.state ?? (this.location.getState() as Record<string, unknown> | null);
     const selection = state?.[ORG_CLA_SIGN_SELECTION_STATE] as OrgClaSignSelection | undefined;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -205,8 +205,22 @@ export class OrgEasyclaDetailComponent {
    */
   protected readonly signingChoice = computed(() => this.signingChoiceFrom(this.claGroup()));
 
+  /**
+   * The preview mode restores from history / cookie change, so the selected organization can arrive
+   * out of step with the choice the preview was made for. The `orgUid$` subscription redirects on
+   * that mismatch, but it is asynchronous — the first render can present an enabled Start button
+   * against a currently-selected organization that is not the one the choice belongs to. Reading it
+   * here (and re-reading it at the action boundary) refuses the click rather than opening the
+   * hand-off for the wrong company.
+   */
+  protected readonly previewOrgMismatch = computed(() => {
+    if (!this.previewing || !this.previewSelection) return false;
+    const uid = this.accountContext.selectedAccount()?.uid;
+    return !!uid && this.previewSelection.orgUid !== uid;
+  });
+
   protected readonly startDisabled = computed(
-    () => !this.hasCompany() || this.signingOpen() || this.hasNoOrgAccess() || !this.orgContextLoaded() || !this.signingChoice()
+    () => !this.hasCompany() || this.signingOpen() || this.hasNoOrgAccess() || !this.orgContextLoaded() || !this.signingChoice() || this.previewOrgMismatch()
   );
 
   protected readonly startAriaLabel = computed(() => {
@@ -215,6 +229,7 @@ export class OrgEasyclaDetailComponent {
     if (!this.orgContextLoaded()) return `${label} — checking your organization access`;
     if (!this.hasCompany()) return `${label} — select an organization first`;
     if (this.signingOpen()) return `${label} — a signing request is already open`;
+    if (this.previewOrgMismatch()) return `${label} — this preview was made for a different organization`;
     if (!this.signingChoice()) return `${label} — ${CCLA_SIGN_COPY.picker.multiProjectDisabledReason}`;
     return label;
   });
@@ -300,6 +315,11 @@ export class OrgEasyclaDetailComponent {
     const orgUid = this.accountContext.selectedAccount()?.uid;
     const chosen = this.signingChoice();
     if (!orgUid || !chosen || this.signingOpen()) return;
+    // The `orgUid$` redirect is asynchronous, so a click can still arrive during a brief window
+    // where the button is enabled against a currently-selected organization the preview was not
+    // made for. Refusing here rather than only in the disabled state keeps a race click from
+    // opening the hand-off for the wrong company.
+    if (this.previewSelection && this.previewSelection.orgUid !== orgUid) return;
 
     this.signingOpen.set(true);
     this.confirmThenHandOff(orgUid, chosen);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -367,8 +367,29 @@ export class OrgEasyclaDetailComponent {
     this.uncommittedSigningDialog = attestationRef;
 
     this.whenSigningDialogEnds(attestationRef, (attestations: OrgClaSignAttestations) => {
-      this.afterDialogTornDown(attestationRef, () => this.openHandOff(orgUid, chosen, attestations));
+      // Wait for `onDestroy`, not `onClose`, because opening a second dialog while the first is
+      // still tearing down leaves PrimeNG's overlay stack half-mounted — the new dialog opens
+      // behind the modal mask of the old one, focus never lands on it, and Escape closes the
+      // wrong one. `onDestroy` fires after the leave animation and after the ref is disposed.
+      //
+      // The wait is what lets the organization or the CLA Group change underneath the callback.
+      // The attestation names neither — its payload is just the ticked boxes — so opening the
+      // hand-off with the captured values would sign a *different* company's CCLA, or a different
+      // agreement for the same company, than the one the viewer confirmed. Re-check both against
+      // the live signals immediately before opening, and release the Start lock on a mismatch so
+      // a subsequent click can start over cleanly.
+      this.afterDialogTornDown(attestationRef, () => this.openHandOffIfContextHeld(orgUid, chosen, attestations));
     });
+  }
+
+  private openHandOffIfContextHeld(orgUid: string, chosen: OrgClaGroupPickerResult, attestations: OrgClaSignAttestations): void {
+    const currentUid = this.accountContext.selectedAccount()?.uid;
+    const currentChoice = this.signingChoice();
+    if (currentUid !== orgUid || currentChoice?.claGroupId !== chosen.claGroupId) {
+      this.signingOpen.set(false);
+      return;
+    }
+    this.openHandOff(orgUid, chosen, attestations);
   }
 
   private afterDialogTornDown(dialogRef: DynamicDialogRef, next: () => void): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, Location } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -59,6 +59,7 @@ import { OrgEasyclaSignHandoffComponent } from '../org-easycla-sign/org-easycla-
 export class OrgEasyclaDetailComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly location = inject(Location);
   private readonly accountContext = inject(AccountContextService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
@@ -507,11 +508,16 @@ export class OrgEasyclaDetailComponent {
    * shape written by an earlier deployment or one truncated on the way. Left unchecked, a partial
    * selection would head the page with an undefined name — and it would still offer Start, because
    * a missing project SFID only disables signing once something reads it.
+   *
+   * Read from the history entry as well as from the navigation that is carrying it. Only the
+   * in-flight navigation exposes `extras.state`, and there is no in-flight navigation on a reload
+   * or a restore — the entry itself survives both, so reading only the former would abandon a
+   * choice the browser still holds and send the signatory back to the list for pressing refresh.
    */
   private readPreviewSelection(): OrgClaSignSelection | null {
     if (!isPlatformBrowser(this.platformId)) return null;
 
-    const state = this.router.getCurrentNavigation()?.extras?.state;
+    const state = this.router.getCurrentNavigation()?.extras?.state ?? (this.location.getState() as Record<string, unknown> | null);
     const selection = state?.[ORG_CLA_SIGN_SELECTION_STATE] as OrgClaSignSelection | undefined;
     if (!selection?.claGroupId || !selection.claGroupName || !selection.projectSfid || !selection.projectName || !selection.orgUid) return null;
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.html
@@ -1,0 +1,68 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+
+Every string below is bound from CCLA_SIGN_COPY.attestation, verbatim from the M3 prototype.
+This is legal attestation copy: do not hardcode a sentence here, and do not reword one.
+-->
+
+<div class="flex flex-col" data-testid="org-easycla-attestation-dialog">
+  <p class="text-sm font-semibold text-slate-900">{{ copy.authorityHeading }}</p>
+  <div class="mt-2">
+    <lfx-checkbox
+      [form]="form"
+      control="authorityAcked"
+      [label]="copy.authorityLabel"
+      labelClass="text-sm text-slate-700"
+      data-testid="org-easycla-attestation-authority" />
+  </div>
+
+  <p class="mt-6 text-sm font-semibold text-slate-900">{{ copy.embargoHeading }}</p>
+  <div class="mt-2">
+    <lfx-checkbox
+      [form]="form"
+      control="embargoAcked"
+      [label]="copy.embargoLabel"
+      labelClass="text-sm text-slate-700"
+      ariaDescribedBy="org-easycla-attestation-conditions"
+      data-testid="org-easycla-attestation-embargo" />
+  </div>
+
+  <!--
+    Described by, not merely adjacent. The checkbox's own label ends "… is not:", and the terms
+    that finish that sentence are these list items. Without the association a screen-reader user
+    arrives at the control having heard an incomplete sentence and affirms terms never read to
+    them, which is not a defensible way to take a legal attestation.
+  -->
+  <ul
+    id="org-easycla-attestation-conditions"
+    class="mt-3 flex list-disc flex-col gap-2 pl-9 text-sm text-slate-700"
+    data-testid="org-easycla-attestation-conditions">
+    @for (condition of copy.embargoConditions; track condition) {
+      <li>{{ condition }}</li>
+    }
+    <!--
+      Split rather than listed with the two above because the link sits mid-sentence. `noopener`
+      is on the link because the opened context must not be handed control of this one — this
+      page is mid-way through a legal act.
+    -->
+    <li>
+      {{ copy.embargoSanctionsCondition.before
+      }}<a [href]="copy.embargoSanctionsCondition.linkUrl" target="_blank" rel="noopener noreferrer" class="text-blue-700 underline">{{
+        copy.embargoSanctionsCondition.linkText
+      }}</a
+      >{{ copy.embargoSanctionsCondition.after }}
+    </li>
+  </ul>
+
+  <!--
+    No "I am not authorized" control here, operable or disabled. The designee path it belongs to
+    is not implemented in this feature, and a legal confirmation step is the wrong place to
+    advertise an unavailable route: a signatory who is genuinely not authorized would read a
+    greyed-out control as their answer and stop, having been shown no way forward at all.
+  -->
+  <div class="mt-8 flex justify-end gap-2">
+    <lfx-button [label]="copy.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-attestation-cancel" />
+    <lfx-button [label]="copy.continueLabel" [disabled]="!bothAcked()" (onClick)="onContinue()" data-testid="org-easycla-attestation-continue" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.spec.ts
@@ -1,0 +1,158 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrgEasyclaAttestationComponent } from './org-easycla-attestation.component';
+
+/**
+ * The attestation gate, from the browser's side.
+ *
+ * The controller specs prove the server refuses an unaffirmed request. These prove the two things
+ * only the client can be wrong about: that the control cannot be reached without both boxes, and
+ * that what leaves the dialog is what the signatory actually set rather than a literal written
+ * on the way out.
+ */
+describe('OrgEasyclaAttestationComponent', () => {
+  const close = vi.fn();
+
+  async function render(): Promise<ComponentFixture<OrgEasyclaAttestationComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaAttestationComponent],
+      providers: [{ provide: DynamicDialogRef, useValue: { close } }],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaAttestationComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  /** Reaches the component's own form, which is what the template binds and the click reads. */
+  function form(fixture: ComponentFixture<OrgEasyclaAttestationComponent>) {
+    return (fixture.componentInstance as unknown as { form: { controls: Record<string, { setValue: (v: boolean) => void }> } }).form;
+  }
+
+  function continueButton(fixture: ComponentFixture<OrgEasyclaAttestationComponent>): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('[data-testid="org-easycla-attestation-continue"] button') as HTMLButtonElement;
+  }
+
+  beforeEach(() => close.mockClear());
+
+  it('opens with neither confirmation given', async () => {
+    const fixture = await render();
+
+    const boxes = Array.from(fixture.nativeElement.querySelectorAll('input[type="checkbox"]')) as HTMLInputElement[];
+    expect(boxes).toHaveLength(2);
+    expect(boxes.every((box) => !box.checked)).toBe(true);
+  });
+
+  it('cannot be continued with neither confirmation', async () => {
+    const fixture = await render();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it.each([['authorityAcked'], ['embargoAcked']])('cannot be continued with only %s given', async (control) => {
+    const fixture = await render();
+
+    form(fixture).controls[control].setValue(true);
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('can be continued once both are given', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    form(fixture).controls['embargoAcked'].setValue(true);
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(false);
+  });
+
+  // Withdrawal must re-close the gate. A `bothAcked` computed once and cached, or a flag set on
+  // first tick and never cleared, would leave the control live after the signatory changed their
+  // mind — and the request would then carry an affirmation they had visibly retracted.
+  it('cannot be continued again after a confirmation is withdrawn', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    form(fixture).controls['embargoAcked'].setValue(true);
+    fixture.detectChanges();
+    form(fixture).controls['embargoAcked'].setValue(false);
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('closes with both confirmations as the signatory set them', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    form(fixture).controls['embargoAcked'].setValue(true);
+    fixture.detectChanges();
+    continueButton(fixture).click();
+
+    expect(close).toHaveBeenCalledWith({ authorityAcked: true, embargoAcked: true });
+  });
+
+  // The load-bearing one. Invoking continue directly bypasses the disabled attribute, which is
+  // exactly what a regression in the template would do. Nothing must close the dialog with an
+  // affirmation the form does not hold.
+  it('closes with nothing when continue is invoked while a confirmation is withdrawn', async () => {
+    const fixture = await render();
+
+    form(fixture).controls['authorityAcked'].setValue(true);
+    fixture.detectChanges();
+    (fixture.componentInstance as unknown as { onContinue: () => void }).onContinue();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('closes with nothing when the signatory backs out', async () => {
+    const fixture = await render();
+
+    (fixture.nativeElement.querySelector('[data-testid="org-easycla-attestation-cancel"] button') as HTMLButtonElement).click();
+
+    expect(close).toHaveBeenCalledWith(null);
+  });
+
+  it('renders the attestation wording verbatim', async () => {
+    const fixture = await render();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.authorityHeading);
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.authorityLabel);
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.embargoHeading);
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.embargoLabel);
+    for (const condition of CCLA_SIGN_COPY.attestation.embargoConditions) {
+      expect(text).toContain(condition);
+    }
+    expect(text).toContain(CCLA_SIGN_COPY.attestation.embargoSanctionsCondition.linkText);
+  });
+
+  it('links the sanctions authority without handing it control of this page', async () => {
+    const fixture = await render();
+
+    const link = fixture.nativeElement.querySelector('[data-testid="org-easycla-attestation-conditions"] a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe(CCLA_SIGN_COPY.attestation.embargoSanctionsCondition.linkUrl);
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toContain('noopener');
+  });
+
+  // Self-sign only in this feature. A disabled "I am not authorized" control would tell a
+  // signatory who genuinely is not authorized that they have no route at all.
+  it('offers no designee control, neither operable nor disabled', async () => {
+    const fixture = await render();
+    const text = ((fixture.nativeElement as HTMLElement).textContent ?? '').toLowerCase();
+
+    expect(text).not.toContain('i am not authorized');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-attestation.component.ts
@@ -1,0 +1,74 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup } from '@angular/forms';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import type { OrgClaSignAttestations } from '@lfx-one/shared/interfaces';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+
+/**
+ * The authorization and export-compliance confirmations, ahead of the corporate signing hand-off
+ * (#1983).
+ *
+ * Every string it renders comes from `CCLA_SIGN_COPY.attestation`, verbatim from the M3
+ * prototype. This is the first attestation the product renders itself — every earlier CLA surface
+ * handed off to another product before any attestation appeared — so the wording is a single
+ * defined artifact, not copy. Do not paraphrase it here, and do not inline a variant.
+ *
+ * Closes with the two confirmations as the signatory actually left them, or `null` if they backed
+ * out. It deliberately does **not** close with a bare "confirmed" signal: the values are what the
+ * request transmits, and reconstructing them at the caller would mean the caller asserting an
+ * attestation rather than relaying one.
+ */
+@Component({
+  selector: 'lfx-org-easycla-attestation',
+  imports: [ButtonComponent, CheckboxComponent],
+  templateUrl: './org-easycla-attestation.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaAttestationComponent {
+  private readonly ref = inject(DynamicDialogRef);
+
+  protected readonly copy = CCLA_SIGN_COPY.attestation;
+
+  /** Both start unticked. Nothing in this flow pre-affirms either one. */
+  protected readonly form = new FormGroup({
+    authorityAcked: new FormControl<boolean>(false, { nonNullable: true }),
+    embargoAcked: new FormControl<boolean>(false, { nonNullable: true }),
+  });
+
+  /**
+   * Mirrors the form rather than being derived in the template, so withdrawing a confirmation
+   * re-disables the control on the same change that cleared it.
+   */
+  protected readonly bothAcked = signal(false);
+
+  public constructor() {
+    this.form.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.bothAcked.set(this.form.controls.authorityAcked.value === true && this.form.controls.embargoAcked.value === true);
+    });
+  }
+
+  protected onContinue(): void {
+    const authorityAcked = this.form.controls.authorityAcked.value === true;
+    const embargoAcked = this.form.controls.embargoAcked.value === true;
+
+    // Re-read from the controls at the moment of the click rather than trusting the disabled
+    // state that led here. The disabled control is the safeguard; this is the record. If the two
+    // ever disagree, the one that matters legally is what the signatory actually set, and closing
+    // with a literal `true` would make that disagreement undetectable everywhere downstream.
+    if (!authorityAcked || !embargoAcked) return;
+
+    const attestations: OrgClaSignAttestations = { authorityAcked, embargoAcked };
+    this.ref.close(attestations);
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -47,7 +47,13 @@ SPDX-License-Identifier: MIT
       @if (error()) {
         <div role="alert" class="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600" data-testid="org-easycla-group-select-error">
           <span>Couldn't load CLA groups.</span>
-          <lfx-button label="Retry" size="small" [text]="true" icon="fa-light fa-arrow-rotate-left" (onClick)="retry()" />
+          <lfx-button
+            label="Retry"
+            size="small"
+            [text]="true"
+            icon="fa-light fa-arrow-rotate-left"
+            data-testid="org-easycla-group-select-retry"
+            (onClick)="retry()" />
         </div>
       } @else if (queryBand() === 'empty') {
         <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-empty">{{ copy.empty }}</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -1,0 +1,138 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+-->
+
+<div class="flex flex-col" data-testid="org-easycla-group-select-dialog">
+  <p class="mb-4 text-sm text-slate-600">{{ copy.body }}</p>
+
+  <!--
+    The results list is in flow, not an absolutely positioned overlay: inside a DynamicDialog an
+    overlay contributes no height, so the dialog stays short and its content box crops the list.
+  -->
+  <!--
+    Keydown is bound here rather than on the rows. The rows are not focusable — focus stays in the
+    text box so the viewer can keep typing while moving the highlight.
+
+    The combobox attributes go on the input itself, not on this container and not on the listbox.
+    `aria-activedescendant` is read from whatever holds focus, which is the text box throughout;
+    on the listbox it names the right element and is never announced, because nothing ever focuses
+    the listbox. That failure is invisible on screen, which is how it survived a first pass.
+  -->
+  <div (keydown)="onKeydown($event)">
+    <label for="org-easycla-group-select-search-input" class="sr-only">{{ copy.placeholder }}</label>
+    <lfx-input-text
+      [id]="'org-easycla-group-select-search-input'"
+      [form]="searchForm"
+      control="query"
+      type="text"
+      size="small"
+      icon="fa-light fa-magnifying-glass"
+      [placeholder]="copy.placeholder"
+      autocomplete="off"
+      styleClass="w-full"
+      role="combobox"
+      ariaAutocomplete="list"
+      ariaControls="org-easycla-group-select-results"
+      [ariaExpanded]="listboxOpen()"
+      [ariaActivedescendant]="activeOptionId()"
+      dataTest="org-easycla-group-select-search" />
+
+    <div
+      id="org-easycla-group-select-results"
+      role="listbox"
+      aria-label="Matching CLA groups"
+      class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg"
+      data-testid="org-easycla-group-select-results">
+      @if (error()) {
+        <div role="alert" class="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600" data-testid="org-easycla-group-select-error">
+          <span>Couldn't load CLA groups.</span>
+          <lfx-button label="Retry" size="small" [text]="true" icon="fa-light fa-arrow-rotate-left" (onClick)="retry()" />
+        </div>
+      } @else if (queryBand() === 'empty') {
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-empty">{{ copy.empty }}</div>
+      } @else if (queryBand() === 'short') {
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-keep-typing">
+          Keep typing — searching starts at {{ minChars }} characters.
+        </div>
+      } @else if (loading() && options().length === 0) {
+        <div class="flex items-center gap-2 px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-loading">
+          <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+          Searching…
+        </div>
+      } @else if (!loading() && options().length === 0) {
+        <div class="px-4 py-3 text-sm text-slate-500" data-testid="org-easycla-group-select-no-match">{{ copy.noMatch }}</div>
+      } @else {
+        <!--
+          Results stay on screen while the next search runs, matching the Me-lens picker: a cold
+          producer search is a multi-table scan, so swapping the list for a spinner on every
+          keystroke past the third would flash the modal empty for that whole window.
+
+          Shown for the debounce as well as the request (`stale`, not just `loading`), because the
+          rows underneath answer the previous term for both — and they are not selectable for
+          either, so the banner is what explains why clicking one does nothing.
+        -->
+        @if (stale()) {
+          <div class="flex items-center gap-2 border-b border-slate-100 px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-pending">
+            <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+            Searching…
+          </div>
+        }
+        @for (option of options(); track option.claGroupId; let index = $index) {
+          <!--
+            A row that cannot be signed keeps its place and states why, rather than disappearing.
+            The reason is rendered as visible text and not only as a tooltip, because a tooltip
+            would never reach a viewer who cannot hover. It is inside the option, so the reason is
+            part of the row's accessible name and is read when the highlight arrives.
+          -->
+          <div
+            role="option"
+            [id]="'org-easycla-group-option-' + option.claGroupId"
+            [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
+            [attr.aria-disabled]="!!option.disabledReason || stale()"
+            class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
+            [class.cursor-pointer]="!option.disabledReason && !stale()"
+            [class.hover:bg-slate-50]="!option.disabledReason && !stale()"
+            [class.cursor-not-allowed]="!!option.disabledReason || stale()"
+            [class.opacity-60]="!!option.disabledReason || stale()"
+            [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
+            [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
+            (click)="onSelect(option)">
+            <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
+            @if (option.secondaryName) {
+              <span class="block text-xs text-slate-500">{{ option.secondaryName }}</span>
+            }
+            <!--
+              Shown only for a repository match, where the row would otherwise contain nothing the
+              viewer typed: pasting a repo link resolves to the CLA Group covering it, whose project
+              and group names need share no text with the address. Without this the row reads as an
+              unrelated result. It is inside the option, so it is part of the accessible name and is
+              read when the highlight arrives.
+            -->
+            @if (option.matchedRepositoryName) {
+              <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-matched-repo-' + option.claGroupId">
+                <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
+                <span class="truncate">{{ option.matchedRepositoryName }}</span>
+              </span>
+            }
+            @if (option.disabledReason) {
+              <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
+                {{ option.disabledReason }}
+              </span>
+            }
+          </div>
+        }
+        @if (truncated()) {
+          <div class="px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-truncated">
+            More CLA groups matched than can be shown. Narrow your search.
+          </div>
+        }
+      }
+    </div>
+  </div>
+
+  <div class="mt-6 flex justify-end gap-2">
+    <lfx-button [label]="copy.cancelLabel" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-group-cancel" />
+    <lfx-button [label]="copy.continueLabel" [disabled]="!selected()" (onClick)="onContinue()" data-testid="org-easycla-group-continue" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -38,12 +38,14 @@ SPDX-License-Identifier: MIT
       [ariaActivedescendant]="activeOptionId()"
       dataTest="org-easycla-group-select-search" />
 
-    <div
-      id="org-easycla-group-select-results"
-      role="listbox"
-      aria-label="Matching CLA groups"
-      class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg"
-      data-testid="org-easycla-group-select-results">
+    <!--
+      Panel is a plain container: `role="listbox"` may only own `option` nodes (or groups of them),
+      so status content (error + Retry, keep-typing, empty, no-match, and the stale banner) sits
+      alongside the listbox rather than inside it. Assistive technology reports each state
+      accurately and the interactive Retry button is not suppressed as an out-of-shape listbox
+      child.
+    -->
+    <div class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg" data-testid="org-easycla-group-select-panel">
       @if (error()) {
         <div role="alert" class="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600" data-testid="org-easycla-group-select-error">
           <span>Couldn't load CLA groups.</span>
@@ -77,6 +79,8 @@ SPDX-License-Identifier: MIT
           Shown for the debounce as well as the request (`stale`, not just `loading`), because the
           rows underneath answer the previous term for both — and they are not selectable for
           either, so the banner is what explains why clicking one does nothing.
+
+          Rendered outside the listbox, because it is a status message, not an option.
         -->
         @if (stale()) {
           <div class="flex items-center gap-2 border-b border-slate-100 px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-pending">
@@ -84,50 +88,56 @@ SPDX-License-Identifier: MIT
             Searching…
           </div>
         }
-        @for (option of options(); track option.claGroupId; let index = $index) {
-          <!--
-            A row that cannot be signed keeps its place and states why, rather than disappearing.
-            The reason is rendered as visible text and not only as a tooltip, because a tooltip
-            would never reach a viewer who cannot hover. It is inside the option, so the reason is
-            part of the row's accessible name and is read when the highlight arrives.
-          -->
-          <div
-            role="option"
-            [id]="'org-easycla-group-option-' + option.claGroupId"
-            [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
-            [attr.aria-disabled]="!!option.disabledReason || stale()"
-            class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
-            [class.cursor-pointer]="!option.disabledReason && !stale()"
-            [class.hover:bg-slate-50]="!option.disabledReason && !stale()"
-            [class.cursor-not-allowed]="!!option.disabledReason || stale()"
-            [class.opacity-60]="!!option.disabledReason || stale()"
-            [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
-            [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
-            (click)="onSelect(option)">
-            <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
-            @if (option.secondaryName) {
-              <span class="block text-xs text-slate-500">{{ option.secondaryName }}</span>
-            }
+        <div id="org-easycla-group-select-results" role="listbox" aria-label="Matching CLA groups" data-testid="org-easycla-group-select-results">
+          @for (option of options(); track option.claGroupId; let index = $index) {
             <!--
-              Shown only for a repository match, where the row would otherwise contain nothing the
-              viewer typed: pasting a repo link resolves to the CLA Group covering it, whose project
-              and group names need share no text with the address. Without this the row reads as an
-              unrelated result. It is inside the option, so it is part of the accessible name and is
-              read when the highlight arrives.
+              A row that cannot be signed keeps its place and states why, rather than disappearing.
+              The reason is rendered as visible text and not only as a tooltip, because a tooltip
+              would never reach a viewer who cannot hover. It is inside the option, so the reason is
+              part of the row's accessible name and is read when the highlight arrives.
             -->
-            @if (option.matchedRepositoryName) {
-              <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-matched-repo-' + option.claGroupId">
-                <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
-                <span class="truncate">{{ option.matchedRepositoryName }}</span>
-              </span>
-            }
-            @if (option.disabledReason) {
-              <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
-                {{ option.disabledReason }}
-              </span>
-            }
-          </div>
-        }
+            <div
+              role="option"
+              [id]="'org-easycla-group-option-' + option.claGroupId"
+              [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
+              [attr.aria-disabled]="!!option.disabledReason || stale()"
+              class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
+              [class.cursor-pointer]="!option.disabledReason && !stale()"
+              [class.hover:bg-slate-50]="!option.disabledReason && !stale()"
+              [class.cursor-not-allowed]="!!option.disabledReason || stale()"
+              [class.opacity-60]="!!option.disabledReason || stale()"
+              [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
+              [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
+              (click)="onSelect(option)">
+              <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
+              @if (option.secondaryName) {
+                <span class="block text-xs text-slate-500">{{ option.secondaryName }}</span>
+              }
+              <!--
+                Shown only for a repository match, where the row would otherwise contain nothing the
+                viewer typed: pasting a repo link resolves to the CLA Group covering it, whose project
+                and group names need share no text with the address. Without this the row reads as an
+                unrelated result. It is inside the option, so it is part of the accessible name and is
+                read when the highlight arrives.
+              -->
+              @if (option.matchedRepositoryName) {
+                <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-matched-repo-' + option.claGroupId">
+                  <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
+                  <span class="truncate">{{ option.matchedRepositoryName }}</span>
+                </span>
+              }
+              @if (option.disabledReason) {
+                <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
+                  {{ option.disabledReason }}
+                </span>
+              }
+            </div>
+          }
+        </div>
+        <!--
+          A status note rather than a row. Rendered outside the listbox so it is not misannounced
+          as an option — it names none.
+        -->
         @if (truncated()) {
           <div class="px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-truncated">
             More CLA groups matched than can be shown. Narrow your search.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -39,6 +39,20 @@ SPDX-License-Identifier: MIT
       dataTest="org-easycla-group-select-search" />
 
     <!--
+      Focus stays in the combobox input throughout, so a state change elsewhere on the panel does
+      not tell a screen-reader user that a search started, that no CLA Group matched, or that
+      results have arrived. This region mirrors those transitions in words: `aria-live="polite"`
+      reads them out without stealing focus; `aria-atomic="true"` reads the whole region on each
+      change so a stale fragment cannot linger.
+
+      `sr-only` keeps it visually hidden — the sighted viewer already sees the loading spinner,
+      the "No matches" panel, or the row count.
+    -->
+    <div class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-testid="org-easycla-group-select-live">
+      {{ liveAnnouncement() }}
+    </div>
+
+    <!--
       Panel is a plain container: `role="listbox"` may only own `option` nodes (or groups of them),
       so status content (error + Retry, keep-typing, empty, no-match, and the stale banner) sits
       alongside the listbox rather than inside it. Assistive technology reports each state

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -519,12 +519,61 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       expect(input().getAttribute('role')).toBe('combobox');
       expect(input().getAttribute('aria-autocomplete')).toBe('list');
       expect(input().getAttribute('aria-controls')).toBe('org-easycla-group-select-results');
-      expect(results_(fixture).id).toBe('org-easycla-group-select-results');
 
       // Before a search there is nothing to expand into; after one there is.
       expect(input().getAttribute('aria-expanded')).toBe('false');
       await search(fixture);
       expect(input().getAttribute('aria-expanded')).toBe('true');
+      // The `aria-controls` target only exists when there is a listbox to point at, and it carries
+      // `role="listbox"` — not the surrounding scroll panel, which owns non-option status content
+      // (error + Retry, keep-typing, stale banner) that a listbox cannot legally contain.
+      const listbox = results_(fixture);
+      expect(listbox.id).toBe('org-easycla-group-select-results');
+      expect(listbox.getAttribute('role')).toBe('listbox');
+      expect(listbox.getAttribute('aria-label')).toBe('Matching CLA groups');
+    });
+
+    /**
+     * ARIA listbox is allowed to contain options (and optgroups of options), and nothing else.
+     * The panel used to wrap the error message, the Retry button, the keep-typing hint, the
+     * loading spinner, the no-match copy, the stale-search banner, and the "more matched than can
+     * be shown" note all inside the listbox. Screen readers either dropped those or announced
+     * them as broken options; the Retry button in particular was reached by pointer only.
+     *
+     * Two shapes are checked here — an error state and a searchable-with-options state — because
+     * the regression is that a status widget re-enters the listbox subtree. A single option-only
+     * snapshot would pass against the broken version if the error state were the one restructured
+     * and the results state left inside a listbox with its status siblings.
+     */
+    it('keeps non-option content out of the listbox in every state', async () => {
+      getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
+
+      const fixture = await render();
+      await search(fixture);
+
+      // In error state, there is no listbox at all. The error and its Retry button are alongside
+      // the search box under the scroll panel.
+      expect(fixture.nativeElement.querySelector('[role="listbox"]')).toBeNull();
+      expect(testid(fixture, 'org-easycla-group-select-error')).not.toBeNull();
+      expect(testid(fixture, 'org-easycla-group-select-retry')).not.toBeNull();
+    });
+
+    it('keeps the stale banner and the truncated note as siblings of the listbox, not inside it', async () => {
+      const many = Array.from({ length: 26 }, (_, index) => ({ ...signable, claGroupId: `cla-${index}`, projectSfid: `sfid-${index}` }));
+      getSignOptions.mockReturnValue(of(results(many, true)));
+
+      const fixture = await render();
+      await search(fixture);
+
+      const listbox = results_(fixture);
+      // Every child of the listbox is an option — nothing else.
+      const nonOptionChildren = Array.from(listbox.children).filter((child) => child.getAttribute('role') !== 'option');
+      expect(nonOptionChildren).toEqual([]);
+
+      // And the "more matched than can be shown" note sits *outside* the listbox, in the panel.
+      const truncated = testid(fixture, 'org-easycla-group-select-truncated');
+      expect(truncated).not.toBeNull();
+      expect(listbox.contains(truncated as Node)).toBe(false);
     });
 
     it('names the highlighted row so a screen reader can follow the arrow keys', async () => {
@@ -552,6 +601,28 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       press(fixture, 'ArrowUp');
 
       expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+    });
+
+    // No row is on before the first key press. Down lands on the first row and Up lands on the
+    // last — the expected entry points into a list a viewer has not touched yet. A modular step
+    // from the empty state would land on `length - 2` for Up, which reads to a screen-reader
+    // user as "the second-to-last CLA Group is highlighted" for no reason they typed.
+    it('lands on the first row on Down and the last row on Up from the fresh list', async () => {
+      getSignOptions.mockReturnValue(of(results([signable, individualOnly, multiProject])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+    });
+
+    it('lands on the last row on the first Up from the fresh list', async () => {
+      getSignOptions.mockReturnValue(of(results([signable, individualOnly, multiProject])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowUp');
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${multiProject.claGroupId}`);
     });
 
     // The highlight does stop on a row that cannot be signed, because the reason it cannot is the

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -1,0 +1,729 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import type { ClaGroupOption, ClaGroupSearchResponse, OrgClaGroup } from '@lfx-one/shared/interfaces';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrgEasyclaGroupSelectComponent } from './org-easycla-group-select.component';
+
+/**
+ * The Organization Lens CLA Group picker.
+ *
+ * The searching itself is the Me-lens picker's debounce and minimum-term behaviour and is covered
+ * there. What is new — and what these specs are for — is that this picker keeps rows it cannot
+ * sign, says why, and refuses to return one.
+ */
+describe('OrgEasyclaGroupSelectComponent', () => {
+  const getSignOptions = vi.fn();
+  const close = vi.fn();
+  const orgUid = '0014100000Te0xxAAC';
+
+  // Not cast. A cast would let a fixture omit a field the shared view mapper reads, and the
+  // failure would surface as an unrelated runtime error rather than a type error here.
+  const signable: ClaGroupOption = {
+    claGroupId: '11111111-1111-4111-8111-111111111111',
+    claGroupName: 'Cascade CLA',
+    projectName: 'Cascade',
+    projectSfid: 'a09410000182dD2AAI',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+  };
+
+  /** A CLA Group covering several projects: the producer cannot be told which one to sign for. */
+  const multiProject: ClaGroupOption = {
+    claGroupId: '22222222-2222-4222-8222-222222222222',
+    claGroupName: 'Driftwood Umbrella CLA',
+    projectName: 'Driftwood Umbrella',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+  };
+
+  /** Reached by pasting a repository address: nothing in the names carries the term that found it. */
+  const repositoryMatch: ClaGroupOption = {
+    claGroupId: '44444444-4444-4444-8444-444444444444',
+    claGroupName: 'Cascade CLA',
+    projectName: 'Cascade',
+    projectSfid: 'a09410000182dD4AAI',
+    cclaEnabled: true,
+    iclaEnabled: true,
+    matchTypes: ['repository'],
+    matchedRepositoryName: 'acme-org/waterfall-sdk',
+    organizations: [],
+  };
+
+  /** A CLA Group configured for individual agreements only. */
+  const individualOnly: ClaGroupOption = {
+    claGroupId: '33333333-3333-4333-8333-333333333333',
+    claGroupName: 'Beacon ICLA-only CLA',
+    projectName: 'Beacon',
+    projectSfid: 'a09410000182dD3AAI',
+    cclaEnabled: false,
+    iclaEnabled: true,
+    matchTypes: ['project'],
+    organizations: [],
+  };
+
+  function results(options: ClaGroupOption[], truncated = false, searchTerm = 'cascade'): ClaGroupSearchResponse {
+    return { results: options, truncated, searchTerm, resultCount: options.length };
+  }
+
+  /** One row of the organization's own CLA list, as the page hands it down. */
+  function held(claGroupId: string): OrgClaGroup {
+    return {
+      id: 'signature-uuid-1',
+      claGroupId,
+      claGroupName: 'Cascade CLA',
+      projects: [{ projectName: 'Cascade', projectSfid: 'a09410000182dD2AAI' }],
+      signed: true,
+      status: 'signed',
+      needsClaManager: false,
+      claManagersCount: 1,
+    };
+  }
+
+  async function render(claGroups: OrgClaGroup[] = []): Promise<ComponentFixture<OrgEasyclaGroupSelectComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaGroupSelectComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: { orgUid, claGroups } } },
+        { provide: OrgLensClaService, useValue: { getSignOptions } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaGroupSelectComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  /** Types a searchable term and lets the debounce elapse. */
+  async function search(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, term = 'cascade'): Promise<void> {
+    const form = (fixture.componentInstance as unknown as { searchForm: { controls: { query: { setValue: (v: string) => void } } } }).searchForm;
+    form.controls.query.setValue(term);
+    await vi.advanceTimersByTimeAsync(600);
+    fixture.detectChanges();
+  }
+
+  function testid(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, id: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+  }
+
+  function row(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, option: ClaGroupOption): HTMLElement {
+    return testid(fixture, `org-easycla-group-select-${option.claGroupId}`) as HTMLElement;
+  }
+
+  function continueButton(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLButtonElement {
+    return testid(fixture, 'org-easycla-group-continue')?.querySelector('button') as HTMLButtonElement;
+  }
+
+  /** The focused element, and so the only one whose ARIA state assistive technology announces. */
+  function searchBoxOf(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLInputElement {
+    return fixture.nativeElement.querySelector('#org-easycla-group-select-search-input') as HTMLInputElement;
+  }
+
+  // jsdom implements no layout, so it ships no `scrollIntoView` at all — an unstubbed arrow press
+  // throws before the assertion is reached. Stubbed on the prototype rather than per element
+  // because the highlight scrolls on every arrow press, not on one deep-linked element.
+  const scrollIntoView = vi.fn();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getSignOptions.mockReset();
+    close.mockClear();
+    scrollIntoView.mockClear();
+    Element.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('uses the M3 prototype copy, not a paraphrase of it', async () => {
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-group-select-dialog')?.querySelector('p')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.body);
+    expect(searchBoxOf(fixture).getAttribute('placeholder')).toBe(CCLA_SIGN_COPY.picker.placeholder);
+    expect(testid(fixture, 'org-easycla-group-select-empty')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.empty);
+    expect(continueButton(fixture).textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.continueLabel);
+  });
+
+  it('searches the viewing organization, not the whole platform', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture, 'cascade');
+
+    expect(getSignOptions).toHaveBeenCalledWith(orgUid, 'cascade');
+  });
+
+  it('does not search before the minimum term length', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture, 'ca'.slice(0, CLA_GROUP_SEARCH_MIN_CHARS - 1));
+
+    expect(getSignOptions).not.toHaveBeenCalled();
+    expect(testid(fixture, 'org-easycla-group-select-keep-typing')).not.toBeNull();
+  });
+
+  it('offers a signable CLA group without a reason against it', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(row(fixture, signable)).not.toBeNull();
+    expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('false');
+    expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)).toBeNull();
+  });
+
+  // A row that cannot be signed stays on screen. Filtering it out would leave the viewer
+  // searching again for a CLA Group they can see in the legacy console, with no explanation.
+  it('keeps a multi-project CLA group visible and says why it cannot be signed here', async () => {
+    getSignOptions.mockReturnValue(of(results([multiProject])));
+
+    const fixture = await render();
+    await search(fixture, 'driftwood');
+
+    expect(row(fixture, multiProject).getAttribute('aria-disabled')).toBe('true');
+    expect(testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.multiProjectDisabledReason);
+  });
+
+  it('keeps an individual-only CLA group visible and says why it cannot be signed corporately', async () => {
+    getSignOptions.mockReturnValue(of(results([individualOnly])));
+
+    const fixture = await render();
+    await search(fixture, 'beacon');
+
+    expect(row(fixture, individualOnly).getAttribute('aria-disabled')).toBe('true');
+    expect(testid(fixture, `org-easycla-group-disabled-${individualOnly.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.cclaDisabledReason);
+  });
+
+  /**
+   * A CLA Group the organization already holds a corporate agreement for.
+   *
+   * Left selectable, Continue carries the viewer to a preview headed "«Org» has not yet signed a
+   * CLA for «Group»" — a false statement about an agreement that exists — and offers to sign it
+   * again. The refusal is what stops that, so these cases assert the row, the reason, and that
+   * neither pointer nor keyboard can get past it.
+   */
+  describe('a CLA group the organization has already signed', () => {
+    it('keeps the row visible and says the organization already holds one', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(signable.claGroupId)]);
+      await search(fixture);
+
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('true');
+      expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.alreadySignedDisabledReason);
+    });
+
+    it('cannot be chosen by pointer or by keyboard', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(signable.claGroupId)]);
+      await search(fixture);
+      row(fixture, signable).click();
+      testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      fixture.detectChanges();
+
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    /**
+     * EasyCLA accepts hyphenated, unhyphenated and mixed-case spellings of the same UUID, and the
+     * two sides of this comparison come from different endpoints — the organization's CLA list and
+     * the CLA Group search. A raw `===` passes every test written with one spelling on both sides
+     * and misses the real match in production, which is the whole failure this guards.
+     */
+    it('matches the held agreement across UUID spellings, not by string equality', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(signable.claGroupId.replaceAll('-', '').toUpperCase())]);
+      await search(fixture);
+
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('true');
+      expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)?.textContent).toContain(CCLA_SIGN_COPY.picker.alreadySignedDisabledReason);
+    });
+
+    // The other half of the check: holding *an* agreement must not refuse every row, or the
+    // picker becomes unusable for any organization that has signed anything.
+    it('leaves a CLA group the organization does not hold selectable', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render([held(individualOnly.claGroupId)]);
+      await search(fixture);
+      row(fixture, signable).click();
+      fixture.detectChanges();
+
+      expect(testid(fixture, `org-easycla-group-disabled-${signable.claGroupId}`)).toBeNull();
+      expect(continueButton(fixture).disabled).toBe(false);
+    });
+
+    // Answered before "covers several projects", which is the less useful of the two: a CLA Group
+    // signed through the legacy console can still be one this flow could not have signed itself.
+    it('names the held agreement ahead of the reason this flow could not have signed it', async () => {
+      getSignOptions.mockReturnValue(of(results([multiProject])));
+
+      const fixture = await render([held(multiProject.claGroupId)]);
+      await search(fixture, 'driftwood');
+
+      const reason = testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`)?.textContent;
+      expect(reason).toContain(CCLA_SIGN_COPY.picker.alreadySignedDisabledReason);
+      expect(reason).not.toContain(CCLA_SIGN_COPY.picker.multiProjectDisabledReason);
+    });
+  });
+
+  // The reason is visible text inside the option, not a tooltip: a tooltip never reaches anyone
+  // who cannot hover, and inside the option it becomes part of the row's accessible name, so it
+  // is read out when the keyboard highlight arrives.
+  it('states the reason as text on the row itself', async () => {
+    getSignOptions.mockReturnValue(of(results([multiProject])));
+
+    const fixture = await render();
+    await search(fixture, 'driftwood');
+
+    const reason = testid(fixture, `org-easycla-group-disabled-${multiProject.claGroupId}`);
+    expect(reason?.textContent?.trim()).toBeTruthy();
+    expect(row(fixture, multiProject).contains(reason)).toBe(true);
+  });
+
+  it('names the repository a pasted address resolved to, on the row it produced', async () => {
+    getSignOptions.mockReturnValue(of(results([repositoryMatch], false, 'https://github.com/acme-org/waterfall-sdk')));
+
+    const fixture = await render();
+    await search(fixture, 'https://github.com/acme-org/waterfall-sdk');
+
+    // On the row, not merely somewhere in the dialog: it has to be part of the option's accessible
+    // name, so the highlight reads it out along with the names it does not resemble.
+    const matched = testid(fixture, `org-easycla-group-matched-repo-${repositoryMatch.claGroupId}`);
+    expect(matched?.textContent).toContain('acme-org/waterfall-sdk');
+    expect(row(fixture, repositoryMatch).contains(matched)).toBe(true);
+  });
+
+  it('does not claim a repository match on a row found by name', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, `org-easycla-group-matched-repo-${signable.claGroupId}`)).toBeNull();
+  });
+
+  it('cannot be continued before a CLA group is chosen', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('returns the chosen CLA group with the project it will be signed for', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+    row(fixture, signable).click();
+    fixture.detectChanges();
+    continueButton(fixture).click();
+
+    expect(close).toHaveBeenCalledWith({
+      claGroupId: signable.claGroupId,
+      projectSfid: signable.projectSfid,
+      projectName: signable.projectName,
+      claGroupName: signable.claGroupName,
+      orgUid,
+    });
+  });
+
+  /**
+   * The name the preview page heads itself with, when search named no CLA Group.
+   *
+   * That page cannot look it up again — there is no fetch-a-CLA-group-by-id endpoint — so a blank
+   * here becomes a preview headed by nothing, offering to start a legal agreement it cannot name.
+   */
+  it('falls back to the row’s own primary line when search named no CLA Group', async () => {
+    const unnamed: ClaGroupOption = { ...signable, claGroupName: undefined };
+    getSignOptions.mockReturnValue(of(results([unnamed])));
+
+    const fixture = await render();
+    await search(fixture);
+    row(fixture, unnamed).click();
+    fixture.detectChanges();
+    continueButton(fixture).click();
+
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ claGroupName: unnamed.projectName }));
+  });
+
+  // Clicking a disabled row must not select it. The template's own disabled state is not the only
+  // guard, because a keyboard activation does not consult a CSS class.
+  it('does not choose a CLA group that cannot be signed', async () => {
+    getSignOptions.mockReturnValue(of(results([multiProject])));
+
+    const fixture = await render();
+    await search(fixture, 'driftwood');
+    row(fixture, multiProject).click();
+    fixture.detectChanges();
+
+    expect(continueButton(fixture).disabled).toBe(true);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  // A typed character invalidates the confirmed choice, so the continue control can never
+  // describe a CLA Group the field no longer matches.
+  it('discards the choice when the search is edited', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+    row(fixture, signable).click();
+    fixture.detectChanges();
+    expect(continueButton(fixture).disabled).toBe(false);
+
+    await search(fixture, 'cascade rewritten');
+
+    expect(continueButton(fixture).disabled).toBe(true);
+  });
+
+  it('distinguishes "nothing matched" from "keep typing"', async () => {
+    getSignOptions.mockReturnValue(of(results([])));
+
+    const fixture = await render();
+    await search(fixture, 'nothingmatches');
+
+    expect(testid(fixture, 'org-easycla-group-select-no-match')?.textContent?.trim()).toBe(CCLA_SIGN_COPY.picker.noMatch);
+    expect(testid(fixture, 'org-easycla-group-select-keep-typing')).toBeNull();
+  });
+
+  it('says when more matched than it can show', async () => {
+    getSignOptions.mockReturnValue(of(results([signable], true)));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, 'org-easycla-group-select-truncated')).not.toBeNull();
+  });
+
+  it('offers a retry when the search fails rather than reading as no matches', async () => {
+    getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, 'org-easycla-group-select-error')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-group-select-no-match')).toBeNull();
+  });
+
+  it('recovers when a retried search succeeds', async () => {
+    getSignOptions.mockReturnValueOnce(throwError(() => new Error('gateway'))).mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+    (fixture.componentInstance as unknown as { retry: () => void }).retry();
+    await vi.advanceTimersByTimeAsync(600);
+    fixture.detectChanges();
+
+    expect(testid(fixture, 'org-easycla-group-select-error')).toBeNull();
+    expect(row(fixture, signable)).not.toBeNull();
+  });
+
+  it('closes with nothing when the viewer backs out', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-group-cancel')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(close).toHaveBeenCalledWith(null);
+  });
+
+  /**
+   * The rows carry `role="option"` on plain elements, which are not focusable and have no
+   * activation behaviour of their own. Without the handling below there is no way to choose a CLA
+   * Group without a pointer — the flow is simply unavailable to a keyboard-only signatory.
+   *
+   * The highlight roves from the text box, which keeps focus, so the combobox attributes have to
+   * be on the text box: `aria-activedescendant` is read from the focused element, and on the
+   * listbox — which nothing ever focuses — it names the right row and is never announced. These
+   * assertions therefore read the input, not the list. Asserting against the list is how the
+   * first version of this passed while being silent to every screen reader.
+   */
+  describe('keyboard', () => {
+    function press(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, key: string): void {
+      testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      fixture.detectChanges();
+    }
+
+    function results_(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLElement {
+      return testid(fixture, 'org-easycla-group-select-results') as HTMLElement;
+    }
+
+    it('chooses the highlighted CLA group on Enter', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'Enter');
+      continueButton(fixture).click();
+
+      expect(close).toHaveBeenCalledWith({
+        claGroupId: signable.claGroupId,
+        projectSfid: signable.projectSfid,
+        projectName: signable.projectName,
+        claGroupName: signable.claGroupName,
+        orgUid,
+      });
+    });
+
+    // Focus stays on the search box throughout the combobox pattern, so the browser scrolls
+    // nothing of its own when the highlight moves. Past the handful of rows the 240px list can
+    // show, a sighted keyboard user would lose sight of which row Enter is about to choose — and
+    // a screen-reader user would notice nothing wrong, which is what makes it easy to ship.
+    it('brings the newly highlighted row into view on each arrow press', async () => {
+      getSignOptions.mockReturnValue(of(results([signable, multiProject])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'ArrowDown');
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      // `nearest` so a row already visible does not scroll; anything else jumps the list under the
+      // reader on every press.
+      expect(scrollIntoView).toHaveBeenLastCalledWith({ block: 'nearest' });
+    });
+
+    // The wiring that makes the highlight audible at all. Without `role="combobox"` and
+    // `aria-controls` on the focused input, `aria-activedescendant` on it has nothing to resolve
+    // against and assistive technology has no reason to look for a list.
+    it('declares the input a combobox controlling the results list', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      const input = () => searchBoxOf(fixture);
+
+      expect(input().getAttribute('role')).toBe('combobox');
+      expect(input().getAttribute('aria-autocomplete')).toBe('list');
+      expect(input().getAttribute('aria-controls')).toBe('org-easycla-group-select-results');
+      expect(results_(fixture).id).toBe('org-easycla-group-select-results');
+
+      // Before a search there is nothing to expand into; after one there is.
+      expect(input().getAttribute('aria-expanded')).toBe('false');
+      await search(fixture);
+      expect(input().getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('names the highlighted row so a screen reader can follow the arrow keys', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBeNull();
+
+      press(fixture, 'ArrowDown');
+
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+      expect(row(fixture, signable).id).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+    });
+
+    it('moves down and back up through the list', async () => {
+      getSignOptions.mockReturnValue(of(results([signable, individualOnly])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'ArrowDown');
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${individualOnly.claGroupId}`);
+
+      press(fixture, 'ArrowUp');
+
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${signable.claGroupId}`);
+    });
+
+    // The highlight does stop on a row that cannot be signed, because the reason it cannot is the
+    // row's whole payload and skipping past it would keep that from a keyboard-only viewer
+    // entirely. Enter is what refuses.
+    it('highlights a CLA group that cannot be signed but will not choose it', async () => {
+      getSignOptions.mockReturnValue(of(results([multiProject])));
+
+      const fixture = await render();
+      await search(fixture, 'driftwood');
+      press(fixture, 'ArrowDown');
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBe(`org-easycla-group-option-${multiProject.claGroupId}`);
+
+      press(fixture, 'Enter');
+
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    // The highlight is a position in the previous list. Carried across a new search it would let
+    // Enter confirm whichever CLA Group happens to land at that offset.
+    it('drops the highlight when a new search arrives', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable, individualOnly]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'ArrowDown');
+
+      await search(fixture, 'beacon');
+
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    it('backs out on Escape', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'Escape');
+
+      expect(close).toHaveBeenCalledWith(null);
+    });
+
+    it('ignores Enter when the search failed and the rows are not on screen', async () => {
+      getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
+
+      const fixture = await render();
+      await search(fixture);
+      press(fixture, 'ArrowDown');
+      press(fixture, 'Enter');
+
+      expect(close).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The window between a keystroke and the results that answer it.
+   *
+   * The rows for the previous term stay rendered across the debounce and the request that follows
+   * it. If they stay choosable, a viewer can pick one in that window and the response that lands
+   * afterwards swaps the list out from under a selection it never contained — and Continue then
+   * opens a corporate agreement for a project the viewer had already started typing away from.
+   *
+   * These cases interleave typing and choosing deliberately. A test that only advances the clock
+   * and asserts on the final list passes against the broken version, because the bug is not in
+   * what is fetched: `switchMap` cancels the previous request correctly. It is in what remains
+   * clickable while that happens.
+   */
+  describe('a search the viewer has moved on from', () => {
+    /** Types without letting the debounce elapse, leaving the previous rows on screen. */
+    function type(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>, term: string): void {
+      const form = (fixture.componentInstance as unknown as { searchForm: { controls: { query: { setValue: (v: string) => void } } } }).searchForm;
+      form.controls.query.setValue(term);
+      fixture.detectChanges();
+    }
+
+    it('refuses a row clicked after the term it belongs to was changed', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      expect(row(fixture, signable)).not.toBeNull();
+
+      // Mid-word. `signable` is still drawn, and is now a result for a term nobody is searching.
+      type(fixture, 'beacon');
+      row(fixture, signable).click();
+      fixture.detectChanges();
+
+      expect(continueButton(fixture).disabled).toBe(true);
+
+      // And it stays refused after the new results land, rather than being resurrected by them.
+      await vi.advanceTimersByTimeAsync(600);
+      fixture.detectChanges();
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+    });
+
+    // The keyboard route to the same defect, and it needs the extra ArrowDown to be worth having.
+    // Typing already resets the highlight, so an Enter pressed straight after it is refused for
+    // that reason alone and the case would pass with no staleness handling at all. Re-highlighting
+    // first puts the cursor back on a superseded row, which is the state only the guard refuses.
+    it('refuses a re-highlighted superseded row on Enter, not only on click', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+
+      type(fixture, 'beacon');
+      const key = (name: string) => {
+        testid(fixture, 'org-easycla-group-select-results')?.dispatchEvent(new KeyboardEvent('keydown', { key: name, bubbles: true }));
+        fixture.detectChanges();
+      };
+      key('ArrowDown');
+      key('Enter');
+
+      expect(continueButton(fixture).disabled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+      // The highlight is not announced either, so nothing reads out a row that cannot be chosen.
+      expect(searchBoxOf(fixture).getAttribute('aria-activedescendant')).toBeNull();
+    });
+
+    it('marks the superseded rows as unavailable while they are still drawn', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([signable]))).mockReturnValue(of(results([individualOnly])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('false');
+
+      type(fixture, 'beacon');
+
+      expect(row(fixture, signable).getAttribute('aria-disabled')).toBe('true');
+      // And the viewer is told why the rows stopped responding, rather than left guessing.
+      expect(testid(fixture, 'org-easycla-group-select-pending')).not.toBeNull();
+    });
+
+    it('makes the rows choosable again once the results catch up with the term', async () => {
+      getSignOptions.mockReturnValueOnce(of(results([individualOnly]))).mockReturnValue(of(results([signable], false, 'cascade')));
+
+      const fixture = await render();
+      await search(fixture, 'beacon');
+      type(fixture, 'cascade');
+      await vi.advanceTimersByTimeAsync(600);
+      fixture.detectChanges();
+
+      expect(testid(fixture, 'org-easycla-group-select-pending')).toBeNull();
+      row(fixture, signable).click();
+      fixture.detectChanges();
+      continueButton(fixture).click();
+
+      expect(close).toHaveBeenCalledWith({
+        claGroupId: signable.claGroupId,
+        projectSfid: signable.projectSfid,
+        projectName: signable.projectName,
+        claGroupName: signable.claGroupName,
+        orgUid,
+      });
+    });
+
+    // Choosing writes the CLA Group's name into the field, which is a value change like any
+    // other. If that were treated as the viewer moving on, every selection would immediately
+    // invalidate itself and Continue would never enable.
+    it('does not treat writing the chosen name into the field as a new search', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture, 'cascade');
+      row(fixture, signable).click();
+      fixture.detectChanges();
+
+      expect(continueButton(fixture).disabled).toBe(false);
+      expect(testid(fixture, 'org-easycla-group-select-pending')).toBeNull();
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -9,7 +9,7 @@ import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/cons
 import type { ClaGroupOption, ClaGroupSearchResponse, OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OrgEasyclaGroupSelectComponent } from './org-easycla-group-select.component';
@@ -795,6 +795,104 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
       expect(continueButton(fixture).disabled).toBe(false);
       expect(testid(fixture, 'org-easycla-group-select-pending')).toBeNull();
+    });
+  });
+
+  /**
+   * Screen-reader users hear the transitions the sighted viewer sees: search starting, no
+   * matches, results arrived, truncation, and load failures. Focus stays in the input, so a
+   * text swap elsewhere is not announced without a live region. `polite` and `atomic` are the
+   * two ARIA choices worth pinning \u2014 an assertive region would interrupt, and a non-atomic
+   * one would leave stale fragments behind.
+   */
+  describe('polite announcements for a screen-reader user', () => {
+    function live(fixture: ComponentFixture<OrgEasyclaGroupSelectComponent>): HTMLElement {
+      return testid(fixture, 'org-easycla-group-select-live') as HTMLElement;
+    }
+
+    it('exists as a polite, atomic region that focus never lands on', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+
+      const region = live(fixture);
+      expect(region).not.toBeNull();
+      expect(region.getAttribute('aria-live')).toBe('polite');
+      expect(region.getAttribute('aria-atomic')).toBe('true');
+      // Visually hidden so the sighted viewer keeps the loading spinner, "No matches" panel, and
+      // row count as their signal — the region is only for assistive technology.
+      expect(region.className).toContain('sr-only');
+    });
+
+    it('announces the search starting, then the row count when it lands', async () => {
+      // A pending Subject holds the response open past the debounce, so `loading` stays true
+      // for the assertion \u2014 a synchronous `of(...)` would flip through both states in one tick
+      // and only the terminal announcement would ever be observable.
+      const pending = new Subject<ClaGroupSearchResponse>();
+      getSignOptions.mockReturnValue(pending);
+
+      const fixture = await render();
+      const form = (fixture.componentInstance as unknown as { searchForm: { controls: { query: { setValue: (v: string) => void } } } }).searchForm;
+      form.controls.query.setValue('cascade');
+      await vi.advanceTimersByTimeAsync(600);
+      fixture.detectChanges();
+      expect(live(fixture).textContent?.trim()).toBe('Searching CLA groups.');
+
+      pending.next(results([signable, individualOnly]));
+      pending.complete();
+      fixture.detectChanges();
+      expect(live(fixture).textContent?.trim()).toBe('2 CLA groups match.');
+    });
+
+    it('reads a single match with singular grammar', async () => {
+      getSignOptions.mockReturnValue(of(results([signable])));
+
+      const fixture = await render();
+      await search(fixture);
+
+      expect(live(fixture).textContent?.trim()).toBe('1 CLA group matches.');
+    });
+
+    it('names the truncation so a viewer knows more matched than are being read', async () => {
+      const many = Array.from({ length: 25 }, (_, index) => ({ ...signable, claGroupId: `cla-${index}`, projectSfid: `sfid-${index}` }));
+      getSignOptions.mockReturnValue(of(results(many, true)));
+
+      const fixture = await render();
+      await search(fixture);
+
+      expect(live(fixture).textContent?.trim()).toBe('More than 25 CLA groups match. Narrow your search.');
+    });
+
+    it('says no matches instead of falling silent on an empty results list', async () => {
+      getSignOptions.mockReturnValue(of(results([])));
+
+      const fixture = await render();
+      await search(fixture);
+
+      expect(live(fixture).textContent?.trim()).toBe('No matching CLA groups.');
+    });
+
+    it('names a load failure so the Retry offer is not silent', async () => {
+      getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
+
+      const fixture = await render();
+      await search(fixture);
+
+      expect(live(fixture).textContent?.trim()).toBe("Couldn't load CLA groups. Retry available.");
+    });
+
+    // "Keep typing" would fire on every keystroke below the minimum, and the visual copy already
+    // says what to do. An empty query is likewise nothing to say. Announcing either would be
+    // noise a screen reader stops attending to; the region stays empty for both.
+    it('stays silent for the empty and keep-typing states', async () => {
+      const fixture = await render();
+      expect(live(fixture).textContent?.trim()).toBe('');
+
+      const form = (fixture.componentInstance as unknown as { searchForm: { controls: { query: { setValue: (v: string) => void } } } }).searchForm;
+      form.controls.query.setValue('ca');
+      await vi.advanceTimersByTimeAsync(600);
+      fixture.detectChanges();
+      expect(live(fixture).textContent?.trim()).toBe('');
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -872,13 +872,24 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       expect(live(fixture).textContent?.trim()).toBe('No matching CLA groups.');
     });
 
-    it('names a load failure so the Retry offer is not silent', async () => {
+    /**
+     * The visible error panel already has `role="alert"`, which assistive technology announces
+     * assertively. Repeating the same text in the polite region would have a screen reader read
+     * the failure twice \u2014 once from the alert, once from the status \u2014 for one event. The alert
+     * owns the failure; the polite region stays silent for it.
+     */
+    it('leaves the failure announcement to the visible alert panel, so it is not read twice', async () => {
       getSignOptions.mockReturnValue(throwError(() => new Error('gateway')));
 
       const fixture = await render();
       await search(fixture);
 
-      expect(live(fixture).textContent?.trim()).toBe("Couldn't load CLA groups. Retry available.");
+      // The alert exists (and carries the failure text), so the announcement is not being lost.
+      const errorPanel = testid(fixture, 'org-easycla-group-select-error');
+      expect(errorPanel).not.toBeNull();
+      expect(errorPanel?.getAttribute('role')).toBe('alert');
+      // But the polite region does not repeat it.
+      expect(live(fixture).textContent?.trim()).toBe('');
     });
 
     // "Keep typing" would fire on every keystroke below the minimum, and the visual copy already

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -1,0 +1,353 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_DEBOUNCE_MS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import type {
+  ClaGroupOption,
+  ClaGroupSearchResponse,
+  OrgClaGroupOptionView,
+  OrgClaGroupSelectDialogData,
+  OrgClaSignSelection,
+} from '@lfx-one/shared/interfaces';
+import { isSameClaGroup, toClaGroupOptionView } from '@lfx-one/shared/utils';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { catchError, debounceTime, map, of, Subject, switchMap } from 'rxjs';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+
+/**
+ * "Sign a CLA" CLA Group picker for the Organization Lens (#1983).
+ *
+ * **A deliberate second picker, not an oversight.** The Me-lens `ClaGroupSelectComponent` was
+ * considered and rejected as a base. It reads its results from `MyClasService` — a route that is
+ * neither dark-launch gated for this section nor organization-scoped — and where a contributor
+ * already holds an agreement it annotates the row and leaves it choosable, because signing the
+ * same CLA Group under a second identity is something a contributor legitimately does. Both
+ * pickers are handed the already-held agreements; they disagree about what the overlap means.
+ * Here it is a refusal, because this flow signs as one party — the selected organization — and
+ * offers no second identity to sign as. Parameterising the data source, the annotation source and
+ * the selectability rule would rewrite the component the Me-lens signing flow depends on, inside a
+ * slice whose risk is already spent on a write path and legal copy.
+ *
+ * What is genuinely shared is shared: the debounce and minimum-term constants, and
+ * `toClaGroupOptionView`. If the two pickers later converge, that is the moment for a common
+ * base — not now, when they disagree about what a row means.
+ *
+ * Closes with the chosen group, or `null` if the viewer backs out.
+ */
+@Component({
+  selector: 'lfx-org-easycla-group-select',
+  imports: [ReactiveFormsModule, ButtonComponent, InputTextComponent],
+  templateUrl: './org-easycla-group-select.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaGroupSelectComponent {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly claService = inject(OrgLensClaService);
+  private readonly config = inject<DynamicDialogConfig<OrgClaGroupSelectDialogData>>(DynamicDialogConfig);
+
+  private readonly orgUid = this.config.data?.orgUid ?? '';
+
+  /** The organization's corporate CLAs, against which a search hit is refused as already signed. */
+  private readonly heldClaGroups = this.config.data?.claGroups ?? [];
+
+  protected readonly copy = CCLA_SIGN_COPY.picker;
+  protected readonly minChars = CLA_GROUP_SEARCH_MIN_CHARS;
+
+  protected readonly searchForm = new FormGroup({
+    query: new FormControl(''),
+  });
+
+  protected readonly options = signal<OrgClaGroupOptionView[]>([]);
+  protected readonly loading = signal(false);
+  protected readonly error = signal(false);
+  protected readonly selected = signal<OrgClaGroupOptionView | null>(null);
+  protected readonly truncated = signal(false);
+
+  private readonly query = signal('');
+
+  /**
+   * The search term `options` came back for, or null when they came back for nothing yet.
+   *
+   * Compared against the live query to decide whether the list on screen still describes what the
+   * viewer has typed. See `stale`.
+   */
+  private readonly resultsFor = signal<string | null>(null);
+
+  /**
+   * Whether the rows on screen belong to a term the viewer has since changed.
+   *
+   * There is a window — the debounce, plus the request — in which the previous term's rows are
+   * still rendered under new text in the field. Left selectable, a click in that window sets
+   * `selected` to a CLA Group that was never a result for the current query, and the response
+   * that lands afterwards replaces the visible list without touching the selection. Continue
+   * would then open a corporate agreement for whichever project the viewer had abandoned
+   * mid-word, which is not a UI blemish on this flow — it is the wrong legal document.
+   *
+   * `switchMap` does not cover this: it cancels the previous request only once the debounce has
+   * elapsed and the new term reaches it, and cancelling a request was never what protected the
+   * selection anyway.
+   */
+  protected readonly stale: Signal<boolean> = computed(() => this.resultsFor() !== this.query().trim());
+
+  /** Position of the keyboard highlight in `options`, or -1 when nothing is highlighted. */
+  protected readonly highlightedIndex = signal(-1);
+
+  /** Whether rows are on screen, for the input's `aria-expanded`. */
+  protected readonly listboxOpen: Signal<boolean> = computed(() => !this.error() && this.queryBand() === 'searchable' && this.options().length > 0);
+
+  /**
+   * The highlighted row's element id, for the input's `aria-activedescendant`, or null.
+   *
+   * Null while the list is stale as well as while nothing is highlighted: pointing focus at a row
+   * from a superseded search would have a screen reader announce a CLA Group that is on its way
+   * off the screen and cannot be chosen.
+   */
+  protected readonly activeOptionId: Signal<string | null> = computed(() => {
+    const option = this.options()[this.highlightedIndex()];
+    if (!option || this.stale()) return null;
+    return `org-easycla-group-option-${option.claGroupId}`;
+  });
+
+  /**
+   * Which "the list is empty" answer applies, so the template never infers one from a zero
+   * length — which cannot tell "you have not typed yet" from "keep going" from "no matches".
+   */
+  protected readonly queryBand: Signal<'empty' | 'short' | 'searchable'> = computed(() => {
+    const length = this.query().trim().length;
+    if (length === 0) return 'empty';
+    return length < CLA_GROUP_SEARCH_MIN_CHARS ? 'short' : 'searchable';
+  });
+
+  private readonly search$ = new Subject<string>();
+
+  /** Set while writing the chosen group's name back into the field, so it is not re-searched. */
+  private suppressNextEmit = false;
+
+  public constructor() {
+    this.search$
+      .pipe(
+        debounceTime(CLA_GROUP_SEARCH_DEBOUNCE_MS),
+        map((query) => query.trim()),
+        switchMap((searchTerm) => {
+          if (searchTerm.length < CLA_GROUP_SEARCH_MIN_CHARS) {
+            this.loading.set(false);
+            this.error.set(false);
+            this.clearResults();
+            return of<{ searchTerm: string; response: ClaGroupSearchResponse | null } | null>(null);
+          }
+
+          this.loading.set(true);
+          this.error.set(false);
+          return this.claService.getSignOptions(this.orgUid, searchTerm).pipe(
+            // Paired with its own term all the way through, so the handler can say which query
+            // the rows it is about to render actually answer. Reading the live query there
+            // instead would be the same race one layer down.
+            map((response) => ({ searchTerm, response: response as ClaGroupSearchResponse | null })),
+            catchError(() => {
+              this.error.set(true);
+              this.clearResults();
+              return of<{ searchTerm: string; response: ClaGroupSearchResponse | null } | null>(null);
+            })
+          );
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((emission) => {
+        this.loading.set(false);
+        if (!emission?.response) return;
+        this.options.set(emission.response.results.map((option) => this.toOrgOptionView(option)));
+        this.truncated.set(emission.response.truncated);
+        // Records which term these rows answer, which is what clears `stale` and makes them
+        // selectable again.
+        this.resultsFor.set(emission.searchTerm);
+        // The highlight is a position in the previous list; carrying it over would let Enter
+        // confirm whichever CLA Group happens to land at that offset in the new one.
+        this.highlightedIndex.set(-1);
+      });
+
+    this.searchForm.controls.query.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
+      if (this.suppressNextEmit) {
+        this.suppressNextEmit = false;
+        return;
+      }
+
+      // A typed character invalidates the confirmed choice, so the summary and the continue
+      // control can never describe a CLA Group the text no longer matches. The highlight is a
+      // position in the previous list, so it has to drop here rather than after the debounce —
+      // Enter during the request window would otherwise confirm a CLA Group the text no longer
+      // describes.
+      this.selected.set(null);
+      this.highlightedIndex.set(-1);
+      this.pushSearch(value ?? '');
+    });
+  }
+
+  /**
+   * Arrow keys, Enter and Escape on the results list.
+   *
+   * Bound at the field's container rather than on each row, and the rows are not focusable: focus
+   * stays in the text box so the viewer can keep typing while moving the highlight, which is what
+   * `aria-activedescendant` *on the input* describes. The Me-lens picker puts that attribute on
+   * the listbox instead, where it is never announced; that is a real defect in that component and
+   * is not fixed here, but it is deliberately not copied.
+   *
+   * The highlight does stop on a row that cannot be signed. Skipping those would be the obvious
+   * reading of "disabled", and it is the wrong one here — the reason a CLA Group cannot be signed
+   * corporately is the row's whole payload, and a keyboard-only viewer who cannot reach the row
+   * never hears it. `onSelect` is what refuses; arriving is allowed.
+   */
+  protected onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.ref.close(null);
+      return;
+    }
+
+    const options = this.options();
+    // Match the template: the error and keep-typing panels replace the rows, so the keyboard must
+    // not treat a leftover list as still on screen.
+    if (this.error() || this.queryBand() !== 'searchable' || options.length === 0) return;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        // Otherwise the caret jumps to the end of the field on every step.
+        event.preventDefault();
+        this.highlightedIndex.set((this.highlightedIndex() + 1) % options.length);
+        this.revealHighlighted(options);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.highlightedIndex.set((this.highlightedIndex() - 1 + options.length) % options.length);
+        this.revealHighlighted(options);
+        break;
+      case 'Enter': {
+        const highlighted = options[this.highlightedIndex()];
+        if (!highlighted) return;
+        event.preventDefault();
+        this.onSelect(highlighted);
+        break;
+      }
+    }
+  }
+
+  protected retry(): void {
+    this.pushSearch(this.searchForm.controls.query.value ?? '');
+  }
+
+  protected onSelect(option: OrgClaGroupOptionView): void {
+    // Belt and braces with the template's disabled state: a row that names why it cannot be
+    // signed must not become the chosen one through a keyboard activation either.
+    if (option.disabledReason) return;
+
+    // A row from a superseded search cannot be chosen, however it was reached. The template also
+    // marks these rows non-interactive, but the guard belongs here as well: this is the last
+    // point before a CLA Group becomes the one a corporate agreement gets opened for.
+    if (this.stale()) return;
+
+    this.selected.set(option);
+    this.suppressNextEmit = true;
+    this.searchForm.controls.query.setValue(option.secondaryName ? `${option.primaryName} — ${option.secondaryName}` : option.primaryName);
+  }
+
+  protected onContinue(): void {
+    const option = this.selected();
+    // `projectSfid` is what makes a row selectable in the first place, so this is unreachable
+    // through the UI. It is here because the alternative to checking is asserting, and the value
+    // being asserted is the key of a request that creates a legal document.
+    if (!option?.projectSfid) return;
+
+    const result: OrgClaSignSelection = {
+      claGroupId: option.claGroupId,
+      projectSfid: option.projectSfid,
+      projectName: option.primaryName,
+      // The CLA Group's own name where search gave one, and the primary line otherwise — the project
+      // name, or the unnamed literal when search could name neither. The preview page heads itself
+      // with this and cannot look it up again, so it must never come through blank.
+      claGroupName: option.claGroupName || option.primaryName,
+      // Stamped here rather than read again on the preview: this is the organization the search was
+      // scoped to and the choice was made under, and the preview's job is to check that it is still
+      // the one in force.
+      orgUid: this.orgUid,
+    };
+    this.ref.close(result);
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+
+  /**
+   * Brings the highlighted row into the scrolling list.
+   *
+   * Focus never leaves the search box — the combobox pattern puts `aria-activedescendant` there —
+   * so the browser does no scrolling of its own when the highlight moves. Past the few rows the
+   * list can show, the highlight would otherwise travel off-screen and a sighted keyboard user
+   * would have no way to tell which row Enter is about to choose. A screen reader is unaffected
+   * either way, which is why this is easy to miss.
+   *
+   * `nearest` so a highlight already in view does not scroll, which would make every arrow press
+   * jump the list under the reader.
+   */
+  private revealHighlighted(options: readonly OrgClaGroupOptionView[]): void {
+    const option = options[this.highlightedIndex()];
+    if (!option) return;
+
+    const row = this.host.nativeElement.querySelector(`#org-easycla-group-option-${CSS.escape(option.claGroupId)}`);
+    row?.scrollIntoView({ block: 'nearest' });
+  }
+
+  private pushSearch(value: string): void {
+    this.query.set(value);
+    this.search$.next(value);
+  }
+
+  /** Drops a list the template is no longer drawing, so Arrow/Enter cannot confirm a hidden row. */
+  private clearResults(): void {
+    this.options.set([]);
+    this.truncated.set(false);
+    this.highlightedIndex.set(-1);
+    this.resultsFor.set(null);
+  }
+
+  /**
+   * A row that cannot be signed stays on screen with its reason, rather than being filtered out.
+   *
+   * Dropping it would leave a viewer searching repeatedly for a CLA Group they can see in the
+   * legacy console, with nothing to explain the absence. Leaving it selectable would carry the
+   * viewer into a preview that states something untrue about the agreement, and from there into a
+   * request that either fails or duplicates one the organization already has.
+   */
+  private toOrgOptionView(option: ClaGroupOption): OrgClaGroupOptionView {
+    const view = toClaGroupOptionView(option);
+
+    // Ahead of the two below because it is the more useful answer where both apply: a CLA Group
+    // signed through the legacy console can still be one this flow could not have signed itself.
+    //
+    // Matched canonically, not with `===`. EasyCLA accepts hyphenated, unhyphenated and mixed-case
+    // spellings of the same UUID, so a raw string compare silently misses real matches — and a
+    // missed match here is the failure this check exists to prevent.
+    //
+    // The refusal is narrower than it looks. The upstream grain is (signing entity x CLA Group), so
+    // an organization can legitimately hold two rows for one CLA Group under different signing
+    // entities, and signing this group again for a *different* legal entity would be a real flow.
+    // It is safe to refuse today only because this flow always signs for the selected organization
+    // — `company_sfid` is the grant-checked `orgUid` — and offers no signing-entity choice. The day
+    // it does, this becomes a check on the entity rather than on the group.
+    if (this.heldClaGroups.some((held) => isSameClaGroup(held.claGroupId, option.claGroupId))) {
+      return { ...view, disabledReason: this.copy.alreadySignedDisabledReason };
+    }
+    if (!option.projectSfid) {
+      return { ...view, disabledReason: this.copy.multiProjectDisabledReason };
+    }
+    if (option.cclaEnabled !== true) {
+      return { ...view, disabledReason: this.copy.cclaDisabledReason };
+    }
+    return { ...view, disabledReason: null };
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -135,7 +135,12 @@ export class OrgEasyclaGroupSelectComponent {
    * about to be replaced by a fresher answer, which will carry the announcement worth reading.
    */
   protected readonly liveAnnouncement: Signal<string> = computed(() => {
-    if (this.error()) return "Couldn't load CLA groups. Retry available.";
+    // The visible error panel already carries `role="alert"`, which announces its own text
+    // assertively when it appears. Returning the failure here as well would queue it in this
+    // polite region and read the same failure out twice — once through the alert, once through
+    // the status — which is exactly the kind of duplicated speech `polite` is meant to avoid.
+    // The alert owns the failure announcement; this region falls silent for it.
+    if (this.error()) return '';
     if (this.queryBand() !== 'searchable') return '';
     // `loading` before `stale` on purpose. `stale` is true from the moment the query changes,
     // so the debounce and the request that follows are both "stale" \u2014 including the fresh case

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -116,6 +116,44 @@ export class OrgEasyclaGroupSelectComponent {
   });
 
   /**
+   * The polite announcement for the search's current state, or empty when there is nothing worth
+   * saying.
+   *
+   * Focus stays in the combobox input throughout: a text swap elsewhere in the DOM changes the
+   * screen for a sighted viewer, but does not tell a screen-reader user that a search started,
+   * that no CLA Group matched, or that results have finally arrived. `aria-activedescendant`
+   * only covers the highlighted row; it says nothing about the transitions between the states of
+   * the panel around it. So a persistent `aria-live="polite"` region beside the field mirrors
+   * those transitions in words, and reads them out as they happen without stealing focus.
+   *
+   * `polite` rather than `assertive`: a search response should not interrupt a screen reader
+   * mid-sentence; it can wait for the current utterance to end. `aria-atomic="true"` in the
+   * template reads the whole region on each change, so a stale fragment cannot be left behind.
+   *
+   * The empty / short-query / stale states return an empty string on purpose. "Keep typing" is
+   * already visually explanatory and would be announced on every keystroke; stale results are
+   * about to be replaced by a fresher answer, which will carry the announcement worth reading.
+   */
+  protected readonly liveAnnouncement: Signal<string> = computed(() => {
+    if (this.error()) return "Couldn't load CLA groups. Retry available.";
+    if (this.queryBand() !== 'searchable') return '';
+    // `loading` before `stale` on purpose. `stale` is true from the moment the query changes,
+    // so the debounce and the request that follows are both "stale" \u2014 including the fresh case
+    // where no options were on screen to begin with. Suppressing the announcement on `stale`
+    // alone would swallow "Searching\u2026" for the first search a viewer runs.
+    if (this.loading()) return 'Searching CLA groups.';
+    // A previous term's rows are still on screen and the response has not arrived yet. The
+    // count that would land next is unknowable; leaving the previous count in the region is
+    // less misleading than announcing a mid-transition state.
+    if (this.stale()) return '';
+    const count = this.options().length;
+    if (count === 0) return 'No matching CLA groups.';
+    const plural = count === 1 ? 'CLA group matches' : 'CLA groups match';
+    if (this.truncated()) return `More than ${count} ${plural}. Narrow your search.`;
+    return `${count} ${plural}.`;
+  });
+
+  /**
    * Which "the list is empty" answer applies, so the template never infers one from a zero
    * length — which cannot tell "you have not typed yet" from "keep going" from "no matches".
    */

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -217,16 +217,20 @@ export class OrgEasyclaGroupSelectComponent {
     // not treat a leftover list as still on screen.
     if (this.error() || this.queryBand() !== 'searchable' || options.length === 0) return;
 
+    // `highlightedIndex` starts at `-1` on a fresh list: no row is on yet, and the CTA is
+    // disabled. The first arrow key should land on the row a viewer expects — the first for
+    // Down, the last for Up. A modular step from `-1` lands on `length - 2` for Up, off by one.
+    const current = this.highlightedIndex();
     switch (event.key) {
       case 'ArrowDown':
         // Otherwise the caret jumps to the end of the field on every step.
         event.preventDefault();
-        this.highlightedIndex.set((this.highlightedIndex() + 1) % options.length);
+        this.highlightedIndex.set(current < 0 ? 0 : (current + 1) % options.length);
         this.revealHighlighted(options);
         break;
       case 'ArrowUp':
         event.preventDefault();
-        this.highlightedIndex.set((this.highlightedIndex() - 1 + options.length) % options.length);
+        this.highlightedIndex.set(current < 0 ? options.length - 1 : (current - 1 + options.length) % options.length);
         this.revealHighlighted(options);
         break;
       case 'Enter': {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -150,7 +150,10 @@ export class OrgEasyclaGroupSelectComponent {
             // the rows it is about to render actually answer. Reading the live query there
             // instead would be the same race one layer down.
             map((response) => ({ searchTerm, response: response as ClaGroupSearchResponse | null })),
-            catchError(() => {
+            catchError((error: unknown) => {
+              // One line, matching the sibling list/detail loaders. Search is high-frequency, so
+              // more than a line would drown the console — but silence made triage guess.
+              console.error('Failed to search CLA groups:', error);
               this.error.set(true);
               this.clearResults();
               return of<{ searchTerm: string; response: ClaGroupSearchResponse | null } | null>(null);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
@@ -1,0 +1,64 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+-->
+
+<!--
+  A polite live region around the whole switch, because the state changes on its own: the signing
+  request is issued as the dialog opens, and when it lands the message is replaced and the Review
+  CCLA control appears. Sighted users see that happen. Without this, a screen-reader user is told
+  the dialog is preparing and then nothing further — the controls arrive silently, and there is no
+  event to prompt them to go looking.
+
+  Focus is deliberately NOT moved to Review CCLA when it appears. That control opens the signing
+  session in this same tab, so auto-focusing it puts a page-leaving action under the next Enter or
+  Space the user happens to press, and it would also cut off the announcement that just told them
+  why focus moved. The dialog already holds focus, so the polite announcement is enough to say the
+  control now exists and can be reached by Tab.
+
+  The failure branch below keeps its own role="alert" and so stays assertive: it interrupts, which
+  a refusal should, and a nested live region overrides this one for its own subtree.
+-->
+<div class="flex flex-col" role="status" aria-live="polite" data-testid="org-easycla-sign-handoff-dialog">
+  @switch (state()) {
+    @case ('preparing') {
+      <div class="flex flex-col items-center gap-3 py-6 text-center" data-testid="org-easycla-sign-preparing">
+        <i class="fa-light fa-spinner-third fa-spin text-3xl text-slate-400" aria-hidden="true"></i>
+        <p class="text-sm text-slate-600">{{ copy.preparing.body }}</p>
+        <!-- Stated before the signatory commits, not after: becoming the initial CLA Manager is a
+             standing responsibility, and learning it afterwards is learning it too late. -->
+        <p class="text-sm font-medium text-slate-900" data-testid="org-easycla-sign-manager-notice">{{ copy.preparing.consequence }}</p>
+      </div>
+    }
+
+    @case ('ready') {
+      <!-- The state's name is the dialog's title, set from the component, and is deliberately not
+           repeated here: it used to be, which put "Review CCLA" on screen twice. -->
+      <div class="flex flex-col gap-4" data-testid="org-easycla-sign-ready">
+        <div class="flex items-start gap-2">
+          <i class="fa-light fa-circle-check mt-0.5 text-xl text-emerald-700" aria-hidden="true"></i>
+          <p class="text-sm text-slate-600">{{ copy.ready.body }}</p>
+        </div>
+        <div class="mt-2 flex justify-end">
+          <lfx-button [label]="copy.ready.continueLabel" (onClick)="onReviewAndSign()" data-testid="org-easycla-sign-review" />
+        </div>
+      </div>
+    }
+
+    @case ('failed') {
+      <div class="flex flex-col gap-4" role="alert" data-testid="org-easycla-sign-failed">
+        <!-- The CLA service's own sentence when it refused in words; the generic copy otherwise.
+             A trade-compliance refusal names the reason and how to challenge it, which nothing
+             written here could reproduce and keep current. The state's name is the dialog's
+             title, set from the component, so it is not repeated alongside the message. -->
+        <div class="flex items-start gap-2">
+          <i class="fa-light fa-triangle-exclamation mt-0.5 text-xl text-red-700" aria-hidden="true"></i>
+          <p class="text-sm text-slate-600" data-testid="org-easycla-sign-failure-message">{{ failureMessage() }}</p>
+        </div>
+        <div class="mt-2 flex justify-end">
+          <lfx-button label="Close" severity="secondary" [outlined]="true" (onClick)="onCancel()" data-testid="org-easycla-sign-failed-close" />
+        </div>
+      </div>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -335,6 +335,40 @@ describe('OrgEasyclaSignHandoffComponent', () => {
       expect(config.closable).toBe(true);
       expect(config.closeOnEscape).toBe(true);
     });
+
+    /**
+     * The key itself, not the flag that is supposed to enable it.
+     *
+     * The shell decides its Escape handling once, as it becomes visible, from the values it holds
+     * then — and this dialog opens sealed. Asserting only the flag would report a dismissible
+     * failure state that a keyboard user cannot actually leave.
+     */
+    describe('pressing Escape', () => {
+      function pressEscape(): void {
+        globalThis.document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      }
+
+      it.each([
+        ['in flight', () => new Observable<OrgClaSignResponse>(() => undefined)],
+        ['open', () => of(response)],
+      ])('does not leave a session that is %s', async (_state, source) => {
+        requestCorporateSignature.mockReturnValue(source());
+
+        await render();
+        pressEscape();
+
+        expect(close).not.toHaveBeenCalled();
+      });
+
+      it('leaves a failure', async () => {
+        requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
+
+        await render();
+        pressEscape();
+
+        expect(close).toHaveBeenCalledWith(null);
+      });
+    });
   });
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -46,7 +46,10 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   // Explicit rather than defaulted: a defaulted parameter would substitute the real selection for
   // the `undefined` the missing-data test means to pass, and that test would silently assert
   // nothing.
-  async function renderWith(dialogData: OrgClaSignHandoffDialogData | undefined): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
+  async function renderWith(
+    dialogData: OrgClaSignHandoffDialogData | undefined,
+    options: { render: boolean } = { render: true }
+  ): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
     let href = 'https://example.test/org/easycla';
     location = {
       get href() {
@@ -85,7 +88,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     }).compileComponents();
 
     const fixture = TestBed.createComponent(OrgEasyclaSignHandoffComponent);
-    fixture.detectChanges();
+    if (options.render) fixture.detectChanges();
     return fixture;
   }
 
@@ -405,6 +408,33 @@ describe('OrgEasyclaSignHandoffComponent', () => {
 
       expect(testid(fixture, 'org-easycla-sign-ready')).not.toBeNull();
       expect(config.header).not.toBe(CCLA_SIGN_COPY.preparing.header);
+    });
+
+    /**
+     * The shell reads these as it renders, and nothing re-renders it when they change on their own.
+     * Deferring the write to a render pass therefore dresses the frame for the state before this
+     * one — so the assertions below are deliberately made with no pass having run at all. Rendering
+     * first would hide exactly the ordering they exist to hold.
+     */
+    describe('without waiting for a render pass', () => {
+      it('names the state the panel is already in', async () => {
+        requestCorporateSignature.mockReturnValue(of(response));
+
+        await renderWith(data, { render: false });
+
+        expect(config.header).toBe(CCLA_SIGN_COPY.ready.header);
+      });
+
+      // The sealed-on-failure case: a frame still refusing Escape over a panel reporting a failure
+      // traps the signatory in it, and there is no envelope here to justify holding them.
+      it('unseals a failure', async () => {
+        requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
+
+        await renderWith(data, { render: false });
+
+        expect(config.closable).toBe(true);
+        expect(config.closeOnEscape).toBe(true);
+      });
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -1,0 +1,410 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { DOCUMENT } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CCLA_SIGN_COPY, ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
+import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { Observable, of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrgEasyclaSignHandoffComponent } from './org-easycla-sign-handoff.component';
+
+/**
+ * The hand-off, from the browser's side.
+ *
+ * Three things are worth a test here and the rest is markup: that the attestations the signatory
+ * gave are the ones sent, that the address the CLA service returned is the one navigated to, and
+ * that a refusal it explained in words reaches the signatory in those words.
+ */
+describe('OrgEasyclaSignHandoffComponent', () => {
+  const requestCorporateSignature = vi.fn();
+  const close = vi.fn();
+  // Assignment goes through a spy so the ordering of close-then-navigate is observable, not just
+  // the final value.
+  const setHref = vi.fn();
+  let location: { href: string };
+  let config: DynamicDialogConfig<OrgClaSignHandoffDialogData>;
+
+  const data: OrgClaSignHandoffDialogData = {
+    orgUid: '0014100000Te0xxAAC',
+    projectSfid: 'a09410000182dD2AAI',
+    claGroupId: 'd5d3f4f0-1a2b-4c3d-8e9f-0a1b2c3d4e5f',
+    attestations: { authorityAcked: true, embargoAcked: true },
+  };
+
+  const response: OrgClaSignResponse = {
+    signUrl: 'https://demo.docusign.net/Signing/StartInSession.aspx?t=abc123',
+    signatureId: '7f1c2f5e-0d44-4a2b-9d61-2c9b8a7e4f30',
+  };
+
+  // Explicit rather than defaulted: a defaulted parameter would substitute the real selection for
+  // the `undefined` the missing-data test means to pass, and that test would silently assert
+  // nothing.
+  async function renderWith(dialogData: OrgClaSignHandoffDialogData | undefined): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
+    let href = 'https://example.test/org/easycla';
+    location = {
+      get href() {
+        return href;
+      },
+      set href(value: string) {
+        setHref(value);
+        href = value;
+      },
+    };
+    // The real shape and the real initial values from the call site, because the component drives
+    // three of these and a bare `{ data }` stub would let a wrong initial value pass unnoticed.
+    config = { data: dialogData, header: CCLA_SIGN_COPY.preparing.header, closable: false, closeOnEscape: false };
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgEasyclaSignHandoffComponent],
+      providers: [
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: config },
+        { provide: OrgLensClaService, useValue: { requestCorporateSignature } },
+        // Only `location` is swapped. TestBed renders through DOCUMENT, so replacing it wholesale
+        // breaks the fixture; jsdom also refuses a direct `document.location` assignment. Methods
+        // are bound to the real document — called on the proxy they would fail on internal slots.
+        {
+          provide: DOCUMENT,
+          useFactory: () =>
+            new Proxy(globalThis.document, {
+              get: (target, prop) => {
+                if (prop === 'location') return location;
+                const value = Reflect.get(target, prop);
+                return typeof value === 'function' ? value.bind(target) : value;
+              },
+            }),
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgEasyclaSignHandoffComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  function render(): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
+    return renderWith(data);
+  }
+
+  function testid(fixture: ComponentFixture<OrgEasyclaSignHandoffComponent>, id: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+  }
+
+  /** What `HttpClient` actually rejects with: a real `HttpErrorResponse` over this BFF's body. */
+  function bffError(status: number, body: unknown): HttpErrorResponse {
+    return new HttpErrorResponse({ status, statusText: 'x', url: '/api/orgs/x/lens/cla-groups/sign', error: body });
+  }
+
+  beforeEach(() => {
+    requestCorporateSignature.mockReset();
+    close.mockClear();
+    // Reset, not clear: one case installs an implementation that reads the stash mid-navigation, and
+    // leaving it in place would have it run for every later case.
+    setHref.mockReset();
+    sessionStorage.clear();
+  });
+
+  it('opens the signing session as the dialog opens', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    await render();
+
+    expect(requestCorporateSignature).toHaveBeenCalledWith(data.orgUid, {
+      projectSfid: data.projectSfid,
+      claGroupId: data.claGroupId,
+      authorityAcked: true,
+      embargoAcked: true,
+    });
+  });
+
+  // The client-side half of the attestation contract. The component must relay what the
+  // attestation step recorded, so that a regression which lets an unaffirmed request through the
+  // dialog is refused by the server rather than laundered into a `true` on the way out.
+  it('relays a withdrawn confirmation as withdrawn', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    await renderWith({ ...data, attestations: { authorityAcked: true, embargoAcked: false } });
+
+    expect(requestCorporateSignature).toHaveBeenCalledWith(data.orgUid, {
+      projectSfid: data.projectSfid,
+      claGroupId: data.claGroupId,
+      authorityAcked: true,
+      embargoAcked: false,
+    });
+  });
+
+  it('tells the signatory they will become the initial CLA Manager before they commit', async () => {
+    requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-preparing')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-manager-notice')?.textContent).toContain(CCLA_SIGN_COPY.preparing.consequence);
+  });
+
+  it('offers the signing control once the session is open', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-ready')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-preparing')).toBeNull();
+  });
+
+  // Navigated to exactly as returned, and in this tab. A new context would leave the signatory's
+  // return from EasyCLA stranded on a second tab behind the console they started from.
+  it('navigates this tab to the address the CLA service returned', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-review')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(location.href).toBe(response.signUrl);
+  });
+
+  // A full-page navigation is not a teardown. Back out of DocuSign can restore this page from
+  // bfcache with the flow still marked open, which disables Sign CLA until a manual reload — so
+  // the dialog must release before it navigates, not after.
+  it('releases the flow before navigating away', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-review')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(setHref).toHaveBeenCalledWith(response.signUrl);
+    expect(close.mock.invocationCallOrder[0]).toBeLessThan(setHref.mock.invocationCallOrder[0]);
+  });
+
+  it('does not navigate when the session came back without an address', async () => {
+    requestCorporateSignature.mockReturnValue(of({ ...response, signUrl: '' }));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failed')).not.toBeNull();
+    expect(location.href).toBe('https://example.test/org/easycla');
+  });
+
+  /**
+   * The signatory returns through a cross-site redirect to an address that was composed before this
+   * signature existed, so this dialog is the last place in the browser that knows which agreement
+   * they are about to sign. Stashing it is what lets the return land on that agreement instead of
+   * the list.
+   */
+  it('stashes the signature before leaving, so the return can land on the agreement', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+    // Read at the moment of the navigation rather than after it. No code of ours runs once the
+    // browser has left, so a stash written afterwards would never be written at all — and reading it
+    // at the end of the test cannot tell the two orders apart.
+    let stashedOnLeaving: string | null = null;
+    setHref.mockImplementation(() => {
+      stashedOnLeaving = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
+    });
+
+    const fixture = await render();
+    (testid(fixture, 'org-easycla-sign-review')?.querySelector('button') as HTMLButtonElement).click();
+
+    expect(setHref).toHaveBeenCalledWith(response.signUrl);
+    expect(stashedOnLeaving).toBe(response.signatureId);
+  });
+
+  // A stash with no hand-off behind it would send the next visit to the list into a detail page for
+  // an agreement nobody was ever handed.
+  it('stashes nothing when the session came back without an address', async () => {
+    requestCorporateSignature.mockReturnValue(of({ ...response, signUrl: '' }));
+
+    await render();
+
+    expect(sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY)).toBeNull();
+  });
+
+  // A trade-compliance hold is explained upstream, names how to challenge it, and will change
+  // when that process does. Replacing it with this application's generic sentence would drop the
+  // only part of the message the signatory could act on.
+  //
+  // The fixtures below are real `HttpErrorResponse`s carrying the body this BFF actually sends.
+  // `BaseApiError#toResponse` puts the message under `error`, and the validation replies put it
+  // under `message`; an earlier version of this suite invented `{ error: { message } }`, which is
+  // neither, and passed against a component that could not read either one.
+  it("shows a refusal in the CLA service's own words", async () => {
+    const refusal = 'This company is subject to a trade-compliance hold. Contact support to review the determination.';
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(403, { error: refusal, code: 'UPSTREAM_ERROR' })));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(refusal);
+  });
+
+  // The BFF's own validation replies answer with `message`, so the relay has to read both spellings
+  // — a reader that knows only one drops half of what the server says.
+  it("shows a refusal the server sent under 'message'", async () => {
+    const refusal = 'Both the authorization and compliance confirmations are required';
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(403, { message: refusal })));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(refusal);
+  });
+
+  it('shows the generic failure when the refusal was not explained', async () => {
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'signature service unavailable' })));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-failure-message')?.textContent).toContain(CCLA_SIGN_COPY.failure.body);
+  });
+
+  // Angular synthesizes a non-empty `HttpErrorResponse.message` ("Http failure response for …")
+  // for every failure, so a reader that falls back to it puts an HTTP debugging string in front of
+  // a signatory who was refused.
+  it('shows the generic failure rather than Angular’s synthesized message when the body is empty', async () => {
+    requestCorporateSignature.mockReturnValue(throwError(() => bffError(403, null)));
+
+    const fixture = await render();
+
+    const shown = testid(fixture, 'org-easycla-sign-failure-message')?.textContent;
+    expect(shown).toContain(CCLA_SIGN_COPY.failure.body);
+    expect(shown).not.toContain('Http failure response');
+  });
+
+  // By the time this state is reached the agreement and its DocuSign envelope exist upstream, and
+  // the address on screen is the only way anyone reaches them. A back-out here would strand a real
+  // agreement that this application cannot cancel or reuse, so the state offers no way back.
+  it('offers no way out of an open session except continuing to sign it', async () => {
+    requestCorporateSignature.mockReturnValue(of(response));
+
+    const fixture = await render();
+
+    expect(testid(fixture, 'org-easycla-sign-cancel')).toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-review')).not.toBeNull();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when it is opened without a selection', async () => {
+    const fixture = await renderWith(undefined);
+
+    expect(requestCorporateSignature).not.toHaveBeenCalled();
+    expect(testid(fixture, 'org-easycla-sign-failed')).not.toBeNull();
+  });
+
+  /**
+   * The signing request runs while this dialog is on screen, and it is the call that creates both
+   * the signature record and the DocuSign envelope. Dismissing the dialog destroys the component
+   * and its subscription, so the address that comes back is discarded and the envelope is left
+   * with nobody holding it. Neither exit is available until there is something to lose.
+   */
+  describe('while the signing request is in flight', () => {
+    it('cannot be dismissed by the header control or by Escape', async () => {
+      requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
+
+      await render();
+
+      expect(config.closable).toBe(false);
+      expect(config.closeOnEscape).toBe(false);
+    });
+
+    // Still sealed on success, not just in flight. The envelope exists by then and the address on
+    // screen is the only copy, so an Escape here abandons a real agreement — and `ready` waits for
+    // a person, where the request itself usually answers in under a second. Sealing only the
+    // in-flight window would close the smaller of the two holes.
+    it('still cannot be dismissed once the session is open', async () => {
+      requestCorporateSignature.mockReturnValue(of(response));
+
+      await render();
+
+      expect(config.closable).toBe(false);
+      expect(config.closeOnEscape).toBe(false);
+    });
+
+    // The one dismissible state: no envelope to strand, and trapping someone in a dialog that
+    // reports a failure would leave them no way out at all.
+    it('can be dismissed once it reaches failed', async () => {
+      requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
+
+      await render();
+
+      expect(config.closable).toBe(true);
+      expect(config.closeOnEscape).toBe(true);
+    });
+  });
+
+  /**
+   * The preparing → ready transition happens on its own, with no user action behind it: the
+   * request is issued as the dialog opens and the panel is rewritten when it lands. A sighted
+   * user watches the spinner become a Review CCLA button. Without a live region a screen-reader
+   * user hears the preparing message and then nothing at all, so the control that carries the
+   * whole flow forward arrives with no event to announce it.
+   */
+  describe('announcing the asynchronous transition', () => {
+    it('holds the dialog content in a polite live region', async () => {
+      requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
+
+      const fixture = await render();
+
+      const panel = testid(fixture, 'org-easycla-sign-handoff-dialog');
+      expect(panel?.getAttribute('aria-live')).toBe('polite');
+      expect(panel?.getAttribute('role')).toBe('status');
+    });
+
+    // The region has to be the container that survives the switch. Placed on a per-state branch it
+    // would be created at the same moment as the content it is meant to announce, and a live
+    // region that appears together with its text announces nothing.
+    it('keeps the region mounted across the transition, so the change is what is announced', async () => {
+      requestCorporateSignature.mockReturnValue(of(response));
+
+      const fixture = await render();
+
+      const panel = testid(fixture, 'org-easycla-sign-handoff-dialog');
+      expect(panel?.getAttribute('aria-live')).toBe('polite');
+      expect(testid(fixture, 'org-easycla-sign-ready')).toBeTruthy();
+      // The ready branch itself must not carry a competing region, or the swap is announced twice.
+      expect(testid(fixture, 'org-easycla-sign-ready')?.getAttribute('aria-live')).toBeNull();
+    });
+
+    // A refusal interrupts rather than waits its turn, and the nested role overrides the polite
+    // ancestor for its own subtree.
+    it('leaves the failure branch assertive', async () => {
+      requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
+
+      const fixture = await render();
+
+      expect(testid(fixture, 'org-easycla-sign-failed')?.getAttribute('role')).toBe('alert');
+    });
+  });
+
+  /**
+   * The shell dialog's title is PrimeNG's, and it is a static string at the call site. Left alone
+   * it keeps saying "Configuring CLA Manager Settings…" above a panel that says the session is
+   * ready, or that it failed.
+   */
+  describe('the dialog title', () => {
+    it.each([
+      ['preparing', () => new Observable<OrgClaSignResponse>(() => undefined), CCLA_SIGN_COPY.preparing.header],
+      ['ready', () => of(response), CCLA_SIGN_COPY.ready.header],
+      ['failed', () => throwError(() => bffError(500, { error: 'nope' })), CCLA_SIGN_COPY.failure.header],
+    ])('names the %s state', async (_state, source, expected) => {
+      requestCorporateSignature.mockReturnValue(source());
+
+      await render();
+
+      expect(config.header).toBe(expected);
+    });
+
+    // Would have been the whole bug: the title is set once at the call site and the panel moves on
+    // without it.
+    it('does not leave the preparing title above a ready panel', async () => {
+      requestCorporateSignature.mockReturnValue(of(response));
+
+      const fixture = await render();
+
+      expect(testid(fixture, 'org-easycla-sign-ready')).not.toBeNull();
+      expect(config.header).not.toBe(CCLA_SIGN_COPY.preparing.header);
+    });
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -3,7 +3,7 @@
 
 import { DOCUMENT } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, HostListener, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
@@ -120,6 +120,23 @@ export class OrgEasyclaSignHandoffComponent {
   }
 
   protected onCancel(): void {
+    this.ref.close(null);
+  }
+
+  /**
+   * Escape, in the one state that permits leaving.
+   *
+   * Handled here because the shell's own Escape handling is decided once, when it becomes visible,
+   * from the values it holds at that moment — and this dialog opens sealed. Turning the flag on
+   * afterwards puts the close control on the frame but installs no key listener, so the state that
+   * is meant to be dismissible would be dismissible only by pointer.
+   *
+   * Guarded on the state rather than on the flag it sets, so a frame that is somehow drawn ahead
+   * of the panel cannot become an exit from a session that is open.
+   */
+  @HostListener('document:keydown.escape')
+  protected onEscape(): void {
+    if (this.state() !== 'failed') return;
     this.ref.close(null);
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -1,0 +1,164 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DOCUMENT } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
+import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
+import { OrgLensClaService } from '@services/org-lens-cla.service';
+import { serverAuthoredMessage } from '@shared/utils/http-error.utils';
+import { stashSignedSignatureId } from '@shared/utils/org-cla-signed-signature.util';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+import { ButtonComponent } from '@components/button/button.component';
+
+/**
+ * Opens the corporate signing session, then hands the signatory off to it (#1983).
+ *
+ * The request is made when this dialog opens — that is, on the signatory's Continue from the
+ * attestation step — rather than on the Review and Sign control below. It is not a rehearsal: the
+ * CLA service persists a signature record and opens a DocuSign envelope in the same call, and
+ * there is no shape of the request that yields a signing address without doing so. Given that,
+ * every failure it can produce is better surfaced *before* the signatory's final commitment than
+ * after it. Waiting would not avoid the envelope; it would only mean telling somebody who has
+ * just pressed "sign" that nothing happened.
+ *
+ * The consequence is that backing out here leaves a sent envelope behind. That belongs to the CLA
+ * service, which already voids them, and is not cleaned up from this side.
+ */
+@Component({
+  selector: 'lfx-org-easycla-sign-handoff',
+  imports: [ButtonComponent],
+  templateUrl: './org-easycla-sign-handoff.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OrgEasyclaSignHandoffComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly claService = inject(OrgLensClaService);
+  private readonly document = inject(DOCUMENT);
+  private readonly config = inject<DynamicDialogConfig<OrgClaSignHandoffDialogData>>(DynamicDialogConfig);
+
+  protected readonly copy = CCLA_SIGN_COPY;
+
+  protected readonly state = signal<'preparing' | 'ready' | 'failed'>('preparing');
+  /** The CLA service's own words for a refusal it explained; the generic copy otherwise. */
+  protected readonly failureMessage = signal<string>(CCLA_SIGN_COPY.failure.body);
+
+  private readonly prepared = signal<OrgClaSignResponse | null>(null);
+
+  /** Shell-dialog title per state, so the frame never contradicts the panel inside it. */
+  private readonly headerFor: Record<'preparing' | 'ready' | 'failed', string> = {
+    preparing: CCLA_SIGN_COPY.preparing.header,
+    ready: CCLA_SIGN_COPY.ready.header,
+    failed: CCLA_SIGN_COPY.failure.header,
+  };
+
+  public constructor() {
+    // The shell dialog is PrimeNG's, and it re-reads `header`, `closable` and `closeOnEscape` from
+    // this config object on every change-detection pass — so driving them from state here is what
+    // keeps the frame honest, rather than fixing them at the call site that cannot see the state.
+    //
+    // The dialog cannot be dismissed while the request is in flight, and still cannot once it
+    // succeeds. The signature record and the DocuSign envelope are created by that one call, and
+    // the address it returns is the only copy — so every exit before the signatory follows it
+    // abandons a real agreement upstream, which this application has no way to cancel or reuse.
+    // Sealing only the in-flight window would close the smaller of the two holes: the request
+    // usually answers in under a second, while `ready` waits for a person.
+    //
+    // `failed` is the one dismissible state. There is no envelope to strand, and trapping someone
+    // in a dialog that reports a failure would leave them no way out at all.
+    effect(() => {
+      const state = this.state();
+      const dismissible = state === 'failed';
+
+      this.config.header = this.headerFor[state];
+      this.config.closable = dismissible;
+      this.config.closeOnEscape = dismissible;
+    });
+
+    const data = this.config.data;
+    if (!data) {
+      this.state.set('failed');
+      return;
+    }
+
+    this.claService
+      .requestCorporateSignature(data.orgUid, {
+        projectSfid: data.projectSfid,
+        claGroupId: data.claGroupId,
+        // Relayed exactly as the attestation step recorded them. Writing `true` here would make
+        // the client's own disabled state the only record that the signatory ever confirmed
+        // anything, and would keep sending an affirmation after that state regressed.
+        authorityAcked: data.attestations.authorityAcked,
+        embargoAcked: data.attestations.embargoAcked,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          // The server already rejects an empty address as a failed hand-off; this is the second
+          // line, because the cost of being wrong is navigating to this application's own root
+          // and reading as a completed signature.
+          if (!response.signUrl) {
+            this.state.set('failed');
+            return;
+          }
+          this.prepared.set(response);
+          this.state.set('ready');
+        },
+        error: (error: unknown) => {
+          this.failureMessage.set(this.messageFor(error));
+          this.state.set('failed');
+        },
+      });
+  }
+
+  /**
+   * A full navigation, not a new context: EasyCLA returns the signatory to the Organization Lens
+   * afterwards, which only reads as one flow if they never left this tab.
+   */
+  protected onReviewAndSign(): void {
+    const prepared = this.prepared();
+    if (!prepared?.signUrl) return;
+
+    // Stashed before the navigation, because after it there is no code of ours left running. The
+    // signatory returns to `/org/easycla` through a cross-site redirect whose address was fixed
+    // before this signature existed, so this is the only moment at which anything in the browser
+    // knows which agreement they are about to sign.
+    stashSignedSignatureId(prepared.signatureId);
+
+    // Closed before the navigation, which releases the page's single-flight flag. A full-page
+    // navigation is not a teardown: a Back out of DocuSign can restore this page from bfcache
+    // exactly as it left it, and a flag still set there disables Sign CLA until a manual reload.
+    this.ref.close(prepared);
+
+    // Navigated to as returned. Composing this from a console base and the identifiers would
+    // ignore the session the request just opened.
+    this.document.location.href = prepared.signUrl;
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+
+  /**
+   * A refusal the CLA service explained is shown in its own words.
+   *
+   * It answers a trade-compliance hold with a sentence naming the reason and the support route,
+   * and a missing signing authority with a statement about the caller's scope. Both are 403s, and
+   * both are more useful than anything this layer could write — the compliance wording in
+   * particular is maintained upstream and will change when the process does. Everything else
+   * shares one message, because there is nothing in it the signatory could act on differently.
+   *
+   * Read through the shared helper rather than by hand. The BFF answers a relayed refusal with
+   * the sentence under `error` (`BaseApiError#toResponse`) and its own validation replies with it
+   * under `message`, so a reader that reaches for one spelling drops the other — and dropping
+   * `error` is dropping every refusal this relay exists for.
+   */
+  private messageFor(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse) || error.status !== 403) return CCLA_SIGN_COPY.failure.body;
+    return serverAuthoredMessage(error, CCLA_SIGN_COPY.failure.body).trim();
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -3,7 +3,7 @@
 
 import { DOCUMENT } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
@@ -57,31 +57,11 @@ export class OrgEasyclaSignHandoffComponent {
   };
 
   public constructor() {
-    // The shell dialog is PrimeNG's, and it re-reads `header`, `closable` and `closeOnEscape` from
-    // this config object on every change-detection pass — so driving them from state here is what
-    // keeps the frame honest, rather than fixing them at the call site that cannot see the state.
-    //
-    // The dialog cannot be dismissed while the request is in flight, and still cannot once it
-    // succeeds. The signature record and the DocuSign envelope are created by that one call, and
-    // the address it returns is the only copy — so every exit before the signatory follows it
-    // abandons a real agreement upstream, which this application has no way to cancel or reuse.
-    // Sealing only the in-flight window would close the smaller of the two holes: the request
-    // usually answers in under a second, while `ready` waits for a person.
-    //
-    // `failed` is the one dismissible state. There is no envelope to strand, and trapping someone
-    // in a dialog that reports a failure would leave them no way out at all.
-    effect(() => {
-      const state = this.state();
-      const dismissible = state === 'failed';
-
-      this.config.header = this.headerFor[state];
-      this.config.closable = dismissible;
-      this.config.closeOnEscape = dismissible;
-    });
+    this.enter('preparing');
 
     const data = this.config.data;
     if (!data) {
-      this.state.set('failed');
+      this.enter('failed');
       return;
     }
 
@@ -102,15 +82,15 @@ export class OrgEasyclaSignHandoffComponent {
           // line, because the cost of being wrong is navigating to this application's own root
           // and reading as a completed signature.
           if (!response.signUrl) {
-            this.state.set('failed');
+            this.enter('failed');
             return;
           }
           this.prepared.set(response);
-          this.state.set('ready');
+          this.enter('ready');
         },
         error: (error: unknown) => {
           this.failureMessage.set(this.messageFor(error));
-          this.state.set('failed');
+          this.enter('failed');
         },
       });
   }
@@ -141,6 +121,35 @@ export class OrgEasyclaSignHandoffComponent {
 
   protected onCancel(): void {
     this.ref.close(null);
+  }
+
+  /**
+   * Moves to a state and dresses the shell dialog to match, in one step.
+   *
+   * The shell is PrimeNG's and reads `header`, `closable` and `closeOnEscape` off this config
+   * object as it renders. They are plain properties rather than signals, so nothing re-renders the
+   * shell when they change: written from an effect — which runs *after* the pass that has already
+   * drawn the frame — the title and the dismiss controls would describe the state before this one,
+   * and stay that way until some unrelated event happened to schedule another pass. Writing them
+   * with the state is what keeps the frame from contradicting the panel inside it.
+   *
+   * The dialog cannot be dismissed while the request is in flight, and still cannot once it
+   * succeeds. The signature record and the DocuSign envelope are created by that one call, and
+   * the address it returns is the only copy — so every exit before the signatory follows it
+   * abandons a real agreement upstream, which this application has no way to cancel or reuse.
+   * Sealing only the in-flight window would close the smaller of the two holes: the request
+   * usually answers in under a second, while `ready` waits for a person.
+   *
+   * `failed` is the one dismissible state. There is no envelope to strand, and trapping someone
+   * in a dialog that reports a failure would leave them no way out at all.
+   */
+  private enter(state: 'preparing' | 'ready' | 'failed'): void {
+    const dismissible = state === 'failed';
+
+    this.state.set(state);
+    this.config.header = this.headerFor[state];
+    this.config.closable = dismissible;
+    this.config.closeOnEscape = dismissible;
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.html
@@ -14,22 +14,28 @@
       <p class="text-sm text-gray-500" data-testid="org-easycla-subtitle">The corporate CLAs your organization holds across Linux Foundation projects.</p>
     </div>
 
-    <!-- Rendered but not yet operable: the signing hand-off ships separately. It is here now
-         because the no-CLAs empty state tells the viewer to use it, and disabled reads as
-         "not yet available" where an enabled control wired to nothing reads as broken. There is
-         deliberately no click handler to leave behind — enabling it is the signing feature's job. -->
-    <!-- The reason is in the accessible name as well as the tooltip, because the tooltip alone
-         cannot reach everyone it needs to: the directive sits on the non-focusable `<p-button>`
-         host while the button inside it is disabled, so it opens on hover and never on focus.
-         Without this, assistive technology announces only "Sign CLA, disabled" and the viewer is
-         left to guess whether the control is unavailable to them or unavailable to everyone. -->
+    <!-- Disabled while no organization is selected — there would be nothing to sign for — while a
+         hand-off is already open, which is the single-flight guard, and while the viewer has no
+         Org Lens access, since every request the flow makes would be refused by the server and the
+         page is already saying the module is unavailable beneath this control.
+
+         Also disabled until the org context has settled. `hasNoOrgAccess()` reads false while the
+         grants and persona are still loading, so without this a viewer with no grant can start the
+         flow inside the loading window and reach a refusal the page would otherwise have prevented.
+         The page body below gates on the same signal.
+
+         Deliberately not disabled for a viewer who lacks signing authority: that is a different
+         thing and not known here. The CLA service is the only party that knows, it decides per
+         project and organization, and it explains its refusal in words worth reading. Hiding the
+         control for those viewers is #1980. Lacking Org Lens access is known locally, which is
+         why it belongs in this expression and signing authority does not. -->
     <lfx-button
       label="Sign CLA"
       icon="fa-light fa-file-signature"
-      [disabled]="true"
-      ariaLabel="Sign CLA — signing a new CLA from the Organization Lens is coming soon."
-      tooltip="Signing a new CLA from the Organization Lens is coming soon."
+      [disabled]="!hasCompany() || signingOpen() || hasNoOrgAccess() || !orgContextLoaded() || !claListReady()"
+      [ariaLabel]="signClaAriaLabel()"
       styleClass="shrink-0"
+      (onClick)="startSigning()"
       data-testid="org-easycla-sign-cla" />
   </header>
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -6,7 +6,7 @@ import '@angular/compiler';
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -16,7 +16,7 @@ import { OrgNavigationService } from '@shared/services/org-navigation.service';
 // The no-access branch renders a `lfxOpenIntercom` support button, which injects MessageService.
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
-import { of, Subject, throwError } from 'rxjs';
+import { NEVER, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OrgEasyclaCoverageDialogComponent } from './org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
@@ -66,7 +66,7 @@ describe('OrgEasyclaComponent', () => {
         { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
         { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
         { provide: PersonaService, useValue: { personaLoaded } },
-        { provide: OrgNavigationService, useValue: { loaded: navLoaded } },
+        { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
         { provide: OrgLensClaService, useValue: { getClaGroups } },
         MessageService,
       ],
@@ -129,22 +129,432 @@ describe('OrgEasyclaComponent', () => {
       expect(byTestId(fixture, 'org-easycla-title')?.textContent).not.toContain('—');
     });
 
-    it('renders the Sign CLA control, disabled, so the empty-state copy points at something real', async () => {
+    it('offers the Sign CLA control once an organization is selected', async () => {
       const fixture = await render();
       const signCla = byTestId(fixture, 'org-easycla-sign-cla');
 
       expect(signCla).toBeTruthy();
-      expect(signCla?.querySelector('button')?.disabled).toBe(true);
+      expect(signCla?.querySelector('button')?.disabled).toBe(false);
     });
 
-    // The tooltip carrying the reason opens on hover only: its directive is on the non-focusable
-    // host while the button inside is disabled. The accessible name is the path that reaches a
-    // screen reader, which would otherwise hear "Sign CLA, disabled" and no reason for it.
-    it('names the reason the Sign CLA control is disabled, not just that it is', async () => {
+    it('cannot be used before an organization resolves, because there is nothing to sign for', async () => {
+      selectedAccount.set(null);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      // A disabled control must say why, or a screen reader hears only "disabled".
+      expect(button?.getAttribute('aria-label')).toContain('select an organization first');
+    });
+
+    // `hasNoOrgAccess()` reads false while the grants and persona are still resolving, so without
+    // this gate a viewer holding no grant can start the flow inside the loading window and reach a
+    // refusal the page would otherwise have prevented.
+    it('cannot be used while the organization context is still resolving', async () => {
+      grantsLoaded.set(false);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      // Every reason the control is disabled needs its own wording, or the announcement is just
+      // "disabled" with nothing behind it.
+      expect(button?.getAttribute('aria-label')).toContain('checking your organization access');
+    });
+
+    /**
+     * The picker greys out the agreements the organization already holds, and it does that from
+     * this page's list. Before the list lands that is `[]`, indistinguishable from holding nothing,
+     * so a picker opened early offers a held agreement as choosable — and choosing it opens a
+     * second DocuSign envelope against an agreement already signed.
+     */
+    it('cannot be used before the organization’s own agreements have loaded', async () => {
+      getClaGroups.mockReturnValue(NEVER);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      expect(button?.getAttribute('aria-label')).toContain('loading the agreements this organization already holds');
+    });
+
+    // A failed load is the same case with no recovery: there is no list to check a choice against,
+    // so the control says so rather than checking against nothing.
+    it('cannot be used when the organization’s agreements failed to load', async () => {
+      getClaGroups.mockReturnValue(throwError(() => new Error('boom')));
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      expect(button?.getAttribute('aria-label')).toContain('could not be loaded');
+    });
+
+    // Not disabled for a viewer who lacks signing authority. The CLA service decides that per
+    // project and organization and explains its refusal in words; this layer cannot know it, and
+    // guessing would hide the control from people who do hold the authority.
+    it('offers the control without pre-judging the viewer’s signing authority', async () => {
       const fixture = await render();
       const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
 
-      expect(button?.getAttribute('aria-label')).toContain('coming soon');
+      expect(button?.disabled).toBe(false);
+      expect(button?.getAttribute('aria-label')).toBe('Sign a corporate CLA');
+    });
+  });
+
+  // The component's own job in the signing flow is only to sequence three dialogs and carry each
+  // one's result to the next. What is worth proving is that it carries rather than reconstructs:
+  // the attestations reaching the hand-off must be the ones the attestation dialog closed with.
+  /**
+   * The picker, and the hand-over to the preview page.
+   *
+   * This page's part of the signing flow ends at the choice. The attestation and the hand-off belong
+   * to the preview the choice is carried to — that is the arrangement the M3 prototype draws, and it
+   * puts the two legally operative steps on a page that names the agreement they apply to.
+   */
+  describe('corporate signing flow', () => {
+    const chosen = { claGroupId: 'cla-group-uuid-1', projectSfid: 'a09410000182dD2AAI', projectName: 'Cascade', claGroupName: 'Cascade CLA' };
+
+    /** Only the four the flow actually sets. The rest of DynamicDialogConfig is PrimeNG's default. */
+    interface DialogHarnessConfig {
+      data?: unknown;
+      closable?: boolean;
+      closeOnEscape?: boolean;
+      dismissableMask?: boolean;
+    }
+
+    /** Each `open` closes with the next queued result, so a whole flow can be driven in order. */
+    function dialogHarness(closeResults: unknown[]) {
+      const opened: { component: unknown; config: DialogHarnessConfig }[] = [];
+      const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
+        opened.push({ component, config });
+        const result = closeResults[opened.length - 1];
+        // `onDestroy` as well as `onClose`: the navigation waits for teardown, so a stub that only
+        // closes would never reach it.
+        return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
+      });
+      return { opened, open };
+    }
+
+    async function renderWithDialogs(closeResults: unknown[]) {
+      const harness = dialogHarness(closeResults);
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [OrgEasyclaComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap({}) } } },
+          { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
+          { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+          { provide: PersonaService, useValue: { personaLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
+          { provide: OrgLensClaService, useValue: { getClaGroups } },
+          MessageService,
+        ],
+      })
+        // The component provides DialogService itself, so the component-level provider is the one
+        // that has to be replaced; a module-level override would not be seen.
+        .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: harness.open } }] } })
+        .compileComponents();
+
+      // The test module declares no routes, so a real navigation would resolve to nothing and the
+      // assertion would be about the router's failure rather than about where the page tried to go.
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      const fixture = TestBed.createComponent(OrgEasyclaComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      return { fixture, harness, navigate };
+    }
+
+    it('asks which CLA group to sign for, scoped to the selected organization', async () => {
+      const { fixture, harness } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(1);
+      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] });
+    });
+
+    /**
+     * The picker refuses a CLA Group the organization already holds an agreement for, and this is
+     * where it learns which those are.
+     *
+     * Handed down rather than fetched: this page has the list on screen, and a second request would
+     * be a second answer to the same question. Nothing else here can supply it, so an omission is
+     * silent — the picker simply refuses nothing and the preview goes on to tell the signatory their
+     * organization has not signed an agreement it has.
+     */
+    it('hands the picker the agreements the organization already holds', async () => {
+      const groups = [claGroup()];
+      getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: groups }));
+      const { fixture, harness } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened[0].config.data).toEqual({ orgUid: SELECTED_ACCOUNT.uid, claGroups: groups });
+    });
+
+    /**
+     * Keyed on the `orgUid` the server echoed, not on a response merely being in hand.
+     *
+     * The previous organization's list stays loaded for a cycle after a switch. Opening the picker
+     * against it would either refuse rows this organization never signed, or — passing the empty
+     * list instead — offer one it already holds, which starts a second envelope against a signed
+     * agreement. Neither is discoverable by the viewer, so the control waits for the real list.
+     */
+    it('does not offer the control while the list in hand belongs to a different organization', async () => {
+      getClaGroups.mockReturnValue(of({ orgUid: '0014100000Zq8xbAAB', claGroups: [claGroup()] }));
+      const { fixture, harness } = await renderWithDialogs([null]);
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+
+      button?.click();
+      expect(harness.opened).toHaveLength(0);
+    });
+
+    /**
+     * The hand-over, and the load-bearing one on this page.
+     *
+     * The choice travels in the navigation's state rather than the address, because an address holds
+     * nothing that could be resolved: there is no fetch-a-CLA-group-by-id endpoint, so the preview
+     * would have to render its heading from text taken out of the URL. Everything the preview needs
+     * has to be in this object, including the display name — a selection missing one of these fields
+     * is one the preview refuses and redirects away from.
+     */
+    it('carries the choice to the preview page in the navigation state', async () => {
+      const { fixture, navigate } = await renderWithDialogs([chosen]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      // The key is spelled out rather than taken from the constant, deliberately. It is written into
+      // a history entry that outlives the deployment that wrote it, so renaming it silently breaks
+      // in-app back and forward into a preview opened before the deploy.
+      expect(navigate).toHaveBeenCalledWith(['/org/easycla', 'new'], { state: { orgClaSignSelection: chosen } });
+    });
+
+    it('goes nowhere when no CLA group was chosen', async () => {
+      const { fixture, harness, navigate } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(1);
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    // Only the picker. The attestation and the hand-off are the preview page's, so a second dialog
+    // opened here would be this page running a flow it no longer owns.
+    it('opens no dialog of its own beyond the picker', async () => {
+      const { fixture, harness } = await renderWithDialogs([chosen]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened).toHaveLength(1);
+    });
+
+    // Freely dismissable: nothing has been created yet, and trapping someone in a legal
+    // confirmation they want to back out of would be its own problem.
+    it('leaves the CLA group picker dismissable, because nothing exists yet to lose', async () => {
+      const { fixture, harness } = await renderWithDialogs([chosen]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+      expect(harness.opened[0].config.closable).toBe(true);
+    });
+
+    // A dismissed flow must release the control, or the page needs a reload to try again.
+    it('offers the control again after a dismissed flow', async () => {
+      const { fixture } = await renderWithDialogs([null]);
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+      fixture.detectChanges();
+
+      expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(false);
+    });
+
+    /**
+     * The lock spans the navigation, not just the dialog.
+     *
+     * Between the picker tearing down and the preview being reached the control is on screen and
+     * live, so releasing at the close would let a second click start a parallel flow in that gap.
+     * Releasing at the navigation instead also covers the case where it never lands — refused by a
+     * guard, or superseded — which would otherwise leave Sign CLA disabled until a reload.
+     */
+    it('holds the control through the navigation and releases it when that settles', async () => {
+      const { fixture, navigate } = await renderWithDialogs([chosen]);
+      let arrive: (landed: boolean) => void = () => undefined;
+      navigate.mockReturnValue(new Promise<boolean>((resolve) => (arrive = resolve)));
+
+      byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+      fixture.detectChanges();
+      const control = (): HTMLButtonElement | null | undefined => byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(control()?.disabled).toBe(true);
+
+      // Refused, which is the case the release has to cover: on a landing navigation this page is
+      // already gone and nothing here would be observable either way.
+      arrive(false);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(control()?.disabled).toBe(false);
+    });
+
+    /**
+     * Switching organizations with the picker part-way open.
+     *
+     * These need a dialog that stays open, so they use a harness whose `onClose` is a Subject the
+     * test controls. The one above emits synchronously, which closes the dialog the instant it opens
+     * — fine for asserting what gets passed along, useless for asserting what happens while it is
+     * still standing.
+     */
+    describe('when the organization changes part-way through', () => {
+      interface OpenDialog {
+        component: unknown;
+        config: DialogHarnessConfig;
+        close: ReturnType<typeof vi.fn>;
+        /** Emit to drive this dialog's own close, which is how the flow advances a step. */
+        onClose: Subject<unknown>;
+        /** Emit after `onClose` to finish the leave animation. The next step waits on this. */
+        onDestroy: Subject<void>;
+      }
+
+      function openDialogHarness() {
+        const opened: OpenDialog[] = [];
+        const open = vi.fn((component: unknown, config: DialogHarnessConfig = {}) => {
+          const dialog: OpenDialog = { component, config, close: vi.fn(), onClose: new Subject<unknown>(), onDestroy: new Subject<void>() };
+          opened.push(dialog);
+          return { onClose: dialog.onClose, onDestroy: dialog.onDestroy, close: dialog.close };
+        });
+        return { opened, open };
+      }
+
+      async function renderWithOpenDialogs() {
+        const harness = openDialogHarness();
+        TestBed.resetTestingModule();
+        await TestBed.configureTestingModule({
+          imports: [OrgEasyclaComponent],
+          providers: [
+            provideRouter([]),
+            provideNoopAnimations(),
+            { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess } },
+            { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+            { provide: PersonaService, useValue: { personaLoaded } },
+            { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
+            { provide: OrgLensClaService, useValue: { getClaGroups } },
+            MessageService,
+          ],
+        })
+          .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: harness.open } }] } })
+          .compileComponents();
+
+        const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+        const fixture = TestBed.createComponent(OrgEasyclaComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+        return { fixture, harness, navigate };
+      }
+
+      /**
+       * The load-bearing one, and the reason the close exists at all.
+       *
+       * `orgUid` is read once when the flow starts and handed to the picker as dialog data, and
+       * switching organizations does not destroy this component. So a picker left standing lists
+       * the previous organization's CLA groups, and choosing one would carry that company into a
+       * signing session for the one the viewer is now looking at — the detail page's stale-download
+       * failure, arriving at a corporate legal agreement instead of a PDF.
+       */
+      it('closes the CLA group picker rather than letting it sign for the organization just left', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        expect(harness.opened).toHaveLength(1);
+
+        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'Meridian Systems' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(harness.opened[0].close).toHaveBeenCalled();
+      });
+
+      /**
+       * Clearing the organization, not just switching to another one.
+       *
+       * This is the half the detail page's download stream originally missed: the cancellation
+       * derived from the non-empty selection, so clearing emitted nothing and the stale request
+       * survived. The same filter sits in this component's `orgUid$`, which is why the signing
+       * close listens on the unfiltered stream instead. Without that, this case leaves a picker
+       * open over a page showing no organization at all.
+       */
+      it('closes the picker when the organization is cleared, not only when it is switched', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        expect(harness.opened).toHaveLength(1);
+
+        selectedAccount.set(null);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(harness.opened[0].close).toHaveBeenCalled();
+      });
+
+      /**
+       * The navigation waits for the picker to be torn down, not merely closed.
+       *
+       * `close()` emits `onClose` synchronously and starts the leave animation from that same
+       * emission, and the end of that animation drops `p-overflow-hidden` from the body. Leaving
+       * from inside `onClose` therefore races that teardown against a page change, and the Me-lens
+       * hand-off found the dialog half of this first (#2066).
+       */
+      it('does not leave for the preview until the picker has torn down', async () => {
+        const { fixture, harness, navigate } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+
+        harness.opened[0].onClose.next(chosen);
+        expect(navigate).not.toHaveBeenCalled();
+
+        harness.opened[0].onDestroy.next();
+        expect(navigate).toHaveBeenCalledTimes(1);
+      });
+
+      /**
+       * PrimeNG's header X and Escape go through `p-dialog` `onHide` → `destroy()`, never `close()`.
+       * `onClose` therefore never fires. The lock has to drop on that teardown, or Sign CLA stays
+       * disabled until reload.
+       */
+      it('offers the control again after the header close tears the dialog down without onClose', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        fixture.detectChanges();
+        expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(true);
+
+        harness.opened[0].onDestroy.next();
+        fixture.detectChanges();
+
+        expect(byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.disabled).toBe(false);
+      });
+
+      // The gap between the picker tearing down and the preview being reached is a window in which
+      // the control is live. It stays disabled across it, or a second click opens a second picker.
+      it('starts no second flow in the gap between the teardown and the navigation', async () => {
+        const { fixture, harness } = await renderWithOpenDialogs();
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        harness.opened[0].onClose.next(chosen);
+
+        byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button')?.click();
+        harness.opened[0].onDestroy.next();
+
+        expect(harness.opened).toHaveLength(1);
+      });
     });
   });
 
@@ -159,6 +569,26 @@ describe('OrgEasyclaComponent', () => {
 
       expect(byTestId(fixture, 'org-easycla-no-access-state')).toBeTruthy();
       expect(byTestId(fixture, 'org-easycla-empty-state')).toBeNull();
+    });
+
+    /**
+     * The organization stays selected here on purpose.
+     *
+     * That combination is what the page actually renders for a caller whose account carries a
+     * company but no Org Lens grant, and it is the one the other no-access cases miss by clearing
+     * `selectedAccount` — which disables the control for the unrelated reason that there is
+     * nothing to sign for. With the company left in place, only an access term can disable it.
+     * Without one, the page offered "Organization Lens is not available" and a live Sign CLA
+     * button together, and every request the flow made would be refused by the server.
+     */
+    it('does not offer Sign CLA to a caller with a company but no org access', async () => {
+      hasOrgSelectorAccess.set(false);
+
+      const fixture = await render();
+
+      const button = byTestId(fixture, 'org-easycla-sign-cla')?.querySelector('button');
+      expect(button?.disabled).toBe(true);
+      expect(button?.getAttribute('aria-label')).toContain('Organization Lens is not available');
     });
 
     it('withholds both answers until the grant and persona fetches have returned', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -182,9 +182,7 @@ export class OrgEasyclaComponent {
    * against an agreement already signed. A failed load is the same case with no recovery: there is
    * no list to check against, so the control waits rather than checking against nothing.
    */
-  protected readonly claListReady = computed(
-    () => !!this.claData() && this.claDataIsForSelectedOrg() && !this.claLoadingState() && !this.fetchError()
-  );
+  protected readonly claListReady = computed(() => !!this.claData() && this.claDataIsForSelectedOrg() && !this.claLoadingState() && !this.fetchError());
 
   protected readonly claGroups: Signal<OrgClaGroup[]> = computed(() => this.claData()?.claGroups ?? []);
   protected readonly filteredClaGroups: Signal<OrgClaGroup[]> = this.initFilteredClaGroups();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
-import { RouterLink } from '@angular/router';
-import type { OrgClaGroup, OrgClaGroupList } from '@lfx-one/shared/interfaces';
+import { Router, RouterLink } from '@angular/router';
+import { CCLA_SIGN_COPY, ORG_CLA_SIGN_SELECTION_STATE, ORG_EASYCLA_NEW_SEGMENT, ORG_EASYCLA_PATH } from '@lfx-one/shared/constants';
+import type { OrgClaGroup, OrgClaGroupList, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, filter, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, of, skip, switchMap, take, tap } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -24,6 +25,7 @@ import { OrgNavigationService } from '@shared/services/org-navigation.service';
 
 import { OrgEasyclaCardComponent } from './org-easycla-card/org-easycla-card.component';
 import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from './org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
+import { OrgEasyclaGroupSelectComponent } from './org-easycla-sign/org-easycla-group-select.component';
 
 @Component({
   selector: 'lfx-org-easycla',
@@ -41,8 +43,23 @@ export class OrgEasyclaComponent {
   private readonly personaService = inject(PersonaService);
   private readonly orgNavigation = inject(OrgNavigationService);
   private readonly claService = inject(OrgLensClaService);
-  private readonly platformId = inject(PLATFORM_ID);
   private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly router = inject(Router);
+
+  /** One hand-off at a time. Also what disables the Sign CLA control while a flow is open. */
+  protected readonly signingOpen = signal(false);
+
+  /**
+   * The CLA Group picker, while it is open. Held so an organization switch can close it; see
+   * `abandonOpenPicker`.
+   *
+   * The only signing dialog this page owns. The steps that follow — the attestation and the
+   * hand-off — belong to the preview page the picker navigates to, which names the agreement they
+   * are about.
+   */
+  private openPickerDialog: DynamicDialogRef | null = null;
 
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
@@ -58,6 +75,26 @@ export class OrgEasyclaComponent {
   // ── Org context ───────────────────────────────────────────────────────────
   protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
   protected readonly hasCompany = computed(() => !!this.accountContext.selectedAccount()?.uid);
+
+  /**
+   * Names the reason when Sign CLA is disabled, so a screen reader hears one instead of a bare
+   * "disabled". Computed rather than a template ternary — the control has three distinct reasons.
+   *
+   * No-access is checked first: it is the one reason the viewer can do nothing about, and it also
+   * subsumes the others, since a viewer without access has no organization to select either.
+   */
+  protected readonly signClaAriaLabel = computed(() => {
+    if (this.hasNoOrgAccess()) return 'Sign a corporate CLA — Organization Lens is not available for your account';
+    // Every reason the control is disabled needs a branch here, or assistive technology announces
+    // "disabled" with no explanation. Loading sits above the company check because it is why the
+    // company is not known yet.
+    if (!this.orgContextLoaded()) return 'Sign a corporate CLA — checking your organization access';
+    if (!this.hasCompany()) return 'Sign a corporate CLA — select an organization first';
+    if (this.signingOpen()) return 'Sign a corporate CLA — a signing request is already open';
+    if (this.fetchError()) return 'Sign a corporate CLA — this organization’s agreements could not be loaded';
+    if (!this.claListReady()) return 'Sign a corporate CLA — loading the agreements this organization already holds';
+    return 'Sign a corporate CLA';
+  });
 
   /**
    * True once both grant fetches have returned and the caller holds no org access. The route guard
@@ -89,11 +126,22 @@ export class OrgEasyclaComponent {
   // ── Data ──────────────────────────────────────────────────────────────────
   private readonly searchTerm: Signal<string> = this.initSearchTerm();
 
+  // Every selection the viewer makes, including clearing it.
+  private readonly selectedOrgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(distinctUntilChanged());
+
   // Shared with the constructor's org-switch reset below — mirrors org-groups' orgUid$.
-  private readonly orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount()?.uid)).pipe(
-    filter((uid): uid is string => !!uid),
-    distinctUntilChanged()
-  );
+  private readonly orgUid$ = this.selectedOrgUid$.pipe(filter((uid): uid is string => !!uid));
+
+  /**
+   * Emits when the viewer leaves the organization a signing flow was started for, skipping the
+   * value present at subscribe time.
+   *
+   * Derived from the unfiltered stream, not `orgUid$`, for the reason the CLA Group detail page
+   * found on its download stream: clearing the selection empties the page just as switching does,
+   * and the non-empty filter would swallow it — leaving exactly the stale thing the stream exists
+   * to cancel. Here that stale thing is a signing flow still pointed at the previous company.
+   */
+  private readonly orgChanged$ = this.selectedOrgUid$.pipe(skip(1));
 
   private readonly claData: Signal<OrgClaGroupList | null | undefined> = this.initClaData();
 
@@ -123,6 +171,19 @@ export class OrgEasyclaComponent {
    */
   protected readonly claLoading = computed(
     () => this.hasCompany() && (this.claData() === undefined || this.claLoadingState() || !this.claDataIsForSelectedOrg()) && !this.fetchError()
+  );
+
+  /**
+   * True once the selected organization's own list is in hand, which is what Sign CLA waits for.
+   *
+   * The picker is given `claGroups()` so it can grey out the agreements the organization already
+   * holds. Until the list lands that is `[]` — indistinguishable from holding nothing — so a picker
+   * opened early offers a held agreement as choosable, and choosing it creates a second envelope
+   * against an agreement already signed. A failed load is the same case with no recovery: there is
+   * no list to check against, so the control waits rather than checking against nothing.
+   */
+  protected readonly claListReady = computed(
+    () => !!this.claData() && this.claDataIsForSelectedOrg() && !this.claLoadingState() && !this.fetchError()
   );
 
   protected readonly claGroups: Signal<OrgClaGroup[]> = computed(() => this.claData()?.claGroups ?? []);
@@ -178,6 +239,10 @@ export class OrgEasyclaComponent {
       this.filterForm.reset({ search: '' });
       this.page.set(0);
     });
+
+    // Separate from the reset above because it listens on the unfiltered stream: a cleared
+    // selection has no list to re-filter but does have a signing flow to abandon.
+    this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonOpenPicker());
   }
 
   protected changePage(delta: number): void {
@@ -193,6 +258,130 @@ export class OrgEasyclaComponent {
    */
   protected openCoverage(claGroup: OrgClaGroup): void {
     this.dialogService.open(OrgEasyclaCoverageDialogComponent, orgClaCoverageDialogConfig(claGroup));
+  }
+
+  /**
+   * Starts the corporate signing flow (#1983): pick a CLA Group, then hand that choice to the
+   * preview page, where the signatory reads what they are about to sign.
+   *
+   * This page stops at the picker. The attestation and the hand-off follow on the preview page,
+   * which is the arrangement the M3 prototype draws and also the one that puts the two legally
+   * operative steps — the confirmations, and the request that opens a real envelope — on a page
+   * that names the agreement they apply to rather than in a dialog stack over a list.
+   */
+  protected startSigning(): void {
+    const orgUid = this.accountContext.selectedAccount()?.uid;
+    // Single-flight: the control is disabled while a flow is open, and this is the second line.
+    if (!orgUid || this.signingOpen()) return;
+
+    this.signingOpen.set(true);
+
+    // The agreements this organization already holds, so the picker can refuse a CLA Group it has
+    // one for. Handed down rather than fetched: this page has the list, and a second request would
+    // be a second answer to the same question.
+    //
+    // Keyed on the `orgUid` the server echoed, not on the response merely being present. A response
+    // that belongs to the organization the viewer just left would refuse rows this organization has
+    // never signed, and an empty list is the safe reading of "not known yet".
+    const claData = this.claData();
+    const claGroups = claData?.orgUid === orgUid ? claData.claGroups : [];
+
+    const pickerRef = this.dialogService.open(OrgEasyclaGroupSelectComponent, {
+      header: CCLA_SIGN_COPY.picker.header,
+      width: '40rem',
+      // The Aura dialog preset caps nothing, so a fixed width alone runs off a 360-390px phone,
+      // taking the controls at its edges with it. Same cap the sibling coverage dialog documents.
+      style: { maxWidth: '90vw' },
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { orgUid, claGroups },
+    }) as DynamicDialogRef;
+
+    this.openPickerDialog = pickerRef;
+
+    this.whenSigningDialogEnds(pickerRef, (chosen: OrgClaSignSelection) => {
+      // The choice comes from `onClose`, which carries it; the navigation waits for teardown.
+      // `signingOpen` stays true across that gap, so the control cannot start a second flow in it.
+      this.afterDialogTornDown(pickerRef, () => this.openPreview(chosen));
+    });
+  }
+
+  /**
+   * Closes the CLA Group picker on an organization switch.
+   *
+   * The picker is opened for one organization — `orgUid` is read once when the flow starts and
+   * handed to it as dialog data — and switching organizations does not destroy this component; it
+   * re-drives the list fetch. So without this the picker stays open over a page that has moved on,
+   * still listing the previous organization's CLA Groups, and choosing one would carry that company
+   * into a signing session. This is the download path's stale-response failure on the detail page,
+   * arriving at a legal agreement instead of a PDF.
+   *
+   * The steps that can actually create something are past the navigation and are not this page's to
+   * close: the preview page leaves for the list on a switch of its own accord, and the hand-off is
+   * deliberately left standing once a session exists behind it.
+   */
+  private abandonOpenPicker(): void {
+    this.openPickerDialog?.close();
+  }
+
+  /**
+   * Hands the chosen CLA Group to the preview page.
+   *
+   * The choice travels in the navigation's state rather than the address. The CLA service exposes
+   * no fetch-a-CLA-group-by-id endpoint, so ids in a URL could not be resolved back into the
+   * agreement the preview has to name — the display names would have to ride along in the URL too,
+   * leaving that page to render its heading from text taken out of the address.
+   */
+  private openPreview(selection: OrgClaSignSelection): void {
+    void this.router
+      .navigate([ORG_EASYCLA_PATH, ORG_EASYCLA_NEW_SEGMENT], { state: { [ORG_CLA_SIGN_SELECTION_STATE]: selection } })
+      // Released at the navigation rather than at the dialog's close, so the control stays disabled
+      // across the teardown gap and a navigation that never lands — refused by a guard, or
+      // superseded by another — cannot leave Sign CLA disabled until a reload. On the ordinary path
+      // this page is already gone by the time this runs.
+      .finally(() => this.signingOpen.set(false));
+  }
+
+  /**
+   * Runs `next` once a dialog is not merely closed but torn down.
+   *
+   * `DynamicDialogRef.close()` emits `onClose` synchronously and starts the leave animation from
+   * that same emission, and the end of that animation is what drops `p-overflow-hidden` from the
+   * body. A dialog opened from inside `onClose` therefore has its own scroll lock stripped a
+   * moment after it appears, and the page scrolls behind it. `onDestroy` fires after that
+   * teardown, which is the boundary a follow-on step has to wait for.
+   *
+   * The Me-lens hand-off found this first (#2066) and carries the same helper. This chain opens
+   * two dialogs from inside a close, so it had the defect twice.
+   */
+  private afterDialogTornDown(dialogRef: DynamicDialogRef, next: () => void): void {
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => next());
+  }
+
+  /**
+   * Releases Sign CLA when a dialog ends, unless `onAdvance` is taking the lock to the next step.
+   *
+   * PrimeNG's header close and Escape go through `p-dialog` `onHide` → `DynamicDialogRef.destroy()`.
+   * That never emits `onClose`. A listener that only watches `onClose` therefore leaves
+   * `signingOpen` true after those dismissals, and the control stays disabled until reload.
+   */
+  private whenSigningDialogEnds<T>(dialogRef: DynamicDialogRef, onAdvance?: (value: T) => void): void {
+    let handedOff = false;
+
+    dialogRef.onClose.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: T | null | undefined) => {
+      if (this.openPickerDialog === dialogRef) this.openPickerDialog = null;
+      if (value && onAdvance) {
+        handedOff = true;
+        onAdvance(value);
+        return;
+      }
+      this.signingOpen.set(false);
+    });
+
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      if (!handedOff) this.signingOpen.set(false);
+    });
   }
 
   private initSearchTerm(): Signal<string> {

--- a/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.html
+++ b/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.html
@@ -8,6 +8,7 @@
       [binary]="binary()"
       [inputId]="inputId() || control()"
       [ariaLabelledBy]="ariaLabelledBy()"
+      [pt]="{ input: { 'aria-describedby': ariaDescribedBy() || null } }"
       [styleClass]="styleClass()"
       class="flex" />
     @if (label()) {

--- a/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.ts
+++ b/apps/lfx-one/src/app/shared/components/checkbox/checkbox.component.ts
@@ -16,6 +16,12 @@ export class CheckboxComponent {
   public readonly inputId = input<string>();
   /** Id of the element naming this checkbox — use when the consent text is richer than `label` allows. */
   public readonly ariaLabelledBy = input<string>();
+  /**
+   * Id of the element carrying the terms this checkbox affirms, for a label that does not stand
+   * alone. `p-checkbox` has no `ariaDescribedBy` of its own, so this is applied to the rendered
+   * input through `pt`.
+   */
+  public readonly ariaDescribedBy = input<string>();
   public readonly label = input<string>('');
   public readonly binary = input<boolean>(true);
   public readonly disabled = input<boolean>(false);

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.html
@@ -28,6 +28,11 @@
         [attr.maxlength]="maxlength()"
         [attr.aria-describedby]="describedBy() || null"
         [attr.aria-invalid]="invalid() ? true : null"
+        [attr.role]="role() ?? null"
+        [attr.aria-controls]="ariaControls() ?? null"
+        [attr.aria-activedescendant]="ariaActivedescendant() ?? null"
+        [attr.aria-expanded]="ariaExpanded() ?? null"
+        [attr.aria-autocomplete]="ariaAutocomplete() ?? null"
         [attr.data-test]="dataTest()" />
     </p-iconfield>
   } @else {
@@ -45,6 +50,11 @@
       [attr.maxlength]="maxlength()"
       [attr.aria-describedby]="describedBy() || null"
       [attr.aria-invalid]="invalid() ? true : null"
+      [attr.role]="role() ?? null"
+      [attr.aria-controls]="ariaControls() ?? null"
+      [attr.aria-activedescendant]="ariaActivedescendant() ?? null"
+      [attr.aria-expanded]="ariaExpanded() ?? null"
+      [attr.aria-autocomplete]="ariaAutocomplete() ?? null"
       [attr.data-test]="dataTest()" />
   }
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/input-text/input-text.component.ts
+++ b/apps/lfx-one/src/app/shared/components/input-text/input-text.component.ts
@@ -32,4 +32,22 @@ export class InputTextComponent {
   public describedBy = input<string>();
   /** Marks the control invalid for assistive tech; the visible error text is the caller's. */
   public invalid = input<boolean>(false);
+
+  /**
+   * Combobox wiring, for the typeahead pickers that put a results list under this field.
+   *
+   * These belong on the `<input>` and nowhere else. `aria-activedescendant` in particular is read
+   * from the element that holds focus, and focus stays in the text box while the arrow keys move
+   * a highlight through the list — so the same attribute placed on the list container, which is
+   * never focused, announces nothing at all. That is a silent failure: the highlight looks right
+   * on screen and a screen reader hears none of it.
+   *
+   * All optional and null by default, so a field that is not a combobox emits no ARIA it has no
+   * business claiming.
+   */
+  public role = input<string>();
+  public ariaControls = input<string>();
+  public ariaActivedescendant = input<string | null>();
+  public ariaExpanded = input<boolean>();
+  public ariaAutocomplete = input<string>();
 }

--- a/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-cla.service.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import type { OrgClaGroupList, PdfUrlResponse } from '@lfx-one/shared/interfaces';
+import type { ClaGroupSearchResponse, OrgClaGroupList, OrgClaSignRequest, OrgClaSignResponse, PdfUrlResponse } from '@lfx-one/shared/interfaces';
 import { Observable } from 'rxjs';
 
 /**
@@ -26,5 +26,23 @@ export class OrgLensClaService {
 
   public getPdfUrl(orgUid: string, signatureId: string): Observable<PdfUrlResponse> {
     return this.http.get<PdfUrlResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups/${encodeURIComponent(signatureId)}/pdf-url`);
+  }
+
+  /** CLA Groups the organization could sign a corporate CLA for (#1983). One call per typed term. */
+  public getSignOptions(orgUid: string, searchTerm: string): Observable<ClaGroupSearchResponse> {
+    const params = new HttpParams().set('search', searchTerm);
+    return this.http.get<ClaGroupSearchResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups/sign-options`, { params });
+  }
+
+  /**
+   * Opens the corporate signing session (#1983).
+   *
+   * `request` carries the signatory's two attestations as they actually stood when they
+   * continued. Nothing on this path substitutes a literal for them, and nothing should: the
+   * server compares against `true` and refuses anything else, which is only meaningful if what
+   * arrives is what the signatory set.
+   */
+  public requestCorporateSignature(orgUid: string, request: OrgClaSignRequest): Observable<OrgClaSignResponse> {
+    return this.http.post<OrgClaSignResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/cla-groups/sign`, request);
   }
 }

--- a/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.spec.ts
@@ -1,0 +1,54 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { stashSignedSignatureId, takeStashedSignedSignatureId } from './org-cla-signed-signature.util';
+
+describe('the signed-signature stash', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it('carries the signature across the trip', () => {
+    stashSignedSignatureId('signature-uuid-1');
+
+    expect(takeStashedSignedSignatureId()).toBe('signature-uuid-1');
+  });
+
+  // Single-use by construction rather than by the caller remembering to clean up. Left behind, it
+  // would send the next ordinary visit to the list into a detail page nobody asked for.
+  it('is spent by the read, so a second visit finds nothing', () => {
+    stashSignedSignatureId('signature-uuid-1');
+    takeStashedSignedSignatureId();
+
+    expect(takeStashedSignedSignatureId()).toBe('');
+    expect(sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY)).toBeNull();
+  });
+
+  /**
+   * Storage access throws outright where it is disabled or the origin is denied it — Safari's
+   * private mode and a locked-down enterprise profile both do this.
+   *
+   * The write happens after EasyCLA has created the signature and the DocuSign envelope, and
+   * before the hand-off dialog releases the signatory. An exception there strands them holding an
+   * agreement that already exists, to save a convenience worth one click.
+   */
+  it('lets the hand-off continue when the browser refuses to store anything', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    });
+
+    expect(() => stashSignedSignatureId('signature-uuid-1')).not.toThrow();
+  });
+
+  it('reads as no signature when the browser refuses to be read', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(takeStashedSignedSignatureId()).toBe('');
+  });
+});

--- a/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.spec.ts
@@ -51,4 +51,31 @@ describe('the signed-signature stash', () => {
 
     expect(takeStashedSignedSignatureId()).toBe('');
   });
+
+  /**
+   * A policy-denied `Window.sessionStorage` getter throws `SecurityError` from the getter itself,
+   * not from `setItem`/`getItem`. `typeof sessionStorage` triggers that getter, so the probe has to
+   * be inside the try. Otherwise the constructor read that both functions do would drag the whole
+   * EasyCLA page down instead of falling back to the list.
+   */
+  it('lets the hand-off continue when the storage getter itself throws', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('Access denied by policy.', 'SecurityError');
+      },
+    });
+
+    try {
+      expect(() => stashSignedSignatureId('signature-uuid-1')).not.toThrow();
+      expect(takeStashedSignedSignatureId()).toBe('');
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(globalThis, 'sessionStorage', originalDescriptor);
+      } else {
+        delete (globalThis as unknown as { sessionStorage?: Storage }).sessionStorage;
+      }
+    }
+  });
 });

--- a/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
@@ -13,10 +13,22 @@ import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
  *
  * SSR-safe: both functions no-op when `sessionStorage` is unavailable, as the sibling
  * `clearPendingProfileSave` does.
+ *
+ * Best-effort in both directions, because the whole feature is a convenience and the caller is
+ * not. Access throws outright in a browser where storage is disabled or the origin is denied it —
+ * Safari's private mode and a locked-down enterprise profile both do this — and the write happens
+ * *after* EasyCLA has created the signature and the DocuSign envelope. An exception there would
+ * strand the signatory in the hand-off dialog holding an agreement that already exists. Losing the
+ * landing costs them one click from the list.
  */
 export function stashSignedSignatureId(signatureId: string): void {
   if (typeof sessionStorage === 'undefined') return;
-  sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, signatureId);
+
+  try {
+    sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, signatureId);
+  } catch {
+    // Deliberately silent: there is no recovery and nothing for the signatory to do about it.
+  }
 }
 
 /**
@@ -29,7 +41,12 @@ export function stashSignedSignatureId(signatureId: string): void {
 export function takeStashedSignedSignatureId(): string {
   if (typeof sessionStorage === 'undefined') return '';
 
-  const signatureId = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY) ?? '';
-  sessionStorage.removeItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
-  return signatureId.trim();
+  try {
+    const signatureId = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY) ?? '';
+    sessionStorage.removeItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
+    return signatureId.trim();
+  } catch {
+    // Nothing was readable, so there is nothing to spend and nowhere to land: the ordinary list.
+    return '';
+  }
 }

--- a/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
@@ -22,9 +22,11 @@ import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
  * landing costs them one click from the list.
  */
 export function stashSignedSignatureId(signatureId: string): void {
-  if (typeof sessionStorage === 'undefined') return;
-
   try {
+    // `typeof sessionStorage` covers SSR (the identifier is undeclared), and the try covers both
+    // Safari private mode (`setItem` throws) and the policy-denied Window storage getter that
+    // itself throws `SecurityError` before the try — which is why the `typeof` probe is inside it.
+    if (typeof sessionStorage === 'undefined') return;
     sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, signatureId);
   } catch {
     // Deliberately silent: there is no recovery and nothing for the signatory to do about it.
@@ -39,9 +41,12 @@ export function stashSignedSignatureId(signatureId: string): void {
  * and it would send the *next* visit to the list into a detail page nobody asked for.
  */
 export function takeStashedSignedSignatureId(): string {
-  if (typeof sessionStorage === 'undefined') return '';
-
   try {
+    // The `typeof` probe is inside the try for the same reason as the sibling above: SSR wants
+    // the check, and a policy-denied Window storage getter throws `SecurityError` on the probe
+    // itself in some browsers. Running under the try means an affected browser falls back to the
+    // list rather than losing the page during the constructor.
+    if (typeof sessionStorage === 'undefined') return '';
     const signatureId = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY) ?? '';
     sessionStorage.removeItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
     return signatureId.trim();

--- a/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/org-cla-signed-signature.util.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
+
+/**
+ * The signature a corporate signing session created, carried across the DocuSign round trip so the
+ * signatory returns to the agreement they signed rather than to the list (#1983).
+ *
+ * `sessionStorage` because nothing lighter survives the trip: the return is a cross-site
+ * navigation, so neither an in-memory value nor a history entry's state comes back with it. Scoped
+ * to the tab that made the request, which is the tab the signatory returns in.
+ *
+ * SSR-safe: both functions no-op when `sessionStorage` is unavailable, as the sibling
+ * `clearPendingProfileSave` does.
+ */
+export function stashSignedSignatureId(signatureId: string): void {
+  if (typeof sessionStorage === 'undefined') return;
+  sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, signatureId);
+}
+
+/**
+ * Reads the stashed signature and clears it in the same breath.
+ *
+ * Single-use by construction rather than by the caller remembering to clean up. A signature id
+ * left behind is a pointer to a named organization's agreement that outlives the trip it was for,
+ * and it would send the *next* visit to the list into a detail page nobody asked for.
+ */
+export function takeStashedSignedSignatureId(): string {
+  if (typeof sessionStorage === 'undefined') return '';
+
+  const signatureId = sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY) ?? '';
+  sessionStorage.removeItem(ORG_CLA_SIGNED_SIGNATURE_KEY);
+  return signatureId.trim();
+}

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -1058,6 +1058,26 @@ describe('ClaService.prepareSign', () => {
     expect(gatewayFetch).toHaveBeenCalledWith(prepareReq, `${claServiceBaseUrl()}/v4/self-serve/prepare-sign`, expect.objectContaining({ method: 'POST' }));
   });
 
+  /**
+   * The 403 body carries the identity or the organization's standing verbatim, which is worth
+   * relaying to the contributor and worth keeping out of the logs. Both halves are asked for
+   * here: `redactResponseBodyFromLogs` stops `gatewayFetch` from writing the body into its own
+   * log line, and the sibling `withoutUpstreamBody` at the throw strips the body off the rethrown
+   * error so `MicroserviceError#getLogContext` and the Pino serializer find nothing to copy. The
+   * corporate signing path documents the same discipline.
+   */
+  it('asks gatewayFetch to redact the response body from the log line', async () => {
+    gatewayFetch.mockResolvedValueOnce(prepared());
+
+    await new ClaService().prepareSign(prepareReq, '12345', CLA_GROUP_ID);
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      prepareReq,
+      `${claServiceBaseUrl()}/v4/self-serve/prepare-sign`,
+      expect.objectContaining({ redactResponseBodyFromLogs: true })
+    );
+  });
+
   it('sends the group, the derived return address, and both identity keys', async () => {
     gatewayFetch.mockResolvedValueOnce(prepared());
 
@@ -1246,6 +1266,32 @@ describe('ClaService.prepareSign', () => {
 
     expect(thrown?.message).not.toContain(refusal);
     expect(thrown?.message).toBe('Failed to prepare the CLA signing session: 403 Forbidden');
+  });
+
+  /**
+   * `withProducerRefusalMessage` puts the refusal sentence on `clientMessage`, but the raw body
+   * it read from is still on the error. `MicroserviceError#getLogContext` returns `error_body`,
+   * and Pino's error serializer enumerates the error's own keys — so an error carrying the body
+   * would still leak it out of the log line. `withoutUpstreamBody` drops it. Composed at the throw
+   * on this path, the same way the corporate signing path composes it at its own throw.
+   */
+  it('strips the upstream body off the rethrown 403 so the log line has nothing to copy', async () => {
+    const refusal = 'the provided identity does not belong to the authenticated user';
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError('Failed to prepare the CLA signing session: 403 Forbidden', 403, 'FORBIDDEN', {
+        service: 'cla_service',
+        errorBody: JSON.stringify({ code: '403', message: refusal }),
+      })
+    );
+
+    const thrown = (await new ClaService()
+      .prepareSign(prepareReq, '12345', CLA_GROUP_ID)
+      .then(() => null)
+      .catch((error: unknown) => error as MicroserviceError)) as MicroserviceError;
+
+    expect(thrown.errorBody).toBeUndefined();
+    expect(thrown.clientMessage).toBe(refusal);
+    expect(JSON.stringify(thrown.getLogContext())).not.toContain(refusal);
   });
 
   it('does not derive a reason code from the refusal prose', async () => {

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -724,6 +724,13 @@ export class ClaService {
         errorMessage: 'Failed to prepare the CLA signing session',
         errorCode: 'UPSTREAM_ERROR',
         method: 'POST',
+        // Both halves of the redaction: the sentence a 403 body carries is the identity or the
+        // organization's standing, which is worth relaying to the contributor but not worth
+        // repeating to the logs. `redactResponseBodyFromLogs` keeps `gatewayFetch` from writing
+        // the body into its own log line, and the sibling `withoutUpstreamBody` below strips the
+        // body off the rethrown error so `MicroserviceError#getLogContext` and the Pino serializer
+        // find nothing to copy. The corporate signing path already composes both.
+        redactResponseBodyFromLogs: true,
         // The account goes as a number: it is stored and queried as one upstream, and the
         // endpoint's own model types it as an integer.
         body: {
@@ -734,7 +741,7 @@ export class ClaService {
         },
       });
     } catch (error) {
-      throw withProducerRefusalMessage(error);
+      throw withoutUpstreamBody(withProducerRefusalMessage(error));
     }
 
     const userId = result?.userId?.trim();

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -835,6 +835,16 @@ export interface OrgClaSignSelection extends OrgClaGroupPickerResult {
    * routinely ("Cascade CLA" over "Cascade"), and search names them separately.
    */
   claGroupName: string;
+
+  /**
+   * The organization the choice was made under.
+   *
+   * Carried because the selected organization is a cookie any other tab can change, and this state
+   * survives history restoration — so a preview can be re-entered under a company its CLA Group was
+   * never chosen for. The receiving page cannot see that as a switch: the wrong organization is its
+   * initial value, and a switch guard has nothing to compare against without this.
+   */
+  orgUid: string;
 }
 
 /**


### PR DESCRIPTION
The outbound half of the corporate CLA hand-off (#1983), as the M3 prototype draws it:
Sign CLA opens a picker, the choice is carried to a preview page that names the
agreement, and the attestation and hand-off happen there rather than over a list that
names nothing.

### Sign CLA, on the list

Waits for the organization's own agreements before it can be used. The picker greys
out what the organization already holds and reads that from this list — before it
lands the list is empty, indistinguishable from holding nothing, so an early picker
offers a held agreement as choosable and starts a second envelope against an agreement
already signed. Every disabled reason has its own accessible wording.

### The picker

A typeahead over the CLA Groups the organization can sign, driven from the keyboard as
a combobox: the ARIA lives on the input, because `aria-activedescendant` is read from
the focused element and focus never leaves the text box. Rows carry the term they
answer, so a result arriving after the viewer has typed on cannot be chosen. Rows that
cannot be signed are shown with their reason rather than hidden.

### The preview page, `/org/easycla/new`

Reached only from the picker and built entirely from the choice the navigation carried
— the CLA service has no fetch-a-CLA-group-by-id endpoint, so an address could carry
nothing this page could resolve. The choice records the organization it was made
under, and the page leaves for the list whenever that is not the organization in
force. A switch is not the only way to get there: the choice survives history
restoration and the selection is a cookie another tab can change, so back or reload
can arrive with the wrong company as the *initial* value, which a switch guard cannot
see.

It also carries the explainer for an agreement nobody has signed — what signing does,
and that the signer becomes the initial CLA Manager — quoted rather than paraphrased,
being the only place the consequence is stated before it happens.

### Attestation and hand-off

Both confirmations are required before anything is requested. Once a session exists
the hand-off dialog has one exit, Continue to DocuSign, because by then the envelope
is real and dismissing it would orphan one. A dialog closed by Escape or the header X
goes through `destroy()` and never emits `onClose`, so both are watched — otherwise
the control stays disabled until reload. An attestation is closed whenever the page's
context moves under it: the organization, and equally the agreement, since Angular
reuses the component when only `:signatureId` changes.

### Reviewing

4,372 lines added, 63% of them tests. The legal copy is the M3 prototype's, verbatim;
sign-off on that wording is still outstanding and tracked separately.

Stacked on #2304. Refs #1983 — the send-by-email / designee path is not here and is
the remaining acceptance criterion.
