### PR TITLE
feat(mentorship): add the Become a Mentor registration page

### DIFF
--- a/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-prerequisites-step/enroll-prerequisites-step.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-prerequisites-step/enroll-prerequisites-step.component.html
@@ -86,38 +86,5 @@
     <p class="text-xs text-gray-500">Add materials unique to your program.</p>
   </div>
 
-  <section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-4">
-    <div class="flex flex-col gap-2">
-      <h2 class="text-lg font-semibold text-gray-900">Terms and Conditions</h2>
-      <p class="text-sm text-gray-600">{{ termsIntro }}</p>
-    </div>
-
-    <div class="flex items-start gap-3">
-      <lfx-checkbox
-        [form]="form()"
-        control="termsAccepted"
-        inputId="mentorship-enroll-terms"
-        ariaLabelledBy="mentorship-enroll-terms-text"
-        data-testid="mentorship-enroll-terms" />
-      <p id="mentorship-enroll-terms-text" class="min-w-0 flex-1 text-sm text-gray-800 leading-5">
-        <span class="text-red-500">*</span>
-        I agree to the
-        <a [href]="platformUseHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium"
-          >LFX Platform Use Agreement</a
-        >
-        and all terms incorporated therein, including the
-        <a [href]="serviceTermsHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">
-          Service-Specific Use Terms
-        </a>
-        , the
-        <a [href]="acceptableUseHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">Acceptable Use Policy</a>
-        and the
-        <a [href]="privacyHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">Privacy Policy</a>
-        .
-      </p>
-    </div>
-    @if (errors().termsAccepted) {
-      <p class="text-xs text-red-600">{{ errors().termsAccepted }}</p>
-    }
-  </section>
+  <lfx-mentorship-terms-acknowledgement [form]="form()" [intro]="termsIntro" idPrefix="mentorship-enroll" [error]="errors().termsAccepted" />
 </div>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-prerequisites-step/enroll-prerequisites-step.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-prerequisites-step/enroll-prerequisites-step.component.ts
@@ -5,23 +5,22 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import {
   createEmptyCustomMentorshipPrerequisite,
   MENTORSHIP_COVER_LETTER_PROMPTS,
   MENTORSHIP_ENROLL_PREREQ_INTRO,
   MENTORSHIP_ENROLL_TERMS_INTRO,
-  mentorshipPolicyHref,
 } from '@lfx-one/shared/constants';
 import { MentorshipEnrollFieldErrors, MentorshipPrerequisite } from '@lfx-one/shared/interfaces';
 import { startWith, switchMap } from 'rxjs';
 
