### PR TITLE
feat(org-lens): return the signatory to the agreement they just signed

### DIFF
--- a/apps/lfx-one/e2e/org-easycla-sign.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign.spec.ts
@@ -25,6 +25,7 @@
  * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
  */
 
+import { ORG_EASYCLA_RETURN_ORG_PARAM } from '@lfx-one/shared/constants';
 import { expect, Page, test } from '@playwright/test';
 
 import {
@@ -35,16 +36,19 @@ import {
   fulfillJson,
   gotoEasyclaList,
   groupSearchInput,
+  MOCK_ACCOUNT_ID,
   PAGE_LOAD_TIMEOUT,
   signOption,
   signOptionsResponse,
   skipWithoutCredentials,
   stubHandoff,
+  STUB_SIGNATURE_ID,
   STUB_SIGN_URL,
 } from './helpers/org-easycla.helper';
 
-// The default budget is one authenticated boot; these cases are a boot plus a four-step chain. The
-// neighbouring Org Lens specs all raise it for the same reason, and the same figure.
+// The default budget is one authenticated boot; these cases are a boot plus a four-step chain, and
+// the return trip is a second boot on top of that. The neighbouring Org Lens specs all raise it for
+// the same reason, and the same figure.
 test.setTimeout(120_000);
 
 const CASCADE = signOption();
@@ -158,6 +162,68 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
     await expect(page).toHaveURL(/\/org\/easycla$/, { timeout: PAGE_LOAD_TIMEOUT });
   });
 