+import { TermsAcknowledgementComponent } from '../../../../components/terms-acknowledgement/terms-acknowledgement.component';
 import { EnrollCustomPrerequisiteComponent } from '../enroll-custom-prerequisite/enroll-custom-prerequisite.component';
 
 @Component({
   selector: 'lfx-mentorship-enroll-prerequisites-step',
-  imports: [ButtonComponent, CheckboxComponent, InputTextComponent, EnrollCustomPrerequisiteComponent],
+  imports: [ButtonComponent, InputTextComponent, EnrollCustomPrerequisiteComponent, TermsAcknowledgementComponent],
   templateUrl: './enroll-prerequisites-step.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -32,10 +31,6 @@ export class EnrollPrerequisitesStepComponent {
   protected readonly prereqIntro = MENTORSHIP_ENROLL_PREREQ_INTRO;
   protected readonly termsIntro = MENTORSHIP_ENROLL_TERMS_INTRO;
   protected readonly coverLetterPrompts = MENTORSHIP_COVER_LETTER_PROMPTS;
-  protected readonly platformUseHref = mentorshipPolicyHref('LFX Platform Use Agreement');
-  protected readonly serviceTermsHref = mentorshipPolicyHref('Service-Specific Use Terms');
-  protected readonly acceptableUseHref = mentorshipPolicyHref('Acceptable Use Policy');
-  protected readonly privacyHref = mentorshipPolicyHref('Privacy Policy');
 
   /** Only the coding-challenge prerequisite carries a URL, so one control covers the whole table. */
   protected readonly challengeForm = new FormGroup({

--- a/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-setup-step/enroll-setup-step.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-setup-step/enroll-setup-step.component.html
@@ -8,48 +8,12 @@
       <p class="text-sm text-gray-600">{{ intro }}</p>
     </div>
 
-    <div class="flex flex-col gap-1">
-      <label class="text-sm font-medium text-gray-700">Required and/or desirable skills and training <span class="text-red-500">*</span></label>
-      <p class="text-sm text-gray-500 mb-1">{{ skillsHelper }}</p>
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <div class="flex-1">
-          <lfx-select
-            [form]="draftSkillForm"
-            control="skill"
-            [options]="availableSkills()"
-            optionLabel="label"
-            optionValue="value"
-            placeholder="Skill Name"
-            [filter]="true"
-            styleClass="w-full"
-            dataTest="mentorship-enroll-skill" />
-        </div>
-        <lfx-button
-          label="Add Skill"
-          icon="fa-light fa-plus"
-          severity="primary"
-          size="small"
-          [disabled]="!draftSkillValue()"
-          (onClick)="addSkill()"
-          styleClass="whitespace-nowrap !py-2.5"
-          data-testid="mentorship-enroll-add-skill" />
-      </div>
-      @if (skills().length) {
-        <div class="mt-1 flex flex-wrap gap-2 rounded-xl border border-gray-200 p-3">
-          @for (skill of skills(); track skill) {
-            <span class="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-neutral-100 text-neutral-600 px-3 py-1 text-xs">
-              {{ skill }}
-              <button type="button" class="text-gray-400 hover:text-gray-700" [attr.aria-label]="'Remove ' + skill" (click)="removeSkill(skill)">
-                <i class="fa-light fa-xmark" aria-hidden="true"></i>
-              </button>
-            </span>
-          }
-        </div>
-      }
-      @if (errors().skills) {
-        <p class="text-xs text-red-600">{{ errors().skills }}</p>
-      }
-    </div>
+    <lfx-mentorship-skills-picker
+      [form]="form()"
+      label="Required and/or desirable skills and training"
+      [helper]="skillsHelper"
+      idPrefix="mentorship-enroll"
+      [error]="errors().skills" />
 
     <div class="flex items-start gap-3 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-700">
       <i class="fa-solid fa-circle-info shrink-0 mt-0.5" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-setup-step/enroll-setup-step.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/enroll-program/components/enroll-setup-step/enroll-setup-step.component.ts
@@ -3,9 +3,8 @@
 
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { SelectComponent } from '@components/select/select.component';
 import {
   MENTORSHIP_ENROLL_DELETE_TERM_CONFIRM,
   MENTORSHIP_ENROLL_SETUP_INTRO,
@@ -15,7 +14,6 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS,
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_MENTOR_DOCS_URL,
-  MENTORSHIP_SKILL_OPTIONS,
 } from '@lfx-one/shared/constants';
 import { MentorshipEnrollFieldErrors, MentorshipProgramTerm, MentorshipTermFormDialogData } from '@lfx-one/shared/interfaces';
 import { formatMentorshipMonthYear } from '@lfx-one/shared/utils';
@@ -23,11 +21,12 @@ import { ConfirmationService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { startWith, switchMap, take } from 'rxjs';
 
+import { SkillsPickerComponent } from '../../../../components/skills-picker/skills-picker.component';
 import { EnrollTermDialogComponent } from '../enroll-term-dialog/enroll-term-dialog.component';
 
 @Component({
   selector: 'lfx-mentorship-enroll-setup-step',
-  imports: [ReactiveFormsModule, SelectComponent, ButtonComponent],
+  imports: [ButtonComponent, SkillsPickerComponent],
   templateUrl: './enroll-setup-step.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -39,10 +38,6 @@ export class EnrollSetupStepComponent {
   private readonly confirmationService = inject(ConfirmationService);
   private readonly destroyRef = inject(DestroyRef);
 
-  protected readonly draftSkillForm = new FormGroup({
-    skill: new FormControl('', { nonNullable: true }),
-  });
-
   protected readonly intro = MENTORSHIP_ENROLL_SETUP_INTRO;
   protected readonly skillsHelper = MENTORSHIP_ENROLL_SETUP_SKILLS_HELPER;
   protected readonly mentorInfo = MENTORSHIP_ENROLL_SETUP_MENTOR_INFO;
@@ -51,16 +46,8 @@ export class EnrollSetupStepComponent {
   protected readonly maxTerms = MENTORSHIP_MAX_OPEN_TERMS;
   protected readonly maxTermsMessage = MENTORSHIP_MAX_OPEN_TERMS_MESSAGE;
 
-  protected readonly draftSkillValue = toSignal(this.draftSkillForm.controls.skill.valueChanges, { initialValue: '' });
-
   private readonly formSnapshot = toSignal(toObservable(this.form).pipe(switchMap((group) => group.valueChanges.pipe(startWith(group.getRawValue())))), {
     initialValue: {} as Record<string, unknown>,
-  });
-
-  protected readonly skills = computed(() => {
-    const fromSnapshot = this.formSnapshot()['skills'];
-    if (Array.isArray(fromSnapshot)) return fromSnapshot as string[];
-    return (this.form().controls['skills']?.value as string[]) ?? [];
   });
 
   protected readonly terms = computed(() => {
@@ -77,25 +64,7 @@ export class EnrollSetupStepComponent {
     }))
   );
 
-  protected readonly availableSkills = computed(() => {
-    const selected = new Set(this.skills().map((item) => item.toLowerCase()));
-    return MENTORSHIP_SKILL_OPTIONS.filter((skill) => !selected.has(skill.toLowerCase())).map((skill) => ({ label: skill, value: skill }));
-  });
-
   protected readonly canAddTerm = computed(() => this.terms().length < this.maxTerms);
-
-  protected addSkill(): void {
-    const value = this.draftSkillForm.controls.skill.value.trim();
-    if (!value) return;
-    const current = this.skills();
-    if (current.some((item) => item.toLowerCase() === value.toLowerCase())) return;
-    this.form().controls['skills'].setValue([...current, value]);
-    this.draftSkillForm.controls.skill.setValue('');
-  }
-
-  protected removeSkill(skill: string): void {
-    this.form().controls['skills'].setValue(this.skills().filter((item) => item !== skill));
-  }
 
   protected addTerm(): void {
     if (!this.canAddTerm()) return;

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/applicants-tab/applicants-tab.component.ts
@@ -37,7 +37,7 @@ import {
 } from '@lfx-one/shared/utils';
 import { startWith, tap } from 'rxjs';
 
-import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { MentorshipComingSoonService } from '../../../../services/mentorship-coming-soon.service';
 import { PersonCellComponent } from '../person-cell/person-cell.component';
 import { RowActionsComponent } from '../row-actions/row-actions.component';
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/current-mentees-tab/current-mentees-tab.component.ts
@@ -31,7 +31,7 @@ import {
 } from '@lfx-one/shared/utils';
 import { startWith, tap } from 'rxjs';
 
-import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { MentorshipComingSoonService } from '../../../../services/mentorship-coming-soon.service';
 import { PersonCellComponent } from '../person-cell/person-cell.component';
 import { RowActionsComponent } from '../row-actions/row-actions.component';
 

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/mentors-tab/mentors-tab.component.ts
@@ -14,7 +14,7 @@ import { formatIsoDateLabel, matchesMentorshipPersonSearch, mentorshipPersonAvat
 import { MentorshipService } from '@services/mentorship.service';
 import { map, startWith } from 'rxjs';
 
-import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { MentorshipComingSoonService } from '../../../../services/mentorship-coming-soon.service';
 
 /**
  * Mentors tab — invitation status, dates, and profile-created flag. The toolbar

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/past-mentees-tab/past-mentees-tab.component.ts
@@ -21,7 +21,7 @@ import { FilterOption, MentorshipMenteeStatus, MentorshipProgramMentee } from '@
 import { matchesMentorshipPersonSearch, mentorshipPersonAvatarClass, mentorshipPersonInitials, mentorshipTermFilterOptions } from '@lfx-one/shared/utils';
 import { startWith, tap } from 'rxjs';
 
-import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { MentorshipComingSoonService } from '../../../../services/mentorship-coming-soon.service';
 import { PersonCellComponent } from '../person-cell/person-cell.component';
 
 /**

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/components/row-actions/row-actions.component.ts
@@ -7,7 +7,7 @@ import { MenuComponent } from '@components/menu/menu.component';
 import { MentorshipRowAction } from '@lfx-one/shared/interfaces';
 import { MenuItem } from 'primeng/api';
 
-import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+import { MentorshipComingSoonService } from '../../../../services/mentorship-coming-soon.service';
 
 /**
  * The trailing row-actions cell shared by the program-detail people tables — an

--- a/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/admin/program-detail/program-detail.component.ts
@@ -20,7 +20,7 @@ import { MentorsTabComponent } from './components/mentors-tab/mentors-tab.compon
 import { PastMenteesTabComponent } from './components/past-mentees-tab/past-mentees-tab.component';
 import { ProgramDetailHeaderComponent } from './components/program-detail-header/program-detail-header.component';
 import { TermsTabComponent } from './components/terms-tab/terms-tab.component';
-import { MentorshipComingSoonService } from './services/mentorship-coming-soon.service';
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 
 /**
  * Admin program-detail page. Loads a program by id (default) or slug and hosts

--- a/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.html
@@ -35,8 +35,9 @@
         <p class="text-sm font-semibold text-gray-900" data-testid="mentorship-profile-card-name">{{ profile.name || placeholder }}</p>
         <div class="flex flex-col gap-0.5" data-testid="mentorship-profile-card-emails">
           @for (entry of profile.emails; track entry.email) {
-            <span class="flex items-center gap-2">
-              <span class="min-w-0 truncate text-sm text-gray-500">{{ entry.email }}</span>
+            <span class="flex items-start gap-2">
+              <!-- Wraps rather than truncates: a clipped address is unverifiable, and the links below already break the same way. -->
+              <span class="min-w-0 break-all text-sm text-gray-500">{{ entry.email }}</span>
               @if (entry.isPrimary) {
                 <span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-600">
                   {{ primaryBadge }}

--- a/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.html
@@ -1,0 +1,124 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="rounded-2xl border border-gray-200 bg-white p-6 flex flex-col gap-4" data-testid="mentorship-profile-card">
+  <div class="flex items-start justify-between gap-4">
+    <div class="flex flex-col gap-1">
+      <h2 class="text-base font-bold text-gray-900" data-testid="mentorship-profile-card-title">{{ title }}</h2>
+      <p class="max-w-md text-xs text-gray-500 leading-5">{{ subtitle }}</p>
+    </div>
+    <div class="shrink-0">
+      <lfx-button
+        [label]="editLabel"
+        icon="fa-light fa-pen"
+        iconPos="right"
+        severity="secondary"
+        size="small"
+        [outlined]="true"
+        (onClick)="onEdit()"
+        data-testid="mentorship-profile-card-edit" />
+    </div>
+  </div>
+
+  @if (summary(); as profile) {
+    <div class="flex items-start gap-3">
+      <lfx-avatar
+        [image]="avatarUrl()"
+        [label]="profile.name"
+        shape="circle"
+        size="normal"
+        styleClass="shrink-0 w-10 h-10 bg-blue-50 text-blue-700 text-sm font-semibold"
+        [ariaLabel]="profile.name"
+        data-testid="mentorship-profile-card-avatar" />
+
+      <div class="min-w-0 flex flex-col gap-0.5">
+        <p class="text-sm font-semibold text-gray-900" data-testid="mentorship-profile-card-name">{{ profile.name || placeholder }}</p>
+        <div class="flex flex-col gap-0.5" data-testid="mentorship-profile-card-emails">
+          @for (entry of profile.emails; track entry.email) {
+            <span class="flex items-center gap-2">
+              <span class="min-w-0 truncate text-sm text-gray-500">{{ entry.email }}</span>
+              @if (entry.isPrimary) {
+                <span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-600">
+                  {{ primaryBadge }}
+                </span>
+              }
+            </span>
+          } @empty {
+            <span class="text-sm text-gray-400">{{ placeholder }}</span>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="h-px bg-gray-100"></div>
+
+    <dl class="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
+      <div class="flex flex-col gap-1">
+        <dt class="text-xs text-gray-400">{{ labels.address }}</dt>
+        <dd class="flex flex-col" data-testid="mentorship-profile-card-address">
+          @for (line of profile.addressLines; track line) {
+            <span class="text-sm text-gray-900">{{ line }}</span>
+          } @empty {
+            <span class="text-sm text-gray-400">{{ placeholder }}</span>
+          }
+        </dd>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <dt class="text-xs text-gray-400">{{ labels.phone }}</dt>
+        <dd data-testid="mentorship-profile-card-phone">
+          @if (profile.phone) {
+            <span class="text-sm text-gray-900">{{ profile.phone }}</span>
+          } @else {
+            <span class="text-sm text-gray-400">{{ placeholder }}</span>
+          }
+        </dd>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <dt class="text-xs text-gray-400">{{ labels.github }}</dt>
+        <dd data-testid="mentorship-profile-card-github">
+          @if (profile.github) {
+            <a [href]="profile.github.url" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline break-all">
+              {{ profile.github.label }}
+            </a>
+          } @else {
+            <span class="text-sm text-gray-400">{{ placeholder }}</span>
+          }
+        </dd>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <dt class="text-xs text-gray-400">{{ labels.linkedin }}</dt>
+        <dd data-testid="mentorship-profile-card-linkedin">
+          @if (profile.linkedin) {
+            <a [href]="profile.linkedin.url" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:underline break-all">
+              {{ profile.linkedin.label }}
+            </a>
+          } @else {
+            <span class="text-sm text-gray-400">{{ placeholder }}</span>
+          }
+        </dd>
+      </div>
+    </dl>
+  } @else {
+    <div class="flex flex-col gap-4" data-testid="mentorship-profile-card-loading">
+      <div class="flex items-start gap-3">
+        <p-skeleton shape="circle" size="1.75rem" />
+        <div class="flex flex-col gap-1">
+          <p-skeleton width="10rem" height="0.875rem" />
+          <p-skeleton width="14rem" height="0.875rem" />
+        </div>
+      </div>
+      <div class="h-px bg-gray-100"></div>
+      <div class="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
+        @for (row of loadingRows; track row) {
+          <div class="flex flex-col gap-1">
+            <p-skeleton width="5rem" height="0.75rem" />
+            <p-skeleton width="11rem" height="0.875rem" />
+          </div>
+        }
+      </div>
+    </div>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.html
@@ -39,6 +39,7 @@
               <!-- Wraps rather than truncates: a clipped address is unverifiable, and the links below already break the same way. -->
               <span class="min-w-0 break-all text-sm text-gray-500">{{ entry.email }}</span>
               @if (entry.isPrimary) {
+                <!-- Design calls for exactly 10px on this badge; the 14px root font-size makes `text-xs` overshoot it. -->
                 <span class="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-600">
                   {{ primaryBadge }}
                 </span>

--- a/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.spec.ts
@@ -1,0 +1,177 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { LFX_PROFILE_CARD_EDIT_LABEL, LFX_PROFILE_CARD_EMPTY } from '@lfx-one/shared/constants';
+import { CombinedProfile, EmailManagementData, EnrichedIdentity } from '@lfx-one/shared/interfaces';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfileCardComponent } from './profile-card.component';
+
+describe('ProfileCardComponent', () => {
+  const combined = {
+    user: {
+      id: 'u_1',
+      email: 'ada@example.org',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      username: 'ada',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    },
+    profile: { city: 'London', country: 'United Kingdom', phone_number: '+44 20 7946 0000' },
+  } as CombinedProfile;
+
+  const emails: EmailManagementData = {
+    primary_email: 'ada@example.org',
+    alternate_emails: [{ email: 'ada@work.example', verified: true }],
+  };
+
+  const identities = [
+    {
+      id: 'i_1',
+      platform: 'github',
+      type: 'username',
+      value: 'ada',
+      verified: true,
+      source: 'cdp',
+      icon: '',
+      createdAt: '',
+      updatedAt: '',
+      displayState: 'verified',
+      inAuth0: true,
+    },
+  ] as EnrichedIdentity[];
+
+  let fixture: ComponentFixture<ProfileCardComponent>;
+  let toast: ReturnType<typeof vi.fn>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const text = (testId: string): string | null => element().querySelector(`[data-testid="${testId}"]`)?.textContent?.replace(/\s+/g, ' ').trim() ?? null;
+  const avatarImage = (): Element | null => element().querySelector('[data-testid="mentorship-profile-card-avatar"] img');
+
+  /** Boots the card against whatever the three profile endpoints return for this spec. */
+  const render = (userService: Partial<Record<keyof UserService, unknown>>): void => {
+    toast = vi.fn();
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ProfileCardComponent],
+      providers: [provideNoopAnimations(), { provide: MessageService, useValue: { add: toast } }, { provide: UserService, useValue: userService }],
+    });
+
+    fixture = TestBed.createComponent(ProfileCardComponent);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    render({
+      getCurrentUserProfile: () => of(combined),
+      getUserEmails: () => of(emails),
+      getIdentities: () => of(identities),
+      effectiveAvatarUrl: () => '',
+    });
+  });
+
+  it('shows the name and phone the profile holds', () => {
+    expect(text('mentorship-profile-card-name')).toBe('Ada Lovelace');
+    expect(text('mentorship-profile-card-phone')).toBe('+44 20 7946 0000');
+  });
+
+  it('renders the mailing address as street then locality', () => {
+    const lines = [...element().querySelectorAll('[data-testid="mentorship-profile-card-address"] span')];
+
+    expect(lines.map((line) => line.textContent?.trim())).toEqual(['London, United Kingdom']);
+  });
+
+  it('badges only the primary address, so the mentor knows which one programs will use', () => {
+    const rows = [...element().querySelectorAll('[data-testid="mentorship-profile-card-emails"] > span')];
+
+    expect(rows.map((row) => row.textContent?.replace(/\s+/g, ' ').trim())).toEqual(['ada@example.org Primary', 'ada@work.example']);
+  });
+
+  it('links a connected account and leaves the unconnected one as a placeholder', () => {
+    const github = element().querySelector('[data-testid="mentorship-profile-card-github"] a');
+
+    expect(github?.getAttribute('href')).toBe('https://github.com/ada');
+    expect(github?.textContent?.trim()).toBe('github.com/ada');
+    expect(text('mentorship-profile-card-linkedin')).toBe(LFX_PROFILE_CARD_EMPTY);
+  });
+
+  it('opens an external profile in a new tab without leaking the referrer', () => {
+    const github = element().querySelector('[data-testid="mentorship-profile-card-github"] a');
+
+    expect(github?.getAttribute('target')).toBe('_blank');
+    expect(github?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('shows the profile picture when there is one', () => {
+    render({
+      getCurrentUserProfile: () => of({ ...combined, profile: { picture: 'https://cdn.example.org/ada.png' } } as CombinedProfile),
+      getUserEmails: () => of(emails),
+      getIdentities: () => of([]),
+      effectiveAvatarUrl: () => '',
+    });
+
+    expect(avatarImage()?.getAttribute('src')).toBe('https://cdn.example.org/ada.png');
+  });
+
+  it('uses the session avatar when the profile itself holds no picture', () => {
+    // Otherwise this card shows a letter for someone whose photo comes from the OIDC
+    // claim, while the sidebar two panels away shows the photo.
+    render({
+      getCurrentUserProfile: () => of(combined),
+      getUserEmails: () => of(emails),
+      getIdentities: () => of([]),
+      effectiveAvatarUrl: () => 'https://sso.example.org/ada.png',
+    });
+
+    expect(avatarImage()?.getAttribute('src')).toBe('https://sso.example.org/ada.png');
+  });
+
+  it('falls back to the first letter of the name when neither the profile nor the session has a picture', () => {
+    expect(avatarImage()).toBeNull();
+    expect(text('mentorship-profile-card-avatar')).toBe('A');
+  });
+
+  it('falls back to the letter when the picture fails to load', () => {
+    render({
+      getCurrentUserProfile: () => of({ ...combined, profile: { picture: 'https://cdn.example.org/gone.png' } } as CombinedProfile),
+      getUserEmails: () => of(emails),
+      getIdentities: () => of([]),
+      effectiveAvatarUrl: () => '',
+    });
+
+    avatarImage()?.dispatchEvent(new Event('error'));
+    fixture.detectChanges();
+
+    expect(avatarImage()).toBeNull();
+    expect(text('mentorship-profile-card-avatar')).toBe('A');
+  });
+
+  it('still renders the fields it could load when one endpoint fails', () => {
+    render({
+      getCurrentUserProfile: () => of(combined),
+      getUserEmails: () => throwError(() => new Error('emails unavailable')),
+      getIdentities: () => throwError(() => new Error('identities unavailable')),
+      effectiveAvatarUrl: () => '',
+    });
+
+    expect(element().querySelector('[data-testid="mentorship-profile-card-loading"]')).toBeNull();
+    expect(text('mentorship-profile-card-phone')).toBe('+44 20 7946 0000');
+    // The signed-in address survives an email outage; the linked accounts cannot.
+    expect(text('mentorship-profile-card-emails')).toBe('ada@example.org Primary');
+    expect(text('mentorship-profile-card-github')).toBe(LFX_PROFILE_CARD_EMPTY);
+  });
+
+  it('tells the user editing is not wired up yet rather than failing silently', () => {
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-profile-card-edit"] button')?.click();
+
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'info', summary: LFX_PROFILE_CARD_EDIT_LABEL });
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.ts
@@ -1,0 +1,84 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
+import {
+  LFX_PROFILE_CARD_EDIT_LABEL,
+  LFX_PROFILE_CARD_EMPTY,
+  LFX_PROFILE_CARD_LABELS,
+  LFX_PROFILE_CARD_PRIMARY_BADGE,
+  LFX_PROFILE_CARD_SUBTITLE,
+  LFX_PROFILE_CARD_TITLE,
+} from '@lfx-one/shared/constants';
+import { LfxProfileSummary } from '@lfx-one/shared/interfaces';
+import { buildLfxProfileSummary } from '@lfx-one/shared/utils';
+import { UserService } from '@services/user.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, forkJoin, map, of } from 'rxjs';
+
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
+
+/**
+ * Read-only summary of the signed-in user's LFX profile, shown above the mentorship
+ * registration forms so the applicant can see what the program admin will receive
+ * without retyping any of it. Nothing here is editable: the profile is the system of
+ * record, and the button sends the user there to change it.
+ *
+ * The card owns its own fetch rather than taking the data as an input, so it can be
+ * dropped onto any mentorship form without that page learning about three profile
+ * endpoints.
+ */
+@Component({
+  selector: 'lfx-mentorship-profile-card',
+  imports: [AvatarComponent, ButtonComponent, SkeletonModule],
+  templateUrl: './profile-card.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfileCardComponent {
+  private readonly userService = inject(UserService);
+  private readonly comingSoon = inject(MentorshipComingSoonService);
+
+  protected readonly title = LFX_PROFILE_CARD_TITLE;
+  protected readonly subtitle = LFX_PROFILE_CARD_SUBTITLE;
+  protected readonly editLabel = LFX_PROFILE_CARD_EDIT_LABEL;
+  protected readonly primaryBadge = LFX_PROFILE_CARD_PRIMARY_BADGE;
+  protected readonly placeholder = LFX_PROFILE_CARD_EMPTY;
+  protected readonly labels = LFX_PROFILE_CARD_LABELS;
+  /** One skeleton row per field the loaded card will show, so the placeholder matches its height. */
+  protected readonly loadingRows = Object.keys(LFX_PROFILE_CARD_LABELS);
+
+  /** Null only while the three requests are still in flight — see `initSummary`. */
+  protected readonly summary = this.initSummary();
+
+  /**
+   * The profile's own picture, falling back to the session's avatar the way the sidebar
+   * and header do. Without the fallback this card would show initials for a user whose
+   * photo comes from the OIDC claim rather than an LFX upload — the same person, with a
+   * photo two panels away.
+   */
+  protected readonly avatarUrl = computed(() => this.summary()?.avatarUrl || this.userService.effectiveAvatarUrl());
+
+  protected onEdit(): void {
+    this.comingSoon.notify(this.editLabel);
+  }
+
+  /**
+   * Name, emails, and linked accounts live behind three separate endpoints, so fetch
+   * them together and let each one fail on its own. A partial outage should cost the
+   * user the affected rows, not the whole card — `buildLfxProfileSummary` fills the
+   * gaps, and the template renders a placeholder per field.
+   */
+  private initSummary() {
+    return toSignal<LfxProfileSummary | null>(
+      forkJoin({
+        combined: this.userService.getCurrentUserProfile().pipe(catchError(() => of(null))),
+        emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
+        identities: this.userService.getIdentities().pipe(catchError(() => of([]))),
+      }).pipe(map(({ combined, emails, identities }) => buildLfxProfileSummary(combined, emails, identities))),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/profile-card/profile-card.component.ts
@@ -13,11 +13,11 @@ import {
   LFX_PROFILE_CARD_SUBTITLE,
   LFX_PROFILE_CARD_TITLE,
 } from '@lfx-one/shared/constants';
-import { LfxProfileSummary } from '@lfx-one/shared/interfaces';
+import { EnrichedIdentity, LfxProfileSummary } from '@lfx-one/shared/interfaces';
 import { buildLfxProfileSummary } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, forkJoin, map, of } from 'rxjs';
+import { catchError, forkJoin, map, Observable, of } from 'rxjs';
 
 import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 
@@ -25,7 +25,8 @@ import { MentorshipComingSoonService } from '../../services/mentorship-coming-so
  * Read-only summary of the signed-in user's LFX profile, shown above the mentorship
  * registration forms so the applicant can see what the program admin will receive
  * without retyping any of it. Nothing here is editable: the profile is the system of
- * record, and the button sends the user there to change it.
+ * record, and the button will send the user there once that navigation is wired up.
+ * Today it raises the module's coming-soon toast.
  *
  * The card owns its own fetch rather than taking the data as an input, so it can be
  * dropped onto any mentorship form without that page learning about three profile
@@ -70,15 +71,24 @@ export class ProfileCardComponent {
    * them together and let each one fail on its own. A partial outage should cost the
    * user the affected rows, not the whole card — `buildLfxProfileSummary` fills the
    * gaps, and the template renders a placeholder per field.
+   *
+   * Each fallback logs before it degrades: the card looks the same whether a field is
+   * genuinely blank or its endpoint is down, so without this an outage is invisible.
    */
   private initSummary() {
     return toSignal<LfxProfileSummary | null>(
       forkJoin({
-        combined: this.userService.getCurrentUserProfile().pipe(catchError(() => of(null))),
-        emails: this.userService.getUserEmails().pipe(catchError(() => of(null))),
-        identities: this.userService.getIdentities().pipe(catchError(() => of([]))),
+        combined: this.userService.getCurrentUserProfile().pipe(catchError((error) => this.degrade('profile', error, null))),
+        emails: this.userService.getUserEmails().pipe(catchError((error) => this.degrade('emails', error, null))),
+        identities: this.userService.getIdentities().pipe(catchError((error) => this.degrade('identities', error, [] as EnrichedIdentity[]))),
       }).pipe(map(({ combined, emails, identities }) => buildLfxProfileSummary(combined, emails, identities))),
       { initialValue: null }
     );
+  }
+
+  /** Records which of the three sources dropped out, then yields its per-field fallback. */
+  private degrade<T>(source: string, error: unknown, fallback: T): Observable<T> {
+    console.error(`mentorship-profile-card: ${source} fetch failed, rendering placeholders for those fields`, error);
+    return of(fallback);
   }
 }

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.html
@@ -1,0 +1,47 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-1">
+  <label class="text-sm font-medium text-gray-700">{{ label() }} <span class="text-red-500">*</span></label>
+  @if (helper()) {
+    <p class="text-sm text-gray-500 mb-1">{{ helper() }}</p>
+  }
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+    <div class="flex-1">
+      <lfx-select
+        [form]="draftForm"
+        control="skill"
+        [options]="availableSkills()"
+        optionLabel="label"
+        optionValue="value"
+        placeholder="Skill Name"
+        [filter]="true"
+        styleClass="w-full"
+        [dataTest]="idPrefix() + '-skill'" />
+    </div>
+    <lfx-button
+      label="Add Skill"
+      icon="fa-light fa-plus"
+      severity="primary"
+      size="small"
+      [disabled]="!draftValue()"
+      (onClick)="addSkill()"
+      styleClass="whitespace-nowrap !py-2.5"
+      [attr.data-testid]="idPrefix() + '-add-skill'" />
+  </div>
+  @if (skills().length) {
+    <div class="mt-1 flex flex-wrap gap-2 rounded-xl border border-gray-200 p-3" [attr.data-testid]="idPrefix() + '-skill-list'">
+      @for (skill of skills(); track skill) {
+        <span class="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-neutral-100 text-neutral-600 px-3 py-1 text-xs">
+          {{ skill }}
+          <button type="button" class="text-gray-400 hover:text-gray-700" [attr.aria-label]="'Remove ' + skill" (click)="removeSkill(skill)">
+            <i class="fa-light fa-xmark" aria-hidden="true"></i>
+          </button>
+        </span>
+      }
+    </div>
+  }
+  @if (error()) {
+    <p class="text-xs text-red-600" [attr.data-testid]="idPrefix() + '-skill-error'">{{ error() }}</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.html
@@ -35,7 +35,12 @@
       @for (skill of skills(); track skill) {
         <span class="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-neutral-100 text-neutral-600 px-3 py-1 text-xs">
           {{ skill }}
-          <button type="button" class="text-gray-400 hover:text-gray-700" [attr.aria-label]="'Remove ' + skill" (click)="removeSkill(skill)">
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-700"
+            [attr.aria-label]="'Remove ' + skill"
+            (click)="removeSkill(skill)"
+            [attr.data-testid]="idPrefix() + '-remove-skill-' + skill">
             <i class="fa-light fa-xmark" aria-hidden="true"></i>
           </button>
         </span>
@@ -43,6 +48,6 @@
     </div>
   }
   @if (error()) {
-    <p class="text-xs text-red-600" [attr.data-testid]="idPrefix() + '-skill-error'">{{ error() }}</p>
+    <p role="alert" class="text-xs text-red-600" [attr.data-testid]="idPrefix() + '-skill-error'">{{ error() }}</p>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-1">
-  <label class="text-sm font-medium text-gray-700">{{ label() }} <span class="text-red-500">*</span></label>
+  <label [id]="idPrefix() + '-skill-label'" class="text-sm font-medium text-gray-700">{{ label() }} <span class="text-red-500">*</span></label>
   @if (helper()) {
     <p class="text-sm text-gray-500 mb-1">{{ helper() }}</p>
   }
@@ -17,6 +17,7 @@
         placeholder="Skill Name"
         [filter]="true"
         styleClass="w-full"
+        [ariaLabelledBy]="idPrefix() + '-skill-label'"
         [dataTest]="idPrefix() + '-skill'" />
     </div>
     <lfx-button

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.spec.ts
@@ -74,7 +74,7 @@ describe('SkillsPickerComponent', () => {
     pick('Go');
     pick('Kubernetes');
 
-    fixture.componentInstance['removeSkill']('Go');
+    element().querySelector<HTMLButtonElement>('[data-testid="picker-remove-skill-Go"]')?.click();
     fixture.detectChanges();
 
     expect(form.controls.skills.value).toEqual(['Kubernetes']);

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.spec.ts
@@ -1,0 +1,100 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MENTORSHIP_SKILL_OPTIONS } from '@lfx-one/shared/constants';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SkillsPickerComponent } from './skills-picker.component';
+
+describe('SkillsPickerComponent', () => {
+  let fixture: ComponentFixture<SkillsPickerComponent>;
+  let form: FormGroup<{ skills: FormControl<string[]> }>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const chipLabels = (): string[] =>
+    Array.from(element().querySelectorAll('[data-testid="picker-skill-list"] span')).map((el) => (el.textContent ?? '').trim());
+
+  const pick = (skill: string): void => {
+    fixture.componentInstance['draftForm'].controls.skill.setValue(skill);
+    fixture.componentInstance['addSkill']();
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    form = new FormGroup({ skills: new FormControl<string[]>([], { nonNullable: true }) });
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [SkillsPickerComponent],
+      providers: [provideNoopAnimations()],
+    });
+
+    fixture = TestBed.createComponent(SkillsPickerComponent);
+    fixture.componentRef.setInput('form', form);
+    fixture.componentRef.setInput('label', 'Which of your skills should we feature?');
+    fixture.componentRef.setInput('idPrefix', 'picker');
+    fixture.detectChanges();
+  });
+
+  it('writes chosen skills to the caller form and renders them as chips', () => {
+    pick('Go');
+    pick('Kubernetes');
+
+    expect(form.controls.skills.value).toEqual(['Go', 'Kubernetes']);
+    expect(chipLabels()).toEqual(['Go', 'Kubernetes']);
+  });
+
+  it('ignores a repeat of a skill already chosen, whatever its casing', () => {
+    pick('Go');
+    pick('go');
+    pick('GO');
+
+    expect(form.controls.skills.value).toEqual(['Go']);
+  });
+
+  it('drops chosen skills from the options so they cannot be picked twice', () => {
+    const before = fixture.componentInstance['availableSkills']().length;
+    pick(MENTORSHIP_SKILL_OPTIONS[0]);
+
+    const after = fixture.componentInstance['availableSkills']();
+    expect(after.length).toBe(before - 1);
+    expect(after.map((option) => option.value)).not.toContain(MENTORSHIP_SKILL_OPTIONS[0]);
+  });
+
+  it('clears the draft select after adding, so the added skill does not look selected', () => {
+    pick('Go');
+
+    expect(fixture.componentInstance['draftForm'].controls.skill.value).toBe('');
+  });
+
+  it('removes a skill from the caller form', () => {
+    pick('Go');
+    pick('Kubernetes');
+
+    fixture.componentInstance['removeSkill']('Go');
+    fixture.detectChanges();
+
+    expect(form.controls.skills.value).toEqual(['Kubernetes']);
+    expect(chipLabels()).toEqual(['Kubernetes']);
+  });
+
+  it('repaints when the caller writes the skills itself', () => {
+    // The enroll wizard prefills skills from an imported program.
+    form.controls.skills.setValue(['Rust']);
+    fixture.detectChanges();
+
+    expect(chipLabels()).toEqual(['Rust']);
+  });
+
+  it('shows the error the caller passes down', () => {
+    expect(element().querySelector('[data-testid="picker-skill-error"]')).toBeNull();
+
+    fixture.componentRef.setInput('error', 'Add at least one skill.');
+    fixture.detectChanges();
+
+    expect(element().querySelector('[data-testid="picker-skill-error"]')?.textContent?.trim()).toBe('Add at least one skill.');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.ts
@@ -3,7 +3,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
 import { MENTORSHIP_SKILL_OPTIONS } from '@lfx-one/shared/constants';
@@ -20,7 +20,7 @@ import { startWith, switchMap } from 'rxjs';
  */
 @Component({
   selector: 'lfx-mentorship-skills-picker',
-  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent],
+  imports: [ButtonComponent, SelectComponent],
   templateUrl: './skills-picker.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/skills-picker/skills-picker.component.ts
@@ -1,0 +1,78 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { SelectComponent } from '@components/select/select.component';
+import { MENTORSHIP_SKILL_OPTIONS } from '@lfx-one/shared/constants';
+import { startWith, switchMap } from 'rxjs';
+
+/**
+ * Skill picker shared by the mentorship forms — a filterable select over the canonical
+ * catalog, an Add button, and the chosen skills as removable chips. The enroll wizard
+ * asks which skills a program needs; the Become a Mentor form asks which a mentor has.
+ *
+ * The chosen skills live in the caller's form under `control`; the draft select is local
+ * so a half-made choice never reaches the caller. Renders the field only, without a
+ * section wrapper, because the enroll wizard nests it beside other fields.
+ */
+@Component({
+  selector: 'lfx-mentorship-skills-picker',
+  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent],
+  templateUrl: './skills-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SkillsPickerComponent {
+  public readonly form = input.required<FormGroup>();
+  public readonly label = input.required<string>();
+  /** Prefixes the select, add-button, and chip test ids. */
+  public readonly idPrefix = input.required<string>();
+  public readonly control = input('skills');
+  public readonly helper = input<string | undefined>(undefined);
+  public readonly error = input<string | undefined>(undefined);
+
+  protected readonly draftForm = new FormGroup({
+    skill: new FormControl('', { nonNullable: true }),
+  });
+
+  protected readonly draftValue = toSignal(this.draftForm.controls.skill.valueChanges, { initialValue: '' });
+
+  protected readonly skills = this.initSkills();
+  protected readonly availableSkills = this.initAvailableSkills();
+
+  protected addSkill(): void {
+    const value = this.draftForm.controls.skill.value.trim();
+    if (!value) return;
+    const current = this.skills();
+    if (current.some((item) => item.toLowerCase() === value.toLowerCase())) return;
+    this.form().controls[this.control()].setValue([...current, value]);
+    this.draftForm.controls.skill.setValue('');
+  }
+
+  protected removeSkill(skill: string): void {
+    this.form().controls[this.control()].setValue(this.skills().filter((item) => item !== skill));
+  }
+
+  private initSkills() {
+    // Reads through a snapshot of the caller's form so chips repaint when the parent
+    // writes skills itself — prefilling from a program, or resetting the form.
+    const snapshot = toSignal(toObservable(this.form).pipe(switchMap((group) => group.valueChanges.pipe(startWith(group.getRawValue())))), {
+      initialValue: {} as Record<string, unknown>,
+    });
+
+    return computed(() => {
+      const fromSnapshot = snapshot()[this.control()];
+      if (Array.isArray(fromSnapshot)) return fromSnapshot as string[];
+      return (this.form().controls[this.control()]?.value as string[]) ?? [];
+    });
+  }
+
+  private initAvailableSkills() {
+    return computed(() => {
+      const selected = new Set(this.skills().map((item) => item.toLowerCase()));
+      return MENTORSHIP_SKILL_OPTIONS.filter((skill) => !selected.has(skill.toLowerCase())).map((skill) => ({ label: skill, value: skill }));
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.html
@@ -30,6 +30,6 @@
     </p>
   </div>
   @if (error()) {
-    <p class="text-xs text-red-600" [attr.data-testid]="idPrefix() + '-terms-error'">{{ error() }}</p>
+    <p role="alert" class="text-xs text-red-600" [attr.data-testid]="idPrefix() + '-terms-error'">{{ error() }}</p>
   }
 </section>

--- a/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.html
@@ -1,0 +1,35 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-4">
+  <div class="flex flex-col gap-2">
+    <h2 class="text-lg font-semibold text-gray-900">Terms and Conditions</h2>
+    <p class="text-sm text-gray-600">{{ intro() }}</p>
+  </div>
+
+  <div class="flex items-start gap-3">
+    <lfx-checkbox
+      [form]="form()"
+      [control]="control()"
+      [inputId]="idPrefix() + '-terms'"
+      [ariaLabelledBy]="idPrefix() + '-terms-text'"
+      [attr.data-testid]="idPrefix() + '-terms'" />
+    <p [id]="idPrefix() + '-terms-text'" class="min-w-0 flex-1 text-sm text-gray-800 leading-5">
+      <span class="text-red-500">*</span>
+      I agree to the
+      <a [href]="platformUseHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">LFX Platform Use Agreement</a>
+      and all terms incorporated therein, including the
+      <a [href]="serviceTermsHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">
+        Service-Specific Use Terms
+      </a>
+      , the
+      <a [href]="acceptableUseHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">Acceptable Use Policy</a>
+      and the
+      <a [href]="privacyHref" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700 font-medium">Privacy Policy</a>
+      .
+    </p>
+  </div>
+  @if (error()) {
+    <p class="text-xs text-red-600" [attr.data-testid]="idPrefix() + '-terms-error'">{{ error() }}</p>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.spec.ts
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MENTORSHIP_POLICY_LINKS } from '@lfx-one/shared/constants';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TermsAcknowledgementComponent } from './terms-acknowledgement.component';
+
+describe('TermsAcknowledgementComponent', () => {
+  let fixture: ComponentFixture<TermsAcknowledgementComponent>;
+  let form: FormGroup<{ termsAccepted: FormControl<boolean> }>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+
+  beforeEach(() => {
+    form = new FormGroup({ termsAccepted: new FormControl(false, { nonNullable: true }) });
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [TermsAcknowledgementComponent],
+      providers: [provideNoopAnimations()],
+    });
+
+    fixture = TestBed.createComponent(TermsAcknowledgementComponent);
+    fixture.componentRef.setInput('form', form);
+    fixture.componentRef.setInput('intro', 'Review and accept the terms below.');
+    fixture.componentRef.setInput('idPrefix', 'mentorship-mentor');
+    fixture.detectChanges();
+  });
+
+  it('links every policy the acknowledgement names, opening each safely', () => {
+    const anchors = Array.from(element().querySelectorAll('a'));
+
+    expect(anchors.map((anchor) => anchor.getAttribute('href'))).toEqual(MENTORSHIP_POLICY_LINKS.map((link) => link.href));
+    // A blank target without noopener hands the opened page a window reference back.
+    expect(anchors.every((anchor) => anchor.getAttribute('rel') === 'noopener noreferrer')).toBe(true);
+    expect(anchors.every((anchor) => anchor.getAttribute('target') === '_blank')).toBe(true);
+  });
+
+  it('points the checkbox at the acknowledgement text, since the label is a paragraph', () => {
+    const labelled = element().querySelector('[aria-labelledby="mentorship-mentor-terms-text"]');
+
+    expect(labelled).not.toBeNull();
+    expect(element().querySelector('#mentorship-mentor-terms-text')).not.toBeNull();
+  });
+
+  it('shows the error the caller passes down', () => {
+    expect(element().querySelector('[data-testid="mentorship-mentor-terms-error"]')).toBeNull();
+
+    fixture.componentRef.setInput('error', 'Please accept the terms and conditions.');
+    fixture.detectChanges();
+
+    expect(element().querySelector('[data-testid="mentorship-mentor-terms-error"]')?.textContent?.trim()).toBe('Please accept the terms and conditions.');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/components/terms-acknowledgement/terms-acknowledgement.component.ts
@@ -1,0 +1,35 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+import { mentorshipPolicyHref } from '@lfx-one/shared/constants';
+
+/**
+ * The Terms and Conditions section shared by the mentorship forms — the enroll wizard and
+ * the Become a Mentor form both close with it. The four policy links are legal copy, so
+ * they live in one place rather than being retyped per form; only the lead-in paragraph
+ * and the id prefix differ between callers.
+ *
+ * Owns no state: the checkbox writes to the caller's form under `control`.
+ */
+@Component({
+  selector: 'lfx-mentorship-terms-acknowledgement',
+  imports: [CheckboxComponent],
+  templateUrl: './terms-acknowledgement.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TermsAcknowledgementComponent {
+  public readonly form = input.required<FormGroup>();
+  public readonly intro = input.required<string>();
+  /** Prefixes the checkbox id, the label id it points at, and the test id. */
+  public readonly idPrefix = input.required<string>();
+  public readonly control = input('termsAccepted');
+  public readonly error = input<string | undefined>(undefined);
+
+  protected readonly platformUseHref = mentorshipPolicyHref('LFX Platform Use Agreement');
+  protected readonly serviceTermsHref = mentorshipPolicyHref('Service-Specific Use Terms');
+  protected readonly acceptableUseHref = mentorshipPolicyHref('Acceptable Use Policy');
+  protected readonly privacyHref = mentorshipPolicyHref('Privacy Policy');
+}

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.html
@@ -26,6 +26,7 @@
 
   @if (rows().length) {
     <div class="overflow-x-auto rounded-xl border border-gray-200">
+      <!-- 36rem is the width the three columns need before the program name starts wrapping; below it the wrapper scrolls. -->
       <table class="w-full min-w-[36rem] text-left">
         <thead>
           <tr class="border-b border-gray-200">

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.html
@@ -8,16 +8,18 @@
   </div>
 
   <div class="flex flex-col gap-1">
-    <label class="text-sm font-medium text-gray-700">Select LFX Mentorship</label>
+    <label id="mentorship-mentor-program-label" class="text-sm font-medium text-gray-700">Select LFX Mentorship</label>
     <lfx-select
       [form]="pickerForm"
       control="programId"
       [options]="availablePrograms()"
       optionLabel="label"
       optionValue="value"
-      placeholder="Select LFX Mentorship"
+      [placeholder]="loading() ? 'Loading programs…' : 'Select LFX Mentorship'"
+      [loading]="loading()"
       [filter]="true"
       styleClass="w-full"
+      ariaLabelledBy="mentorship-mentor-program-label"
       dataTest="mentorship-mentor-program" />
     <p class="text-xs text-gray-500 mt-1">{{ helper }}</p>
   </div>
@@ -36,7 +38,7 @@
           @for (row of rows(); track row.id) {
             <tr class="border-b border-gray-100 last:border-b-0" [attr.data-testid]="'mentorship-mentor-request-row-' + row.id">
               <td class="px-4 py-4">
-                <span class="text-sm font-medium text-gray-900" [title]="row.programName">{{ row.programName }}</span>
+                <span class="text-sm font-medium text-gray-900">{{ row.programName }}</span>
               </td>
               <td class="px-4 py-4">
                 <span

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.html
@@ -1,0 +1,66 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-6" data-testid="mentorship-mentor-programs">
+  <div class="flex flex-col gap-2">
+    <h2 class="text-lg font-semibold text-gray-900">Mentorship Program Details</h2>
+    <p class="text-sm text-gray-600">{{ intro }}</p>
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <label class="text-sm font-medium text-gray-700">Select LFX Mentorship</label>
+    <lfx-select
+      [form]="pickerForm"
+      control="programId"
+      [options]="availablePrograms()"
+      optionLabel="label"
+      optionValue="value"
+      placeholder="Select LFX Mentorship"
+      [filter]="true"
+      styleClass="w-full"
+      dataTest="mentorship-mentor-program" />
+    <p class="text-xs text-gray-500 mt-1">{{ helper }}</p>
+  </div>
+
+  @if (rows().length) {
+    <div class="overflow-x-auto rounded-xl border border-gray-200">
+      <table class="w-full min-w-[36rem] text-left">
+        <thead>
+          <tr class="border-b border-gray-200">
+            <th class="px-4 py-3 text-sm font-medium text-gray-600">Mentorship Projects</th>
+            <th class="px-4 py-3 text-sm font-medium text-gray-600">Status</th>
+            <th class="px-4 py-3 text-sm font-medium text-gray-600">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of rows(); track row.id) {
+            <tr class="border-b border-gray-100 last:border-b-0" [attr.data-testid]="'mentorship-mentor-request-row-' + row.id">
+              <td class="px-4 py-4">
+                <span class="text-sm font-medium text-gray-900" [title]="row.programName">{{ row.programName }}</span>
+              </td>
+              <td class="px-4 py-4">
+                <span
+                  class="inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium"
+                  [class]="row.statusBadgeClass"
+                  [attr.data-testid]="'mentorship-mentor-request-status-' + row.id">
+                  {{ row.statusLabel }}
+                </span>
+              </td>
+              <td class="px-4 py-4">
+                <lfx-button
+                  label="Withdraw"
+                  severity="danger"
+                  size="small"
+                  [text]="true"
+                  styleClass="!px-0"
+                  [ariaLabel]="'Withdraw request to join ' + row.programName"
+                  (onClick)="withdraw.emit(row.id)"
+                  [attr.data-testid]="'mentorship-mentor-withdraw-' + row.id" />
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.spec.ts
@@ -94,7 +94,7 @@ describe('MentorProgramsSectionComponent', () => {
     element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentor-withdraw-req_1"] button')?.click();
 
     expect(withdrawn).toEqual(['req_1']);
-    // The parent owns the list, because form validation depends on its length.
+    // The parent owns the list, because it — not this section — will POST the registration.
     expect(element().querySelector('[data-testid="mentorship-mentor-request-row-req_1"]')).not.toBeNull();
   });
 

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.spec.ts
@@ -1,0 +1,107 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MENTORSHIP_MENTOR_REQUEST_STATUS_LABELS, MENTORSHIP_MENTOR_STATUS_LABELS, MENTORSHIP_MENTOR_STATUSES } from '@lfx-one/shared/constants';
+import { MentorshipMentorProgramRequest, MentorshipProgram } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MentorProgramsSectionComponent } from './mentor-programs-section.component';
+
+describe('MentorProgramsSectionComponent', () => {
+  const program = (id: string, name: string): MentorshipProgram => ({
+    id,
+    slug: name.toLowerCase().replace(/\s+/g, '-'),
+    name,
+    projectName: 'LF Energy',
+    term: 'Fall 2026',
+    status: 'open',
+    stats: { mentors: 2, mentees: 1, graduated: 0 },
+    createdOn: '2026-05-01',
+    updatedOn: '2026-07-02',
+  });
+
+  const request: MentorshipMentorProgramRequest = {
+    id: 'req_1',
+    programId: 'mp_kubernetes',
+    programName: 'Kubernetes Contributors',
+    status: 'accepted',
+  };
+
+  let fixture: ComponentFixture<MentorProgramsSectionComponent>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [MentorProgramsSectionComponent],
+      providers: [provideNoopAnimations()],
+    });
+
+    fixture = TestBed.createComponent(MentorProgramsSectionComponent);
+    fixture.componentRef.setInput('programs', [program('mp_kubernetes', 'Kubernetes Contributors'), program('mp_gridflow', 'GridFlow Ingestion')]);
+    fixture.componentRef.setInput('requests', [request]);
+    fixture.detectChanges();
+  });
+
+  it('offers only programs the mentor has not already requested', () => {
+    expect(fixture.componentInstance['availablePrograms']().map((option) => option.value)).toEqual(['mp_gridflow']);
+  });
+
+  it('emits the picked program and clears the select, so it never looks selected', () => {
+    const added: MentorshipProgram[] = [];
+    fixture.componentInstance.add.subscribe((program) => added.push(program));
+
+    fixture.componentInstance['pickerForm'].controls.programId.setValue('mp_gridflow');
+    fixture.detectChanges();
+
+    expect(added.map((program) => program.id)).toEqual(['mp_gridflow']);
+    expect(fixture.componentInstance['pickerForm'].controls.programId.value).toBeNull();
+  });
+
+  it('renders one row per request, with its status badge', () => {
+    expect(element().querySelector('[data-testid="mentorship-mentor-request-row-req_1"]')).not.toBeNull();
+    expect(element().querySelector('[data-testid="mentorship-mentor-request-status-req_1"]')?.textContent?.trim()).toBe('Accepted');
+  });
+
+  it('calls an undecided request Pending, not Invited as the admin tab does', () => {
+    // Same wire status, opposite direction: the admin invited them, or they asked to join.
+    fixture.componentRef.setInput('requests', [{ ...request, status: 'pending' }]);
+    fixture.detectChanges();
+
+    expect(element().querySelector('[data-testid="mentorship-mentor-request-status-req_1"]')?.textContent?.trim()).toBe('Pending');
+    expect(MENTORSHIP_MENTOR_STATUS_LABELS.pending).toBe('Invited');
+  });
+
+  it('reuses the admin wording for every status it does not deliberately override', () => {
+    for (const status of MENTORSHIP_MENTOR_STATUSES.filter((value) => value !== 'pending')) {
+      expect(MENTORSHIP_MENTOR_REQUEST_STATUS_LABELS[status]).toBe(MENTORSHIP_MENTOR_STATUS_LABELS[status]);
+    }
+  });
+
+  it('names the program in the withdraw label, since every row has the same button text', () => {
+    const withdraw = element().querySelector('[data-testid="mentorship-mentor-withdraw-req_1"]');
+
+    expect(withdraw?.querySelector('button')?.getAttribute('aria-label')).toBe('Withdraw request to join Kubernetes Contributors');
+  });
+
+  it('emits the request id on withdraw rather than removing the row itself', () => {
+    const withdrawn: string[] = [];
+    fixture.componentInstance.withdraw.subscribe((id) => withdrawn.push(id));
+
+    element().querySelector<HTMLButtonElement>('[data-testid="mentorship-mentor-withdraw-req_1"] button')?.click();
+
+    expect(withdrawn).toEqual(['req_1']);
+    // The parent owns the list, because form validation depends on its length.
+    expect(element().querySelector('[data-testid="mentorship-mentor-request-row-req_1"]')).not.toBeNull();
+  });
+
+  it('hides the request table entirely when nothing has been requested', () => {
+    fixture.componentRef.setInput('requests', []);
+    fixture.detectChanges();
+
+    expect(element().querySelector('table')).toBeNull();
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.ts
@@ -3,7 +3,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
@@ -25,12 +25,14 @@ import { MentorshipMentorProgramRequest, MentorshipProgram } from '@lfx-one/shar
  */
 @Component({
   selector: 'lfx-mentorship-mentor-programs-section',
-  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent],
+  imports: [ButtonComponent, SelectComponent],
   templateUrl: './mentor-programs-section.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MentorProgramsSectionComponent {
   public readonly programs = input.required<MentorshipProgram[]>();
+  /** While true the select shows a loading state and says so, rather than looking like a program-less platform. */
+  public readonly loading = input(false);
   public readonly requests = input.required<MentorshipMentorProgramRequest[]>();
   public readonly add = output<MentorshipProgram>();
   public readonly withdraw = output<string>();

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.ts
@@ -15,9 +15,10 @@ import {
 import { MentorshipMentorProgramRequest, MentorshipProgram } from '@lfx-one/shared/interfaces';
 
 /**
- * Program picker for the Become a Mentor form. Picking a program raises a request to that
- * program's admin, so the select acts as a one-shot action rather than a stored value: it
- * clears itself on choose and drops programs already requested from its options.
+ * Program picker for the Become a Mentor form. Picking a program adds a pending row to the
+ * list below — nothing reaches the program's admin until the registration endpoint exists —
+ * so the select acts as a one-shot action rather than a stored value: it clears itself on
+ * choose and drops programs already listed from its options.
  *
  * Applying is optional — a mentor may register a profile and come back for programs later
  * — so nothing here is required and the section surfaces no validation error. The parent

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-programs-section/mentor-programs-section.component.ts
@@ -1,0 +1,77 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { SelectComponent } from '@components/select/select.component';
+import {
+  MENTORSHIP_MENTOR_PROGRAMS_HELPER,
+  MENTORSHIP_MENTOR_PROGRAMS_INTRO,
+  MENTORSHIP_MENTOR_REQUEST_STATUS_LABELS,
+  MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES,
+} from '@lfx-one/shared/constants';
+import { MentorshipMentorProgramRequest, MentorshipProgram } from '@lfx-one/shared/interfaces';
+
+/**
+ * Program picker for the Become a Mentor form. Picking a program raises a request to that
+ * program's admin, so the select acts as a one-shot action rather than a stored value: it
+ * clears itself on choose and drops programs already requested from its options.
+ *
+ * Applying is optional — a mentor may register a profile and come back for programs later
+ * — so nothing here is required and the section surfaces no validation error. The parent
+ * owns the request list because it, not this section, will POST the registration.
+ */
+@Component({
+  selector: 'lfx-mentorship-mentor-programs-section',
+  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent],
+  templateUrl: './mentor-programs-section.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MentorProgramsSectionComponent {
+  public readonly programs = input.required<MentorshipProgram[]>();
+  public readonly requests = input.required<MentorshipMentorProgramRequest[]>();
+  public readonly add = output<MentorshipProgram>();
+  public readonly withdraw = output<string>();
+
+  protected readonly intro = MENTORSHIP_MENTOR_PROGRAMS_INTRO;
+  protected readonly helper = MENTORSHIP_MENTOR_PROGRAMS_HELPER;
+
+  protected readonly pickerForm = new FormGroup({
+    programId: new FormControl<string | null>(null),
+  });
+
+  protected readonly availablePrograms = this.initAvailablePrograms();
+  protected readonly rows = this.initRows();
+
+  public constructor() {
+    // Choosing is the whole interaction: hand the program up, then clear so the same
+    // program can never look "selected" while its request is already listed below.
+    this.pickerForm.controls.programId.valueChanges.pipe(takeUntilDestroyed()).subscribe((programId) => {
+      if (!programId) return;
+      const program = this.programs().find((item) => item.id === programId);
+      this.pickerForm.controls.programId.setValue(null, { emitEvent: false });
+      if (program) this.add.emit(program);
+    });
+  }
+
+  private initAvailablePrograms() {
+    return computed(() => {
+      const requested = new Set(this.requests().map((item) => item.programId));
+      return this.programs()
+        .filter((program) => !requested.has(program.id))
+        .map((program) => ({ label: program.name, value: program.id }));
+    });
+  }
+
+  private initRows() {
+    return computed(() =>
+      this.requests().map((request) => ({
+        ...request,
+        statusLabel: MENTORSHIP_MENTOR_REQUEST_STATUS_LABELS[request.status],
+        statusBadgeClass: MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES[request.status],
+      }))
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.html
@@ -10,7 +10,11 @@
   <div class="flex flex-col gap-1">
     <label class="text-sm font-medium text-gray-700" for="mentorship-mentor-resume-input">Upload Resume</label>
     <div class="flex items-stretch overflow-hidden rounded-lg border border-gray-200 bg-white">
-      <span class="flex flex-1 min-w-0 items-center truncate px-3 py-2 text-sm" [class]="resumeFileName() ? 'text-gray-900' : 'text-gray-500'">
+      <!-- Stays one line to keep the control's height; the title exposes a long file name the truncation hides. -->
+      <span
+        class="flex flex-1 min-w-0 items-center truncate px-3 py-2 text-sm"
+        [class]="resumeFileName() ? 'text-gray-900' : 'text-gray-500'"
+        [attr.title]="resumeFileName() || null">
         {{ resumeFileName() || emptyLabel }}
       </span>
       @if (resumeFileName()) {
@@ -28,9 +32,8 @@
         label="Browse"
         severity="primary"
         size="small"
-        styleClass="!rounded-none shrink-0 whitespace-nowrap"
+        styleClass="!rounded-none shrink-0 whitespace-nowrap !py-2.5"
         (onClick)="onBrowse()"
-        styleClass="!py-2.5"
         data-testid="mentorship-mentor-resume-browse" />
     </div>
     <input

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.html
@@ -10,11 +10,21 @@
   <div class="flex flex-col gap-1">
     <label class="text-sm font-medium text-gray-700" for="mentorship-mentor-resume-input">Upload Resume</label>
     <div class="flex items-stretch overflow-hidden rounded-lg border border-gray-200 bg-white">
-      <!-- Stays one line to keep the control's height; the title exposes a long file name the truncation hides. -->
+      <!--
+        Stays one line to keep the control's height, so a long file name is truncated. The tooltip
+        exposes the rest, and the name becomes a tab stop while one is chosen so it is reachable on
+        focus as well as hover. `role="status"` announces a newly chosen file to a screen reader.
+      -->
       <span
         class="flex flex-1 min-w-0 items-center truncate px-3 py-2 text-sm"
         [class]="resumeFileName() ? 'text-gray-900' : 'text-gray-500'"
-        [attr.title]="resumeFileName() || null">
+        [attr.tabindex]="resumeFileName() ? 0 : null"
+        [attr.role]="resumeFileName() ? 'status' : null"
+        [pTooltip]="resumeFileName()"
+        [tooltipDisabled]="!resumeFileName()"
+        tooltipEvent="both"
+        tooltipPosition="top"
+        data-testid="mentorship-mentor-resume-name">
         {{ resumeFileName() || emptyLabel }}
       </span>
       @if (resumeFileName()) {
@@ -46,7 +56,7 @@
       data-testid="mentorship-mentor-resume-file" />
     <p class="text-xs text-gray-500 mt-1">{{ helper }}</p>
     @if (fileError()) {
-      <p class="text-xs text-red-600" data-testid="mentorship-mentor-resume-error">{{ fileError() }}</p>
+      <p role="alert" class="text-xs text-red-600" data-testid="mentorship-mentor-resume-error">{{ fileError() }}</p>
     }
   </div>
 </section>

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.html
@@ -1,0 +1,49 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-6" data-testid="mentorship-mentor-resume">
+  <div class="flex flex-col gap-2">
+    <h2 class="text-lg font-semibold text-gray-900">Resume</h2>
+    <p class="text-sm text-gray-600">{{ intro }}</p>
+  </div>
+
+  <div class="flex flex-col gap-1">
+    <label class="text-sm font-medium text-gray-700" for="mentorship-mentor-resume-input">Upload Resume</label>
+    <div class="flex items-stretch overflow-hidden rounded-lg border border-gray-200 bg-white">
+      <span class="flex flex-1 min-w-0 items-center truncate px-3 py-2 text-sm" [class]="resumeFileName() ? 'text-gray-900' : 'text-gray-500'">
+        {{ resumeFileName() || emptyLabel }}
+      </span>
+      @if (resumeFileName()) {
+        <lfx-button
+          icon="fa-light fa-xmark"
+          severity="secondary"
+          size="small"
+          [text]="true"
+          styleClass="!rounded-none shrink-0"
+          [ariaLabel]="'Remove ' + resumeFileName()"
+          (onClick)="onClear()"
+          data-testid="mentorship-mentor-resume-clear" />
+      }
+      <lfx-button
+        label="Browse"
+        severity="primary"
+        size="small"
+        styleClass="!rounded-none shrink-0 whitespace-nowrap"
+        (onClick)="onBrowse()"
+        styleClass="!py-2.5"
+        data-testid="mentorship-mentor-resume-browse" />
+    </div>
+    <input
+      #fileInput
+      id="mentorship-mentor-resume-input"
+      type="file"
+      class="hidden"
+      [accept]="accept"
+      (change)="onFileChange($event)"
+      data-testid="mentorship-mentor-resume-file" />
+    <p class="text-xs text-gray-500 mt-1">{{ helper }}</p>
+    @if (fileError()) {
+      <p class="text-xs text-red-600" data-testid="mentorship-mentor-resume-error">{{ fileError() }}</p>
+    }
+  </div>
+</section>

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.spec.ts
@@ -14,13 +14,27 @@ describe('MentorResumeSectionComponent', () => {
   let form: FormGroup<{ resumeFileName: FormControl<string> }>;
 
   const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
-  const fileName = (): string => element().querySelector('span.flex-1')?.textContent?.trim() ?? '';
+  const fileName = (): string => element().querySelector('[data-testid="mentorship-mentor-resume-name"]')?.textContent?.trim() ?? '';
   const error = (): string | null => element().querySelector('[data-testid="mentorship-mentor-resume-error"]')?.textContent?.trim() ?? null;
 
-  /** Stands in for the change event, so the spec never has to build a real FileList. */
+  /**
+   * A real input carrying a real `File`, so the spec exercises the component against the
+   * shapes the browser hands it. `size` and `value` are redefined rather than assigned
+   * because neither is writable on the genuine article.
+   */
   const select = (name: string, size = 1024): HTMLInputElement => {
-    const input = { files: [{ name, size }], value: name } as unknown as HTMLInputElement;
-    fixture.componentInstance['onFileChange']({ target: input } as unknown as Event);
+    const input = document.createElement('input');
+    input.type = 'file';
+
+    const file = new File([], name);
+    Object.defineProperty(file, 'size', { value: size });
+    Object.defineProperty(input, 'files', { value: [file] });
+    Object.defineProperty(input, 'value', { value: name, writable: true });
+
+    const event = new Event('change');
+    Object.defineProperty(event, 'target', { value: input });
+
+    fixture.componentInstance['onFileChange'](event);
     fixture.detectChanges();
     return input;
   };

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.spec.ts
@@ -1,0 +1,106 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MENTORSHIP_MENTOR_RESUME_MAX_BYTES, MENTORSHIP_MENTOR_RESUME_SIZE_ERROR, MENTORSHIP_MENTOR_RESUME_TYPE_ERROR } from '@lfx-one/shared/constants';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MentorResumeSectionComponent } from './mentor-resume-section.component';
+
+describe('MentorResumeSectionComponent', () => {
+  let fixture: ComponentFixture<MentorResumeSectionComponent>;
+  let form: FormGroup<{ resumeFileName: FormControl<string> }>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const fileName = (): string => element().querySelector('span.flex-1')?.textContent?.trim() ?? '';
+  const error = (): string | null => element().querySelector('[data-testid="mentorship-mentor-resume-error"]')?.textContent?.trim() ?? null;
+
+  /** Stands in for the change event, so the spec never has to build a real FileList. */
+  const select = (name: string, size = 1024): HTMLInputElement => {
+    const input = { files: [{ name, size }], value: name } as unknown as HTMLInputElement;
+    fixture.componentInstance['onFileChange']({ target: input } as unknown as Event);
+    fixture.detectChanges();
+    return input;
+  };
+
+  beforeEach(() => {
+    form = new FormGroup({ resumeFileName: new FormControl('', { nonNullable: true }) });
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [MentorResumeSectionComponent],
+      providers: [provideNoopAnimations()],
+    });
+
+    fixture = TestBed.createComponent(MentorResumeSectionComponent);
+    fixture.componentRef.setInput('form', form);
+    fixture.detectChanges();
+  });
+
+  it('prompts for a file until one is chosen', () => {
+    expect(fileName()).toBe('Choose file');
+    expect(element().querySelector('[data-testid="mentorship-mentor-resume-clear"]')).toBeNull();
+  });
+
+  it('stores the file name on the form, not the bytes, since there is no upload endpoint', () => {
+    select('resume.pdf');
+
+    expect(form.controls.resumeFileName.value).toBe('resume.pdf');
+    expect(fileName()).toBe('resume.pdf');
+    expect(error()).toBeNull();
+  });
+
+  it('rejects a file that is not a document, and clears the input so it can be retried', () => {
+    const input = select('headshot.png');
+
+    expect(error()).toBe(MENTORSHIP_MENTOR_RESUME_TYPE_ERROR);
+    expect(form.controls.resumeFileName.value).toBe('');
+    expect(input.value).toBe('');
+  });
+
+  it('rejects a document over the size cap', () => {
+    select('resume.pdf', MENTORSHIP_MENTOR_RESUME_MAX_BYTES + 1);
+
+    expect(error()).toBe(MENTORSHIP_MENTOR_RESUME_SIZE_ERROR);
+    expect(form.controls.resumeFileName.value).toBe('');
+  });
+
+  it('accepts a document exactly at the cap', () => {
+    select('resume.docx', MENTORSHIP_MENTOR_RESUME_MAX_BYTES);
+
+    expect(error()).toBeNull();
+    expect(form.controls.resumeFileName.value).toBe('resume.docx');
+  });
+
+  it('drops a stale error once an acceptable file replaces the rejected one', () => {
+    select('headshot.png');
+    expect(error()).toBe(MENTORSHIP_MENTOR_RESUME_TYPE_ERROR);
+
+    select('resume.pdf');
+    expect(error()).toBeNull();
+  });
+
+  it('clears a chosen resume, naming it for a screen reader', () => {
+    select('resume.pdf');
+
+    const clear = element().querySelector('[data-testid="mentorship-mentor-resume-clear"]');
+    expect(clear?.querySelector('button')?.getAttribute('aria-label')).toBe('Remove resume.pdf');
+
+    fixture.componentInstance['onClear']();
+    fixture.detectChanges();
+
+    expect(form.controls.resumeFileName.value).toBe('');
+    expect(fileName()).toBe('Choose file');
+  });
+
+  it('follows a parent-side reset of the form', () => {
+    select('resume.pdf');
+
+    form.reset();
+    fixture.detectChanges();
+
+    expect(fileName()).toBe('Choose file');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.ts
@@ -15,6 +15,7 @@ import {
   MENTORSHIP_MENTOR_RESUME_INTRO,
 } from '@lfx-one/shared/constants';
 import { isMentorshipResumeFileName } from '@lfx-one/shared/utils';
+import { TooltipModule } from 'primeng/tooltip';
 import { startWith, switchMap } from 'rxjs';
 
 /**
@@ -28,7 +29,7 @@ import { startWith, switchMap } from 'rxjs';
  */
 @Component({
   selector: 'lfx-mentorship-mentor-resume-section',
-  imports: [ButtonComponent],
+  imports: [ButtonComponent, TooltipModule],
   templateUrl: './mentor-resume-section.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/components/mentor-resume-section/mentor-resume-section.component.ts
@@ -1,0 +1,104 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, ElementRef, input, signal, viewChild } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormGroup } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import {
+  MENTORSHIP_MENTOR_RESUME_ACCEPT,
+  MENTORSHIP_MENTOR_RESUME_EMPTY_LABEL,
+  MENTORSHIP_MENTOR_RESUME_HELPER,
+  MENTORSHIP_MENTOR_RESUME_MAX_BYTES,
+  MENTORSHIP_MENTOR_RESUME_SIZE_ERROR,
+  MENTORSHIP_MENTOR_RESUME_TYPE_ERROR,
+  MENTORSHIP_MENTOR_RESUME_INTRO,
+} from '@lfx-one/shared/constants';
+import { isMentorshipResumeFileName } from '@lfx-one/shared/utils';
+import { startWith, switchMap } from 'rxjs';
+
+/**
+ * Resume upload for the Become a Mentor form. Like the enroll wizard's logo picker, this
+ * stores the file *name* on the form and keeps the bytes in the input element only —
+ * there is no upload endpoint yet, so nothing else would have anywhere to send them.
+ *
+ * Type and size are rejected at selection rather than at submit, so the mentor finds out
+ * while the picker is still in front of them. That is why the resume has no entry in
+ * `MentorshipMentorRegisterFieldErrors`.
+ */
+@Component({
+  selector: 'lfx-mentorship-mentor-resume-section',
+  imports: [ButtonComponent],
+  templateUrl: './mentor-resume-section.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MentorResumeSectionComponent {
+  public readonly form = input.required<FormGroup>();
+
+  protected readonly fileInput = viewChild<ElementRef<HTMLInputElement>>('fileInput');
+
+  protected readonly intro = MENTORSHIP_MENTOR_RESUME_INTRO;
+  protected readonly accept = MENTORSHIP_MENTOR_RESUME_ACCEPT;
+  protected readonly helper = MENTORSHIP_MENTOR_RESUME_HELPER;
+  protected readonly emptyLabel = MENTORSHIP_MENTOR_RESUME_EMPTY_LABEL;
+
+  protected readonly fileError = signal('');
+
+  protected readonly resumeFileName = this.initResumeFileName();
+
+  protected onBrowse(): void {
+    this.fileInput()?.nativeElement.click();
+  }
+
+  protected onFileChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    this.fileError.set('');
+
+    if (!file) {
+      this.setFileName('');
+      return;
+    }
+    if (!isMentorshipResumeFileName(file.name)) {
+      this.reject(input, MENTORSHIP_MENTOR_RESUME_TYPE_ERROR);
+      return;
+    }
+    if (file.size > MENTORSHIP_MENTOR_RESUME_MAX_BYTES) {
+      this.reject(input, MENTORSHIP_MENTOR_RESUME_SIZE_ERROR);
+      return;
+    }
+
+    this.setFileName(file.name);
+  }
+
+  protected onClear(): void {
+    const input = this.fileInput()?.nativeElement;
+    if (input) input.value = '';
+    this.fileError.set('');
+    this.setFileName('');
+  }
+
+  private initResumeFileName() {
+    // Read back through the form rather than a local copy, so a parent-side reset clears
+    // the displayed name too.
+    const snapshot = toSignal(toObservable(this.form).pipe(switchMap((group) => group.valueChanges.pipe(startWith(group.getRawValue())))), {
+      initialValue: {} as Record<string, unknown>,
+    });
+
+    return computed(() => {
+      const fromSnapshot = snapshot()['resumeFileName'];
+      if (typeof fromSnapshot === 'string') return fromSnapshot;
+      return (this.form().controls['resumeFileName']?.value as string) ?? '';
+    });
+  }
+
+  private reject(input: HTMLInputElement, message: string): void {
+    this.fileError.set(message);
+    input.value = '';
+    this.setFileName('');
+  }
+
+  private setFileName(fileName: string): void {
+    this.form().controls['resumeFileName'].setValue(fileName);
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
@@ -10,7 +10,12 @@
 
     <lfx-mentorship-profile-card />
 
-    <lfx-mentorship-mentor-programs-section [programs]="programs()" [requests]="requests()" (add)="onAddProgram($event)" (withdraw)="onWithdraw($event)" />
+    <lfx-mentorship-mentor-programs-section
+      [programs]="programs()"
+      [loading]="programsLoading()"
+      [requests]="requests()"
+      (add)="onAddProgram($event)"
+      (withdraw)="onWithdraw($event)" />
 
     <section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-6" data-testid="mentorship-mentor-introduction">
       <div class="flex flex-col gap-2">

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
@@ -25,12 +25,15 @@
       </div>
 
       <div class="flex flex-col gap-1">
-        <label class="text-sm font-medium text-gray-700">Tell us a little bit about yourself. <span class="text-red-500">*</span></label>
+        <label id="mentorship-mentor-introduction-label" class="text-sm font-medium text-gray-700">
+          Tell us a little bit about yourself. <span class="text-red-500">*</span>
+        </label>
         <lfx-rich-editor
           [form]="form"
           control="introduction"
           [placeholder]="introductionPlaceholder"
           [editorStyle]="{ minHeight: '260px' }"
+          ariaLabelledBy="mentorship-mentor-introduction-label"
           dataTest="mentorship-mentor-introduction" />
         @if (errors().introduction) {
           <p role="alert" class="text-xs text-red-600" data-testid="mentorship-mentor-introduction-error">{{ errors().introduction }}</p>

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
@@ -1,6 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<p-confirmDialog />
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="mentorship-mentor-register">
   <div class="flex flex-col gap-6 mt-3">
     <header class="flex flex-col gap-2">
@@ -32,7 +33,7 @@
           [editorStyle]="{ minHeight: '260px' }"
           dataTest="mentorship-mentor-introduction" />
         @if (errors().introduction) {
-          <p class="text-xs text-red-600" data-testid="mentorship-mentor-introduction-error">{{ errors().introduction }}</p>
+          <p role="alert" class="text-xs text-red-600" data-testid="mentorship-mentor-introduction-error">{{ errors().introduction }}</p>
         }
       </div>
     </section>
@@ -68,7 +69,7 @@
         </div>
       </div>
       @if (errors().complianceAccepted) {
-        <p class="text-xs text-red-600" data-testid="mentorship-mentor-compliance-error">{{ errors().complianceAccepted }}</p>
+        <p role="alert" class="text-xs text-red-600" data-testid="mentorship-mentor-compliance-error">{{ errors().complianceAccepted }}</p>
       }
     </section>
 

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.html
@@ -1,0 +1,80 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="mentorship-mentor-register">
+  <div class="flex flex-col gap-6 mt-3">
+    <header class="flex flex-col gap-2">
+      <h1 class="font-display font-light text-2xl md:text-3xl text-gray-900" data-testid="mentorship-mentor-register-title">{{ title }}</h1>
+      <p class="max-w-3xl text-sm text-gray-600">{{ subtitle }}</p>
+    </header>
+
+    <lfx-mentorship-profile-card />
+
+    <lfx-mentorship-mentor-programs-section [programs]="programs()" [requests]="requests()" (add)="onAddProgram($event)" (withdraw)="onWithdraw($event)" />
+
+    <section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-6" data-testid="mentorship-mentor-introduction">
+      <div class="flex flex-col gap-2">
+        <h2 class="text-lg font-semibold text-gray-900">Introduction</h2>
+        <p class="text-sm text-gray-600">{{ introductionIntro }}</p>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <label class="text-sm font-medium text-gray-700">Tell us a little bit about yourself. <span class="text-red-500">*</span></label>
+        <lfx-rich-editor
+          [form]="form"
+          control="introduction"
+          [placeholder]="introductionPlaceholder"
+          [editorStyle]="{ minHeight: '260px' }"
+          dataTest="mentorship-mentor-introduction" />
+        @if (errors().introduction) {
+          <p class="text-xs text-red-600" data-testid="mentorship-mentor-introduction-error">{{ errors().introduction }}</p>
+        }
+      </div>
+    </section>
+
+    <section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-6" data-testid="mentorship-mentor-skills">
+      <div class="flex flex-col gap-2">
+        <h2 class="text-lg font-semibold text-gray-900">Skills</h2>
+        <p class="text-sm text-gray-600">{{ skillsIntro }}</p>
+      </div>
+
+      <lfx-mentorship-skills-picker [form]="form" label="Which of your skills should we feature?" idPrefix="mentorship-mentor" [error]="errors().skills" />
+    </section>
+
+    <lfx-mentorship-mentor-resume-section [form]="form" />
+
+    <section class="rounded-2xl border border-gray-200 bg-white p-6 md:p-8 flex flex-col gap-4" data-testid="mentorship-mentor-compliance">
+      <h2 class="text-lg font-semibold text-gray-900">Compliance Confirmation</h2>
+
+      <div class="flex items-start gap-3">
+        <lfx-checkbox
+          [form]="form"
+          control="complianceAccepted"
+          inputId="mentorship-mentor-compliance"
+          ariaLabelledBy="mentorship-mentor-compliance-text"
+          data-testid="mentorship-mentor-compliance-checkbox" />
+        <div id="mentorship-mentor-compliance-text" class="min-w-0 flex-1 flex flex-col gap-2">
+          <span class="text-sm text-gray-800 leading-5"> <span class="text-red-500">*</span> {{ complianceLead }} </span>
+          <ul class="list-disc pl-5 flex flex-col gap-2 text-sm text-gray-600 leading-5">
+            @for (item of complianceItems; track item) {
+              <li>{{ item }}</li>
+            }
+          </ul>
+        </div>
+      </div>
+      @if (errors().complianceAccepted) {
+        <p class="text-xs text-red-600" data-testid="mentorship-mentor-compliance-error">{{ errors().complianceAccepted }}</p>
+      }
+    </section>
+
+    <lfx-mentorship-terms-acknowledgement [form]="form" [intro]="termsIntro" idPrefix="mentorship-mentor" [error]="errors().termsAccepted" />
+
+    <div class="flex flex-col gap-4 pt-2 pb-8 md:flex-row md:items-end md:justify-between">
+      <p class="max-w-2xl text-xs text-gray-500 leading-5">{{ exportDisclaimer }}</p>
+      <div class="flex shrink-0 items-center justify-end gap-3">
+        <lfx-button label="Cancel" severity="secondary" size="small" [outlined]="true" [routerLink]="cancelRoute" data-testid="mentorship-mentor-cancel" />
+        <lfx-button label="Submit" severity="primary" size="small" (onClick)="onSubmit()" data-testid="mentorship-mentor-submit" />
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.spec.ts
@@ -7,6 +7,7 @@ import { FormGroup } from '@angular/forms';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { RichEditorComponent } from '@components/rich-editor/rich-editor.component';
+import { MENTORSHIP_COMING_SOON_DETAIL } from '@lfx-one/shared/constants';
 import { MentorshipMentorProgramRequest, MentorshipProgram, MentorshipProgramsResponse } from '@lfx-one/shared/interfaces';
 import { MentorshipService } from '@services/mentorship.service';
 import { UserService } from '@services/user.service';
@@ -30,6 +31,7 @@ class StubRichEditorComponent {
   public readonly control = input.required<string>();
   public readonly placeholder = input<string>('');
   public readonly editorStyle = input<Record<string, string>>({});
+  public readonly ariaLabelledBy = input<string>('');
   public readonly dataTest = input<string>();
 }
 
@@ -157,22 +159,27 @@ describe('MentorRegisterComponent', () => {
     expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'warn', detail: 'Please accept the terms and conditions.' });
   });
 
-  it('registers a mentor who has withdrawn from every program, since applying is optional', () => {
+  it('accepts a mentor who has withdrawn from every program, since applying is optional', () => {
     fillValidForm();
     component['requests'].set([]);
 
     component['onSubmit']();
 
-    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'success' });
+    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'info' });
   });
 
-  it('confirms submission once the form is complete', () => {
+  it('says submitting is not available yet rather than claiming the registration was sent', () => {
     fillValidForm();
 
     component['onSubmit']();
 
     expect(toast).toHaveBeenCalledTimes(1);
-    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'success' });
+    // Nothing is persisted, so a success toast here would be a false confirmation.
+    expect(toast.mock.calls[0][0]).toMatchObject({
+      severity: 'info',
+      summary: 'Submit mentor registration',
+      detail: MENTORSHIP_COMING_SOON_DETAIL,
+    });
     // Errors go back into hiding, so a second visit to the form starts clean.
     expect(component['errors']()).toEqual({});
   });

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.spec.ts
@@ -7,11 +7,10 @@ import { FormGroup } from '@angular/forms';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { RichEditorComponent } from '@components/rich-editor/rich-editor.component';
-import { MENTORSHIP_MENTOR_SEED_REQUESTS } from '@lfx-one/shared/constants';
-import { MentorshipProgram, MentorshipProgramsResponse } from '@lfx-one/shared/interfaces';
+import { MentorshipMentorProgramRequest, MentorshipProgram, MentorshipProgramsResponse } from '@lfx-one/shared/interfaces';
 import { MentorshipService } from '@services/mentorship.service';
 import { UserService } from '@services/user.service';
-import { MessageService } from 'primeng/api';
+import { Confirmation, ConfirmationService, MessageService } from 'primeng/api';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -49,9 +48,15 @@ describe('MentorRegisterComponent', () => {
 
   const programs: MentorshipProgramsResponse = { data: [program('mp_gridflow', 'GridFlow Ingestion')], total: 1 };
 
+  /** Stands in for requests the mentor already raised. The component itself starts empty. */
+  const existingRequests: MentorshipMentorProgramRequest[] = [
+    { id: 'req_gridflow', programId: 'mp_gridflow', programName: 'GridFlow Ingestion', status: 'accepted' },
+  ];
+
   let fixture: ComponentFixture<MentorRegisterComponent>;
   let component: MentorRegisterComponent;
   let toast: ReturnType<typeof vi.fn>;
+  let confirm: ReturnType<typeof vi.fn>;
 
   const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
   const errorText = (testId: string): string | null => element().querySelector(`[data-testid="${testId}"]`)?.textContent?.trim() ?? null;
@@ -98,6 +103,17 @@ describe('MentorRegisterComponent', () => {
 
     fixture = TestBed.createComponent(MentorRegisterComponent);
     component = fixture.componentInstance;
+
+    // Stand down only `confirm`, on the page's own instance: the rendered `<p-confirmDialog>`
+    // subscribes to the real service, so replacing the service wholesale breaks the dialog.
+    // Accept by default, so a spec that means to test the cancel path says so explicitly.
+    const confirmationService = fixture.debugElement.injector.get(ConfirmationService);
+    confirm = vi.fn((options: Confirmation) => {
+      options.accept?.();
+      return confirmationService;
+    });
+    confirmationService.confirm = confirm;
+
     fixture.detectChanges();
   });
 
@@ -114,8 +130,9 @@ describe('MentorRegisterComponent', () => {
     expect(sections.indexOf('mentorship-profile-card')).toBeLessThan(sections.indexOf('mentorship-mentor-programs'));
   });
 
-  it('seeds the mentor’s existing program requests', () => {
-    expect(component['requests']()).toEqual(MENTORSHIP_MENTOR_SEED_REQUESTS);
+  it('starts with no program requests, rather than showing requests the mentor never made', () => {
+    expect(component['requests']()).toEqual([]);
+    expect(element().querySelector('[data-testid^="mentorship-mentor-request-row-"]')).toBeNull();
   });
 
   it('keeps errors hidden until the mentor tries to submit', () => {
@@ -167,20 +184,31 @@ describe('MentorRegisterComponent', () => {
   });
 
   it('ignores a program already requested, so it cannot be queued twice', () => {
-    const before = component['requests']().length;
-    const [seeded] = component['requests']();
+    component['requests'].set([...existingRequests]);
+    const [existing] = existingRequests;
 
-    component['onAddProgram'](program(seeded.programId, seeded.programName));
+    component['onAddProgram'](program(existing.programId, existing.programName));
 
-    expect(component['requests']().length).toBe(before);
+    expect(component['requests']().length).toBe(existingRequests.length);
   });
 
-  it('drops a withdrawn request', () => {
-    const [seeded] = component['requests']();
+  it('drops a withdrawn request once the mentor confirms', () => {
+    component['requests'].set([...existingRequests]);
+    const [existing] = existingRequests;
 
-    component['onWithdraw'](seeded.id);
+    component['onWithdraw'](existing.id);
 
-    expect(component['requests']().some((request) => request.id === seeded.id)).toBe(false);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(component['requests']().some((request) => request.id === existing.id)).toBe(false);
+  });
+
+  it('keeps the request when the mentor backs out of the confirmation', () => {
+    confirm.mockImplementationOnce(() => undefined);
+    component['requests'].set([...existingRequests]);
+
+    component['onWithdraw'](existingRequests[0].id);
+
+    expect(component['requests']()).toEqual(existingRequests);
   });
 
   it('sends Cancel back to the mentorship admin page', () => {

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.spec.ts
@@ -1,0 +1,191 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { RichEditorComponent } from '@components/rich-editor/rich-editor.component';
+import { MENTORSHIP_MENTOR_SEED_REQUESTS } from '@lfx-one/shared/constants';
+import { MentorshipProgram, MentorshipProgramsResponse } from '@lfx-one/shared/interfaces';
+import { MentorshipService } from '@services/mentorship.service';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MentorRegisterComponent } from './mentor-register.component';
+
+/**
+ * The real editor lazy-loads TipTap and mounts it against `document` in `afterNextRender`,
+ * which the test environment tears down underneath it. The introduction field's behavior
+ * under test is the validation gate, not the editor, so stand it down here.
+ */
+@Component({
+  selector: 'lfx-rich-editor',
+  template: '',
+})
+class StubRichEditorComponent {
+  public readonly form = input.required<FormGroup>();
+  public readonly control = input.required<string>();
+  public readonly placeholder = input<string>('');
+  public readonly editorStyle = input<Record<string, string>>({});
+  public readonly dataTest = input<string>();
+}
+
+describe('MentorRegisterComponent', () => {
+  const program = (id: string, name: string): MentorshipProgram => ({
+    id,
+    slug: name.toLowerCase().replace(/\s+/g, '-'),
+    name,
+    projectName: 'LF Energy',
+    term: 'Fall 2026',
+    status: 'open',
+    stats: { mentors: 2, mentees: 1, graduated: 0 },
+    createdOn: '2026-05-01',
+    updatedOn: '2026-07-02',
+  });
+
+  const programs: MentorshipProgramsResponse = { data: [program('mp_gridflow', 'GridFlow Ingestion')], total: 1 };
+
+  let fixture: ComponentFixture<MentorRegisterComponent>;
+  let component: MentorRegisterComponent;
+  let toast: ReturnType<typeof vi.fn>;
+
+  const element = (): HTMLElement => fixture.nativeElement as HTMLElement;
+  const errorText = (testId: string): string | null => element().querySelector(`[data-testid="${testId}"]`)?.textContent?.trim() ?? null;
+
+  /** Fills every required field, so a spec can isolate the one it means to break. */
+  const fillValidForm = (): void => {
+    component['form'].patchValue({
+      introduction: '<p>Maintainer on two CNCF projects.</p>',
+      skills: ['Go'],
+      complianceAccepted: true,
+      termsAccepted: true,
+    });
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    toast = vi.fn();
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [MentorRegisterComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: MessageService, useValue: { add: toast } },
+        { provide: MentorshipService, useValue: { getPrograms: () => of(programs) } },
+        // The profile card at the top of the page fetches these three itself.
+        {
+          provide: UserService,
+          useValue: {
+            getCurrentUserProfile: () => of(null),
+            getUserEmails: () => of(null),
+            getIdentities: () => of([]),
+            effectiveAvatarUrl: () => '',
+          },
+        },
+      ],
+    });
+
+    await TestBed.overrideComponent(MentorRegisterComponent, {
+      remove: { imports: [RichEditorComponent] },
+      add: { imports: [StubRichEditorComponent] },
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MentorRegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('renders every section of the registration form', () => {
+    for (const section of ['programs', 'introduction', 'skills', 'resume', 'compliance']) {
+      expect(element().querySelector(`[data-testid="mentorship-mentor-${section}"]`)).not.toBeNull();
+    }
+    expect(element().querySelector('#mentorship-mentor-terms-text')).not.toBeNull();
+  });
+
+  it('leads with the LFX profile card, so the mentor sees what the admin will receive', () => {
+    const sections = [...element().querySelectorAll('[data-testid]')].map((node) => node.getAttribute('data-testid'));
+
+    expect(sections.indexOf('mentorship-profile-card')).toBeLessThan(sections.indexOf('mentorship-mentor-programs'));
+  });
+
+  it('seeds the mentor’s existing program requests', () => {
+    expect(component['requests']()).toEqual(MENTORSHIP_MENTOR_SEED_REQUESTS);
+  });
+
+  it('keeps errors hidden until the mentor tries to submit', () => {
+    // An empty form is invalid from the outset, but saying so before they act is noise.
+    expect(component['errors']()).toEqual({});
+    expect(errorText('mentorship-mentor-introduction-error')).toBeNull();
+
+    component['onSubmit']();
+    fixture.detectChanges();
+
+    expect(errorText('mentorship-mentor-introduction-error')).toBe('Introduction is required.');
+    expect(errorText('mentorship-mentor-compliance-error')).toBe('Please confirm the compliance statement.');
+  });
+
+  it('warns rather than succeeds when a required field is missing', () => {
+    fillValidForm();
+    component['form'].controls.termsAccepted.setValue(false);
+
+    component['onSubmit']();
+
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'warn', detail: 'Please accept the terms and conditions.' });
+  });
+
+  it('registers a mentor who has withdrawn from every program, since applying is optional', () => {
+    fillValidForm();
+    component['requests'].set([]);
+
+    component['onSubmit']();
+
+    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'success' });
+  });
+
+  it('confirms submission once the form is complete', () => {
+    fillValidForm();
+
+    component['onSubmit']();
+
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast.mock.calls[0][0]).toMatchObject({ severity: 'success' });
+    // Errors go back into hiding, so a second visit to the form starts clean.
+    expect(component['errors']()).toEqual({});
+  });
+
+  it('raises a pending request for a picked program', () => {
+    component['onAddProgram'](program('mp_gridflow', 'GridFlow Ingestion'));
+
+    expect(component['requests']().at(-1)).toMatchObject({ programId: 'mp_gridflow', programName: 'GridFlow Ingestion', status: 'pending' });
+  });
+
+  it('ignores a program already requested, so it cannot be queued twice', () => {
+    const before = component['requests']().length;
+    const [seeded] = component['requests']();
+
+    component['onAddProgram'](program(seeded.programId, seeded.programName));
+
+    expect(component['requests']().length).toBe(before);
+  });
+
+  it('drops a withdrawn request', () => {
+    const [seeded] = component['requests']();
+
+    component['onWithdraw'](seeded.id);
+
+    expect(component['requests']().some((request) => request.id === seeded.id)).toBe(false);
+  });
+
+  it('sends Cancel back to the mentorship admin page', () => {
+    const cancel = element().querySelector('[data-testid="mentorship-mentor-cancel"] a');
+
+    expect(cancel?.getAttribute('href')).toBe('/mentorship/admin');
+  });
+});

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
@@ -24,7 +24,7 @@ import { MentorshipMentorProgramRequest, MentorshipMentorRegisterForm, Mentorshi
 import { getMentorshipMentorRegisterErrors } from '@lfx-one/shared/utils';
 import { MentorshipService } from '@services/mentorship.service';
 import { MessageService } from 'primeng/api';
-import { catchError, map, of, startWith } from 'rxjs';
+import { map, startWith } from 'rxjs';
 
 import { ProfileCardComponent } from '../../components/profile-card/profile-card.component';
 import { SkillsPickerComponent } from '../../components/skills-picker/skills-picker.component';
@@ -86,7 +86,11 @@ export class MentorRegisterComponent {
   protected readonly requests = signal<MentorshipMentorProgramRequest[]>([...MENTORSHIP_MENTOR_SEED_REQUESTS]);
   protected readonly showErrors = signal(false);
 
-  protected readonly programs = this.initPrograms();
+  private readonly programsState = this.initPrograms();
+
+  protected readonly programs = computed(() => this.programsState().programs);
+  /** True until the first emission, so the picker shows a loading state instead of an empty list. */
+  protected readonly programsLoading = computed(() => this.programsState().loading);
 
   private readonly formSnapshot = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
     initialValue: this.form.getRawValue(),
@@ -121,14 +125,16 @@ export class MentorRegisterComponent {
     });
   }
 
+  /**
+   * `MentorshipService.getPrograms` already ends in its own `catchError` returning
+   * `EMPTY_MENTORSHIP_PROGRAMS_RESPONSE`, so this stream cannot error and needs no
+   * handler of its own. `loading` flips on the first emission — failure included —
+   * because either way the picker has all the options it is ever going to get.
+   */
   private initPrograms() {
-    return toSignal(
-      this.mentorshipService.getPrograms({ status: 'open' }).pipe(
-        map((response) => response.data),
-        catchError(() => of([] as MentorshipProgram[]))
-      ),
-      { initialValue: [] as MentorshipProgram[] }
-    );
+    return toSignal(this.mentorshipService.getPrograms({ status: 'open' }).pipe(map((response) => ({ programs: response.data, loading: false }))), {
+      initialValue: { programs: [] as MentorshipProgram[], loading: true },
+    });
   }
 
   private currentForm(): MentorshipMentorRegisterForm {

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
@@ -16,14 +16,15 @@ import {
   MENTORSHIP_MENTOR_INTRODUCTION_PLACEHOLDER,
   MENTORSHIP_MENTOR_REGISTER_SUBTITLE,
   MENTORSHIP_MENTOR_REGISTER_TITLE,
-  MENTORSHIP_MENTOR_SEED_REQUESTS,
   MENTORSHIP_MENTOR_SKILLS_INTRO,
   MENTORSHIP_MENTOR_TERMS_INTRO,
+  MENTORSHIP_MENTOR_WITHDRAW_CONFIRM,
 } from '@lfx-one/shared/constants';
 import { MentorshipMentorProgramRequest, MentorshipMentorRegisterForm, MentorshipProgram } from '@lfx-one/shared/interfaces';
 import { getMentorshipMentorRegisterErrors } from '@lfx-one/shared/utils';
 import { MentorshipService } from '@services/mentorship.service';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { map, startWith } from 'rxjs';
 
 import { ProfileCardComponent } from '../../components/profile-card/profile-card.component';
@@ -49,6 +50,7 @@ import { MentorResumeSectionComponent } from './components/mentor-resume-section
   imports: [
     ButtonComponent,
     CheckboxComponent,
+    ConfirmDialogModule,
     RichEditorComponent,
     MentorProgramsSectionComponent,
     MentorResumeSectionComponent,
@@ -56,12 +58,14 @@ import { MentorResumeSectionComponent } from './components/mentor-resume-section
     SkillsPickerComponent,
     TermsAcknowledgementComponent,
   ],
+  providers: [ConfirmationService],
   templateUrl: './mentor-register.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MentorRegisterComponent {
   private readonly mentorshipService = inject(MentorshipService);
   private readonly messageService = inject(MessageService);
+  private readonly confirmationService = inject(ConfirmationService);
 
   protected readonly title = MENTORSHIP_MENTOR_REGISTER_TITLE;
   protected readonly subtitle = MENTORSHIP_MENTOR_REGISTER_SUBTITLE;
@@ -82,8 +86,12 @@ export class MentorRegisterComponent {
     termsAccepted: new FormControl(false, { nonNullable: true }),
   });
 
-  /** Seeded with the mentor's existing requests; local until a registration API exists. */
-  protected readonly requests = signal<MentorshipMentorProgramRequest[]>([...MENTORSHIP_MENTOR_SEED_REQUESTS]);
+  /**
+   * The mentor's program requests. Starts empty and stays local: there is no endpoint to
+   * read existing requests from yet, and standing in fake rows would show the mentor
+   * requests they never made.
+   */
+  protected readonly requests = signal<MentorshipMentorProgramRequest[]>([]);
   protected readonly showErrors = signal(false);
 
   private readonly programsState = this.initPrograms();
@@ -104,7 +112,20 @@ export class MentorRegisterComponent {
   }
 
   protected onWithdraw(requestId: string): void {
-    this.requests.update((requests) => requests.filter((request) => request.id !== requestId));
+    // Confirm first, as the enroll wizard does for deleting a term: an accepted request is
+    // not something to drop on a stray click, and this is where the withdraw call will land.
+    this.confirmationService.confirm({
+      header: 'Withdraw Request',
+      message: MENTORSHIP_MENTOR_WITHDRAW_CONFIRM,
+      icon: 'fa-light fa-triangle-exclamation',
+      acceptLabel: 'Withdraw',
+      rejectLabel: 'Cancel',
+      acceptButtonStyleClass: 'p-button-sm p-button-danger',
+      rejectButtonStyleClass: 'p-button-secondary p-button-sm p-button-outlined',
+      accept: () => {
+        this.requests.update((requests) => requests.filter((request) => request.id !== requestId));
+      },
+    });
   }
 
   protected onSubmit(): void {

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+import { RichEditorComponent } from '@components/rich-editor/rich-editor.component';
+import {
+  createEmptyMentorshipMentorForm,
+  MENTORSHIP_MENTOR_COMPLIANCE_ITEMS,
+  MENTORSHIP_MENTOR_COMPLIANCE_LEAD,
+  MENTORSHIP_MENTOR_EXPORT_DISCLAIMER,
+  MENTORSHIP_MENTOR_INTRODUCTION_INTRO,
+  MENTORSHIP_MENTOR_INTRODUCTION_PLACEHOLDER,
+  MENTORSHIP_MENTOR_REGISTER_SUBTITLE,
+  MENTORSHIP_MENTOR_REGISTER_TITLE,
+  MENTORSHIP_MENTOR_SEED_REQUESTS,
+  MENTORSHIP_MENTOR_SKILLS_INTRO,
+  MENTORSHIP_MENTOR_TERMS_INTRO,
+} from '@lfx-one/shared/constants';
+import { MentorshipMentorProgramRequest, MentorshipMentorRegisterForm, MentorshipProgram } from '@lfx-one/shared/interfaces';
+import { getMentorshipMentorRegisterErrors } from '@lfx-one/shared/utils';
+import { MentorshipService } from '@services/mentorship.service';
+import { MessageService } from 'primeng/api';
+import { catchError, map, of, startWith } from 'rxjs';
+
+import { ProfileCardComponent } from '../../components/profile-card/profile-card.component';
+import { SkillsPickerComponent } from '../../components/skills-picker/skills-picker.component';
+import { TermsAcknowledgementComponent } from '../../components/terms-acknowledgement/terms-acknowledgement.component';
+import { MentorProgramsSectionComponent } from './components/mentor-programs-section/mentor-programs-section.component';
+import { MentorResumeSectionComponent } from './components/mentor-resume-section/mentor-resume-section.component';
+
+/**
+ * Become a Mentor registration form. Ported from menv3 `mentor-register`.
+ *
+ * This is the mentor landing page for now. Once the profiles API can say whether the
+ * signed-in user already holds a mentor profile, the route keeps its path and serves the
+ * mentor's own landing page instead, falling back to this form when they have none.
+ *
+ * Validation follows the enroll wizard: one parent FormGroup, error text derived in
+ * `@lfx-one/shared/utils`, and errors kept hidden behind `showErrors` until the mentor
+ * actually tries to submit. There is no registration endpoint yet, so submit stops at a
+ * toast; the program requests and the resume file name are local state either way.
+ */
+@Component({
+  selector: 'lfx-mentorship-mentor-register',
+  imports: [
+    ButtonComponent,
+    CheckboxComponent,
+    RichEditorComponent,
+    MentorProgramsSectionComponent,
+    MentorResumeSectionComponent,
+    ProfileCardComponent,
+    SkillsPickerComponent,
+    TermsAcknowledgementComponent,
+  ],
+  templateUrl: './mentor-register.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MentorRegisterComponent {
+  private readonly mentorshipService = inject(MentorshipService);
+  private readonly messageService = inject(MessageService);
+
+  protected readonly title = MENTORSHIP_MENTOR_REGISTER_TITLE;
+  protected readonly subtitle = MENTORSHIP_MENTOR_REGISTER_SUBTITLE;
+  protected readonly introductionIntro = MENTORSHIP_MENTOR_INTRODUCTION_INTRO;
+  protected readonly introductionPlaceholder = MENTORSHIP_MENTOR_INTRODUCTION_PLACEHOLDER;
+  protected readonly skillsIntro = MENTORSHIP_MENTOR_SKILLS_INTRO;
+  protected readonly complianceLead = MENTORSHIP_MENTOR_COMPLIANCE_LEAD;
+  protected readonly complianceItems = MENTORSHIP_MENTOR_COMPLIANCE_ITEMS;
+  protected readonly termsIntro = MENTORSHIP_MENTOR_TERMS_INTRO;
+  protected readonly exportDisclaimer = MENTORSHIP_MENTOR_EXPORT_DISCLAIMER;
+  protected readonly cancelRoute = '/mentorship/admin';
+
+  protected readonly form = new FormGroup({
+    introduction: new FormControl('', { nonNullable: true }),
+    skills: new FormControl<string[]>([], { nonNullable: true }),
+    resumeFileName: new FormControl('', { nonNullable: true }),
+    complianceAccepted: new FormControl(false, { nonNullable: true }),
+    termsAccepted: new FormControl(false, { nonNullable: true }),
+  });
+
+  /** Seeded with the mentor's existing requests; local until a registration API exists. */
+  protected readonly requests = signal<MentorshipMentorProgramRequest[]>([...MENTORSHIP_MENTOR_SEED_REQUESTS]);
+  protected readonly showErrors = signal(false);
+
+  protected readonly programs = this.initPrograms();
+
+  private readonly formSnapshot = toSignal(this.form.valueChanges.pipe(startWith(this.form.getRawValue())), {
+    initialValue: this.form.getRawValue(),
+  });
+
+  protected readonly errors = computed(() => (this.showErrors() ? getMentorshipMentorRegisterErrors(this.currentForm()) : {}));
+
+  protected onAddProgram(program: MentorshipProgram): void {
+    if (this.requests().some((request) => request.programId === program.id)) return;
+    this.requests.update((requests) => [...requests, { id: `req_${program.id}`, programId: program.id, programName: program.name, status: 'pending' }]);
+  }
+
+  protected onWithdraw(requestId: string): void {
+    this.requests.update((requests) => requests.filter((request) => request.id !== requestId));
+  }
+
+  protected onSubmit(): void {
+    const errors = getMentorshipMentorRegisterErrors(this.currentForm());
+    const firstError = Object.values(errors)[0];
+    if (firstError) {
+      this.showErrors.set(true);
+      this.messageService.add({ severity: 'warn', summary: 'Check your registration', detail: firstError, life: 4000 });
+      return;
+    }
+
+    this.showErrors.set(false);
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Registration submitted',
+      detail: 'Your mentor registration was submitted and each program admin has been notified.',
+      life: 5000,
+    });
+  }
+
+  private initPrograms() {
+    return toSignal(
+      this.mentorshipService.getPrograms({ status: 'open' }).pipe(
+        map((response) => response.data),
+        catchError(() => of([] as MentorshipProgram[]))
+      ),
+      { initialValue: [] as MentorshipProgram[] }
+    );
+  }
+
+  private currentForm(): MentorshipMentorRegisterForm {
+    // Read the snapshot first so `errors` recomputes as the mentor types.
+    this.formSnapshot();
+    return { ...createEmptyMentorshipMentorForm(), ...this.form.getRawValue() };
+  }
+}

--- a/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentor/mentor-register/mentor-register.component.ts
@@ -30,6 +30,7 @@ import { map, startWith } from 'rxjs';
 import { ProfileCardComponent } from '../../components/profile-card/profile-card.component';
 import { SkillsPickerComponent } from '../../components/skills-picker/skills-picker.component';
 import { TermsAcknowledgementComponent } from '../../components/terms-acknowledgement/terms-acknowledgement.component';
+import { MentorshipComingSoonService } from '../../services/mentorship-coming-soon.service';
 import { MentorProgramsSectionComponent } from './components/mentor-programs-section/mentor-programs-section.component';
 import { MentorResumeSectionComponent } from './components/mentor-resume-section/mentor-resume-section.component';
 
@@ -42,8 +43,9 @@ import { MentorResumeSectionComponent } from './components/mentor-resume-section
  *
  * Validation follows the enroll wizard: one parent FormGroup, error text derived in
  * `@lfx-one/shared/utils`, and errors kept hidden behind `showErrors` until the mentor
- * actually tries to submit. There is no registration endpoint yet, so submit stops at a
- * toast; the program requests and the resume file name are local state either way.
+ * actually tries to submit. There is no registration endpoint yet, so a complete form stops
+ * at the module's coming-soon toast rather than claiming it was submitted; the program
+ * requests and the resume file name are local state either way.
  */
 @Component({
   selector: 'lfx-mentorship-mentor-register',
@@ -66,6 +68,7 @@ export class MentorRegisterComponent {
   private readonly mentorshipService = inject(MentorshipService);
   private readonly messageService = inject(MessageService);
   private readonly confirmationService = inject(ConfirmationService);
+  private readonly comingSoon = inject(MentorshipComingSoonService);
 
   protected readonly title = MENTORSHIP_MENTOR_REGISTER_TITLE;
   protected readonly subtitle = MENTORSHIP_MENTOR_REGISTER_SUBTITLE;
@@ -138,12 +141,9 @@ export class MentorRegisterComponent {
     }
 
     this.showErrors.set(false);
-    this.messageService.add({
-      severity: 'success',
-      summary: 'Registration submitted',
-      detail: 'Your mentor registration was submitted and each program admin has been notified.',
-      life: 5000,
-    });
+    // Nothing is persisted yet, so this cannot claim the registration was submitted. The
+    // module's coming-soon toast is what every other stubbed mentorship write says.
+    this.comingSoon.notify('Submit mentor registration');
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/mentorship/mentorship.routes.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentorship.routes.ts
@@ -21,4 +21,10 @@ export const MENTORSHIP_ROUTES: Routes = [
     path: 'admin/:programId',
     loadComponent: () => import('./admin/program-detail/program-detail.component').then((m) => m.ProgramDetailComponent),
   },
+  {
+    // Serves the Become a Mentor form until the profiles API can tell us the signed-in
+    // user already has a mentor profile, at which point this path serves that instead.
+    path: 'mentor',
+    loadComponent: () => import('./mentor/mentor-register/mentor-register.component').then((m) => m.MentorRegisterComponent),
+  },
 ];

--- a/apps/lfx-one/src/app/modules/mentorship/services/mentorship-coming-soon.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/services/mentorship-coming-soon.service.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { TestBed } from '@angular/core/testing';
-import { MENTORSHIP_COMING_SOON_TOAST_LIFE, MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
+import { MENTORSHIP_COMING_SOON_DETAIL, MENTORSHIP_COMING_SOON_TOAST_LIFE } from '@lfx-one/shared/constants';
 import { MessageService } from 'primeng/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -29,7 +29,7 @@ describe('MentorshipComingSoonService', () => {
     expect(add).toHaveBeenCalledWith({
       severity: 'info',
       summary: 'Decline Alex Rivera',
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      detail: MENTORSHIP_COMING_SOON_DETAIL,
       life: MENTORSHIP_COMING_SOON_TOAST_LIFE,
     });
   });

--- a/apps/lfx-one/src/app/modules/mentorship/services/mentorship-coming-soon.service.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/services/mentorship-coming-soon.service.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import { inject, Injectable } from '@angular/core';
-import { MENTORSHIP_COMING_SOON_TOAST_LIFE, MENTORSHIP_PROGRAM_DETAIL_COMING_SOON } from '@lfx-one/shared/constants';
+import { MENTORSHIP_COMING_SOON_DETAIL, MENTORSHIP_COMING_SOON_TOAST_LIFE } from '@lfx-one/shared/constants';
 import { MessageService } from 'primeng/api';
 
 /**
- * Every write action on the program-detail tabs is stubbed until the mentorship service
- * exists. One place to say so, rather than the same toast payload in each tab — delete
- * this along with the last caller once the endpoints land.
+ * Every write action across the mentorship module — the program-detail tabs and the
+ * mentor-facing pages alike — is stubbed until the mentorship service exists. One place
+ * to say so, rather than the same toast payload at each call site; delete this along with
+ * the last caller once the endpoints land.
  */
 @Injectable({ providedIn: 'root' })
 export class MentorshipComingSoonService {
@@ -19,7 +20,7 @@ export class MentorshipComingSoonService {
     this.messageService.add({
       severity: 'info',
       summary,
-      detail: MENTORSHIP_PROGRAM_DETAIL_COMING_SOON,
+      detail: MENTORSHIP_COMING_SOON_DETAIL,
       life: MENTORSHIP_COMING_SOON_TOAST_LIFE,
     });
   }

--- a/apps/lfx-one/src/app/shared/components/rich-editor/rich-editor.component.ts
+++ b/apps/lfx-one/src/app/shared/components/rich-editor/rich-editor.component.ts
@@ -29,6 +29,12 @@ export class RichEditorComponent {
   public readonly editorStyle = input<Record<string, string>>({ minHeight: '320px' });
   public readonly readonly = input<boolean>(false);
   public readonly dataTest = input<string>();
+  /**
+   * Id of the element naming this editor, usually the visible `<label>` above it. A `<label for>`
+   * cannot name TipTap's `contenteditable`, so without this a screen reader reaches the editor
+   * with no name at all. Omitted from the DOM when unset, leaving existing call sites untouched.
+   */
+  public readonly ariaLabelledBy = input<string>('');
 
   // viewChild for the editor mount point
   protected readonly editorHost = viewChild.required<ElementRef<HTMLDivElement>>('editorHost');
@@ -135,6 +141,7 @@ export class RichEditorComponent {
         attributes: {
           class: 'lfx-rich-editor__content max-w-none focus:outline-none',
           'data-testid': this.dataTest() ?? '',
+          ...(this.ariaLabelledBy() ? { 'aria-labelledby': this.ariaLabelledBy() } : {}),
         },
         transformPastedHTML: (html: string) => cleanPastedHtml(html),
       },

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -263,6 +263,11 @@ export class SidebarNavService {
           icon: 'fa-solid fa-shield-halved',
           routerLink: '/mentorship/admin',
         },
+        {
+          label: 'Mentor',
+          icon: 'fa-solid fa-user-graduate',
+          routerLink: '/mentorship/mentor',
+        },
       ],
     },
   ];

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -81,6 +81,8 @@ export * from './akrites.constants';
 export * from './crowdfunding.constants';
 export * from './mentorship.constants';
 export * from './mentorship-enroll.constants';
+export * from './mentorship-lfx-profile-card.constants';
+export * from './mentorship-mentor.constants';
 export * from './mentorship-program-detail.constants';
 export * from './mktg-os-agents.constants';
 export * from './mktg-run.constants';

--- a/packages/shared/src/constants/mentorship-lfx-profile-card.constants.ts
+++ b/packages/shared/src/constants/mentorship-lfx-profile-card.constants.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export const LFX_PROFILE_CARD_TITLE = 'From Your LFX Profile';
+export const LFX_PROFILE_CARD_SUBTITLE = 'Your name, avatar, email, mailing address, phone number and connected accounts are used from your LFX account.';
+export const LFX_PROFILE_CARD_EDIT_LABEL = 'Edit LFX Profile';
+export const LFX_PROFILE_CARD_PRIMARY_BADGE = 'Primary';
+
+/** Shown in place of a field the profile has not filled in. */
+export const LFX_PROFILE_CARD_EMPTY = 'Not provided';
+
+/**
+ * The card's labelled fields, in the order the design lays them out across two
+ * columns. Name and emails are deliberately absent: they sit unlabelled beside
+ * the avatar rather than in this grid.
+ */
+export const LFX_PROFILE_CARD_LABELS = {
+  address: 'Mailing Address',
+  phone: 'Phone',
+  github: 'GitHub',
+  linkedin: 'LinkedIn',
+} as const;
+
+/**
+ * How a stored platform handle becomes a link. `host` doubles as the visible
+ * label prefix, so the card reads `github.com/octocat` rather than a bare
+ * handle; `path` is the segment LinkedIn requires before the handle.
+ */
+export const LFX_PROFILE_SOCIAL_LINKS = {
+  github: { host: 'github.com', path: '' },
+  linkedin: { host: 'linkedin.com', path: 'in/' },
+} as const;

--- a/packages/shared/src/constants/mentorship-mentor.constants.ts
+++ b/packages/shared/src/constants/mentorship-mentor.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { MentorshipMentorProgramRequest, MentorshipMentorRegisterForm, MentorshipMentorStatus } from '../interfaces/mentorship.interface';
+import type { MentorshipMentorRegisterForm, MentorshipMentorStatus } from '../interfaces/mentorship.interface';
 import { MENTORSHIP_MENTOR_STATUS_LABELS } from './mentorship.constants';
 
 export const MENTORSHIP_MENTOR_REGISTER_TITLE = 'Become a Mentor';
@@ -18,6 +18,9 @@ export const MENTORSHIP_MENTOR_INTRODUCTION_PLACEHOLDER = `What is your current 
 Why are you interested in volunteering as a mentor?
 
 Tell us something that makes you unique.`;
+
+/** Matches `MENTORSHIP_ENROLL_DESCRIPTION_MAX`, since both feed the same kind of rich-text field. */
+export const MENTORSHIP_MENTOR_INTRODUCTION_MAX = 3000;
 
 export const MENTORSHIP_MENTOR_SKILLS_INTRO = 'What are the skills that you are respected and known for? This helps match you with the right candidates.';
 
@@ -51,10 +54,18 @@ const RESUME_DOTTED = MENTORSHIP_MENTOR_RESUME_EXTENSIONS.map((extension) => `.$
 const RESUME_UPPERCASE = MENTORSHIP_MENTOR_RESUME_EXTENSIONS.map((extension) => extension.toUpperCase());
 
 /**
- * The `accept` filter for the hidden file input. Carries `application/pdf` alongside the
- * extensions because macOS Finder filters on MIME type rather than suffix.
+ * MIME type per accepted format, because macOS Finder filters on MIME type rather than
+ * suffix. Typed against the extension list so a new format cannot be added there without
+ * a type on this side too — leaving one out is what made Word documents unselectable.
  */
-export const MENTORSHIP_MENTOR_RESUME_ACCEPT = [...RESUME_DOTTED, 'application/pdf'].join(',');
+const RESUME_MIME_TYPES: Record<(typeof MENTORSHIP_MENTOR_RESUME_EXTENSIONS)[number], string> = {
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+};
+
+/** The `accept` filter for the hidden file input: every extension and its MIME type. */
+export const MENTORSHIP_MENTOR_RESUME_ACCEPT = [...RESUME_DOTTED, ...Object.values(RESUME_MIME_TYPES)].join(',');
 
 export const MENTORSHIP_MENTOR_RESUME_HELPER = `File type: ${RESUME_UPPERCASE.join(', ')} · Max size: ${RESUME_MAX_MB} MB`;
 export const MENTORSHIP_MENTOR_RESUME_TYPE_ERROR = `Please upload a ${RESUME_UPPERCASE.slice(0, -1).join(', ')}, or ${RESUME_UPPERCASE.at(-1)} file.`;
@@ -73,11 +84,7 @@ export const MENTORSHIP_MENTOR_REQUEST_STATUS_LABELS: Record<MentorshipMentorSta
   pending: 'Pending',
 };
 
-/** Seed rows standing in for the mentor's existing requests until the API lands. */
-export const MENTORSHIP_MENTOR_SEED_REQUESTS: MentorshipMentorProgramRequest[] = [
-  { id: 'req_1', programId: 'mp_kubernetes_contributors', programName: 'Kubernetes Contributors', status: 'accepted' },
-  { id: 'req_2', programId: 'mp_apicurio_registry', programName: 'Apicurio Registry: Prompt Template Playground', status: 'pending' },
-];
+export const MENTORSHIP_MENTOR_WITHDRAW_CONFIRM = 'Are you sure you want to withdraw this request?';
 
 export function createEmptyMentorshipMentorForm(): MentorshipMentorRegisterForm {
   return {

--- a/packages/shared/src/constants/mentorship-mentor.constants.ts
+++ b/packages/shared/src/constants/mentorship-mentor.constants.ts
@@ -1,0 +1,74 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { MentorshipMentorProgramRequest, MentorshipMentorRegisterForm, MentorshipMentorStatus } from '../interfaces/mentorship.interface';
+import { MENTORSHIP_MENTOR_STATUS_LABELS } from './mentorship.constants';
+
+export const MENTORSHIP_MENTOR_REGISTER_TITLE = 'Become a Mentor';
+export const MENTORSHIP_MENTOR_REGISTER_SUBTITLE = 'Register as a mentor and request to join the programs you want to support. Fields marked * are required.';
+
+export const MENTORSHIP_MENTOR_PROGRAMS_INTRO =
+  'Select the LFX mentorship you would like to join as a mentor, and the program administrator will be notified of your request.';
+export const MENTORSHIP_MENTOR_PROGRAMS_HELPER = 'Selecting a program sends a request to its administrator. You can request more than one.';
+
+export const MENTORSHIP_MENTOR_INTRODUCTION_INTRO =
+  'This information is displayed on your mentor profile page. Your name, email and avatar come from your LFX account.';
+export const MENTORSHIP_MENTOR_INTRODUCTION_PLACEHOLDER = `What is your current contributor status (i.e., experience in contributing to or maintaining open source projects, open source contributions)?
+
+Why are you interested in volunteering as a mentor?
+
+Tell us something that makes you unique.`;
+
+export const MENTORSHIP_MENTOR_SKILLS_INTRO = 'What are the skills that you are respected and known for? This helps match you with the right candidates.';
+
+export const MENTORSHIP_MENTOR_RESUME_INTRO = 'Optional, but candidates often look you up before applying.';
+
+export const MENTORSHIP_MENTOR_TERMS_INTRO =
+  'Before you submit your mentor registration to the LFX Platform, review and accept the terms and conditions below.';
+
+export const MENTORSHIP_MENTOR_EXPORT_DISCLAIMER =
+  'At this moment we are not accepting applications from a person or entity restricted by U.S. export controls or sanction programs, or a resident of Cuba, Iran, North Korea, Syria, Sudan, Russian Federation or Crimea region of Ukraine.';
+
+export const MENTORSHIP_MENTOR_COMPLIANCE_LEAD = 'I hereby certify that I am not, and/or the organization I am representing is not:';
+
+export const MENTORSHIP_MENTOR_COMPLIANCE_ITEMS: readonly string[] = [
+  'located in Cuba, Iran, North Korea, Syria, the Crimea Region of Ukraine, or the Russian-controlled areas of the Donetsk or Luhansk regions of Ukraine;',
+  'owned or controlled by, acting for or on behalf of, or an individual or entity that has in the past acted for or on behalf of the Government of Cuba, Iran, North Korea, Syria, or Venezuela; or',
+  "listed as a blocked person by the U.S. Department of the Treasury's Office of Foreign Assets Control (OFAC), or directly or indirectly owned 50 percent or more by such a listed person.",
+];
+
+export const MENTORSHIP_MENTOR_RESUME_ACCEPT = '.pdf,.doc,.docx,application/pdf';
+export const MENTORSHIP_MENTOR_RESUME_EXTENSIONS = ['pdf', 'doc', 'docx'] as const;
+export const MENTORSHIP_MENTOR_RESUME_MAX_BYTES = 10 * 1024 * 1024;
+export const MENTORSHIP_MENTOR_RESUME_HELPER = 'File type: PDF, .DOC, .DOCX · Max size: 10 MB';
+export const MENTORSHIP_MENTOR_RESUME_TYPE_ERROR = 'Please upload a PDF, DOC, or DOCX file.';
+export const MENTORSHIP_MENTOR_RESUME_SIZE_ERROR = 'File must be 10 MB or smaller.';
+export const MENTORSHIP_MENTOR_RESUME_EMPTY_LABEL = 'Choose file';
+
+/**
+ * Request statuses as the mentor sees them. Spread from the admin labels so the two can
+ * only differ where this file says so, and reuse
+ * `MENTORSHIP_MENTOR_STATUS_BADGE_CLASSES` for the colors.
+ */
+export const MENTORSHIP_MENTOR_REQUEST_STATUS_LABELS: Record<MentorshipMentorStatus, string> = {
+  ...MENTORSHIP_MENTOR_STATUS_LABELS,
+  // The admin tab reads "Invited" because the admin sent the invitation. The same status
+  // also covers a request the mentor raised themselves, so from this side it stays neutral.
+  pending: 'Pending',
+};
+
+/** Seed rows standing in for the mentor's existing requests until the API lands. */
+export const MENTORSHIP_MENTOR_SEED_REQUESTS: MentorshipMentorProgramRequest[] = [
+  { id: 'req_1', programId: 'mp_kubernetes_contributors', programName: 'Kubernetes Contributors', status: 'accepted' },
+  { id: 'req_2', programId: 'mp_apicurio_registry', programName: 'Apicurio Registry: Prompt Template Playground', status: 'pending' },
+];
+
+export function createEmptyMentorshipMentorForm(): MentorshipMentorRegisterForm {
+  return {
+    introduction: '',
+    skills: [],
+    resumeFileName: '',
+    complianceAccepted: false,
+    termsAccepted: false,
+  };
+}

--- a/packages/shared/src/constants/mentorship-mentor.constants.ts
+++ b/packages/shared/src/constants/mentorship-mentor.constants.ts
@@ -37,12 +37,28 @@ export const MENTORSHIP_MENTOR_COMPLIANCE_ITEMS: readonly string[] = [
   "listed as a blocked person by the U.S. Department of the Treasury's Office of Foreign Assets Control (OFAC), or directly or indirectly owned 50 percent or more by such a listed person.",
 ];
 
-export const MENTORSHIP_MENTOR_RESUME_ACCEPT = '.pdf,.doc,.docx,application/pdf';
+/**
+ * The accepted resume formats, and the single source the rest of this block derives
+ * from. `isMentorshipResumeFileName` validates against this list, so adding a format
+ * here reaches the validator, the file-picker filter, and both user-facing strings at
+ * once rather than leaving three of them behind.
+ */
 export const MENTORSHIP_MENTOR_RESUME_EXTENSIONS = ['pdf', 'doc', 'docx'] as const;
 export const MENTORSHIP_MENTOR_RESUME_MAX_BYTES = 10 * 1024 * 1024;
-export const MENTORSHIP_MENTOR_RESUME_HELPER = 'File type: PDF, .DOC, .DOCX · Max size: 10 MB';
-export const MENTORSHIP_MENTOR_RESUME_TYPE_ERROR = 'Please upload a PDF, DOC, or DOCX file.';
-export const MENTORSHIP_MENTOR_RESUME_SIZE_ERROR = 'File must be 10 MB or smaller.';
+
+const RESUME_MAX_MB = MENTORSHIP_MENTOR_RESUME_MAX_BYTES / (1024 * 1024);
+const RESUME_DOTTED = MENTORSHIP_MENTOR_RESUME_EXTENSIONS.map((extension) => `.${extension}`);
+const RESUME_UPPERCASE = MENTORSHIP_MENTOR_RESUME_EXTENSIONS.map((extension) => extension.toUpperCase());
+
+/**
+ * The `accept` filter for the hidden file input. Carries `application/pdf` alongside the
+ * extensions because macOS Finder filters on MIME type rather than suffix.
+ */
+export const MENTORSHIP_MENTOR_RESUME_ACCEPT = [...RESUME_DOTTED, 'application/pdf'].join(',');
+
+export const MENTORSHIP_MENTOR_RESUME_HELPER = `File type: ${RESUME_UPPERCASE.join(', ')} · Max size: ${RESUME_MAX_MB} MB`;
+export const MENTORSHIP_MENTOR_RESUME_TYPE_ERROR = `Please upload a ${RESUME_UPPERCASE.slice(0, -1).join(', ')}, or ${RESUME_UPPERCASE.at(-1)} file.`;
+export const MENTORSHIP_MENTOR_RESUME_SIZE_ERROR = `File must be ${RESUME_MAX_MB} MB or smaller.`;
 export const MENTORSHIP_MENTOR_RESUME_EMPTY_LABEL = 'Choose file';
 
 /**

--- a/packages/shared/src/constants/mentorship-mentor.constants.ts
+++ b/packages/shared/src/constants/mentorship-mentor.constants.ts
@@ -7,9 +7,14 @@ import { MENTORSHIP_MENTOR_STATUS_LABELS } from './mentorship.constants';
 export const MENTORSHIP_MENTOR_REGISTER_TITLE = 'Become a Mentor';
 export const MENTORSHIP_MENTOR_REGISTER_SUBTITLE = 'Register as a mentor and request to join the programs you want to support. Fields marked * are required.';
 
-export const MENTORSHIP_MENTOR_PROGRAMS_INTRO =
-  'Select the LFX mentorship you would like to join as a mentor, and the program administrator will be notified of your request.';
-export const MENTORSHIP_MENTOR_PROGRAMS_HELPER = 'Selecting a program sends a request to its administrator. You can request more than one.';
+/**
+ * Both strings stop short of promising that anything was sent: selections live on this page
+ * until the registration endpoint exists, so copy claiming an administrator had been notified
+ * would be a false confirmation. Reword them once the POST lands.
+ */
+export const MENTORSHIP_MENTOR_PROGRAMS_INTRO = 'Choose the LFX mentorships you would like to join as a mentor. Your choices are listed below.';
+export const MENTORSHIP_MENTOR_PROGRAMS_HELPER =
+  'You can choose more than one. Nothing is sent to a program administrator yet — requesting to join is not available in this release.';
 
 export const MENTORSHIP_MENTOR_INTRODUCTION_INTRO =
   'This information is displayed on your mentor profile page. Your name, email and avatar come from your LFX account.';

--- a/packages/shared/src/constants/mentorship.constants.ts
+++ b/packages/shared/src/constants/mentorship.constants.ts
@@ -218,7 +218,7 @@ export const MENTORSHIP_TERM_ROW_STATUS_BADGE_CLASSES: Record<MentorshipTermRowS
   closed: 'bg-gray-100 text-gray-600',
 };
 
-export const MENTORSHIP_PROGRAM_DETAIL_COMING_SOON = 'This action is not available yet.';
+export const MENTORSHIP_COMING_SOON_DETAIL = 'This action is not available yet.';
 
 export const MENTORSHIP_TERM_SHOULD_CLOSE_WARNING = 'This term should be closed because it has ended. Please close it to prevent new applications.';
 export const MENTORSHIP_TERM_CANNOT_CLOSE_MESSAGE =

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -284,6 +284,7 @@ export * from './crowdfunding.interface';
 
 // Mentorship interfaces
 export * from './mentorship.interface';
+export * from './mentorship-lfx-profile-card.interface';
 
 // EasyCLA "CLAs" interfaces (Me lens)
 export * from './cla.interface';

--- a/packages/shared/src/interfaces/mentorship-lfx-profile-card.interface.ts
+++ b/packages/shared/src/interfaces/mentorship-lfx-profile-card.interface.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * One address on the "From Your LFX Profile" card. `isPrimary` marks the
+ * address auth-service returns as `primary_email`; the rest are alternates.
+ */
+export interface LfxProfileEmail {
+  email: string;
+  isPrimary: boolean;
+}
+
+/**
+ * A linked external profile, ready to render as an anchor: `label` is the
+ * host-qualified handle shown to the user (`github.com/octocat`) and `url` is
+ * where it points.
+ */
+export interface LfxProfileLink {
+  label: string;
+  url: string;
+}
+
+/** The external platforms the LFX profile card links out to. */
+export type LfxProfileSocialProvider = 'github' | 'linkedin';
+
+/**
+ * Read-only projection of the signed-in user's LFX profile, as shown by the
+ * "From Your LFX Profile" card. Assembled by `buildLfxProfileSummary` from the
+ * three sources that own these fields — the profile, the email list, and the
+ * connected identities — so the card holds no derivation logic of its own.
+ *
+ * Every field is display-ready: missing data is an empty string, empty array,
+ * or null, and the card renders its own placeholder for those. Initials and the
+ * avatar's fallback color are absent by design; `lfx-person-avatar` derives both
+ * from `name` so every avatar in the app picks the same color for a person.
+ */
+export interface LfxProfileSummary {
+  name: string;
+  avatarUrl: string;
+  emails: LfxProfileEmail[];
+  addressLines: string[];
+  phone: string;
+  github: LfxProfileLink | null;
+  linkedin: LfxProfileLink | null;
+}

--- a/packages/shared/src/interfaces/mentorship-lfx-profile-card.interface.ts
+++ b/packages/shared/src/interfaces/mentorship-lfx-profile-card.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { LFX_PROFILE_SOCIAL_LINKS } from '../constants/mentorship-lfx-profile-card.constants';
+
 /**
  * One address on the "From Your LFX Profile" card. `isPrimary` marks the
  * address auth-service returns as `primary_email`; the rest are alternates.
@@ -21,7 +23,7 @@ export interface LfxProfileLink {
 }
 
 /** The external platforms the LFX profile card links out to. */
-export type LfxProfileSocialProvider = 'github' | 'linkedin';
+export type LfxProfileSocialProvider = keyof typeof LFX_PROFILE_SOCIAL_LINKS;
 
 /**
  * Read-only projection of the signed-in user's LFX profile, as shown by the
@@ -30,9 +32,9 @@ export type LfxProfileSocialProvider = 'github' | 'linkedin';
  * connected identities — so the card holds no derivation logic of its own.
  *
  * Every field is display-ready: missing data is an empty string, empty array,
- * or null, and the card renders its own placeholder for those. Initials and the
- * avatar's fallback color are absent by design; `lfx-person-avatar` derives both
- * from `name` so every avatar in the app picks the same color for a person.
+ * or null, and the card renders its own placeholder for those. Initials are
+ * absent because `lfx-avatar` takes `name` and derives its own letter from it,
+ * and the fallback color is absent because the card styles that itself.
  */
 export interface LfxProfileSummary {
   name: string;

--- a/packages/shared/src/interfaces/mentorship.interface.ts
+++ b/packages/shared/src/interfaces/mentorship.interface.ts
@@ -135,6 +135,43 @@ export interface MentorshipEnrollFieldErrors {
   termsAccepted?: string;
 }
 
+/**
+ * One program a mentor has asked to join, as listed on the Become a Mentor form. Carries
+ * the same `MentorshipMentorStatus` the admin Mentors tab shows for that person, since it
+ * is the same fact viewed from the mentor's side.
+ */
+export interface MentorshipMentorProgramRequest {
+  id: string;
+  programId: string;
+  programName: string;
+  status: MentorshipMentorStatus;
+}
+
+/**
+ * Become a Mentor form state. Name, email, and avatar are not here — they come from the
+ * signed-in LFX account. `resumeFileName` is metadata only, like the enroll wizard's
+ * `logoFileName`: there is no upload endpoint yet, so the picked bytes are never sent.
+ */
+export interface MentorshipMentorRegisterForm {
+  introduction: string;
+  skills: string[];
+  resumeFileName: string;
+  complianceAccepted: boolean;
+  termsAccepted: boolean;
+}
+
+/**
+ * Field-keyed validation errors for the Become a Mentor form. Program requests have no
+ * entry: applying to a program is optional, so a mentor can register a profile and pick
+ * programs later.
+ */
+export interface MentorshipMentorRegisterFieldErrors {
+  introduction?: string;
+  skills?: string;
+  complianceAccepted?: string;
+  termsAccepted?: string;
+}
+
 /** Linux Foundation project option for the enroll project picker. */
 export interface MentorshipLfProject {
   id: string;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -64,6 +64,7 @@ export * from './committee-engagement-classifier.utils';
 export * from './committee-engagement-display.utils';
 export * from './committee-engagement-freshness.utils';
 export * from './public-profile.utils';
+export * from './mentorship-lfx-profile-card.utils';
 export * from './brand-kit.utils';
 export * from './foundation-message.utils';
 export * from './mktg-envelope.utils';

--- a/packages/shared/src/utils/mentorship-lfx-profile-card.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship-lfx-profile-card.utils.spec.ts
@@ -111,6 +111,16 @@ describe('buildLfxProfileSummary', () => {
     expect(summary.linkedin).toEqual({ label: 'linkedin.com/in/ada-lovelace', url: 'https://linkedin.com/in/ada-lovelace' });
   });
 
+  it('drops the query and fragment a browser address bar adds, which would otherwise become the handle', () => {
+    const summary = buildLfxProfileSummary(combinedProfile(), null, [
+      identity('github', 'https://github.com/ada?tab=repositories'),
+      identity('linkedin', 'https://linkedin.com/in/ada-lovelace/?originalSubdomain=uk'),
+    ]);
+
+    expect(summary.github).toEqual({ label: 'github.com/ada', url: 'https://github.com/ada' });
+    expect(summary.linkedin).toEqual({ label: 'linkedin.com/in/ada-lovelace', url: 'https://linkedin.com/in/ada-lovelace' });
+  });
+
   it('leaves a platform null when the user has no identity on it', () => {
     const summary = buildLfxProfileSummary(combinedProfile(), null, [identity('github', '  ')]);
 

--- a/packages/shared/src/utils/mentorship-lfx-profile-card.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship-lfx-profile-card.utils.spec.ts
@@ -1,0 +1,158 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import type { EnrichedIdentity } from '../interfaces/profile.interface';
+import type { CombinedProfile, EmailManagementData, UserMetadata } from '../interfaces/user-profile.interface';
+import { buildLfxProfileSummary, formatLfxMailingAddress } from './mentorship-lfx-profile-card.utils';
+
+function combinedProfile(user: Partial<CombinedProfile['user']> = {}, profile: UserMetadata | null = null): CombinedProfile {
+  return {
+    user: {
+      id: 'u_1',
+      email: 'ada@example.org',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      username: 'ada',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      ...user,
+    },
+    profile,
+  };
+}
+
+function identity(platform: string, value: string, inAuth0 = true): EnrichedIdentity {
+  return {
+    id: `id_${platform}`,
+    platform,
+    type: 'username',
+    value,
+    verified: true,
+    source: 'cdp',
+    icon: '',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    displayState: 'verified',
+    inAuth0,
+  };
+}
+
+describe('buildLfxProfileSummary', () => {
+  it('assembles the card from the profile, the email list, and the connected identities', () => {
+    const emails: EmailManagementData = {
+      primary_email: 'ada@example.org',
+      alternate_emails: [{ email: 'ada@work.example', verified: true }],
+    };
+    const profile: UserMetadata = {
+      picture: 'https://cdn.example.org/ada.png',
+      address: '1 Analytical Way',
+      city: 'London',
+      state_province: 'Greater London',
+      postal_code: 'NW1 1AA',
+      country: 'United Kingdom',
+      phone_number: '+44 20 7946 0000',
+    };
+
+    const summary = buildLfxProfileSummary(combinedProfile({}, profile), emails, [identity('github', 'ada'), identity('linkedin', 'ada-lovelace')]);
+
+    expect(summary).toEqual({
+      name: 'Ada Lovelace',
+      avatarUrl: 'https://cdn.example.org/ada.png',
+      emails: [
+        { email: 'ada@example.org', isPrimary: true },
+        { email: 'ada@work.example', isPrimary: false },
+      ],
+      addressLines: ['1 Analytical Way', 'London, Greater London, NW1 1AA, United Kingdom'],
+      phone: '+44 20 7946 0000',
+      github: { label: 'github.com/ada', url: 'https://github.com/ada' },
+      linkedin: { label: 'linkedin.com/in/ada-lovelace', url: 'https://linkedin.com/in/ada-lovelace' },
+    });
+  });
+
+  it('prefers the name the user typed into their profile over the account first/last', () => {
+    expect(buildLfxProfileSummary(combinedProfile({}, { name: 'A. Lovelace' }), null).name).toBe('A. Lovelace');
+  });
+
+  it('falls back through username and then the email local part so the name is never blank', () => {
+    expect(buildLfxProfileSummary(combinedProfile({ first_name: null, last_name: null }), null).name).toBe('ada');
+    expect(buildLfxProfileSummary(combinedProfile({ first_name: null, last_name: null, username: null }), null).name).toBe('ada');
+    expect(buildLfxProfileSummary(combinedProfile({ first_name: null, last_name: null, username: '  ' }), null).name).toBe('ada');
+  });
+
+  it('shows the signed-in address when the email endpoint fails, rather than an empty section', () => {
+    expect(buildLfxProfileSummary(combinedProfile(), null).emails).toEqual([{ email: 'ada@example.org', isPrimary: true }]);
+  });
+
+  it('does not list an address twice when it is returned as both primary and alternate', () => {
+    const emails: EmailManagementData = {
+      primary_email: 'ada@example.org',
+      // Same address, different case — a duplicate row is still a duplicate.
+      alternate_emails: [
+        { email: 'Ada@Example.org', verified: true },
+        { email: 'ada@work.example', verified: true },
+      ],
+    };
+
+    expect(buildLfxProfileSummary(combinedProfile(), emails).emails).toEqual([
+      { email: 'ada@example.org', isPrimary: true },
+      { email: 'ada@work.example', isPrimary: false },
+    ]);
+  });
+
+  it('reads a handle stored as a full URL without doubling the host', () => {
+    const summary = buildLfxProfileSummary(combinedProfile(), null, [
+      identity('GitHub', 'https://github.com/ada/'),
+      identity('linkedin', 'linkedin.com/in/ada-lovelace'),
+    ]);
+
+    expect(summary.github).toEqual({ label: 'github.com/ada', url: 'https://github.com/ada' });
+    expect(summary.linkedin).toEqual({ label: 'linkedin.com/in/ada-lovelace', url: 'https://linkedin.com/in/ada-lovelace' });
+  });
+
+  it('leaves a platform null when the user has no identity on it', () => {
+    const summary = buildLfxProfileSummary(combinedProfile(), null, [identity('github', '  ')]);
+
+    expect(summary.github).toBeNull();
+    expect(summary.linkedin).toBeNull();
+  });
+
+  it('ignores an account CDP only suspects is theirs, since the card presents these to an admin as their own', () => {
+    const summary = buildLfxProfileSummary(combinedProfile(), null, [identity('github', 'someone-else', false)]);
+
+    expect(summary.github).toBeNull();
+  });
+
+  it('degrades field by field when every source is unavailable', () => {
+    expect(buildLfxProfileSummary(null, null)).toMatchObject({
+      name: '',
+      avatarUrl: '',
+      emails: [],
+      addressLines: [],
+      phone: '',
+      github: null,
+      linkedin: null,
+    });
+  });
+});
+
+describe('formatLfxMailingAddress', () => {
+  it('puts the street on its own line and everything locating it on the next', () => {
+    expect(formatLfxMailingAddress({ address: '22 Bourdillon Rd', city: 'Lagos', postal_code: '106104', country: 'Nigeria' })).toEqual([
+      '22 Bourdillon Rd',
+      'Lagos, 106104, Nigeria',
+    ]);
+  });
+
+  it('drops the segments the profile has not filled in instead of leaving stray commas', () => {
+    expect(formatLfxMailingAddress({ country: 'Kenya' })).toEqual(['Kenya']);
+    expect(formatLfxMailingAddress({ city: 'Nairobi', country: 'Kenya' })).toEqual(['Nairobi, Kenya']);
+    expect(formatLfxMailingAddress({ city: 'Nairobi', postal_code: '00100' })).toEqual(['Nairobi, 00100']);
+  });
+
+  it('returns no lines for a profile with no address at all', () => {
+    expect(formatLfxMailingAddress(null)).toEqual([]);
+    expect(formatLfxMailingAddress({ address: '   ' })).toEqual([]);
+  });
+});

--- a/packages/shared/src/utils/mentorship-lfx-profile-card.utils.ts
+++ b/packages/shared/src/utils/mentorship-lfx-profile-card.utils.ts
@@ -54,9 +54,12 @@ function resolveSocialLink(identities: EnrichedIdentity[], provider: LfxProfileS
   const match = identities.find((identity) => identity.platform?.trim().toLowerCase() === provider && identity.inAuth0 && identity.value?.trim());
   if (!match) return null;
 
-  // Splitting on '/' and dropping the empty segments also strips any trailing slash, so this
-  // needs no separate trim pass — a regex for one would be quadratic on a run of slashes.
-  const handle = match.value.trim().split('/').filter(Boolean).pop() ?? '';
+  // Drop any query or fragment first: a value pasted from the browser's address bar arrives as
+  // `github.com/ada?tab=repositories`, and none of that trailing state belongs in the handle.
+  // Splitting on '/' then dropping the empty segments also strips a trailing slash, so neither
+  // step needs a trimming regex — one anchored to a run of slashes would be quadratic.
+  const withoutQuery = match.value.trim().split(/[?#]/)[0];
+  const handle = withoutQuery.split('/').filter(Boolean).pop() ?? '';
   if (!handle) return null;
 
   const { host, path } = LFX_PROFILE_SOCIAL_LINKS[provider];

--- a/packages/shared/src/utils/mentorship-lfx-profile-card.utils.ts
+++ b/packages/shared/src/utils/mentorship-lfx-profile-card.utils.ts
@@ -54,7 +54,9 @@ function resolveSocialLink(identities: EnrichedIdentity[], provider: LfxProfileS
   const match = identities.find((identity) => identity.platform?.trim().toLowerCase() === provider && identity.inAuth0 && identity.value?.trim());
   if (!match) return null;
 
-  const handle = match.value.trim().replace(/\/+$/, '').split('/').filter(Boolean).pop() ?? '';
+  // Splitting on '/' and dropping the empty segments also strips any trailing slash, so this
+  // needs no separate trim pass — a regex for one would be quadratic on a run of slashes.
+  const handle = match.value.trim().split('/').filter(Boolean).pop() ?? '';
   if (!handle) return null;
 
   const { host, path } = LFX_PROFILE_SOCIAL_LINKS[provider];

--- a/packages/shared/src/utils/mentorship-lfx-profile-card.utils.ts
+++ b/packages/shared/src/utils/mentorship-lfx-profile-card.utils.ts
@@ -1,0 +1,105 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { LFX_PROFILE_SOCIAL_LINKS } from '../constants/mentorship-lfx-profile-card.constants';
+import type { LfxProfileEmail, LfxProfileLink, LfxProfileSocialProvider, LfxProfileSummary } from '../interfaces/mentorship-lfx-profile-card.interface';
+import type { EnrichedIdentity } from '../interfaces/profile.interface';
+import type { CombinedProfile, EmailManagementData, UserMetadata } from '../interfaces/user-profile.interface';
+
+/**
+ * Display name, preferring the `name` the user typed into their profile over one
+ * assembled from the account's first/last, then falling back to the username and
+ * finally the email's local part — the card should never render a blank name.
+ */
+function resolveDisplayName(combined: CombinedProfile | null): string {
+  const typed = combined?.profile?.name?.trim();
+  if (typed) return typed;
+
+  const assembled = [combined?.user?.first_name, combined?.user?.last_name]
+    .map((part) => part?.trim() ?? '')
+    .filter(Boolean)
+    .join(' ');
+  if (assembled) return assembled;
+
+  return combined?.user?.username?.trim() || (combined?.user?.email?.split('@')[0].trim() ?? '');
+}
+
+/**
+ * Mailing address over two lines, as the design lays it out: the street, then
+ * everything that locates it — city, state, postal code, country — joined by
+ * commas. Empty parts are dropped, so a profile carrying only a country renders
+ * one line rather than a run of stray commas.
+ */
+export function formatLfxMailingAddress(profile: UserMetadata | null | undefined): string[] {
+  const street = profile?.address?.trim() ?? '';
+  const locality = [profile?.city, profile?.state_province, profile?.postal_code, profile?.country]
+    .map((part) => part?.trim() ?? '')
+    .filter(Boolean)
+    .join(', ');
+
+  return [street, locality].filter(Boolean);
+}
+
+/**
+ * The user's handle on `provider`, as a label/url pair. CDP stores a bare
+ * handle, but tolerate a value pasted as a full URL by keeping only its last
+ * path segment — otherwise the href would double up the host.
+ *
+ * `inAuth0` is required, matching the profile panel's GitHub row: CDP also
+ * surfaces accounts it merely *suspects* belong to this person, and the card
+ * presents these as the user's own to a program admin. An unclaimed guess has
+ * no business in that list.
+ */
+function resolveSocialLink(identities: EnrichedIdentity[], provider: LfxProfileSocialProvider): LfxProfileLink | null {
+  const match = identities.find((identity) => identity.platform?.trim().toLowerCase() === provider && identity.inAuth0 && identity.value?.trim());
+  if (!match) return null;
+
+  const handle = match.value.trim().replace(/\/+$/, '').split('/').filter(Boolean).pop() ?? '';
+  if (!handle) return null;
+
+  const { host, path } = LFX_PROFILE_SOCIAL_LINKS[provider];
+  return { label: `${host}/${path}${handle}`, url: `https://${host}/${path}${encodeURIComponent(handle)}` };
+}
+
+/**
+ * The account's addresses, primary first. Falls back to the profile's own email
+ * when the email endpoint fails, so a partial outage still shows the address the
+ * user signed in with instead of an empty section. De-duplicated because an
+ * address listed as both primary and alternate must not render twice.
+ */
+function resolveEmails(combined: CombinedProfile | null, emailData: EmailManagementData | null): LfxProfileEmail[] {
+  const primary = emailData?.primary_email?.trim() || combined?.user?.email?.trim() || '';
+  const alternates = (emailData?.alternate_emails ?? []).map((entry) => entry.email?.trim() ?? '');
+
+  const seen = new Set<string>();
+  return [primary, ...alternates]
+    .filter((email) => {
+      const key = email.toLowerCase();
+      if (!email || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .map((email) => ({ email, isPrimary: email === primary }));
+}
+
+/**
+ * Builds the "From Your LFX Profile" card's data from the three endpoints that
+ * own it. Each argument is nullable on purpose: the card fetches them
+ * independently and lets any one fail, so this must degrade field by field
+ * rather than refuse to render.
+ */
+export function buildLfxProfileSummary(
+  combined: CombinedProfile | null,
+  emailData: EmailManagementData | null,
+  identities: EnrichedIdentity[] = []
+): LfxProfileSummary {
+  return {
+    name: resolveDisplayName(combined),
+    avatarUrl: combined?.profile?.picture?.trim() ?? '',
+    emails: resolveEmails(combined, emailData),
+    addressLines: formatLfxMailingAddress(combined?.profile),
+    phone: combined?.profile?.phone_number?.trim() ?? '',
+    github: resolveSocialLink(identities, 'github'),
+    linkedin: resolveSocialLink(identities, 'linkedin'),
+  };
+}

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { createDefaultMentorshipTerm, createEmptyMentorshipEnrollForm } from '../constants/mentorship-enroll.constants';
-import { createEmptyMentorshipMentorForm } from '../constants/mentorship-mentor.constants';
+import { createEmptyMentorshipMentorForm, MENTORSHIP_MENTOR_INTRODUCTION_MAX } from '../constants/mentorship-mentor.constants';
 import { MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
 import type { MentorshipMentorRegisterForm, MentorshipProgramMentee } from '../interfaces/mentorship.interface';
 import {
@@ -470,6 +470,16 @@ describe('program detail helpers', () => {
     expect(getMentorshipMentorRegisterErrors({ ...form, introduction: '<p></p>' }).introduction).toBe('Introduction is required.');
     expect(getMentorshipMentorRegisterErrors({ ...form, introduction: '<p>  </p>' }).introduction).toBe('Introduction is required.');
     expect(getMentorshipMentorRegisterErrors({ ...form, introduction: '<p>Hi</p>' }).introduction).toBeUndefined();
+  });
+
+  it('caps the introduction, since it reaches a mentor profile the whole platform can read', () => {
+    const form = { ...createEmptyMentorshipMentorForm(), skills: ['Go'], complianceAccepted: true, termsAccepted: true };
+    const atCap = `<p>${'a'.repeat(MENTORSHIP_MENTOR_INTRODUCTION_MAX)}</p>`;
+
+    expect(getMentorshipMentorRegisterErrors({ ...form, introduction: atCap }).introduction).toBeUndefined();
+    expect(getMentorshipMentorRegisterErrors({ ...form, introduction: `${atCap}<p>a</p>` }).introduction).toBe(
+      `Introduction must be ${MENTORSHIP_MENTOR_INTRODUCTION_MAX} characters or fewer.`
+    );
   });
 
   it('accepts only document extensions for a resume', () => {

--- a/packages/shared/src/utils/mentorship.utils.spec.ts
+++ b/packages/shared/src/utils/mentorship.utils.spec.ts
@@ -4,8 +4,9 @@
 import { describe, expect, it } from 'vitest';
 
 import { createDefaultMentorshipTerm, createEmptyMentorshipEnrollForm } from '../constants/mentorship-enroll.constants';
+import { createEmptyMentorshipMentorForm } from '../constants/mentorship-mentor.constants';
 import { MENTORSHIP_PROGRAM_AVATAR_PALETTE } from '../constants/mentorship.constants';
-import type { MentorshipProgramMentee } from '../interfaces/mentorship.interface';
+import type { MentorshipMentorRegisterForm, MentorshipProgramMentee } from '../interfaces/mentorship.interface';
 import {
   buildMentorshipProgramDetail,
   formatMentorshipDateRange,
@@ -13,6 +14,7 @@ import {
   formatMentorshipShortMonthYear,
   formatMentorshipTaskProgress,
   getMentorshipEnrollStepErrors,
+  getMentorshipMentorRegisterErrors,
   getMentorshipTermDateErrors,
   isMentorshipTermEnded,
   mentorshipDateOnlyFloor,
@@ -23,6 +25,7 @@ import {
   isMentorshipHttpUrl,
   isMentorshipIsoDate,
   isMentorshipLogoFileName,
+  isMentorshipResumeFileName,
   isMentorshipTermsAccepted,
   matchesMentorshipPersonSearch,
   mentorshipApplicantActionsFor,
@@ -436,6 +439,47 @@ describe('program detail helpers', () => {
     // decline appears. `pending` is an applicant either way.
     expect(mentorshipMenteesForProgram(mentees, true).map((person) => person.id)).toEqual(['3', '4']);
     expect(mentorshipMenteesForProgram([], false)).toEqual([]);
+  });
+
+  it('requires an introduction, skills, and both acknowledgements to become a mentor', () => {
+    expect(getMentorshipMentorRegisterErrors(createEmptyMentorshipMentorForm())).toEqual({
+      introduction: 'Introduction is required.',
+      skills: 'Add at least one skill.',
+      complianceAccepted: 'Please confirm the compliance statement.',
+      termsAccepted: 'Please accept the terms and conditions.',
+    });
+  });
+
+  it('registers a mentor who has neither applied to a program nor attached a resume', () => {
+    // Both are optional: a mentor can register a profile now and apply to programs later.
+    const complete: MentorshipMentorRegisterForm = {
+      introduction: '<p>Maintainer on two CNCF projects.</p>',
+      skills: ['Go'],
+      resumeFileName: '',
+      complianceAccepted: true,
+      termsAccepted: true,
+    };
+
+    expect(getMentorshipMentorRegisterErrors(complete)).toEqual({});
+  });
+
+  it('treats markup with no text as an empty introduction', () => {
+    const form = { ...createEmptyMentorshipMentorForm(), skills: ['Go'], complianceAccepted: true, termsAccepted: true };
+
+    // The rich editor leaves an empty paragraph behind when the user clears the field.
+    expect(getMentorshipMentorRegisterErrors({ ...form, introduction: '<p></p>' }).introduction).toBe('Introduction is required.');
+    expect(getMentorshipMentorRegisterErrors({ ...form, introduction: '<p>  </p>' }).introduction).toBe('Introduction is required.');
+    expect(getMentorshipMentorRegisterErrors({ ...form, introduction: '<p>Hi</p>' }).introduction).toBeUndefined();
+  });
+
+  it('accepts only document extensions for a resume', () => {
+    expect(isMentorshipResumeFileName('resume.pdf')).toBe(true);
+    expect(isMentorshipResumeFileName('resume.DOCX')).toBe(true);
+    expect(isMentorshipResumeFileName('resume.doc')).toBe(true);
+    expect(isMentorshipResumeFileName('resume.png')).toBe(false);
+    // No extension at all, and a name that only looks like one.
+    expect(isMentorshipResumeFileName('resume')).toBe(false);
+    expect(isMentorshipResumeFileName('')).toBe(false);
   });
 
   it('tints an avatar deterministically, and survives an empty name', () => {

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -16,6 +16,7 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_TERM_NAME_MAX,
 } from '../constants/mentorship-enroll.constants';
+import { MENTORSHIP_MENTOR_RESUME_EXTENSIONS } from '../constants/mentorship-mentor.constants';
 import {
   MENTORSHIP_APPLICANT_ACTIONS,
   MENTORSHIP_CURRENT_MENTEE_STATUSES,
@@ -33,6 +34,8 @@ import type {
   MentorshipEnrollStep,
   MentorshipMenteeAction,
   MentorshipMenteeStatus,
+  MentorshipMentorRegisterFieldErrors,
+  MentorshipMentorRegisterForm,
   MentorshipNoteDisplay,
   MentorshipProgram,
   MentorshipProgramDetail,
@@ -232,6 +235,31 @@ export function getMentorshipEnrollStepErrors(step: MentorshipEnrollStep, form: 
   if (!isMentorshipTermsAccepted(form.termsAccepted)) {
     errors.termsAccepted = 'Please accept terms and conditions in order to proceed.';
   }
+  return errors;
+}
+
+export function isMentorshipResumeFileName(fileName: string): boolean {
+  const ext = fileName.trim().split('.').pop()?.toLowerCase() ?? '';
+  return (MENTORSHIP_MENTOR_RESUME_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+/**
+ * Validates the Become a Mentor form.
+ *
+ * Two things a mentor supplies are deliberately unvalidated. Program requests are
+ * optional: a mentor may register a profile now and apply to programs later, so the
+ * request list is not checked here and does not reach this function at all. The resume
+ * is optional too, and its picker rejects a bad type or an oversized file at selection
+ * time rather than letting either reach submit.
+ */
+export function getMentorshipMentorRegisterErrors(form: MentorshipMentorRegisterForm): MentorshipMentorRegisterFieldErrors {
+  const errors: MentorshipMentorRegisterFieldErrors = {};
+
+  if (mentorshipDescriptionLength(form.introduction) === 0) errors.introduction = 'Introduction is required.';
+  if (!form.skills.length) errors.skills = 'Add at least one skill.';
+  if (!isMentorshipTermsAccepted(form.complianceAccepted)) errors.complianceAccepted = 'Please confirm the compliance statement.';
+  if (!isMentorshipTermsAccepted(form.termsAccepted)) errors.termsAccepted = 'Please accept the terms and conditions.';
+
   return errors;
 }
 

--- a/packages/shared/src/utils/mentorship.utils.ts
+++ b/packages/shared/src/utils/mentorship.utils.ts
@@ -16,7 +16,7 @@ import {
   MENTORSHIP_MAX_OPEN_TERMS_MESSAGE,
   MENTORSHIP_TERM_NAME_MAX,
 } from '../constants/mentorship-enroll.constants';
-import { MENTORSHIP_MENTOR_RESUME_EXTENSIONS } from '../constants/mentorship-mentor.constants';
+import { MENTORSHIP_MENTOR_INTRODUCTION_MAX, MENTORSHIP_MENTOR_RESUME_EXTENSIONS } from '../constants/mentorship-mentor.constants';
 import {
   MENTORSHIP_APPLICANT_ACTIONS,
   MENTORSHIP_CURRENT_MENTEE_STATUSES,
@@ -255,7 +255,11 @@ export function isMentorshipResumeFileName(fileName: string): boolean {
 export function getMentorshipMentorRegisterErrors(form: MentorshipMentorRegisterForm): MentorshipMentorRegisterFieldErrors {
   const errors: MentorshipMentorRegisterFieldErrors = {};
 
-  if (mentorshipDescriptionLength(form.introduction) === 0) errors.introduction = 'Introduction is required.';
+  if (mentorshipDescriptionLength(form.introduction) === 0) {
+    errors.introduction = 'Introduction is required.';
+  } else if (mentorshipDescriptionLength(form.introduction) > MENTORSHIP_MENTOR_INTRODUCTION_MAX) {
+    errors.introduction = `Introduction must be ${MENTORSHIP_MENTOR_INTRODUCTION_MAX} characters or fewer.`;
+  }
   if (!form.skills.length) errors.skills = 'Add at least one skill.';
   if (!isMentorshipTermsAccepted(form.complianceAccepted)) errors.complianceAccepted = 'Please confirm the compliance statement.';
   if (!isMentorshipTermsAccepted(form.termsAccepted)) errors.termsAccepted = 'Please accept the terms and conditions.';


### PR DESCRIPTION
## Summary

Adds the **Become a Mentor** registration page at `/mentorship/mentor`, ported from menv3's `mentor-register`, and extracts three reusable components out of the enroll wizard along the way.

This is the mentor landing route for now. Once the profiles API can tell us whether the signed-in user already holds a mentor profile, the same path serves that profile page instead and falls back to this form when they have none.

## Scope and gating

The whole mentorship module sits behind `canMatch: [mentorshipEnabledGuard]` in `app.routes.ts`, which is fail-closed, so this page is only reachable where mentorship is already enabled. A `Mentor` entry joins the mentorship group in the sidebar.

## What's in it

**The page** (`mentor/mentor-register/`) — one parent `FormGroup`, error text derived in `@lfx-one/shared/utils`, and errors kept hidden behind `showErrors` until the mentor actually submits, following the enroll wizard. Two sub-sections are local to it: `mentor-programs-section` (program picker plus the requests table) and `mentor-resume-section` (file picker that stores the file name and validates type and size at selection).

**Three components extracted to `mentorship/components/`** and now shared with the enroll wizard, which is where the duplication came from:

- `profile-card` — read-only "From Your LFX Profile" card over the existing `getCurrentUserProfile`, `getUserEmails` and `getIdentities` endpoints, with per-field placeholders and a skeleton loading state.
- `skills-picker` — used by `enroll-setup-step` and the new page.
- `terms-acknowledgement` — used by `enroll-prerequisites-step` and the new page.

**`mentorship-coming-soon.service` moved** from `admin/program-detail/services/` up to `mentorship/services/`, since the mentor page needs it too. Six call sites updated, no behaviour change.

**Shared package** — new `mentorship-mentor.constants.ts` (form copy, resume rules, validation limits), `mentorship-lfx-profile-card.{constants,interface,utils}.ts` (the card's projection and its social-link resolution), plus additions to the existing `mentorship.{constants,interface,utils}` files and the three barrels.

44 files: 23 new, 19 modified, 2 renamed. +2,374 / −132.

## Not in this PR

There is no mentor registration endpoint yet, so **Submit validates and raises a toast** — nothing is persisted. Program requests are local component state for the same reason, and the resume keeps its bytes in the file input because there is nothing to upload them to. No files under `apps/lfx-one/src/server/` are touched and no new API is called; the only data read is the signed-in user's own profile, through endpoints they already own.

## Testing

- `ng test` — 96 mentorship specs pass, covering validation gating, the request add/withdraw flow, resume type and size rejection, and every profile-card placeholder and degraded-fetch branch.
- `packages/shared` — 1,688 specs pass, including the new profile-card projection and mentor-form validation utils.
- `lint:check`, `check-types` and Prettier clean; license headers present on all 23 new files.

## Reviewer notes

`mentor-resume-section.component.html` uses a visually hidden `<input type="file">` clicked from an `lfx-button`, which reads as a violation of frontend-checklist §14.1. It is deliberate and matches four existing call sites (`enroll-details-step`, `profile-edit-drawer`, `org-profile-edit`, `settings-branding-tab`): `lfx-file-upload` wraps PrimeNG's `p-fileUpload` and renders that component's own upload chrome, which this design does not use. The hidden input still carries a `<label for>` association and a `data-testid`.