+  /**
+   * The return trip, which is the half of the hand-off no dialog can assert.
+   *
+   * `return_url` is an input to the signing request, so it is fixed before the signature exists and
+   * cannot name it. The signature crosses in `sessionStorage` instead, and this is the test that the
+   * two halves meet: the signatory comes back to the list address and is put on the agreement they
+   * just signed.
+   */
+  test('returns the signatory to the agreement they just signed', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // What EasyCLA does at the end of the ceremony: sends the browser to the address the request
+    // named, which is the list plus the organization the session was opened for.
+    await page.goto(`${EASYCLA_URL}?${ORG_EASYCLA_RETURN_ORG_PARAM}=${MOCK_ACCOUNT_ID}`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(new RegExp(`/org/easycla/${STUB_SIGNATURE_ID}$`), { timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-detail-title')).toBeVisible();
+  });
+
+  // Single-use, and spent on the visit that finds it. Otherwise an abandoned ceremony leaves a
+  // signature behind that hijacks an ordinary visit to the list — days later, on any return trip.
+  test('does not divert an ordinary visit to the list', async ({ page }) => {
+    await gotoEasyclaList(page, async (p) => {
+      await stubList(p);
+      await stubHandoff(p);
+    });
+
+    await chooseThenStart(page);
+    await confirmBoth(page);
+    await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
+
+    await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await page.getByTestId('org-easycla-sign-review').locator('button').click();
+    await expect(page).toHaveURL(STUB_SIGN_URL, { timeout: PAGE_LOAD_TIMEOUT });
+
+    // Back to the list without the return parameter — a bookmark, or the signatory navigating there
+    // themselves rather than being sent by EasyCLA.
+    //
+    // Waiting on a card, not on the page shell: the shell arrives in the server-rendered HTML, so
+    // asserting it is satisfied before the client bundle has run — and the stash is read by the
+    // client. Navigating away on the shell alone leaves it unspent and the case asserts nothing. A
+    // card can only come from the list request the client makes.
+    await page.goto(EASYCLA_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('org-easycla-card').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/org\/easycla$/);
+
+    // And spent by that visit, so the genuine return address no longer has one to follow either.
+    await page.goto(`${EASYCLA_URL}?${ORG_EASYCLA_RETURN_ORG_PARAM}=${MOCK_ACCOUNT_ID}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('org-easycla-card').first()).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page).toHaveURL(/\/org\/easycla$/);
+  });
   /**
    * The attestation gate, driven the way a signatory would.
    *

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -1337,6 +1337,64 @@ describe('OrgEasyclaComponent', () => {
     });
 
     /**
+     * Adoption is itself a change of selection, and the page learns of it a beat after it happens.
+     * A wait that gave up on any change would therefore give up on the one that put it there,
+     * ending the trip on the list for the very organization it was waiting for.
+     */
+    it('keeps waiting through the adoption that moved the signatory to the named organization', async () => {
+      vi.useFakeTimers();
+      try {
+        const NAMED = { uid: '0014100000Te0OKAAZ', accountId: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation' };
+        const { fixture, navigate } = await renderAfterSigning({
+          org: NAMED.uid,
+          listOrgUid: NAMED.uid,
+          claGroups: [],
+          authorized: [SELECTED_ACCOUNT, NAMED],
+        });
+        expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+
+        getClaGroups.mockReturnValue(of({ orgUid: NAMED.uid, claGroups: [claGroup()] }));
+        await vi.advanceTimersByTimeAsync(2000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
+     * This page survives an organization switch, so a retry left running would answer for a company
+     * the viewer has deliberately left — taking them to an agreement the detail page then looks up
+     * under the new selection and reports missing.
+     *
+     * The trip is spent either way, so the address is cleaned up rather than left to pull the
+     * viewer back to the old organization on reload.
+     */
+    it('gives up when the viewer selects another organization while it is still waiting', async () => {
+      vi.useFakeTimers();
+      try {
+        const { fixture, navigate } = await renderAfterSigning({ claGroups: [] });
+
+        selectedAccount.set({ uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // The callback lands, but for the organization no longer being looked at.
+        getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+        await vi.advanceTimersByTimeAsync(30_000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+        expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
      * Whichever organization was selected at boot settles first and cannot contain the new
      * agreement, so a decision taken against that list would spend the trip on a row that was never
      * going to be in it.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -3,10 +3,11 @@
 
 import '@angular/compiler';
 
-import { signal } from '@angular/core';
+import { ApplicationRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
 import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
@@ -999,6 +1000,314 @@ describe('OrgEasyclaComponent', () => {
       await switchOrg(fixture);
 
       expect(byTestId(fixture, 'org-easycla-page-label')?.textContent).toContain('Showing 1–8 of 11');
+    });
+  });
+  /**
+   * Returning from DocuSign, where the organization is named on the address.
+   *
+   * The signatory comes back through a cross-site navigation carrying only a `SameSite=Lax`
+   * cookie; when it does not come back, bootstrap selects the first organization in their list, so
+   * signing for one company returns them looking at another.
+   */
+  describe('when EasyCLA returns the signatory with an organization named on the address', () => {
+    const MICROSOFT = { uid: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation', accountId: 'acct-microsoft' };
+    const CONTAINERSHIP = { uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.', accountId: 'acct-containership' };
+
+    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT]) {
+      const setAccount = vi.fn();
+      const resetAndReload = vi.fn();
+      const navigate = vi.fn();
+      const availableAccounts = signal(authorized);
+
+      selectedAccount.set(CONTAINERSHIP);
+      getClaGroups.mockReturnValue(of({ orgUid: CONTAINERSHIP.uid, claGroups: [] }));
+
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [OrgEasyclaComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts, setAccount } },
+          { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+          { provide: PersonaService, useValue: { personaLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload } },
+          { provide: OrgLensClaService, useValue: { getClaGroups } },
+          { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(namedOrg ? { org: namedOrg } : {}) } } },
+          MessageService,
+        ],
+      })
+        .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: openDialog } }] } })
+        .compileComponents();
+
+      const fixture = TestBed.createComponent(OrgEasyclaComponent);
+      const router = TestBed.inject(Router);
+      vi.spyOn(router, 'navigate').mockImplementation(navigate);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      return { fixture, setAccount, resetAndReload, navigate, availableAccounts };
+    }
+
+    it('selects the organization the signature was made for, not the first in the list', async () => {
+      const { setAccount } = await renderReturnedFrom(MICROSOFT.uid);
+
+      // `setAccount` also rewrites the cookie, so the selection that went missing is repaired.
+      expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+    });
+
+    /**
+     * Selecting it is not enough to keep it.
+     *
+     * The org selector requests its first page for whichever organization was current at bootstrap,
+     * which on a cold return is still the stale cookie. When that page lands, the pending default
+     * selection reassigns to its first row unless the current selection is on it — so adopting
+     * without re-pinning is overwritten a beat later by a page requested before the adoption
+     * happened, and the signatory lands back on the organization they did not sign for.
+     */
+    it('re-pins the catalogue on the adopted organization, so the pending default selection cannot reassign it', async () => {
+      const { resetAndReload } = await renderReturnedFrom(MICROSOFT.uid);
+
+      expect(resetAndReload).toHaveBeenCalledWith(MICROSOFT.uid);
+    });
+
+    // The mirror of ignoring it above: an organization that was not adopted must not be pinned
+    // either, or a crafted link would reorder the viewer's catalogue around a company it named.
+    it('does not re-pin an organization the viewer does not hold', async () => {
+      const { resetAndReload } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(resetAndReload).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The parameter names an organization; it does not grant one.
+     *
+     * A crafted link must not select a company the viewer does not hold — and specifically must
+     * not render its name, which is what building a stub from the value (the way the cookie path
+     * hydrates an id it trusts) would do.
+     */
+    it('ignores an organization the viewer does not hold rather than selecting it', async () => {
+      const { setAccount, fixture } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).not.toContain('0014100000TeZZZAAA');
+    });
+
+    it('strips the parameter once adopted, so a reload or a copied link cannot pin a stale organization', async () => {
+      const { navigate } = await renderReturnedFrom(MICROSOFT.uid);
+
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null }, replaceUrl: true }));
+    });
+
+    // Left in place it would keep re-asserting an organization the viewer cannot have, on a page
+    // that has already settled without it.
+    it('strips the parameter even when it named an organization it could not use', async () => {
+      const { navigate } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(navigate).toHaveBeenCalled();
+    });
+
+    /**
+     * The strip and the landing on the signed agreement race each other — this one waits on the
+     * authorized accounts, the other on the CLA list — and this one navigates *relative to this
+     * route*. Arriving second, it would take the signatory straight back off the agreement they
+     * had just been landed on, which reads as the landing being broken rather than the strip.
+     *
+     * There is nothing left to strip in that case either: the agreement's address carries no
+     * parameter.
+     */
+    // The list arrives after this page is constructed, so resolving against the empty list it starts
+    // with would throw away a legitimate hand-off.
+    it('waits for the authorized list rather than discarding the hand-off against an empty one', async () => {
+      navLoaded.set(false);
+      const { setAccount, availableAccounts } = await renderReturnedFrom(MICROSOFT.uid, []);
+
+      expect(setAccount).not.toHaveBeenCalled();
+
+      availableAccounts.set([CONTAINERSHIP, MICROSOFT]);
+      navLoaded.set(true);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+    });
+
+    // The mirror of the wait above: once the organization list has genuinely settled without it,
+    // there is nothing left to wait for and the page stops trying.
+    it('gives up once the organization context has settled without that organization', async () => {
+      const { setAccount, navigate } = await renderReturnedFrom(MICROSOFT.uid, []);
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalled();
+    });
+
+    it('touches nothing on an ordinary visit that carries no organization', async () => {
+      const { setAccount, navigate } = await renderReturnedFrom(null);
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Landing on the agreement just signed, rather than on the list the signatory left.
+   *
+   * The return address cannot name it: `return_url` is an input to the upstream signing request and
+   * so is fixed before a signature exists. The signature crosses in `sessionStorage` instead, and
+   * this page spends it.
+   */
+  describe('when EasyCLA returns the signatory after a signing ceremony', () => {
+    const SIGNED = ['/org/easycla', 'signature-uuid-1'];
+
+    async function renderAfterSigning(options: { stash?: string; org?: string | null; listOrgUid?: string; claGroups?: OrgClaGroup[] } = {}) {
+      const { stash = 'signature-uuid-1', org = SELECTED_ACCOUNT.uid, listOrgUid = SELECTED_ACCOUNT.uid, claGroups = [claGroup()] } = options;
+
+      if (stash) sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, stash);
+      selectedAccount.set(SELECTED_ACCOUNT);
+      getClaGroups.mockReturnValue(of({ orgUid: listOrgUid, claGroups }));
+
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [OrgEasyclaComponent],
+        providers: [
+          provideRouter([]),
+          provideNoopAnimations(),
+          {
+            provide: AccountContextService,
+            useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts: signal([SELECTED_ACCOUNT]), setAccount: vi.fn() },
+          },
+          { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
+          { provide: PersonaService, useValue: { personaLoaded } },
+          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
+          { provide: OrgLensClaService, useValue: { getClaGroups } },
+          { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(org ? { org } : {}) } } },
+          MessageService,
+        ],
+      })
+        .overrideComponent(OrgEasyclaComponent, { set: { providers: [{ provide: DialogService, useValue: { open: openDialog } }] } })
+        .compileComponents();
+
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      const fixture = TestBed.createComponent(OrgEasyclaComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      return { fixture, navigate };
+    }
+
+    beforeEach(() => sessionStorage.clear());
+
+    // Replaces rather than pushes: the address left behind is the return address, and an entry for
+    // it is one Back re-enters — spending nothing and stripping a parameter all over again.
+    it('lands on the agreement just signed, without leaving the return address in history', async () => {
+      const { navigate } = await renderAfterSigning();
+
+      expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+    });
+
+    /**
+     * EasyCLA may not have finished processing the DocuSign callback by the time the signatory is
+     * back. Navigating blind would land them on "This CLA was not found", which is strictly worse
+     * than the list — so the first answer without the row is treated as too early, not as no.
+     */
+    it('asks again rather than giving up when the signed agreement is not in the list yet', async () => {
+      vi.useFakeTimers();
+      try {
+        getClaGroups.mockReturnValueOnce(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] }));
+        const { fixture, navigate } = await renderAfterSigning({ claGroups: [] });
+        expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+
+        // The callback lands between the first answer and the retry.
+        getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+        await vi.advanceTimersByTimeAsync(2000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
+     * Bounded, because past a few seconds the likelier explanations are ones no amount of waiting
+     * fixes — and a page that keeps asking for ever is worse than one that leaves them on the list.
+     *
+     * Clearing the address is this flow's job by then. The sibling adoption stands down as soon as
+     * a landing is intended, so nothing else will do it, and the organization surviving the visit
+     * is the one thing it must not do.
+     */
+    it('gives up on a budget, leaving the signatory on the list with a clean address', async () => {
+      vi.useFakeTimers();
+      try {
+        const { fixture, navigate } = await renderAfterSigning({ claGroups: [] });
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+        expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
+     * Whichever organization was selected at boot settles first and cannot contain the new
+     * agreement, so a decision taken against that list would spend the trip on a row that was never
+     * going to be in it.
+     */
+    it('waits for the named organization’s own list rather than deciding on the one in hand', async () => {
+      const { navigate } = await renderAfterSigning({ listOrgUid: '0014100000Te2QjAAJ' });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+    });
+
+    // Otherwise an abandoned ceremony leaves a signature behind that hijacks an ordinary visit to
+    // the list, days later, on whatever return trip finds it.
+    it('does not divert an ordinary visit, and spends the signature anyway', async () => {
+      const { navigate } = await renderAfterSigning({ org: null });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+      // Spent either way, which is what makes it single-use whichever visit finds it.
+      expect(sessionStorage.getItem(ORG_CLA_SIGNED_SIGNATURE_KEY)).toBeNull();
+    });
+
+    it('stays on the list when no ceremony left a signature behind', async () => {
+      const { navigate } = await renderAfterSigning({ stash: '' });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+    });
+
+    /**
+     * Both return flows navigate, and Angular cancels an in-flight navigation when another begins,
+     * so the address has to be arbitrated rather than stripped by both. Landing wins; the parameter
+     * leaves with the route it sat on.
+     *
+     * Asserted as the ONLY navigation, because the defect this pins was not a wrong destination. It
+     * was a second, entirely correct-looking strip back to the list, which cancelled the landing and
+     * left the signatory exactly where they would have been with no feature at all. Asserting only
+     * that the landing was requested passes against it — the request was always made.
+     */
+    it('does not strip the address back to the list while landing on the agreement', async () => {
+      const { navigate } = await renderAfterSigning();
+
+      expect(navigate).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+    });
+
+    // No list is ever fetched for an organization the viewer does not hold, so waiting on one would
+    // wait for ever and strand the organization on the address.
+    it('gives up, and still clears the address, when the named organization is not the viewer’s', async () => {
+      const { navigate } = await renderAfterSigning({ org: 'not-an-organization-they-hold' });
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -8,7 +8,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
-import type { OrgClaGroup } from '@lfx-one/shared/interfaces';
+import type { Account, OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
@@ -1013,7 +1013,7 @@ describe('OrgEasyclaComponent', () => {
     const MICROSOFT = { uid: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation', accountId: 'acct-microsoft' };
     const CONTAINERSHIP = { uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.', accountId: 'acct-containership' };
 
-    async function renderReturnedFrom(namedOrg: string | null, authorized = [CONTAINERSHIP, MICROSOFT]) {
+    async function renderReturnedFrom(namedOrg: string | null, authorized: Partial<Account>[] = [CONTAINERSHIP, MICROSOFT]) {
       const setAccount = vi.fn();
       const resetAndReload = vi.fn();
       const navigate = vi.fn();
@@ -1056,6 +1056,26 @@ describe('OrgEasyclaComponent', () => {
 
       // `setAccount` also rewrites the cookie, so the selection that went missing is repaired.
       expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+    });
+
+    /**
+     * The authorized list does not keep the shape it starts with. Persona seeds carry `uid`, and
+     * each is then replaced by the Snowflake-enriched record for the same company, which carries
+     * `accountId` and no `uid` — the two being the same Salesforce id for an organization account.
+     * Recognising only the seed shape means the recognition expires partway through the page's own
+     * bootstrap, and which side of that the return lands on is a race.
+     *
+     * The pinned `uid` is the other half: the enriched record has none, `setAccount` persists the
+     * selection by it, and a selection saved without one clears the cookie the return exists to
+     * repair.
+     */
+    it('selects the organization after its record has been enriched and no longer carries a uid', async () => {
+      const enriched = { accountId: MICROSOFT.uid, accountName: MICROSOFT.accountName };
+
+      const { setAccount, resetAndReload } = await renderReturnedFrom(MICROSOFT.uid, [CONTAINERSHIP, enriched]);
+
+      expect(setAccount).toHaveBeenCalledWith(expect.objectContaining({ accountName: MICROSOFT.accountName, uid: MICROSOFT.uid }));
+      expect(resetAndReload).toHaveBeenCalledWith(MICROSOFT.uid);
     });
 
     /**
@@ -1223,6 +1243,31 @@ describe('OrgEasyclaComponent', () => {
 
         // The callback lands between the first answer and the retry.
         getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [claGroup()] }));
+        await vi.advanceTimersByTimeAsync(2000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
+     * A failed request answers nothing about the row, but it does answer whether to keep waiting.
+     * The page fetches once per organization, so nothing arrives to replace the failure — and a
+     * wait on the list it did not return never ends. Left there, a transient outage strands the
+     * signatory on an error page with the organization still on the address and the stash already
+     * spent, so not even a reload recovers the landing.
+     */
+    it('asks again rather than waiting for ever when the list request fails', async () => {
+      vi.useFakeTimers();
+      try {
+        getClaGroups.mockReturnValueOnce(throwError(() => new Error('upstream')));
+
+        const { fixture, navigate } = await renderAfterSigning();
+        expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+
         await vi.advanceTimersByTimeAsync(2000);
         fixture.detectChanges();
         await fixture.whenStable();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -1451,6 +1451,41 @@ describe('OrgEasyclaComponent', () => {
     });
 
     /**
+     * The retry budget is count-bounded, but each attempt talks to the BFF and the BFF's own
+     * gateway timeout is 30 seconds. `concatMap` runs the retries in series, so a stalled BFF
+     * would leave three attempts waiting the full 30 seconds each — about 90 seconds against a
+     * doc comment that describes a few-second budget. The per-attempt `timeout()` bounds the
+     * whole poll in wall-clock time as well as in count.
+     *
+     * A hanging request that neither errors nor completes is what the fixture models: a Subject
+     * that is never fed. Without the timeout, `concatMap` waits for it for ever and even
+     * `advanceTimersByTimeAsync(30_000)` cannot spend the budget. With the timeout, the first
+     * attempt gives up at `perAttemptTimeoutMs`, the poll moves on, and the trip is cleaned up
+     * within the retryCount × (retryDelayMs + perAttemptTimeoutMs) window.
+     */
+    it('bounds the poll in wall-clock time when each attempt hangs, not only in count', async () => {
+      vi.useFakeTimers();
+      try {
+        // A retry-delay + per-attempt-timeout window is (2000 + 3000)ms = 5000ms; three attempts
+        // is 15_000ms. Sizing the wait a beat past that so a fix off by one attempt still fails.
+        const perTripBudgetMs = 3 * (2000 + 3000);
+
+        const { fixture, navigate } = await renderAfterSigning({ claGroups: [] });
+        // From the first retry onwards the mock hangs, so nothing but the timeout can advance it.
+        getClaGroups.mockReturnValue(new Subject());
+
+        await vi.advanceTimersByTimeAsync(perTripBudgetMs + 1000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+        expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
      * A retry that succeeds without the row is still an answer about the list — and the one the
      * page will show once the trip is spent. Without preserving it, the initial failure's error
      * state stays on the template even though the list is now in hand.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -1395,6 +1395,57 @@ describe('OrgEasyclaComponent', () => {
     });
 
     /**
+     * `resetAndReload` clears the selected account when its own page comes back empty or upstream
+     * fails, so a return trip whose reload does not succeed loses the selection after adoption.
+     * Left counted as still-this-one, a list response arriving afterwards would still take the
+     * signatory to the detail page — which, keyed on the now-cleared selection, would then greet
+     * them with "no company selected".
+     */
+    /**
+     * `resetAndReload` clears the selected account when its own page comes back empty or upstream
+     * fails, so a return trip whose reload does not succeed loses the selection after adoption.
+     * The wait treats an empty selection the same as a switch: an answer arriving afterwards would
+     * still take the signatory to the detail page, which — keyed on the now-cleared selection —
+     * would greet them with "no company selected".
+     */
+    it('gives up when the selection is cleared after the return-trip adoption', async () => {
+      const { fixture, navigate } = await renderAfterSigning({ claGroups: [] });
+
+      // The retry would eventually strip the address itself once its budget was spent, so the
+      // observation must be that stripping happens promptly on the clear — not after the retries.
+      selectedAccount.set({ uid: undefined, accountName: '' } as unknown as { accountName: string });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
+    });
+
+    /**
+     * A retry that succeeds without the row is still an answer about the list — and the one the
+     * page will show once the trip is spent. Without preserving it, the initial failure's error
+     * state stays on the template even though the list is now in hand.
+     */
+    it('preserves a list that a retry recovered when the row is still missing at the end', async () => {
+      vi.useFakeTimers();
+      try {
+        getClaGroups.mockReturnValueOnce(throwError(() => new Error('upstream')));
+        getClaGroups.mockReturnValue(of({ orgUid: SELECTED_ACCOUNT.uid, claGroups: [] }));
+
+        const { fixture } = await renderAfterSigning({ claGroups: [] });
+        await vi.advanceTimersByTimeAsync(2000);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const component = fixture.componentInstance as unknown as { fetchError: () => boolean; claGroups: () => OrgClaGroup[] };
+        expect(component.fetchError()).toBe(false);
+        expect(component.claGroups()).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    /**
      * Whichever organization was selected at boot settles first and cannot contain the new
      * agreement, so a decision taken against that list would spend the trip on a row that was never
      * going to be in it.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -1397,13 +1397,6 @@ describe('OrgEasyclaComponent', () => {
     /**
      * `resetAndReload` clears the selected account when its own page comes back empty or upstream
      * fails, so a return trip whose reload does not succeed loses the selection after adoption.
-     * Left counted as still-this-one, a list response arriving afterwards would still take the
-     * signatory to the detail page — which, keyed on the now-cleared selection, would then greet
-     * them with "no company selected".
-     */
-    /**
-     * `resetAndReload` clears the selected account when its own page comes back empty or upstream
-     * fails, so a return trip whose reload does not succeed loses the selection after adoption.
      * The wait treats an empty selection the same as a switch: an answer arriving afterwards would
      * still take the signatory to the detail page, which — keyed on the now-cleared selection —
      * would greet them with "no company selected".
@@ -1414,6 +1407,42 @@ describe('OrgEasyclaComponent', () => {
       // The retry would eventually strip the address itself once its budget was spent, so the
       // observation must be that stripping happens promptly on the clear — not after the retries.
       selectedAccount.set({ uid: undefined, accountName: '' } as unknown as { accountName: string });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(navigate).not.toHaveBeenCalledWith(SIGNED, expect.anything());
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null } }));
+    });
+
+    /**
+     * The list and the selection feed the same take(1), and rxjs picks a winner when both change in
+     * one flush. If the list-with-row wins, the row-bearing outcome fires while the selection has
+     * already moved — and reading it as "safe to land" would take the signatory to the detail page
+     * keyed on nothing. The re-check happens at the moment of landing, not at the moment of
+     * subscribing, so the outcome observer that fires with the row must ask "is the selection this
+     * organization now?" before it calls `landOn`.
+     *
+     * Reached through the private method rather than a subject race, because rxjs's own microtask
+     * scheduling makes the "one flush" the reviewer described hard to reproduce deterministically —
+     * whichever branch of `merge(outcome$, cancelled$)` is queued first wins take(1), and vitest's
+     * queue happens to cancel first here. The re-check is what the reviewer asked for, and this
+     * asserts it holds.
+     */
+    it('does not land if the selection is no longer the named organization when the row arrives', async () => {
+      const NAMED = { uid: '0014100000Te0OKAAZ', accountId: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation' };
+      const { fixture, navigate } = await renderAfterSigning({
+        org: NAMED.uid,
+        listOrgUid: NAMED.uid,
+        authorized: [SELECTED_ACCOUNT, NAMED],
+      });
+      const component = fixture.componentInstance as unknown as { landOnIfSelectionMatches: (n: string, s: string) => void };
+      navigate.mockClear();
+
+      // The row was in hand and the outcome fired — but the selection has moved on. The guard is
+      // the only reason the address is stripped instead of navigating to the detail page for a
+      // company that is no longer selected.
+      selectedAccount.set({ uid: undefined, accountName: '' } as unknown as { accountName: string });
+      component.landOnIfSelectionMatches(NAMED.uid, 'signature-uuid-1');
       fixture.detectChanges();
       await fixture.whenStable();
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -26,7 +26,7 @@ import { OrgEasyclaComponent } from './org-easycla.component';
 describe('OrgEasyclaComponent', () => {
   const SELECTED_ACCOUNT = { uid: '0014100000Te2ovAAB', accountName: 'Vertex Robotics' };
 
-  const selectedAccount = signal<{ uid?: string; accountName: string } | null>(null);
+  const selectedAccount = signal<{ uid?: string | null; accountName: string } | null>(null);
   const hasOrgSelectorAccess = signal(true);
   const grantsLoaded = signal(true);
   const personaLoaded = signal(true);
@@ -1180,8 +1180,16 @@ describe('OrgEasyclaComponent', () => {
   describe('when EasyCLA returns the signatory after a signing ceremony', () => {
     const SIGNED = ['/org/easycla', 'signature-uuid-1'];
 
-    async function renderAfterSigning(options: { stash?: string; org?: string | null; listOrgUid?: string; claGroups?: OrgClaGroup[] } = {}) {
-      const { stash = 'signature-uuid-1', org = SELECTED_ACCOUNT.uid, listOrgUid = SELECTED_ACCOUNT.uid, claGroups = [claGroup()] } = options;
+    async function renderAfterSigning(
+      options: { stash?: string; org?: string | null; listOrgUid?: string; claGroups?: OrgClaGroup[]; authorized?: Partial<Account>[] } = {}
+    ) {
+      const {
+        stash = 'signature-uuid-1',
+        org = SELECTED_ACCOUNT.uid,
+        listOrgUid = SELECTED_ACCOUNT.uid,
+        claGroups = [claGroup()],
+        authorized = [SELECTED_ACCOUNT],
+      } = options;
 
       if (stash) sessionStorage.setItem(ORG_CLA_SIGNED_SIGNATURE_KEY, stash);
       selectedAccount.set(SELECTED_ACCOUNT);
@@ -1195,7 +1203,15 @@ describe('OrgEasyclaComponent', () => {
           provideNoopAnimations(),
           {
             provide: AccountContextService,
-            useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts: signal([SELECTED_ACCOUNT]), setAccount: vi.fn() },
+            // Adoption really moves the selection, as it does in the browser: a stub that records
+            // the call and changes nothing leaves the page fetching for the organization being
+            // left, and every ordering that depends on the selection catching up goes untested.
+            useValue: {
+              selectedAccount,
+              hasOrgSelectorAccess,
+              availableAccounts: signal(authorized),
+              setAccount: (account: Account) => selectedAccount.set(account),
+            },
           },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
@@ -1276,6 +1292,24 @@ describe('OrgEasyclaComponent', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    /**
+     * Two requests are made on a return trip — one for the organization being left, one for the
+     * organization signed with — and a stored failure belongs to neither in particular. Reading
+     * the first one as this organization's answer starts asking upstream while the real request is
+     * still in flight, and on this trip before the adoption has even happened.
+     *
+     * No timers are advanced here on purpose: the named organization's own response is what should
+     * land the signatory, and needing the retry to rescue it is the failure this asserts against.
+     */
+    it('waits for the named organization rather than acting on a failure from the one being left', async () => {
+      const NAMED = { uid: '0014100000Te0OKAAZ', accountId: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation' };
+      getClaGroups.mockReturnValueOnce(throwError(() => new Error('upstream')));
+
+      const { navigate } = await renderAfterSigning({ org: NAMED.uid, listOrgUid: NAMED.uid, authorized: [SELECTED_ACCOUNT, NAMED] });
+
+      expect(navigate).toHaveBeenCalledWith(SIGNED, { replaceUrl: true });
     });
 
     /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -101,6 +101,15 @@ export class OrgEasyclaComponent {
   });
 
   protected readonly fetchError = signal(false);
+
+  /**
+   * The organization whose list request failed, which `claData` cannot say.
+   *
+   * A failure is stored as `null`, and a `null` carries no `orgUid` — so on a return trip, where
+   * one request is in flight for the organization being left and another for the one signed with,
+   * the failure of either is indistinguishable from the failure of the other.
+   */
+  private readonly failedOrgUid = signal<string | null>(null);
   private readonly claLoadingState = signal(false);
   private readonly page = signal(0);
 
@@ -568,16 +577,28 @@ export class OrgEasyclaComponent {
     // interleave. From here the parameter is this method's to remove.
     this.returnLandingPending = true;
 
-    combineLatest([toObservable(this.claData), toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
+    combineLatest([
+      toObservable(this.claData),
+      toObservable(this.accountContext.availableAccounts),
+      toObservable(this.orgContextLoaded),
+      toObservable(this.failedOrgUid),
+    ])
       .pipe(
-        map(([data, accounts, loaded]) => ({
+        map(([data, accounts, loaded, failedFor]) => ({
           list: data?.orgUid === named ? data : null,
           // A failed request answers nothing about the row, but it does answer the question of
           // whether to keep waiting. The page fetches once per organization, so nothing is coming
           // to replace the failure, and a wait for the list it did not return never ends — leaving
           // the signatory on an error page with the parameter still on the address and the stash
           // already spent, so not even a reload could recover the landing.
-          failed: data === null,
+          //
+          // Only this organization's failure counts, which is why it is read from the request's own
+          // record of what it asked for rather than inferred from `claData`. Two requests are made
+          // on a return trip — one for the organization being left, one for the organization signed
+          // with — and a stored `null` belongs to neither in particular. Reading the failure as this
+          // organization's would start the retry while the real request is still in flight, and
+          // before adoption on the trip where the first request is the one that failed.
+          failed: failedFor === named,
           // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
           // context has settled without it there is no list coming and waiting on one would leave
           // the parameter on the address for good.
@@ -664,6 +685,7 @@ export class OrgEasyclaComponent {
         tap(() => {
           this.claLoadingState.set(true);
           this.fetchError.set(false);
+          this.failedOrgUid.set(null);
         }),
         switchMap((uid) =>
           this.claService.getClaGroups(uid).pipe(
@@ -675,6 +697,7 @@ export class OrgEasyclaComponent {
               // one of those is a claim about the company's legal position.
               console.error('Failed to load organization CLA groups:', error);
               this.fetchError.set(true);
+              this.failedOrgUid.set(uid);
               this.claLoadingState.set(false);
               return of(null);
             })

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -25,6 +25,7 @@ import {
   filter,
   first,
   map,
+  merge,
   Observable,
   of,
   skip,
@@ -201,7 +202,15 @@ export class OrgEasyclaComponent {
    */
   private readonly orgChanged$ = this.selectedOrgUid$.pipe(skip(1));
 
-  private readonly claData: Signal<OrgClaGroupList | null | undefined> = this.initClaData();
+  /**
+   * The organization's CLA list.
+   *
+   * Written from two places: the main fetch keyed on `orgUid$`, and the return-trip retry which
+   * asks upstream directly and pushes what it hears back in. Without the second the retry could
+   * recover the list without the row and still leave "we couldn't load your CLAs" on screen — the
+   * error state having been set by the failed initial attempt and never cleared.
+   */
+  private readonly claData = signal<OrgClaGroupList | null | undefined>(undefined);
 
   /**
    * True while the response in hand does not belong to the organization named in the header.
@@ -300,6 +309,7 @@ export class OrgEasyclaComponent {
     // selection has no list to re-filter but does have a signing flow to abandon.
     this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonOpenPicker());
 
+    this.subscribeClaData();
     this.adoptOrganizationFromReturnAddress();
     this.landOnSignedAgreement();
   }
@@ -594,47 +604,60 @@ export class OrgEasyclaComponent {
     // interleave. From here the parameter is this method's to remove.
     this.returnLandingPending = true;
 
-    combineLatest([
+    type Outcome =
+      | { kind: 'list'; list: OrgClaGroupList | null }
+      | { kind: 'failed' }
+      | { kind: 'unreachable' }
+      | { kind: 'cancelled' };
+
+    const outcome$ = combineLatest([
       toObservable(this.claData),
       toObservable(this.accountContext.availableAccounts),
       toObservable(this.orgContextLoaded),
       toObservable(this.failedOrgUid),
-    ])
-      .pipe(
-        map(([data, accounts, loaded, failedFor]) => ({
-          list: data?.orgUid === named ? data : null,
-          // A failed request answers nothing about the row, but it does answer the question of
-          // whether to keep waiting. The page fetches once per organization, so nothing is coming
-          // to replace the failure, and a wait for the list it did not return never ends — leaving
-          // the signatory on an error page with the parameter still on the address and the stash
-          // already spent, so not even a reload could recover the landing.
-          //
-          // Only this organization's failure counts, which is why it is read from the request's own
-          // record of what it asked for rather than inferred from `claData`. Two requests are made
-          // on a return trip — one for the organization being left, one for the organization signed
-          // with — and a stored `null` belongs to neither in particular. Reading the failure as this
-          // organization's would start the retry while the real request is still in flight, and
-          // before adoption on the trip where the first request is the one that failed.
-          failed: failedFor === named,
-          // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
-          // context has settled without it there is no list coming and waiting on one would leave
-          // the parameter on the address for good.
-          unreachable: loaded && !this.authorizedAccountNamed(accounts, named),
-        })),
-        filter(({ list, failed, unreachable }) => !!list || failed || unreachable),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(({ list, unreachable }) => {
-        if (list?.claGroups.some((group) => group.id === signatureId)) {
+    ]).pipe(
+      map(([data, accounts, loaded, failedFor]): Outcome | null => {
+        // A failed request answers nothing about the row, but it does answer the question of
+        // whether to keep waiting. The page fetches once per organization, so nothing is coming
+        // to replace the failure, and a wait for the list it did not return never ends — leaving
+        // the signatory on an error page with the parameter still on the address and the stash
+        // already spent, so not even a reload could recover the landing.
+        //
+        // Only this organization's failure counts, which is why it is read from the request's own
+        // record of what it asked for rather than inferred from `claData`. Two requests are made
+        // on a return trip — one for the organization being left, one for the organization signed
+        // with — and a stored `null` belongs to neither in particular. Reading the failure as this
+        // organization's would start the retry while the real request is still in flight, and
+        // before adoption on the trip where the first request is the one that failed.
+        if (failedFor === named) return { kind: 'failed' };
+        // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
+        // context has settled without it there is no list coming and waiting on one would leave
+        // the parameter on the address for good.
+        if (loaded && !this.authorizedAccountNamed(accounts, named)) return { kind: 'unreachable' };
+        if (data?.orgUid === named) return { kind: 'list', list: data };
+        return null;
+      }),
+      filter((outcome): outcome is Outcome => outcome !== null)
+    );
+
+    // A "selection moved off" that fires post-adoption is `resetAndReload` clearing the account
+    // after its own upstream call came back empty or failed, or the viewer walking away while the
+    // list is in flight. Either way the wait is over, and reading a later list response would land
+    // the signatory on a detail page with no context.
+    const cancelled$ = this.selectionMovedOff(named).pipe(map((): Outcome => ({ kind: 'cancelled' })));
+
+    merge(outcome$, cancelled$)
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe((outcome) => {
+        if (outcome.kind === 'list' && outcome.list?.claGroups.some((group) => group.id === signatureId)) {
           this.landOn(signatureId);
           return;
         }
 
-        // An organization the viewer does not hold is the one case no amount of asking again can
-        // fix. Staying on the list, so the address still has to be cleaned up — the sibling flow
-        // stood down on the strength of the flag and will not do it.
-        if (unreachable) {
+        // An organization the viewer does not hold, or one the viewer has moved off, is a case no
+        // amount of asking again can fix. Staying on the list, so the address still has to be
+        // cleaned up — the sibling flow stood down on the strength of the flag and will not do it.
+        if (outcome.kind === 'unreachable' || outcome.kind === 'cancelled') {
           this.stripReturnOrganizationFromAddress();
           return;
         }
@@ -669,6 +692,15 @@ export class OrgEasyclaComponent {
       .pipe(
         take(OrgEasyclaComponent.signedAgreementRetries),
         concatMap(() => this.claService.getClaGroups(orgUid).pipe(catchError(() => of(null)))),
+        // A retry that succeeds without the row is still an answer about the list, and the one the
+        // page will show once this trip is spent. Without this, an initial failure followed by a
+        // recovery leaves the error state on the template even though the list is now in hand.
+        tap((list) => {
+          if (!list) return;
+          this.claData.set(list);
+          this.fetchError.set(false);
+          this.failedOrgUid.set(null);
+        }),
         map((list) => !!list?.claGroups.some((group) => group.id === signatureId)),
         takeUntil(this.selectionMovedOff(orgUid)),
         first((found) => found, false),
@@ -685,15 +717,21 @@ export class OrgEasyclaComponent {
   }
 
   /**
-   * Fires once the viewer has selected an organization other than this one.
+   * Fires once the selection has moved off this organization, whether onto a different one or onto
+   * nothing at all.
    *
    * Waits for the selection to be this organization first. Adoption on a return trip is itself a
    * change of selection, and one arriving late would otherwise read as the viewer walking away
    * from the very organization being adopted.
+   *
+   * An empty selection is treated the same as a switch, because `resetAndReload` clears the account
+   * when its own page comes back empty or upstream fails. Left counted as still-this-one, the
+   * signatory would be landed on the detail page for the organization they signed for, then read as
+   * having no context there and greeted with the very "no company selected" message the return trip
+   * exists to avoid.
    */
-  private selectionMovedOff(orgUid: string): Observable<string> {
+  private selectionMovedOff(orgUid: string): Observable<string | null | undefined> {
     return this.selectedOrgUid$.pipe(
-      filter((uid): uid is string => !!uid),
       skipWhile((uid) => uid !== orgUid),
       filter((uid) => uid !== orgUid)
     );
@@ -714,13 +752,11 @@ export class OrgEasyclaComponent {
     return computed(() => value().trim().toLowerCase());
   }
 
-  private initClaData(): Signal<OrgClaGroupList | null | undefined> {
-    if (!isPlatformBrowser(this.platformId)) {
-      return signal<OrgClaGroupList | null | undefined>(undefined);
-    }
+  private subscribeClaData(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
 
-    return toSignal(
-      this.orgUid$.pipe(
+    this.orgUid$
+      .pipe(
         tap(() => {
           this.claLoadingState.set(true);
           this.fetchError.set(false);
@@ -742,9 +778,9 @@ export class OrgEasyclaComponent {
             })
           )
         ),
-        takeUntilDestroyed()
+        takeUntilDestroyed(this.destroyRef)
       )
-    );
+      .subscribe((list) => this.claData.set(list));
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -5,13 +5,19 @@ import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
-import { CCLA_SIGN_COPY, ORG_CLA_SIGN_SELECTION_STATE, ORG_EASYCLA_NEW_SEGMENT, ORG_EASYCLA_PATH } from '@lfx-one/shared/constants';
-import type { OrgClaGroup, OrgClaGroupList, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import {
+  CCLA_SIGN_COPY,
+  ORG_CLA_SIGN_SELECTION_STATE,
+  ORG_EASYCLA_NEW_SEGMENT,
+  ORG_EASYCLA_PATH,
+  ORG_EASYCLA_RETURN_ORG_PARAM,
+} from '@lfx-one/shared/constants';
+import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, filter, of, skip, switchMap, take, tap } from 'rxjs';
+import { catchError, combineLatest, concatMap, distinctUntilChanged, filter, first, map, of, skip, switchMap, take, tap, timer } from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -22,6 +28,7 @@ import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
+import { takeStashedSignedSignatureId } from '@shared/utils/org-cla-signed-signature.util';
 
 import { OrgEasyclaCardComponent } from './org-easycla-card/org-easycla-card.component';
 import { orgClaCoverageDialogConfig, OrgEasyclaCoverageDialogComponent } from './org-easycla-coverage-dialog/org-easycla-coverage-dialog.component';
@@ -38,6 +45,17 @@ export class OrgEasyclaComponent {
   /** Matches the approved design's page size. */
   private static readonly pageSize = 8;
 
+  /**
+   * How long the return leg keeps asking for the agreement that was just signed.
+   *
+   * EasyCLA writes the signature when DocuSign calls it back, and that callback races the
+   * signatory's own return trip — so the first list can legitimately not have the row yet. Bounded
+   * rather than open-ended: past a few seconds the likelier explanations are ones no amount of
+   * waiting fixes, and the list is a reasonable place to be left.
+   */
+  private static readonly signedAgreementRetryDelayMs = 2000;
+  private static readonly signedAgreementRetries = 3;
+
   private readonly accountContext = inject(AccountContextService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
@@ -47,6 +65,7 @@ export class OrgEasyclaComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   /** One hand-off at a time. Also what disables the Sign CLA control while a flow is open. */
   protected readonly signingOpen = signal(false);
@@ -60,6 +79,19 @@ export class OrgEasyclaComponent {
    * are about.
    */
   private openPickerDialog: DynamicDialogRef | null = null;
+
+  /**
+   * Whether this page load is a return from a signing ceremony that intends to land on an
+   * agreement, which makes the return organization on the address `landOnSignedAgreement`'s to
+   * remove rather than `adoptOrganizationFromReturnAddress`'s.
+   *
+   * Both flows start in the constructor and both navigate, and Angular cancels an in-flight
+   * navigation when another begins — so unarbitrated they take turns cancelling each other and the
+   * signatory stays on the list. The committed address cannot arbitrate them, being still the return
+   * address at the moment either decides; this is set synchronously instead, before anything is
+   * awaited, so it reads true no matter which of them resolves first.
+   */
+  private returnLandingPending = false;
 
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
@@ -241,6 +273,9 @@ export class OrgEasyclaComponent {
     // Separate from the reset above because it listens on the unfiltered stream: a cleared
     // selection has no list to re-filter but does have a signing flow to abandon.
     this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonOpenPicker());
+
+    this.adoptOrganizationFromReturnAddress();
+    this.landOnSignedAgreement();
   }
 
   protected changePage(delta: number): void {
@@ -380,6 +415,205 @@ export class OrgEasyclaComponent {
     dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (!handedOff) this.signingOpen.set(false);
     });
+  }
+
+  /**
+   * Selects the organization EasyCLA named on the return address after a corporate signing.
+   *
+   * The signatory comes back through a cross-site navigation, and which organization is selected
+   * survives that only in a `SameSite=Lax` cookie. When it does not come back, bootstrap falls to
+   * the first organization in the viewer's list — so signing for one company returns them looking
+   * at another, with their new agreement nowhere in sight. The return address names the
+   * organization the session was opened for so this page does not have to guess.
+   *
+   * **The parameter names an organization; it does not grant one.** It is resolved against the
+   * viewer's own authorized accounts and anything absent from that list is ignored, so a crafted
+   * link cannot select a company they do not hold. Deliberately no stub is built from the value —
+   * that is how the cookie path hydrates an id it trusts, and doing it here would render an
+   * arbitrary organization's name from the URL.
+   */
+  private adoptOrganizationFromReturnAddress(): void {
+    // The address is only followed in a browser, and the strip below is a browser navigation.
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const named = this.route.snapshot.queryParamMap.get(ORG_EASYCLA_RETURN_ORG_PARAM);
+    if (!named) return;
+
+    // The authorized list arrives after this component is constructed, so resolving immediately
+    // would discard a legitimate hand-off against an empty list. Waits for whichever comes first:
+    // the organization appearing, or the org context settling without it.
+    combineLatest([toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
+      .pipe(
+        map(([accounts, loaded]) => ({ match: accounts.find((account: Account) => account.uid === named) ?? null, loaded })),
+        filter(({ match, loaded }) => !!match || loaded),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ match }) => {
+        // `setAccount` also rewrites the cookie, so the round trip repairs the selection that went
+        // missing rather than leaving the next reload to fall back all over again.
+        //
+        // Selecting it is not enough to keep it. The org selector bootstraps its catalogue with
+        // whichever organization was current at the time, which on a cold return is still the stale
+        // cookie — so the first page comes back pinned to that one. When it lands, the pending
+        // default selection asks whether the *current* selection is on the page it received, and
+        // reassigns to the first row when it is not. Adopting early therefore gets overwritten a
+        // beat later by a page that was requested before the adoption happened.
+        //
+        // Re-pinning refetches that page for the organization actually selected, which both
+        // supersedes the in-flight one and satisfies the check when the replacement arrives.
+        if (match) {
+          this.accountContext.setAccount(match);
+          this.orgNavigation.resetAndReload(match.uid);
+        }
+
+        // Not when a landing is intended. `landOnSignedAgreement` navigates off this route, and the
+        // navigation below is relative to it, so both in flight means Angular cancels whichever
+        // started first — leaving the signatory on the list either way.
+        //
+        // A flag rather than a look at `this.router.url`, which is the *committed* address: both
+        // flows start from this constructor and `navigate` resolves later, so at this point the
+        // committed address is still the return address whichever one goes on to win. The flag is
+        // set synchronously, before anything is awaited, so it is already true here. Removing the
+        // parameter then belongs to the landing, which does it if it declines to navigate.
+        if (this.returnLandingPending) return;
+
+        this.stripReturnOrganizationFromAddress();
+      });
+  }
+
+  /**
+   * Takes the organization back off the address once it has been acted on.
+   *
+   * Whether or not it matched: left in place it would pin a stale organization on reload and on any
+   * copied link, and would contradict the viewer the moment they switch.
+   */
+  private stripReturnOrganizationFromAddress(): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { [ORG_EASYCLA_RETURN_ORG_PARAM]: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+
+  /**
+   * Lands the signatory on the agreement they just signed, instead of the list they left.
+   *
+   * The return address cannot name it: `return_url` is an *input* to the upstream signing request
+   * and so is fixed before a signature exists, while the signature id only comes back on the
+   * response. The client carries it across the trip in `sessionStorage`, and this spends it.
+   *
+   * Three conditions, each of which is a way of not being wrong:
+   *
+   * - **Only when the return parameter is present**, so an abandoned ceremony followed by an
+   *   ordinary visit to the list does not teleport the viewer into a detail page. The stash is
+   *   spent either way, which is what makes it single-use whichever visit finds it.
+   * - **Only once the named organization's own list has landed.** Whichever organization was
+   *   selected at boot settles first and cannot contain the new agreement, so a decision taken
+   *   against that list would spend the trip on a row that was never going to be in it.
+   * - **Only if the row is actually there.** EasyCLA may not have finished processing the DocuSign
+   *   callback by the time the signatory is back, and navigating blind would land them on "This CLA
+   *   was not found" — strictly worse than the list. A first answer without the row is treated as
+   *   too early rather than as no, and asked again on a budget; see `retryForSignedAgreement`.
+   *
+   * Matching the row by the CLA Group instead would need none of the stash, and is not equivalent:
+   * the upstream grain is (signing entity x CLA Group), so one organization can hold two rows for
+   * the same CLA Group, and the match is ambiguous exactly where it matters.
+   *
+   * Waiting on that list also has to be able to give up. No list is ever fetched for an organization
+   * the viewer does not hold, so a crafted or stale return address would otherwise wait for one
+   * forever and leave the organization on the address — which is the one thing FR-027a says must not
+   * survive the visit. Settling without the organization is therefore an outcome, not a hang.
+   *
+   * From the moment a landing is intended this method owns that parameter: it removes it itself when
+   * it decides to stay on the list, because `adoptOrganizationFromReturnAddress` stands down as soon
+   * as the intent is claimed. Leaving both to strip it is what made the two cancel each other.
+   */
+  private landOnSignedAgreement(): void {
+    // Same browser-only boundary the return-address adoption above documents: `sessionStorage` is
+    // one, and the navigation below is the other.
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    const signatureId = takeStashedSignedSignatureId();
+    const named = this.route.snapshot.queryParamMap.get(ORG_EASYCLA_RETURN_ORG_PARAM);
+    if (!signatureId || !named) return;
+
+    // Claimed before anything is awaited, so the sibling flow above sees it however the two
+    // interleave. From here the parameter is this method's to remove.
+    this.returnLandingPending = true;
+
+    combineLatest([toObservable(this.claData), toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
+      .pipe(
+        map(([data, accounts, loaded]) => ({
+          list: data?.orgUid === named ? data : null,
+          // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
+          // context has settled without it there is no list coming and waiting on one would leave
+          // the parameter on the address for good.
+          unreachable: loaded && !accounts.some((account: Account) => account.uid === named),
+        })),
+        filter(({ list, unreachable }) => !!list || unreachable),
+        take(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ list }) => {
+        if (list?.claGroups.some((group) => group.id === signatureId)) {
+          this.landOn(signatureId);
+          return;
+        }
+
+        // No list at all means the organization is not the viewer's, and no amount of asking again
+        // will produce one. Staying on the list, so the address still has to be cleaned up — the
+        // sibling flow stood down on the strength of the flag and will not do it.
+        if (!list) {
+          this.stripReturnOrganizationFromAddress();
+          return;
+        }
+
+        this.retryForSignedAgreement(named, signatureId);
+      });
+  }
+
+  /**
+   * Asks again for the list, a bounded number of times, when the signed agreement is not in it.
+   *
+   * The list arriving without the row is not evidence that it will never have one: EasyCLA writes
+   * the signature when DocuSign calls it back, and that callback races the signatory's return trip.
+   * Nothing else would ever bring the row in either — the page fetches once per organization, and
+   * the stash has already been spent, so without this the trip ends on the list and even a reload
+   * cannot recover it.
+   *
+   * Asked of the service directly rather than through the page's own stream, which is keyed on the
+   * organization and would re-raise the skeleton over a list the viewer is already reading. A
+   * failed attempt is treated as "not yet" and simply costs one of the tries.
+   */
+  private retryForSignedAgreement(orgUid: string, signatureId: string): void {
+    timer(OrgEasyclaComponent.signedAgreementRetryDelayMs, OrgEasyclaComponent.signedAgreementRetryDelayMs)
+      .pipe(
+        take(OrgEasyclaComponent.signedAgreementRetries),
+        concatMap(() => this.claService.getClaGroups(orgUid).pipe(catchError(() => of(null)))),
+        map((list) => !!list?.claGroups.some((group) => group.id === signatureId)),
+        first((found) => found, false),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((found) => {
+        if (found) {
+          this.landOn(signatureId);
+          return;
+        }
+
+        this.stripReturnOrganizationFromAddress();
+      });
+  }
+
+  /**
+   * Replaces rather than pushes: the address being left behind is the return address, and an entry
+   * for it in the viewer's history is one Back re-enters, spending nothing and stripping a
+   * parameter all over again. The parameter needs no separate removal — this leaves the route it
+   * sits on, and query parameters are not carried across.
+   */
+  private landOn(signatureId: string): void {
+    void this.router.navigate([ORG_EASYCLA_PATH, signatureId], { replaceUrl: true });
   }
 
   private initSearchTerm(): Signal<string> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -310,8 +310,13 @@ export class OrgEasyclaComponent {
     this.orgChanged$.pipe(takeUntilDestroyed()).subscribe(() => this.abandonOpenPicker());
 
     this.subscribeClaData();
-    this.adoptOrganizationFromReturnAddress();
+    // Landing before adoption is deliberate: `landOnSignedAgreement` sets `returnLandingPending`
+    // synchronously before it subscribes, and only that ordering makes the flag observable to
+    // adoption no matter how the schedulers interleave. The previous order relied on
+    // `toObservable` deferring adoption's first emission until after landing's synchronous prelude
+    // ran; safe on the current scheduler but scheduler-dependent, and not the arbitration we mean.
     this.landOnSignedAgreement();
+    this.adoptOrganizationFromReturnAddress();
   }
 
   protected changePage(delta: number): void {
@@ -604,11 +609,7 @@ export class OrgEasyclaComponent {
     // interleave. From here the parameter is this method's to remove.
     this.returnLandingPending = true;
 
-    type Outcome =
-      | { kind: 'list'; list: OrgClaGroupList | null }
-      | { kind: 'failed' }
-      | { kind: 'unreachable' }
-      | { kind: 'cancelled' };
+    type Outcome = { kind: 'list'; list: OrgClaGroupList | null } | { kind: 'failed' } | { kind: 'unreachable' } | { kind: 'cancelled' };
 
     const outcome$ = combineLatest([
       toObservable(this.claData),
@@ -650,7 +651,7 @@ export class OrgEasyclaComponent {
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe((outcome) => {
         if (outcome.kind === 'list' && outcome.list?.claGroups.some((group) => group.id === signatureId)) {
-          this.landOn(signatureId);
+          this.landOnIfSelectionMatches(named, signatureId);
           return;
         }
 
@@ -666,6 +667,24 @@ export class OrgEasyclaComponent {
         // again, of upstream directly, and cleans the address up itself once the budget is spent.
         this.retryForSignedAgreement(named, signatureId);
       });
+  }
+
+  /**
+   * Lands only if the selection is still this organization at the moment of landing, otherwise
+   * strips the return address and leaves the signatory on the list.
+   *
+   * The wait's `cancelled$` branch reads the selection stream, so a clear that reaches it before
+   * the list does turns into a `cancelled` outcome. A clear that reaches the observers in the same
+   * flush as a row-bearing list, though, presents the row-bearing outcome first — and reading it as
+   * "landing is safe" would take the signatory to the detail page keyed on a company that is no
+   * longer selected. This is the synchronous re-check that closes that window.
+   */
+  private landOnIfSelectionMatches(named: string, signatureId: string): void {
+    if (this.accountContext.selectedAccount()?.uid !== named) {
+      this.stripReturnOrganizationFromAddress();
+      return;
+    }
+    this.landOn(signatureId);
   }
 
   /**
@@ -691,7 +710,17 @@ export class OrgEasyclaComponent {
     timer(OrgEasyclaComponent.signedAgreementRetryDelayMs, OrgEasyclaComponent.signedAgreementRetryDelayMs)
       .pipe(
         take(OrgEasyclaComponent.signedAgreementRetries),
-        concatMap(() => this.claService.getClaGroups(orgUid).pipe(catchError(() => of(null)))),
+        // One line per failed attempt, so triage of a stranded landing can see whether the retries
+        // failed or found nothing. Silence here was inconsistent with the initial fetch's log line
+        // and left the retry invisible to the console.
+        concatMap(() =>
+          this.claService.getClaGroups(orgUid).pipe(
+            catchError((error: unknown) => {
+              console.warn('Retry for signed agreement failed:', error);
+              return of(null);
+            })
+          )
+        ),
         // A retry that succeeds without the row is still an answer about the list, and the one the
         // page will show once this trip is spent. Without this, an initial failure followed by a
         // recovery leaves the error state on the template even though the list is now in hand.
@@ -708,7 +737,7 @@ export class OrgEasyclaComponent {
       )
       .subscribe((found) => {
         if (found) {
-          this.landOn(signatureId);
+          this.landOnIfSelectionMatches(orgUid, signatureId);
           return;
         }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -17,7 +17,24 @@ import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaSignSelection } from 
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, concatMap, distinctUntilChanged, filter, first, map, of, skip, switchMap, take, tap, timer } from 'rxjs';
+import {
+  catchError,
+  combineLatest,
+  concatMap,
+  distinctUntilChanged,
+  filter,
+  first,
+  map,
+  Observable,
+  of,
+  skip,
+  skipWhile,
+  switchMap,
+  take,
+  takeUntil,
+  tap,
+  timer,
+} from 'rxjs';
 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -640,6 +657,12 @@ export class OrgEasyclaComponent {
    * Asked of the service directly rather than through the page's own stream, which is keyed on the
    * organization and would re-raise the skeleton over a list the viewer is already reading. A
    * failed attempt is treated as "not yet" and simply costs one of the tries.
+   *
+   * Given up on the moment the viewer selects a different organization. This page survives that
+   * switch, so an answer arriving afterwards would take a viewer who has deliberately moved on to
+   * an agreement belonging to the company they left — and the detail page, keyed on the selection,
+   * would look it up under the new one and report it missing. Giving up still spends the trip, so
+   * the return address is cleaned up rather than left to contradict the viewer on reload.
    */
   private retryForSignedAgreement(orgUid: string, signatureId: string): void {
     timer(OrgEasyclaComponent.signedAgreementRetryDelayMs, OrgEasyclaComponent.signedAgreementRetryDelayMs)
@@ -647,6 +670,7 @@ export class OrgEasyclaComponent {
         take(OrgEasyclaComponent.signedAgreementRetries),
         concatMap(() => this.claService.getClaGroups(orgUid).pipe(catchError(() => of(null)))),
         map((list) => !!list?.claGroups.some((group) => group.id === signatureId)),
+        takeUntil(this.selectionMovedOff(orgUid)),
         first((found) => found, false),
         takeUntilDestroyed(this.destroyRef)
       )
@@ -658,6 +682,21 @@ export class OrgEasyclaComponent {
 
         this.stripReturnOrganizationFromAddress();
       });
+  }
+
+  /**
+   * Fires once the viewer has selected an organization other than this one.
+   *
+   * Waits for the selection to be this organization first. Adoption on a return trip is itself a
+   * change of selection, and one arriving late would otherwise read as the viewer walking away
+   * from the very organization being adopted.
+   */
+  private selectionMovedOff(orgUid: string): Observable<string> {
+    return this.selectedOrgUid$.pipe(
+      filter((uid): uid is string => !!uid),
+      skipWhile((uid) => uid !== orgUid),
+      filter((uid) => uid !== orgUid)
+    );
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -444,7 +444,7 @@ export class OrgEasyclaComponent {
     // the organization appearing, or the org context settling without it.
     combineLatest([toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
       .pipe(
-        map(([accounts, loaded]) => ({ match: accounts.find((account: Account) => account.uid === named) ?? null, loaded })),
+        map(([accounts, loaded]) => ({ match: this.authorizedAccountNamed(accounts, named), loaded })),
         filter(({ match, loaded }) => !!match || loaded),
         take(1),
         takeUntilDestroyed(this.destroyRef)
@@ -480,6 +480,29 @@ export class OrgEasyclaComponent {
 
         this.stripReturnOrganizationFromAddress();
       });
+  }
+
+  /**
+   * The viewer's own account for the organization named on the return address, or null.
+   *
+   * Resolved on either identifier the record may carry. The authorized list starts as persona
+   * seeds, which hold `uid`, and is then replaced row by row with the Snowflake-enriched record
+   * for the same company — which carries `accountId` and no `uid` at all. Matching on `uid` alone
+   * therefore stops matching the moment enrichment lands, and the company the signatory has just
+   * signed for reads as one they do not hold. For an organization account the two are the same
+   * Salesforce id (spec 002: the b2b_org uid *is* the 18-char SFID), which is what makes either
+   * one an honest answer to the same question.
+   *
+   * `uid` is pinned onto the result because the enriched record has none and everything
+   * downstream is keyed on it — `setAccount` persists the selection by `uid`, and clears the
+   * cookie outright when it is absent.
+   *
+   * Still only a resolution, never a grant: an organization that is not in this list is not
+   * matched, so a crafted address selects nothing.
+   */
+  private authorizedAccountNamed(accounts: Account[], named: string): Account | null {
+    const match = accounts.find((account: Account) => account.uid === named || account.accountId === named);
+    return match ? { ...match, uid: named } : null;
   }
 
   /**
@@ -521,10 +544,12 @@ export class OrgEasyclaComponent {
    * the upstream grain is (signing entity x CLA Group), so one organization can hold two rows for
    * the same CLA Group, and the match is ambiguous exactly where it matters.
    *
-   * Waiting on that list also has to be able to give up. No list is ever fetched for an organization
-   * the viewer does not hold, so a crafted or stale return address would otherwise wait for one
-   * forever and leave the organization on the address — which is the one thing FR-027a says must not
-   * survive the visit. Settling without the organization is therefore an outcome, not a hang.
+   * Waiting on that list also has to be able to give up, and there are two ways it never arrives.
+   * No list is ever fetched for an organization the viewer does not hold, so a crafted or stale
+   * return address would otherwise wait for one forever; and a request that fails is not retried by
+   * the page, so the wait outlives the only attempt that could have ended it. Either would leave the
+   * organization on the address — the one thing FR-027a says must not survive the visit. Both are
+   * therefore outcomes rather than hangs: the first settles, the second is asked again.
    *
    * From the moment a landing is intended this method owns that parameter: it removes it itself when
    * it decides to stay on the list, because `adoptOrganizationFromReturnAddress` stands down as soon
@@ -547,29 +572,37 @@ export class OrgEasyclaComponent {
       .pipe(
         map(([data, accounts, loaded]) => ({
           list: data?.orgUid === named ? data : null,
+          // A failed request answers nothing about the row, but it does answer the question of
+          // whether to keep waiting. The page fetches once per organization, so nothing is coming
+          // to replace the failure, and a wait for the list it did not return never ends — leaving
+          // the signatory on an error page with the parameter still on the address and the stash
+          // already spent, so not even a reload could recover the landing.
+          failed: data === null,
           // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
           // context has settled without it there is no list coming and waiting on one would leave
           // the parameter on the address for good.
-          unreachable: loaded && !accounts.some((account: Account) => account.uid === named),
+          unreachable: loaded && !this.authorizedAccountNamed(accounts, named),
         })),
-        filter(({ list, unreachable }) => !!list || unreachable),
+        filter(({ list, failed, unreachable }) => !!list || failed || unreachable),
         take(1),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe(({ list }) => {
+      .subscribe(({ list, unreachable }) => {
         if (list?.claGroups.some((group) => group.id === signatureId)) {
           this.landOn(signatureId);
           return;
         }
 
-        // No list at all means the organization is not the viewer's, and no amount of asking again
-        // will produce one. Staying on the list, so the address still has to be cleaned up — the
-        // sibling flow stood down on the strength of the flag and will not do it.
-        if (!list) {
+        // An organization the viewer does not hold is the one case no amount of asking again can
+        // fix. Staying on the list, so the address still has to be cleaned up — the sibling flow
+        // stood down on the strength of the flag and will not do it.
+        if (unreachable) {
           this.stripReturnOrganizationFromAddress();
           return;
         }
 
+        // Everything else — the list without the row yet, and the request that failed — is asked
+        // again, of upstream directly, and cleans the address up itself once the budget is spent.
         this.retryForSignedAgreement(named, signatureId);
       });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -34,6 +34,8 @@ import {
   take,
   takeUntil,
   tap,
+  timeout,
+  TimeoutError,
   timer,
 } from 'rxjs';
 
@@ -70,9 +72,18 @@ export class OrgEasyclaComponent {
    * signatory's own return trip — so the first list can legitimately not have the row yet. Bounded
    * rather than open-ended: past a few seconds the likelier explanations are ones no amount of
    * waiting fixes, and the list is a reasonable place to be left.
+   *
+   * `perAttemptTimeoutMs` bounds the whole poll in wall-clock time, not only in count. Without it,
+   * a stalled BFF can leave each attempt waiting the gateway timeout (`API_GW_TIMEOUT_MS`, 30s),
+   * and `concatMap` runs the retries in series — so three stalled attempts would take about 90s
+   * against a doc comment that says "a few seconds". A timed-out attempt is treated the same as
+   * a failed one: another try if the budget still has one, otherwise the same not-found cleanup
+   * as any exhausted poll. Sized well below the gateway timeout so a genuine network stall
+   * cannot swallow the whole retry budget on a single attempt.
    */
   private static readonly signedAgreementRetryDelayMs = 2000;
   private static readonly signedAgreementRetries = 3;
+  private static readonly signedAgreementPerAttemptTimeoutMs = 3000;
 
   private readonly accountContext = inject(AccountContextService);
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
@@ -715,8 +726,17 @@ export class OrgEasyclaComponent {
         // and left the retry invisible to the console.
         concatMap(() =>
           this.claService.getClaGroups(orgUid).pipe(
+            // Bounds each attempt in wall-clock time. Without it, a stalled BFF can wait the full
+            // gateway timeout (30s) per attempt and three retries would take about 90s against a
+            // doc comment that describes a few-second budget. A timeout is treated as another
+            // failed attempt: a not-yet, not a hard error.
+            timeout({ each: OrgEasyclaComponent.signedAgreementPerAttemptTimeoutMs }),
             catchError((error: unknown) => {
-              console.warn('Retry for signed agreement failed:', error);
+              if (error instanceof TimeoutError) {
+                console.warn('Retry for signed agreement timed out:', error);
+              } else {
+                console.warn('Retry for signed agreement failed:', error);
+              }
               return of(null);
             })
           )


### PR DESCRIPTION
The inbound half of the corporate CLA hand-off (#1983). The trip back from DocuSign is
a cross-site navigation, which is why it needs code of its own: neither an in-memory
value nor a history entry survives it.

### The organization

A signing session's return address names the organization it was opened for, and the
page selects it. Without that the selection comes back only in a `SameSite=Lax`
cookie, and when it does not, bootstrap falls to the first organization in the
viewer's list — so signing for one company returns them looking at another with their
new agreement nowhere in sight.

**The parameter names an organization; it does not grant one.** It is resolved against
the viewer's own authorized accounts and anything absent from that list is ignored, so
a crafted link cannot select a company they do not hold.

Selecting it is not enough to keep it. The org selector bootstraps its catalogue
against whichever organization was current at the time — on a cold return, the stale
cookie — and reassigns the selection when that page lands. So the page re-pins the
catalogue on the organization it adopted.

### The agreement

`return_url` is an input to the signing request, so it is fixed before the signature
exists and cannot name it. The signature crosses in `sessionStorage` instead, and is
spent by whichever visit finds it. A first list without the row is treated as too
early rather than as no — EasyCLA writes the signature when DocuSign calls it back,
and that callback races the signatory's own return trip — so the list is asked again
on a short budget before the trip ends on the list.

Storage access is best-effort in both directions: it throws outright where the browser
disallows it, and the write happens *after* the envelope exists, so an exception there
would strand the signatory holding an agreement that already exists.

### Arbitrating the two

Both flows start in the same constructor and both navigate, and Angular cancels an
in-flight navigation when another begins — so unarbitrated they take turns cancelling
each other and the signatory stays on the list. The committed address cannot arbitrate
them, being still the return address at the moment either decides, so intent is
claimed synchronously before anything is awaited. This was invisible to the unit
tests, whose navigation spy meant nothing was ever in flight, and it failed on the
first E2E run.

### Reviewing

691 lines, 62% of them tests — the smallest of the three and the one carrying the
subtlest behaviour.

Stacked on #2305. Refs #1983.
