### PR TITLE
feat(dashboards): add My formations card and formation Pending Actions rows

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
@@ -4,6 +4,7 @@
 <lfx-formation-item-drawer
   [itemProjectUid]="projectUid()"
   [itemKey]="itemKey()"
+  [mutationInFlight]="skipInFlight()"
   [skipInFlight]="skipInFlight()"
   [(visible)]="visible"
   (itemChanged)="onItemChanged()"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
@@ -1,0 +1,11 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-formation-item-drawer
+  [itemProjectUid]="projectUid()"
+  [itemKey]="itemKey()"
+  [skipInFlight]="skipInFlight()"
+  [(visible)]="visible"
+  (itemChanged)="onItemChanged()"
+  (skipRequested)="onSkipRequested($event)"
+  data-testid="dashboard-formation-item-drawer-host" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
@@ -4,6 +4,7 @@
 <lfx-formation-item-drawer
   [itemProjectUid]="projectUid()"
   [itemKey]="itemKey()"
+  [canWrite]="canWrite()"
   [mutationInFlight]="mutationInFlight()"
   [skipInFlight]="skipInFlight()"
   [(visible)]="visible"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
@@ -4,9 +4,12 @@
 <lfx-formation-item-drawer
   [itemProjectUid]="projectUid()"
   [itemKey]="itemKey()"
-  [mutationInFlight]="skipInFlight()"
+  [mutationInFlight]="mutationInFlight()"
   [skipInFlight]="skipInFlight()"
   [(visible)]="visible"
   (itemChanged)="onItemChanged()"
+  (itemUpdated)="onItemUpdated()"
   (skipRequested)="onSkipRequested($event)"
+  (writeStarted)="onWriteStarted()"
+  (writeEnded)="onWriteEnded()"
   data-testid="dashboard-formation-item-drawer-host" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.html
@@ -5,6 +5,7 @@
   [itemProjectUid]="projectUid()"
   [itemKey]="itemKey()"
   [canWrite]="canWrite()"
+  [assigneeOnly]="assigneeOnly()"
   [mutationInFlight]="mutationInFlight()"
   [skipInFlight]="skipInFlight()"
   [(visible)]="visible"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReasonPromptDialogComponent } from '@components/reason-prompt-dialog/reason-prompt-dialog.component';
 import { FormationService } from '@services/formation.service';
 import { MessageService } from 'primeng/api';
@@ -21,6 +22,9 @@ import type { FormationItem, ReasonPromptDialogResult } from '@lfx-one/shared/in
  * call `updateFormationItemStatus` directly) still wires the drawer's `skipRequested` output —
  * skip has no dedicated Pending Actions row action, but the drawer offers it once open, so it must
  * work here too, mirroring `formation-checklist-section.component.ts`'s `onSkipRequested`.
+ *
+ * Emits `itemMutated` after any successful write so the hosting dashboard can refresh its Pending
+ * Actions list — see `itemMutated`'s doc comment for why that refresh can't be left implicit.
  */
 @Component({
   selector: 'lfx-dashboard-formation-item-drawer-host',
@@ -32,6 +36,13 @@ export class DashboardFormationItemDrawerHostComponent {
   private readonly formationService = inject(FormationService);
   private readonly dialogService = inject(DialogService);
   private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Emits after Mark complete, Save, or Skip succeeds — `FormationService`'s mutations only
+  // invalidate the `formation-work` stream (the card/tile), which is a separate cache from Pending
+  // Actions' own `pending-actions` stream. The dashboard hosts bind this to their own refresh so a
+  // drawer mutation doesn't leave the Pending Actions row showing stale status/actions.
+  public readonly itemMutated = output<void>();
 
   protected readonly projectUid = signal<string | null>(null);
   protected readonly itemKey = signal<string | null>(null);
@@ -54,14 +65,14 @@ export class DashboardFormationItemDrawerHostComponent {
 
   protected onItemChanged(): void {
     this.visible.set(false);
+    this.itemMutated.emit();
   }
 
-  // Metadata-only save (notes/assignee/due-date) — the drawer stays open. The service call already
-  // invalidates `FormationService.getMyFormationWork()` for every live subscriber, so there's no list
-  // for this host to refresh itself; the binding exists so the drawer's write is never silently
-  // unhandled.
+  // Metadata-only save (notes/assignee/due-date) — the drawer stays open, but due_date/notes changes
+  // can still affect a Pending Actions row (e.g. its displayed due date), so this must also notify
+  // the dashboard the same as a status change does.
   protected onItemUpdated(): void {
-    // No-op: FormationService's mutation already re-fetches my-formation-work for every subscriber.
+    this.itemMutated.emit();
   }
 
   protected onWriteStarted(): void {
@@ -84,22 +95,26 @@ export class DashboardFormationItemDrawerHostComponent {
       },
     });
 
-    ref?.onClose.pipe(take(1)).subscribe((result: ReasonPromptDialogResult | undefined) => {
+    ref?.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((result: ReasonPromptDialogResult | undefined) => {
       if (!result?.reason) return;
       this.skipInFlight.set(true);
 
-      this.formationService.skipFormationItem(item.project_uid, item.template_item_key, result.reason).subscribe({
-        next: () => {
-          this.skipInFlight.set(false);
-          this.visible.set(false);
-          this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
-        },
-        error: (error: unknown) => {
-          this.skipInFlight.set(false);
-          console.error('[DashboardFormationItemDrawerHost] Skip failed', error);
-          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not skip this item.' });
-        },
-      });
+      this.formationService
+        .skipFormationItem(item.project_uid, item.template_item_key, result.reason)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: () => {
+            this.skipInFlight.set(false);
+            this.visible.set(false);
+            this.itemMutated.emit();
+            this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
+          },
+          error: (error: unknown) => {
+            this.skipInFlight.set(false);
+            console.error('[DashboardFormationItemDrawerHost] Skip failed', error);
+            this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not skip this item.' });
+          },
+        });
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -109,18 +109,18 @@ export class DashboardFormationItemDrawerHostComponent {
       // complete once sent; unsubscribing on host destroy would cancel the in-flight HTTP request
       // and leave the item in an inconsistent state relative to what the server actually persisted.
       this.formationService.skipFormationItem(item.project_uid, item.template_item_key, result.reason).subscribe({
-          next: () => {
-            this.skipInFlight.set(false);
-            this.visible.set(false);
-            this.itemMutated.emit();
-            this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
-          },
-          error: (error: unknown) => {
-            this.skipInFlight.set(false);
-            console.error('[DashboardFormationItemDrawerHost] Skip failed', error);
-            this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not skip this item.' });
-          },
-        });
+        next: () => {
+          this.skipInFlight.set(false);
+          this.visible.set(false);
+          this.itemMutated.emit();
+          this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
+        },
+        error: (error: unknown) => {
+          this.skipInFlight.set(false);
+          console.error('[DashboardFormationItemDrawerHost] Skip failed', error);
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not skip this item.' });
+        },
+      });
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -11,7 +11,7 @@ import { take } from 'rxjs';
 
 import { FormationItemDrawerComponent } from '../formation-item-drawer/formation-item-drawer.component';
 
-import type { FormationItem, ReasonPromptDialogResult } from '@lfx-one/shared/interfaces';
+import type { FormationItem, FormationItemOpenRequest, ReasonPromptDialogResult } from '@lfx-one/shared/interfaces';
 
 /**
  * Dashboard-level host for the existing `formation-item-drawer` (GH-1956) — same precedent as
@@ -56,10 +56,16 @@ export class DashboardFormationItemDrawerHostComponent {
   // drawer's `mutationInFlight` input, so its buttons disable for either write kind.
   protected readonly writeInFlight = signal<boolean>(false);
   protected readonly mutationInFlight = computed(() => this.writeInFlight() || this.skipInFlight());
+  // Mirrors `PendingActionItem.formationCanWrite` from the row that triggered `open()` — the drawer's
+  // own `can_complete` gate has no relationship to real project write access (copilot review: an
+  // auditor-only assignee would otherwise see an enabled Mark complete/Save that 403s server-side via
+  // `assertItemProjectWriteAccess`). Defaults `true` so a future caller that omits it stays permissive.
+  protected readonly canWrite = signal<boolean>(true);
 
-  public open(request: { projectUid: string; itemKey: string }): void {
+  public open(request: FormationItemOpenRequest): void {
     this.projectUid.set(request.projectUid);
     this.itemKey.set(request.itemKey);
+    this.canWrite.set(request.canWrite ?? true);
     this.visible.set(true);
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -48,6 +48,7 @@ export class DashboardFormationItemDrawerHostComponent {
 
   protected onItemChanged(): void {
     this.visible.set(false);
+    this.formationService.invalidateMyFormationWork();
   }
 
   protected onSkipRequested(item: FormationItem): void {
@@ -70,6 +71,7 @@ export class DashboardFormationItemDrawerHostComponent {
         next: () => {
           this.skipInFlight.set(false);
           this.visible.set(false);
+          this.formationService.invalidateMyFormationWork();
           this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
         },
         error: (error: unknown) => {

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { ReasonPromptDialogComponent } from '@components/reason-prompt-dialog/reason-prompt-dialog.component';
 import { FormationService } from '@services/formation.service';
 import { MessageService } from 'primeng/api';
@@ -37,8 +37,14 @@ export class DashboardFormationItemDrawerHostComponent {
   protected readonly itemKey = signal<string | null>(null);
   protected readonly visible = signal<boolean>(false);
   // A single host only ever has one drawer open at a time, so one flag (not the section's per-uid
-  // map) is enough to gate both the drawer's `mutationInFlight` and `skipInFlight` inputs.
+  // map) is enough to gate the drawer's `skipInFlight` input.
   protected readonly skipInFlight = signal<boolean>(false);
+  // Set around the drawer's own Mark complete/Save (writeStarted/writeEnded), mirroring
+  // `formation-checklist-section.component.ts`'s `drawerItemMutationInFlight` — a single host has no
+  // per-uid map to key off, so one flag is enough. Combined with `skipInFlight` below to drive the
+  // drawer's `mutationInFlight` input, so its buttons disable for either write kind.
+  protected readonly writeInFlight = signal<boolean>(false);
+  protected readonly mutationInFlight = computed(() => this.writeInFlight() || this.skipInFlight());
 
   public open(request: { projectUid: string; itemKey: string }): void {
     this.projectUid.set(request.projectUid);
@@ -48,6 +54,22 @@ export class DashboardFormationItemDrawerHostComponent {
 
   protected onItemChanged(): void {
     this.visible.set(false);
+  }
+
+  // Metadata-only save (notes/assignee/due-date) — the drawer stays open. The service call already
+  // invalidates `FormationService.getMyFormationWork()` for every live subscriber, so there's no list
+  // for this host to refresh itself; the binding exists so the drawer's write is never silently
+  // unhandled.
+  protected onItemUpdated(): void {
+    // No-op: FormationService's mutation already re-fetches my-formation-work for every subscriber.
+  }
+
+  protected onWriteStarted(): void {
+    this.writeInFlight.set(true);
+  }
+
+  protected onWriteEnded(): void {
+    this.writeInFlight.set(false);
   }
 
   protected onSkipRequested(item: FormationItem): void {

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -18,10 +18,13 @@ import type { FormationItem, FormationItemOpenRequest, ReasonPromptDialogResult 
  * `dashboard-cast-drawer-host` for `vote-cast-drawer`. Opened from a Pending Actions row's **Open**
  * action; hosts one drawer instance per dashboard so the row component doesn't have to embed it.
  *
- * Reuses the drawer's own Mark complete/Save, and (unlike the row's Claim/Block-with-note, which
- * call `updateFormationItemStatus` directly) still wires the drawer's `skipRequested` output —
- * skip has no dedicated Pending Actions row action, but the drawer offers it once open, so it must
- * work here too, mirroring `formation-checklist-section.component.ts`'s `onSkipRequested`.
+ * Reuses the drawer's own Save (and, when `assigneeOnly` is unset, Mark complete/Skip), and (unlike
+ * the row's Claim/Block-with-note, which call `updateFormationItemStatus` directly) still wires the
+ * drawer's `skipRequested` output — skip has no dedicated Pending Actions row action, but the drawer
+ * offers it once open, so it must work here too, mirroring
+ * `formation-checklist-section.component.ts`'s `onSkipRequested`. `assigneeOnly` is always set `true`
+ * here (see `open()`) since every caller of this host is the Me-lens Pending Actions flow, where
+ * GH-1956 decision 3 forbids the assignee from setting status at all.
  *
  * Emits `itemMutated` after any successful write so the hosting dashboard can refresh its Pending
  * Actions list — see `itemMutated`'s doc comment for why that refresh can't be left implicit.
@@ -61,6 +64,11 @@ export class DashboardFormationItemDrawerHostComponent {
   // auditor-only assignee would otherwise see an enabled Mark complete/Save that 403s server-side via
   // `assertItemProjectWriteAccess`). Defaults `true` so a future caller that omits it stays permissive.
   protected readonly canWrite = signal<boolean>(true);
+  // GH-1956 decision 3: the Me-lens assignee never sets status ("No 'Mark done'"). This host is only
+  // ever opened from the Pending Actions flow (see class doc comment), so this is always true rather
+  // than a per-request flag — the drawer hides Mark complete/Accept/Skip entirely instead of merely
+  // disabling them (copilot review, PR #2309).
+  protected readonly assigneeOnly = signal<boolean>(true);
 
   public open(request: FormationItemOpenRequest): void {
     this.projectUid.set(request.projectUid);

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -1,0 +1,83 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject, signal } from '@angular/core';
+import { ReasonPromptDialogComponent } from '@components/reason-prompt-dialog/reason-prompt-dialog.component';
+import { FormationService } from '@services/formation.service';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { take } from 'rxjs';
+
+import { FormationItemDrawerComponent } from '../formation-item-drawer/formation-item-drawer.component';
+
+import type { FormationItem, ReasonPromptDialogResult } from '@lfx-one/shared/interfaces';
+
+/**
+ * Dashboard-level host for the existing `formation-item-drawer` (GH-1956) — same precedent as
+ * `dashboard-cast-drawer-host` for `vote-cast-drawer`. Opened from a Pending Actions row's **Open**
+ * action; hosts one drawer instance per dashboard so the row component doesn't have to embed it.
+ *
+ * Reuses the drawer's own Mark complete/Save, and (unlike the row's Claim/Block-with-note, which
+ * call `updateFormationItemStatus` directly) still wires the drawer's `skipRequested` output —
+ * skip has no dedicated Pending Actions row action, but the drawer offers it once open, so it must
+ * work here too, mirroring `formation-checklist-section.component.ts`'s `onSkipRequested`.
+ */
+@Component({
+  selector: 'lfx-dashboard-formation-item-drawer-host',
+  imports: [FormationItemDrawerComponent],
+  providers: [DialogService],
+  templateUrl: './dashboard-formation-item-drawer-host.component.html',
+})
+export class DashboardFormationItemDrawerHostComponent {
+  private readonly formationService = inject(FormationService);
+  private readonly dialogService = inject(DialogService);
+  private readonly messageService = inject(MessageService);
+
+  protected readonly projectUid = signal<string | null>(null);
+  protected readonly itemKey = signal<string | null>(null);
+  protected readonly visible = signal<boolean>(false);
+  // A single host only ever has one drawer open at a time, so one flag (not the section's per-uid
+  // map) is enough to gate both the drawer's `mutationInFlight` and `skipInFlight` inputs.
+  protected readonly skipInFlight = signal<boolean>(false);
+
+  public open(request: { projectUid: string; itemKey: string }): void {
+    this.projectUid.set(request.projectUid);
+    this.itemKey.set(request.itemKey);
+    this.visible.set(true);
+  }
+
+  protected onItemChanged(): void {
+    this.visible.set(false);
+  }
+
+  protected onSkipRequested(item: FormationItem): void {
+    const ref = this.dialogService.open(ReasonPromptDialogComponent, {
+      header: 'Skip item',
+      width: '480px',
+      modal: true,
+      data: {
+        prompt: `Skipping "${item.title}" requires a reason. This is logged in the item's history.`,
+        placeholder: 'Why is this item being skipped?',
+        confirmLabel: 'Skip item',
+      },
+    });
+
+    ref?.onClose.pipe(take(1)).subscribe((result: ReasonPromptDialogResult | undefined) => {
+      if (!result?.reason) return;
+      this.skipInFlight.set(true);
+
+      this.formationService.skipFormationItem(item.project_uid, item.template_item_key, result.reason).subscribe({
+        next: () => {
+          this.skipInFlight.set(false);
+          this.visible.set(false);
+          this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
+        },
+        error: (error: unknown) => {
+          this.skipInFlight.set(false);
+          console.error('[DashboardFormationItemDrawerHost] Skip failed', error);
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Could not skip this item.' });
+        },
+      });
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -99,10 +99,10 @@ export class DashboardFormationItemDrawerHostComponent {
       if (!result?.reason) return;
       this.skipInFlight.set(true);
 
-      this.formationService
-        .skipFormationItem(item.project_uid, item.template_item_key, result.reason)
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
+      // No takeUntilDestroyed here (unlike the dialog's onClose above) — this is a write that must
+      // complete once sent; unsubscribing on host destroy would cancel the in-flight HTTP request
+      // and leave the item in an inconsistent state relative to what the server actually persisted.
+      this.formationService.skipFormationItem(item.project_uid, item.template_item_key, result.reason).subscribe({
           next: () => {
             this.skipInFlight.set(false);
             this.visible.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component.ts
@@ -48,7 +48,6 @@ export class DashboardFormationItemDrawerHostComponent {
 
   protected onItemChanged(): void {
     this.visible.set(false);
-    this.formationService.invalidateMyFormationWork();
   }
 
   protected onSkipRequested(item: FormationItem): void {
@@ -71,7 +70,6 @@ export class DashboardFormationItemDrawerHostComponent {
         next: () => {
           this.skipInFlight.set(false);
           this.visible.set(false);
-          this.formationService.invalidateMyFormationWork();
           this.messageService.add({ severity: 'success', summary: 'Skipped', detail: `"${item.title}" was skipped.` });
         },
         error: (error: unknown) => {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
@@ -70,7 +70,11 @@
                 data-testid="formation-item-drawer-skip" />
             }
           </div>
-          @if (currentItem.is_gating && !currentItem.can_complete) {
+          @if (!canWrite()) {
+            <!-- A disabled button isn't focusable, so a hover-only tooltip would never reach a keyboard/screen-reader user — render the reason as visible text instead, same pattern as the
+                 gate_writer message below. Takes priority over that message since it blocks every action here (Mark complete, Save, Skip), not just accepting a gating item. -->
+            <span class="text-xs text-gray-500" data-testid="formation-item-drawer-no-write-access">You need write access to this project to make changes here.</span>
+          } @else if (currentItem.is_gating && !currentItem.can_complete) {
             <!-- A disabled button isn't focusable, so a hover-only tooltip would never reach a keyboard/screen-reader user — render the reason as visible text instead. `can_complete` only ever
                  gates *accepting* an already-awaiting-acceptance item (formation.service.ts's completeFormationItem) — a non-gate-writer can still submit the item, so the copy must not
                  imply they can't act at all. -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
@@ -73,7 +73,9 @@
           @if (!canWrite()) {
             <!-- A disabled button isn't focusable, so a hover-only tooltip would never reach a keyboard/screen-reader user — render the reason as visible text instead, same pattern as the
                  gate_writer message below. Takes priority over that message since it blocks every action here (Mark complete, Save, Skip), not just accepting a gating item. -->
-            <span class="text-xs text-gray-500" data-testid="formation-item-drawer-no-write-access">You need write access to this project to make changes here.</span>
+            <span class="text-xs text-gray-500" data-testid="formation-item-drawer-no-write-access"
+              >You need write access to this project to make changes here.</span
+            >
           } @else if (currentItem.is_gating && !currentItem.can_complete) {
             <!-- A disabled button isn't focusable, so a hover-only tooltip would never reach a keyboard/screen-reader user — render the reason as visible text instead. `can_complete` only ever
                  gates *accepting* an already-awaiting-acceptance item (formation.service.ts's completeFormationItem) — a non-gate-writer can still submit the item, so the copy must not

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
@@ -47,8 +47,10 @@
     } @else if (item(); as currentItem) {
       <div class="flex flex-col gap-2">
         <!-- status_only items are updated by external tooling only — see formation.service.ts's
-             completeFormationItem rejection for the same rule enforced server-side. -->
-        @if (currentItem.status !== 'done' && currentItem.status !== 'skipped' && currentItem.action !== 'status_only') {
+             completeFormationItem rejection for the same rule enforced server-side. assigneeOnly
+             (GH-1956 decision 3): the Me-lens assignee never sets status, so Mark complete/Accept/Skip
+             are hidden entirely here rather than disabled — those rows have no "Mark done" at all. -->
+        @if (!assigneeOnly() && currentItem.status !== 'done' && currentItem.status !== 'skipped' && currentItem.action !== 'status_only') {
           <div class="flex items-center gap-2">
             <lfx-button
               [label]="completeLabel()"

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -52,6 +52,16 @@ export class FormationItemDrawerComponent {
    * `formation-checklist-section`'s existing usage, which doesn't pass this input, is unaffected.
    */
   public readonly canWrite = input<boolean>(true);
+  /**
+   * True when the drawer was opened from the Me-lens Pending Actions flow, where GH-1956 decision 3
+   * forbids the assignee from setting item status at all ("No 'Mark done'" — claim/block/open only,
+   * with status changes left to the formation team). Hides Mark complete/Accept/Skip entirely rather
+   * than merely disabling them, unlike `canWrite` above which still shows the controls (disabled, with
+   * an explanatory message) since that's a real-access question rather than a flow restriction.
+   * Defaults `false` so `formation-checklist-section`'s existing usage, which doesn't pass this input,
+   * is unaffected (copilot review, PR #2309).
+   */
+  public readonly assigneeOnly = input<boolean>(false);
 
   /** Fired for a status-changing action (Mark complete) — the section refreshes the row list, and closes the drawer if it's still showing this item. */
   public readonly itemChanged = output<FormationItem>();

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -43,6 +43,15 @@ export class FormationItemDrawerComponent {
   public readonly mutationInFlight = input<boolean>(false);
   /** True specifically while a skip the user submitted from this drawer is in flight — scoped narrower than `mutationInFlight` so a row action elsewhere doesn't spin this button. */
   public readonly skipInFlight = input<boolean>(false);
+  /**
+   * Whether the caller has real project write access — every mutation this drawer can trigger
+   * (Mark complete, Save, Skip) hard-requires `project.writer` server-side via
+   * `assertItemProjectWriteAccess`, independent of the item's own `can_complete` (copilot review:
+   * `can_complete` only encodes the gating-item LF-staff check, not real write access, so an
+   * auditor-only assignee would otherwise see enabled buttons that always 403). Defaults `true` so
+   * `formation-checklist-section`'s existing usage, which doesn't pass this input, is unaffected.
+   */
+  public readonly canWrite = input<boolean>(true);
 
   /** Fired for a status-changing action (Mark complete) — the section refreshes the row list, and closes the drawer if it's still showing this item. */
   public readonly itemChanged = output<FormationItem>();
@@ -104,7 +113,7 @@ export class FormationItemDrawerComponent {
    * `mutationInFlight`) the section-owned Skip/row-action mutation. All three write the same item,
    * so any one of them in flight must block the other two, not just its own button.
    */
-  protected readonly busy: Signal<boolean> = computed(() => this.completing() || this.savingDetails() || this.mutationInFlight());
+  protected readonly busy: Signal<boolean> = computed(() => this.completing() || this.savingDetails() || this.mutationInFlight() || !this.canWrite());
   protected readonly drawerData: Signal<FormationDrawerData> = this.initDrawerData();
   protected readonly item = computed(() => this.drawerData().item);
   protected readonly history = computed(() => this.drawerData().history);

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
@@ -1,0 +1,64 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (showSkeleton()) {
+  <section class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col gap-3" data-testid="me-formations-card-loading">
+    <p-skeleton width="10rem" height="1.25rem" />
+    <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+  </section>
+} @else if (visible()) {
+  <section class="bg-white rounded-2xl border border-gray-200 shadow-sm p-5 flex flex-col gap-4" data-testid="me-formations-card">
+    <h2 class="font-display font-light text-lg m-0">My formations</h2>
+
+    <div class="flex flex-col divide-y divide-gray-100">
+      @for (formation of visibleFormations(); track formation.formation_uid) {
+        <div class="flex flex-col gap-2 py-3 first:pt-0 last:pb-0" [attr.data-testid]="'me-formations-card-row-' + formation.formation_uid">
+          <div class="flex items-center justify-between gap-3 flex-wrap">
+            <a
+              [routerLink]="['/project/overview']"
+              [queryParams]="{ project: formation.project_slug }"
+              class="text-sm font-medium text-gray-900 no-underline hover:underline"
+              [attr.data-testid]="'me-formations-card-open-' + formation.formation_uid">
+              {{ formation.project_name }}
+            </a>
+            <lfx-tag [value]="stageLabels[formation.sub_stage]" [severity]="stageSeverities[formation.sub_stage]" />
+          </div>
+
+          <p class="text-xs text-gray-500 m-0" data-testid="me-formations-card-subtitle">{{ subtitleFor(formation) }}</p>
+
+          <div class="flex flex-col gap-1">
+            <div class="flex items-center justify-between text-xs text-gray-600">
+              <span>{{ formation.items_done }} of {{ formation.items_total }} done</span>
+              @if (formation.gating_total > 0) {
+                <span>{{ formation.gating_done }} of {{ formation.gating_total }} required for Active</span>
+              }
+            </div>
+            <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden w-full">
+              <div
+                class="h-full bg-blue-600 rounded-full"
+                [style.width.%]="progressPercentFor(formation)"
+                role="progressbar"
+                [attr.aria-valuenow]="progressPercentFor(formation)"
+                aria-valuemin="0"
+                aria-valuemax="100"></div>
+            </div>
+          </div>
+
+          <div class="flex items-center justify-between gap-3 flex-wrap text-xs text-gray-500">
+            @if (announcementLabelFor(formation); as announcementLabel) {
+              <span data-testid="me-formations-card-announcement">Announcement: {{ announcementLabel }}</span>
+            } @else {
+              <span>Announcement date not set</span>
+            }
+            @if (formation.blocking_item_title) {
+              <span class="text-amber-600" data-testid="me-formations-card-blocking">
+                <i class="fa-light fa-triangle-exclamation" aria-hidden="true"></i>
+                Blocked on: {{ formation.blocking_item_title }}
+              </span>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </section>
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
@@ -38,6 +38,7 @@
                 class="h-full bg-blue-600 rounded-full"
                 [style.width.%]="formation.progressPercent"
                 role="progressbar"
+                [attr.aria-label]="formation.project_name + ' checklist progress'"
                 [attr.aria-valuenow]="formation.progressPercent"
                 aria-valuemin="0"
                 aria-valuemax="100"></div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
@@ -38,7 +38,7 @@
                 class="h-full bg-blue-600 rounded-full"
                 [style.width.%]="formation.progressPercent"
                 role="progressbar"
-                [attr.aria-label]="formation.project_name + ' checklist progress'"
+                [attr.aria-label]="formation.project_name + ' checklist progress: ' + formation.items_done + ' of ' + formation.items_total + ' done'"
                 [attr.aria-valuenow]="formation.progressPercent"
                 aria-valuemin="0"
                 aria-valuemax="100"></div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
@@ -24,7 +24,7 @@
             <lfx-tag [value]="stageLabels[formation.sub_stage]" [severity]="stageSeverities[formation.sub_stage]" />
           </div>
 
-          <p class="text-xs text-gray-500 m-0" data-testid="me-formations-card-subtitle">{{ subtitleFor(formation) }}</p>
+          <p class="text-xs text-gray-500 m-0" data-testid="me-formations-card-subtitle">{{ formation.subtitle }}</p>
 
           <div class="flex flex-col gap-1">
             <div class="flex items-center justify-between text-xs text-gray-600">
@@ -36,16 +36,16 @@
             <div class="h-1.5 bg-gray-200 rounded-full overflow-hidden w-full">
               <div
                 class="h-full bg-blue-600 rounded-full"
-                [style.width.%]="progressPercentFor(formation)"
+                [style.width.%]="formation.progressPercent"
                 role="progressbar"
-                [attr.aria-valuenow]="progressPercentFor(formation)"
+                [attr.aria-valuenow]="formation.progressPercent"
                 aria-valuemin="0"
                 aria-valuemax="100"></div>
             </div>
           </div>
 
           <div class="flex items-center justify-between gap-3 flex-wrap text-xs text-gray-500">
-            @if (announcementLabelFor(formation); as announcementLabel) {
+            @if (formation.announcementLabel; as announcementLabel) {
               <span data-testid="me-formations-card-announcement">Announcement: {{ announcementLabel }}</span>
             } @else {
               <span>Announcement date not set</span>

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
@@ -1,0 +1,83 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import type { MyFormationSummary, MyFormationWorkResponse } from '@lfx-one/shared/interfaces';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { FormationService } from '@services/formation.service';
+import { describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
+
+import { MyFormationsCardComponent } from './my-formations-card.component';
+
+const formation = (overrides: Partial<MyFormationSummary> = {}): MyFormationSummary => ({
+  formation_uid: 'formation-1',
+  project_uid: 'project-1',
+  project_slug: 'acme-project',
+  project_name: 'Acme Project',
+  sub_stage: 'exploratory',
+  announcement_date: null,
+  assigned_to_do: 1,
+  assigned_with_team: 0,
+  assigned_done: 0,
+  items_done: 0,
+  items_total: 2,
+  gating_done: 0,
+  gating_total: 1,
+  blocking_item_title: null,
+  ...overrides,
+});
+
+async function render(formations: MyFormationSummary[], flagEnabled = true): Promise<ComponentFixture<MyFormationsCardComponent>> {
+  const response: MyFormationWorkResponse = { formations, items: [], data_source: 'fixture' };
+
+  await TestBed.configureTestingModule({
+    imports: [MyFormationsCardComponent],
+    providers: [
+      provideRouter([]),
+      { provide: FeatureFlagService, useValue: { getBooleanFlag: () => signal(flagEnabled) } },
+      { provide: FormationService, useValue: { getMyFormationWork: vi.fn().mockReturnValue(of(response)) } },
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(MyFormationsCardComponent);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('MyFormationsCardComponent (GH-1956)', () => {
+  it('renders a single formation as the card body (N=1)', async () => {
+    const fixture = await render([formation()]);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(1);
+    expect(fixture.nativeElement.textContent).toContain('1 to do');
+  });
+
+  it('renders multiple formations as sibling rows (N=3)', async () => {
+    const fixture = await render([
+      formation({ formation_uid: 'formation-1' }),
+      formation({ formation_uid: 'formation-2' }),
+      formation({ formation_uid: 'formation-3' }),
+    ]);
+
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(3);
+  });
+
+  it('renders nothing when there are no formations', async () => {
+    const fixture = await render([]);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card-loading"]')).toBeNull();
+  });
+
+  it('renders nothing when the flag is off, even with formations in the response', async () => {
+    const fixture = await render([formation()], false);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card"]')).toBeNull();
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
@@ -22,6 +22,7 @@ const formation = (overrides: Partial<MyFormationSummary> = {}): MyFormationSumm
   assigned_to_do: 1,
   assigned_with_team: 0,
   assigned_done: 0,
+  assigned_skipped: 0,
   items_done: 0,
   items_total: 2,
   gating_done: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -11,7 +11,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { FormationService } from '@services/formation.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, finalize, map, of } from 'rxjs';
+import { catchError, map, of, tap } from 'rxjs';
 
 /**
  * "My formations" card (GH-1956) — one row per formation the caller has at least one checklist item
@@ -61,16 +61,20 @@ export class MyFormationsCardComponent {
     );
   }
 
+  // `getMyFormationWork()` now stays open for the app's lifetime (it re-emits on
+  // `invalidateMyFormationWork()`), so it never completes — `finalize` would never fire. `tap`/
+  // `catchError` clear `loading` on each emission instead.
   private initFormations(): Signal<MyFormationSummary[]> {
     return toSignal(
       this.formationService.getMyFormationWork().pipe(
+        tap(() => this.loading.set(false)),
         map((response) => response.formations),
         catchError((error: unknown) => {
           console.error('[MyFormationsCard] Failed to load formation work', error);
           this.hasError.set(true);
+          this.loading.set(false);
           return of([] as MyFormationSummary[]);
-        }),
-        finalize(() => this.loading.set(false))
+        })
       ),
       { initialValue: [] as MyFormationSummary[] }
     );

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -35,6 +35,9 @@ export class MyFormationsCardComponent {
   private readonly formationService = inject(FormationService);
 
   protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
+  // Only ever cleared, never re-armed by a post-mutation `invalidateMyFormationWork()` refresh — a
+  // deliberate choice so an in-place update (e.g. claiming a row) swaps the card's rows in place
+  // instead of flashing the skeleton back in.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
 
@@ -61,13 +64,19 @@ export class MyFormationsCardComponent {
     );
   }
 
-  // `getMyFormationWork()` now stays open for the app's lifetime (it re-emits on
-  // `invalidateMyFormationWork()`), so it never completes — `finalize` would never fire. `tap`/
-  // `catchError` clear `loading` on each emission instead.
+  // `getMyFormationWork()` re-emits on every `invalidateMyFormationWork()` rather than completing,
+  // so `finalize` would never fire — `tap`/`catchError` clear `loading` on each emission instead.
+  // The service's own fetch never errors (its `catchError` sits inside the shared stream and falls
+  // back to an empty response there), so this `catchError` is defensive only; `hasError` still
+  // resets on every successful emission so a page that loaded fine doesn't stay flagged from an
+  // earlier defensive trip.
   private initFormations(): Signal<MyFormationSummary[]> {
     return toSignal(
       this.formationService.getMyFormationWork().pipe(
-        tap(() => this.loading.set(false)),
+        tap(() => {
+          this.loading.set(false);
+          this.hasError.set(false);
+        }),
         map((response) => response.formations),
         catchError((error: unknown) => {
           console.error('[MyFormationsCard] Failed to load formation work', error);

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { FORMATION_ENABLED_FLAG, FORMATION_SUB_STAGE_LABELS, FORMATION_SUB_STAGE_SEVERITY } from '@lfx-one/shared/constants';
+import type { MyFormationSummary } from '@lfx-one/shared/interfaces';
+import { formatFormationAnnouncementLabel, formatMyFormationSubtitle } from '@lfx-one/shared/utils';
+import { TagComponent } from '@components/tag/tag.component';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { FormationService } from '@services/formation.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, finalize, map, of } from 'rxjs';
+
+/**
+ * "My formations" card (GH-1956) — one row per formation the caller has at least one checklist item
+ * assigned to (see `MyFormationSummary`'s doc comment for why that, not a direct grant, is the
+ * definition). Renders on both Me-lens dashboards (`multi-persona-dashboard`, `user-dashboard`);
+ * the "In formation" tile is `multi-persona-dashboard`-only, added separately there.
+ *
+ * N=1 is the primary layout, not a degenerate single-row table — a lone formation renders as the
+ * card's one full-width row, and additional formations stack as sibling rows separated by a divider.
+ * The card renders nothing (returns to the DOM as empty) once the flag is off, the fetch errored, or
+ * there are no formations to show — an Active project drops out of the response entirely, so this
+ * is also how the card disappears once the caller's last formation goes Active.
+ */
+@Component({
+  selector: 'lfx-my-formations-card',
+  imports: [SkeletonModule, TagComponent, RouterLink],
+  templateUrl: './my-formations-card.component.html',
+})
+export class MyFormationsCardComponent {
+  private readonly featureFlagService = inject(FeatureFlagService);
+  private readonly formationService = inject(FormationService);
+
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
+  protected readonly loading = signal(true);
+  protected readonly hasError = signal(false);
+
+  private readonly formations: Signal<MyFormationSummary[]> = this.initFormations();
+  protected readonly visible = computed(() => this.formationFlagEnabled() && !this.loading() && !this.hasError() && this.formations().length > 0);
+  protected readonly showSkeleton = computed(() => this.formationFlagEnabled() && this.loading());
+  protected readonly visibleFormations = this.formations;
+
+  protected readonly stageLabels = FORMATION_SUB_STAGE_LABELS;
+  protected readonly stageSeverities = FORMATION_SUB_STAGE_SEVERITY;
+
+  protected subtitleFor(formation: MyFormationSummary): string {
+    return formatMyFormationSubtitle({
+      assigned_to_do: formation.assigned_to_do,
+      assigned_with_team: formation.assigned_with_team,
+      assigned_done: formation.assigned_done,
+    });
+  }
+
+  protected announcementLabelFor(formation: MyFormationSummary): string | null {
+    return formatFormationAnnouncementLabel(formation.announcement_date);
+  }
+
+  protected progressPercentFor(formation: MyFormationSummary): number {
+    if (formation.items_total <= 0) return 0;
+    return Math.round((formation.items_done / formation.items_total) * 100);
+  }
+
+  private initFormations(): Signal<MyFormationSummary[]> {
+    return toSignal(
+      this.formationService.getMyFormationWork().pipe(
+        map((response) => response.formations),
+        catchError((error: unknown) => {
+          console.error('[MyFormationsCard] Failed to load formation work', error);
+          this.hasError.set(true);
+          return of([] as MyFormationSummary[]);
+        }),
+        finalize(() => this.loading.set(false))
+      ),
+      { initialValue: [] as MyFormationSummary[] }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -57,6 +57,7 @@ export class MyFormationsCardComponent {
           assigned_to_do: formation.assigned_to_do,
           assigned_with_team: formation.assigned_with_team,
           assigned_done: formation.assigned_done,
+          assigned_skipped: formation.assigned_skipped,
         }),
         progressPercent: formation.items_total > 0 ? Math.round((formation.items_done / formation.items_total) * 100) : 0,
         announcementLabel: formatFormationAnnouncementLabel(formation.announcement_date),

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, Signal, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { FORMATION_ENABLED_FLAG, FORMATION_SUB_STAGE_LABELS, FORMATION_SUB_STAGE_SEVERITY } from '@lfx-one/shared/constants';
 import type { DecoratedMyFormation, MyFormationSummary } from '@lfx-one/shared/interfaces';
@@ -11,7 +11,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { FormationService } from '@services/formation.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, map, of, tap } from 'rxjs';
+import { catchError, filter, map, of, switchMap, take, tap } from 'rxjs';
 
 /**
  * "My formations" card (GH-1956) — one row per formation the caller has at least one checklist item
@@ -64,6 +64,8 @@ export class MyFormationsCardComponent {
     );
   }
 
+  // Gated on the flag so a disabled flag never issues the request — mirrors
+  // `multi-persona-dashboard.component.ts`'s `initFormationCount`.
   // `getMyFormationWork()` re-emits on every `invalidateMyFormationWork()` rather than completing,
   // so `finalize` would never fire — `tap`/`catchError` clear `loading` on each emission instead.
   // The service's own fetch never errors (its `catchError` sits inside the shared stream and falls
@@ -72,18 +74,24 @@ export class MyFormationsCardComponent {
   // earlier defensive trip.
   private initFormations(): Signal<MyFormationSummary[]> {
     return toSignal(
-      this.formationService.getMyFormationWork().pipe(
-        tap(() => {
-          this.loading.set(false);
-          this.hasError.set(false);
-        }),
-        map((response) => response.formations),
-        catchError((error: unknown) => {
-          console.error('[MyFormationsCard] Failed to load formation work', error);
-          this.hasError.set(true);
-          this.loading.set(false);
-          return of([] as MyFormationSummary[]);
-        })
+      toObservable(this.formationFlagEnabled).pipe(
+        filter(Boolean),
+        take(1),
+        switchMap(() =>
+          this.formationService.getMyFormationWork().pipe(
+            tap(() => {
+              this.loading.set(false);
+              this.hasError.set(false);
+            }),
+            map((response) => response.formations),
+            catchError((error: unknown) => {
+              console.error('[MyFormationsCard] Failed to load formation work', error);
+              this.hasError.set(true);
+              this.loading.set(false);
+              return of([] as MyFormationSummary[]);
+            })
+          )
+        )
       ),
       { initialValue: [] as MyFormationSummary[] }
     );

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, Signal, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { FORMATION_ENABLED_FLAG, FORMATION_SUB_STAGE_LABELS, FORMATION_SUB_STAGE_SEVERITY } from '@lfx-one/shared/constants';
-import type { MyFormationSummary } from '@lfx-one/shared/interfaces';
+import type { DecoratedMyFormation, MyFormationSummary } from '@lfx-one/shared/interfaces';
 import { formatFormationAnnouncementLabel, formatMyFormationSubtitle } from '@lfx-one/shared/utils';
 import { TagComponent } from '@components/tag/tag.component';
 import { FeatureFlagService } from '@services/feature-flag.service';
@@ -41,26 +41,24 @@ export class MyFormationsCardComponent {
   private readonly formations: Signal<MyFormationSummary[]> = this.initFormations();
   protected readonly visible = computed(() => this.formationFlagEnabled() && !this.loading() && !this.hasError() && this.formations().length > 0);
   protected readonly showSkeleton = computed(() => this.formationFlagEnabled() && this.loading());
-  protected readonly visibleFormations = this.formations;
+  protected readonly visibleFormations: Signal<DecoratedMyFormation[]> = this.initVisibleFormations();
 
   protected readonly stageLabels = FORMATION_SUB_STAGE_LABELS;
   protected readonly stageSeverities = FORMATION_SUB_STAGE_SEVERITY;
 
-  protected subtitleFor(formation: MyFormationSummary): string {
-    return formatMyFormationSubtitle({
-      assigned_to_do: formation.assigned_to_do,
-      assigned_with_team: formation.assigned_with_team,
-      assigned_done: formation.assigned_done,
-    });
-  }
-
-  protected announcementLabelFor(formation: MyFormationSummary): string | null {
-    return formatFormationAnnouncementLabel(formation.announcement_date);
-  }
-
-  protected progressPercentFor(formation: MyFormationSummary): number {
-    if (formation.items_total <= 0) return 0;
-    return Math.round((formation.items_done / formation.items_total) * 100);
+  private initVisibleFormations(): Signal<DecoratedMyFormation[]> {
+    return computed(() =>
+      this.formations().map((formation) => ({
+        ...formation,
+        subtitle: formatMyFormationSubtitle({
+          assigned_to_do: formation.assigned_to_do,
+          assigned_with_team: formation.assigned_with_team,
+          assigned_done: formation.assigned_done,
+        }),
+        progressPercent: formation.items_total > 0 ? Math.round((formation.items_done / formation.items_total) * 100) : 0,
+        announcementLabel: formatFormationAnnouncementLabel(formation.announcement_date),
+      }))
+    );
   }
 
   private initFormations(): Signal<MyFormationSummary[]> {

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
@@ -126,7 +126,9 @@
                       (onClick)="onClaimFormationItem(item)"
                       data-testid="pending-actions-drawer-formation-claim" />
                   }
-                  @if (item.formationItemAction !== 'status_only' && (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress')) {
+                  @if (
+                    item.formationItemAction !== 'status_only' && (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress')
+                  ) {
                     <lfx-button
                       size="small"
                       severity="secondary"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
@@ -121,7 +121,8 @@
                       size="small"
                       severity="primary"
                       label="Claim"
-                      [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                      [disabled]="formationMutationRowKeys().has(item.rowKey) || item.formationCanWrite === false"
+                      [tooltip]="item.formationCanWrite === false ? 'You need write access to this project to claim this item.' : undefined"
                       (onClick)="onClaimFormationItem(item)"
                       data-testid="pending-actions-drawer-formation-claim" />
                   }
@@ -131,7 +132,8 @@
                       severity="secondary"
                       [outlined]="true"
                       label="Block…"
-                      [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                      [disabled]="formationMutationRowKeys().has(item.rowKey) || item.formationCanWrite === false"
+                      [tooltip]="item.formationCanWrite === false ? 'You need write access to this project to block this item.' : undefined"
                       (onClick)="onBlockFormationItemRequested(item)"
                       data-testid="pending-actions-drawer-formation-block" />
                   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
@@ -116,7 +116,7 @@
                 </div>
               } @else if (item.isFormationItem) {
                 <div class="flex items-center gap-2">
-                  @if (item.formationItemStatus === 'not_started') {
+                  @if (item.formationItemAction !== 'status_only' && item.formationItemStatus === 'not_started') {
                     <lfx-button
                       size="small"
                       severity="primary"
@@ -126,7 +126,7 @@
                       (onClick)="onClaimFormationItem(item)"
                       data-testid="pending-actions-drawer-formation-claim" />
                   }
-                  @if (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress') {
+                  @if (item.formationItemAction !== 'status_only' && (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress')) {
                     <lfx-button
                       size="small"
                       severity="secondary"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.html
@@ -114,6 +114,35 @@
                     (onClick)="onDeclineInvitation(item)"
                     data-testid="pending-actions-drawer-invitation-decline" />
                 </div>
+              } @else if (item.isFormationItem) {
+                <div class="flex items-center gap-2">
+                  @if (item.formationItemStatus === 'not_started') {
+                    <lfx-button
+                      size="small"
+                      severity="primary"
+                      label="Claim"
+                      [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                      (onClick)="onClaimFormationItem(item)"
+                      data-testid="pending-actions-drawer-formation-claim" />
+                  }
+                  @if (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress') {
+                    <lfx-button
+                      size="small"
+                      severity="secondary"
+                      [outlined]="true"
+                      label="Block…"
+                      [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                      (onClick)="onBlockFormationItemRequested(item)"
+                      data-testid="pending-actions-drawer-formation-block" />
+                  }
+                  <lfx-button
+                    size="small"
+                    severity="secondary"
+                    [text]="true"
+                    label="Open"
+                    (onClick)="onOpenFormationItem(item)"
+                    data-testid="pending-actions-drawer-formation-open" />
+                </div>
               } @else if (item.buttonLink) {
                 <lfx-button
                   size="small"
@@ -137,8 +166,9 @@
               }
             </div>
             <!-- Dismiss — skeleton while RSVP meeting data is loading, real button once ready. Invitations are resolved
-                 server-side (Accept/Decline), never cookie-dismissed, so they render no Dismiss control. -->
-            @if (!item.isInvitation) {
+                 server-side (Accept/Decline), never cookie-dismissed, so they render no Dismiss control. Formation items
+                 are owned by the assignee's Claim/Block/Open actions, not a generic dismiss, so they're excluded too. -->
+            @if (!item.isInvitation && !item.isFormationItem) {
               @if (item.isRsvpInline && (item.isMeetingLoading || !item.meeting)) {
                 <p-skeleton width="4.5rem" height="1.25rem" styleClass="shrink-0" />
               } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -142,20 +142,20 @@ export class PendingActionsDrawerComponent {
     if (this.formationMutationRowKeys().has(rowKey)) return;
     this.formationMutationRowKeys.update((s) => new Set(s).add(rowKey));
 
-    this.formationService
-      .updateFormationItemStatus(projectUid, itemKey, 'in_progress')
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => {
-          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
-          this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
-          this.formationItemMutated.emit(item);
-        },
-        error: () => {
-          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
-          this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't claim — try again.", life: 5000 });
-        },
-      });
+    // No takeUntilDestroyed on the write itself — this must complete once sent; unsubscribing on
+    // destroy (e.g. the drawer closing or the dashboard navigating away) would cancel the in-flight
+    // HTTP request and leave the item in an inconsistent state relative to what the server persisted.
+    this.formationService.updateFormationItemStatus(projectUid, itemKey, 'in_progress').subscribe({
+      next: () => {
+        this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+        this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
+        this.formationItemMutated.emit(item);
+      },
+      error: () => {
+        this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+        this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't claim — try again.", life: 5000 });
+      },
+    });
   }
 
   // Block with note (GH-1956), mirroring `pending-actions.component.ts`'s `onBlockFormationItemRequested`.
@@ -180,20 +180,18 @@ export class PendingActionsDrawerComponent {
       if (!result?.reason || this.formationMutationRowKeys().has(rowKey)) return;
       this.formationMutationRowKeys.update((s) => new Set(s).add(rowKey));
 
-      this.formationService
-        .updateFormationItemStatus(projectUid, itemKey, 'blocked', result.reason)
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
-          next: () => {
-            this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
-            this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
-            this.formationItemMutated.emit(item);
-          },
-          error: () => {
-            this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
-            this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't mark this item blocked — try again.", life: 5000 });
-          },
-        });
+      // No takeUntilDestroyed on the write itself — see the matching comment on onClaimFormationItem.
+      this.formationService.updateFormationItemStatus(projectUid, itemKey, 'blocked', result.reason).subscribe({
+        next: () => {
+          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
+          this.formationItemMutated.emit(item);
+        },
+        error: () => {
+          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't mark this item blocked — try again.", life: 5000 });
+        },
+      });
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -20,7 +20,15 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { filter, take, timer } from 'rxjs';
 
-import type { DrawerActionRow, FormationItemOpenRequest, Meeting, MeetingRsvp, PendingActionItem, ReasonPromptDialogResult, RsvpResponse } from '@lfx-one/shared/interfaces';
+import type {
+  DrawerActionRow,
+  FormationItemOpenRequest,
+  Meeting,
+  MeetingRsvp,
+  PendingActionItem,
+  ReasonPromptDialogResult,
+  RsvpResponse,
+} from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-pending-actions-drawer',

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -7,21 +7,25 @@ import { Router, UrlTree } from '@angular/router';
 import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { ReasonPromptDialogComponent } from '@components/reason-prompt-dialog/reason-prompt-dialog.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_FADE_OUT_MS, PENDING_ACTION_LABEL } from '@lfx-one/shared/constants';
+import { FormationService } from '@services/formation.service';
 import { MeetingService } from '@services/meeting.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
 import { InvitationService } from '@shared/services/invitation.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
+import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { filter, timer } from 'rxjs';
+import { filter, take, timer } from 'rxjs';
 
-import type { DrawerActionRow, Meeting, MeetingRsvp, PendingActionItem, RsvpResponse } from '@lfx-one/shared/interfaces';
+import type { DrawerActionRow, Meeting, MeetingRsvp, PendingActionItem, ReasonPromptDialogResult, RsvpResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-pending-actions-drawer',
   imports: [DrawerModule, SkeletonModule, ButtonComponent, TagComponent, EmptyStateComponent, RsvpButtonGroupComponent],
+  providers: [DialogService],
   templateUrl: './pending-actions-drawer.component.html',
   styleUrl: './pending-actions-drawer.component.scss',
 })
@@ -29,6 +33,8 @@ export class PendingActionsDrawerComponent {
   private readonly hiddenActionsService = inject(HiddenActionsService);
   private readonly meetingService = inject(MeetingService);
   private readonly invitationService = inject(InvitationService);
+  private readonly formationService = inject(FormationService);
+  private readonly dialogService = inject(DialogService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
@@ -46,10 +52,16 @@ export class PendingActionsDrawerComponent {
   // deferred-undo decline (whose Undo affordance lives in the parent's shared p-toast) are all owned in one place.
   public readonly acceptInvitationRequested = output<PendingActionItem>();
   public readonly declineInvitationRequested = output<PendingActionItem>();
+  // Emits {projectUid, itemKey} when a FormationItem row's Open action needs the existing
+  // formation-item-drawer (GH-1956) — mirrors `pending-actions.component.ts`'s own output;
+  // the parent dashboard hosts `dashboard-formation-item-drawer-host` and opens it on this event.
+  public readonly formationItemRequested = output<{ projectUid: string; itemKey: string }>();
 
   private readonly hiddenActionsVersion = signal(0);
   // Rows currently in the fade-out + collapse transition; keeps them rendered through the animation.
   protected readonly completingRowKeys = signal<ReadonlySet<string>>(new Set());
+  // Rows with an in-flight claim/block mutation — mirrors `pending-actions.component.ts`'s own signal.
+  protected readonly formationMutationRowKeys = signal<ReadonlySet<string>>(new Set());
   private readonly meetingCache = signal<Record<string, Meeting>>({});
   private readonly loadingMeetingUids = signal<ReadonlySet<string>>(new Set());
   private readonly failedMeetingUids = signal<ReadonlySet<string>>(new Set());
@@ -107,6 +119,80 @@ export class PendingActionsDrawerComponent {
 
   protected onDeclineInvitation(item: DrawerActionRow): void {
     this.declineInvitationRequested.emit(item);
+  }
+
+  // Claim a formation checklist item assigned to the caller (GH-1956), mirroring
+  // `pending-actions.component.ts`'s `onClaimFormationItem`. The row stays on the list — a
+  // successful claim just clears the in-flight flag so the drawer's next render (driven by the
+  // parent's refreshed `pendingActions` input) picks up the new status/actions.
+  protected onClaimFormationItem(item: DrawerActionRow): void {
+    const projectUid = item.formationProjectUid;
+    const itemKey = item.formationItemKey;
+    if (!projectUid || !itemKey) return;
+
+    const rowKey = item.rowKey;
+    if (this.formationMutationRowKeys().has(rowKey)) return;
+    this.formationMutationRowKeys.update((s) => new Set(s).add(rowKey));
+
+    this.formationService
+      .updateFormationItemStatus(projectUid, itemKey, 'in_progress')
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
+        },
+        error: () => {
+          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't claim — try again.", life: 5000 });
+        },
+      });
+  }
+
+  // Block with note (GH-1956), mirroring `pending-actions.component.ts`'s `onBlockFormationItemRequested`.
+  protected onBlockFormationItemRequested(item: DrawerActionRow): void {
+    const projectUid = item.formationProjectUid;
+    const itemKey = item.formationItemKey;
+    if (!projectUid || !itemKey) return;
+
+    const rowKey = item.rowKey;
+    const ref = this.dialogService.open(ReasonPromptDialogComponent, {
+      header: 'Mark blocked',
+      width: '480px',
+      modal: true,
+      data: {
+        prompt: `Marking "${item.text}" blocked requires a reason. This is logged in the item's history.`,
+        placeholder: 'What is blocking this item?',
+        confirmLabel: 'Mark blocked',
+      },
+    });
+
+    ref?.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((result: ReasonPromptDialogResult | undefined) => {
+      if (!result?.reason || this.formationMutationRowKeys().has(rowKey)) return;
+      this.formationMutationRowKeys.update((s) => new Set(s).add(rowKey));
+
+      this.formationService
+        .updateFormationItemStatus(projectUid, itemKey, 'blocked', result.reason)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: () => {
+            this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+            this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
+          },
+          error: () => {
+            this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+            this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't mark this item blocked — try again.", life: 5000 });
+          },
+        });
+    });
+  }
+
+  // Open (GH-1956): opens the existing formation-item-drawer via the parent-hosted dashboard-formation-item-drawer-host.
+  protected onOpenFormationItem(item: DrawerActionRow): void {
+    const projectUid = item.formationProjectUid;
+    const itemKey = item.formationItemKey;
+    if (!projectUid || !itemKey) return;
+    this.formationItemRequested.emit({ projectUid, itemKey });
   }
 
   protected handleRsvpSubmit(item: DrawerActionRow, rsvp: MeetingRsvp): void {
@@ -190,6 +276,12 @@ export class PendingActionsDrawerComponent {
     if (item.voteUid) {
       return `${item.type}-${item.voteUid}`;
     }
+    if (item.briefActionUid) {
+      return `${item.type}-${item.briefActionUid}`;
+    }
+    if (item.formationItemUid) {
+      return `${item.type}-${item.formationItemUid}`;
+    }
     const base = `${item.type}-${item.badge}-${item.text}`;
     return item.buttonLink ? `${base}|${item.buttonLink}` : base;
   }
@@ -232,6 +324,7 @@ export class PendingActionsDrawerComponent {
           const isVoteInline = item.type === 'Vote' && !!item.voteUid;
           // Require committeeUid too — Accept/Decline delegate to the parent which calls the API with it.
           const isInvitation = item.type === 'Invitation' && !!item.inviteUid && !!item.committeeUid;
+          const isFormationItem = item.type === 'FormationItem' && !!item.formationProjectUid && !!item.formationItemKey;
           const inviteGroupName = item.inviteGroupName ?? item.badge;
           return {
             ...item,
@@ -242,6 +335,7 @@ export class PendingActionsDrawerComponent {
             isMeetingLoading: !!item.meetingUid && loading.has(item.meetingUid),
             meetingLoadFailed,
             isInvitation,
+            isFormationItem,
             acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
             declineAriaLabel: `Decline invite to ${inviteGroupName}`,
           };

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -130,8 +130,9 @@ export class PendingActionsDrawerComponent {
 
   // Claim a formation checklist item assigned to the caller (GH-1956), mirroring
   // `pending-actions.component.ts`'s `onClaimFormationItem`. The row stays on the list — a
-  // successful claim just clears the in-flight flag so the drawer's next render (driven by the
-  // parent's refreshed `pendingActions` input) picks up the new status/actions.
+  // successful claim clears the in-flight flag and emits `formationItemMutated`, which the host
+  // (`pending-actions.component.html`) forwards as `actionClick` to trigger the parent dashboard's
+  // refresh, so the drawer's next render picks up the new status/actions.
   protected onClaimFormationItem(item: DrawerActionRow): void {
     const projectUid = item.formationProjectUid;
     const itemKey = item.formationItemKey;

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -20,7 +20,7 @@ import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { filter, take, timer } from 'rxjs';
 
-import type { DrawerActionRow, Meeting, MeetingRsvp, PendingActionItem, ReasonPromptDialogResult, RsvpResponse } from '@lfx-one/shared/interfaces';
+import type { DrawerActionRow, FormationItemOpenRequest, Meeting, MeetingRsvp, PendingActionItem, ReasonPromptDialogResult, RsvpResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-pending-actions-drawer',
@@ -55,7 +55,7 @@ export class PendingActionsDrawerComponent {
   // Emits {projectUid, itemKey} when a FormationItem row's Open action needs the existing
   // formation-item-drawer (GH-1956) — mirrors `pending-actions.component.ts`'s own output;
   // the parent dashboard hosts `dashboard-formation-item-drawer-host` and opens it on this event.
-  public readonly formationItemRequested = output<{ projectUid: string; itemKey: string }>();
+  public readonly formationItemRequested = output<FormationItemOpenRequest>();
   // Emits after a successful Claim/Block-with-note so the parent (`pending-actions.component.ts`)
   // can re-fetch the server-truth pending actions list — mirroring its own `actionClick` output for
   // the same two actions on the main inline list. `actionCompleted` above only drives the local
@@ -200,7 +200,7 @@ export class PendingActionsDrawerComponent {
     const projectUid = item.formationProjectUid;
     const itemKey = item.formationItemKey;
     if (!projectUid || !itemKey) return;
-    this.formationItemRequested.emit({ projectUid, itemKey });
+    this.formationItemRequested.emit({ projectUid, itemKey, canWrite: item.formationCanWrite });
   }
 
   protected handleRsvpSubmit(item: DrawerActionRow, rsvp: MeetingRsvp): void {

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions-drawer/pending-actions-drawer.component.ts
@@ -56,6 +56,13 @@ export class PendingActionsDrawerComponent {
   // formation-item-drawer (GH-1956) — mirrors `pending-actions.component.ts`'s own output;
   // the parent dashboard hosts `dashboard-formation-item-drawer-host` and opens it on this event.
   public readonly formationItemRequested = output<{ projectUid: string; itemKey: string }>();
+  // Emits after a successful Claim/Block-with-note so the parent (`pending-actions.component.ts`)
+  // can re-fetch the server-truth pending actions list — mirroring its own `actionClick` output for
+  // the same two actions on the main inline list. `actionCompleted` above only drives the local
+  // hide-cookie recompute (correct for RSVP/dismiss, which are purely client-side), so it can't be
+  // reused here: a claim/block changes the item's status server-side and the row stays visible, so
+  // without this the row's status/actions go stale until the next unrelated refresh.
+  public readonly formationItemMutated = output<PendingActionItem>();
 
   private readonly hiddenActionsVersion = signal(0);
   // Rows currently in the fade-out + collapse transition; keeps them rendered through the animation.
@@ -141,6 +148,7 @@ export class PendingActionsDrawerComponent {
         next: () => {
           this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
           this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
+          this.formationItemMutated.emit(item);
         },
         error: () => {
           this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
@@ -178,6 +186,7 @@ export class PendingActionsDrawerComponent {
           next: () => {
             this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
             this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
+            this.formationItemMutated.emit(item);
           },
           error: () => {
             this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -220,14 +220,16 @@
                               (onClick)="onClaimFormationItem(item)"
                               data-testid="dashboard-pending-actions-formation-claim" />
                           }
-                          <lfx-button
-                            size="small"
-                            severity="secondary"
-                            [outlined]="true"
-                            label="Block…"
-                            [disabled]="formationMutationRowKeys().has(item.rowKey)"
-                            (onClick)="onBlockFormationItemRequested(item)"
-                            data-testid="dashboard-pending-actions-formation-block" />
+                          @if (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress') {
+                            <lfx-button
+                              size="small"
+                              severity="secondary"
+                              [outlined]="true"
+                              label="Block…"
+                              [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                              (onClick)="onBlockFormationItemRequested(item)"
+                              data-testid="dashboard-pending-actions-formation-block" />
+                          }
                           <lfx-button
                             size="small"
                             severity="secondary"
@@ -291,7 +293,8 @@
         (actionCompleted)="onDrawerActionCompleted()"
         (castVoteRequested)="castVoteRequested.emit($event)"
         (acceptInvitationRequested)="onAcceptInvitation($event)"
-        (declineInvitationRequested)="onDeclineInvitation($event)" />
+        (declineInvitationRequested)="onDeclineInvitation($event)"
+        (formationItemRequested)="formationItemRequested.emit($event)" />
     }
   </section>
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -221,7 +221,10 @@
                               (onClick)="onClaimFormationItem(item)"
                               data-testid="dashboard-pending-actions-formation-claim" />
                           }
-                          @if (item.formationItemAction !== 'status_only' && (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress')) {
+                          @if (
+                            item.formationItemAction !== 'status_only' &&
+                            (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress')
+                          ) {
                             <lfx-button
                               size="small"
                               severity="secondary"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -207,6 +207,33 @@
                             (onClick)="onDeclineInvitation(item)"
                             data-testid="dashboard-pending-actions-invitation-decline" />
                         </div>
+                      } @else if (item.isFormationItem) {
+                        <div class="flex items-center gap-2">
+                          @if (item.formationItemStatus === 'not_started') {
+                            <lfx-button
+                              size="small"
+                              severity="primary"
+                              label="Claim"
+                              [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                              (onClick)="onClaimFormationItem(item)"
+                              data-testid="dashboard-pending-actions-formation-claim" />
+                          }
+                          <lfx-button
+                            size="small"
+                            severity="secondary"
+                            [outlined]="true"
+                            label="Block…"
+                            [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                            (onClick)="onBlockFormationItemRequested(item)"
+                            data-testid="dashboard-pending-actions-formation-block" />
+                          <lfx-button
+                            size="small"
+                            severity="secondary"
+                            [text]="true"
+                            label="Open"
+                            (onClick)="onOpenFormationItem(item)"
+                            data-testid="dashboard-pending-actions-formation-open" />
+                        </div>
                       } @else if (item.buttonLink) {
                         <lfx-button
                           size="small"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -129,12 +129,14 @@
                         }
                       </div>
                     } @else {
-                      <p
-                        class="text-sm font-medium text-gray-900 sm:flex-1 sm:min-w-0 sm:truncate sm:px-4"
-                        [attr.title]="item.text"
-                        data-testid="dashboard-pending-actions-title">
-                        {{ item.text }}
-                      </p>
+                      <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
+                        <p class="text-sm font-medium text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
+                          {{ item.text }}
+                        </p>
+                        @if (item.isFormationItem && item.formationIsGating) {
+                          <span class="text-xs text-amber-600" data-testid="dashboard-pending-actions-formation-gating">Required for Active</span>
+                        }
+                      </div>
                     }
                     <!-- Action button — right-aligned, fixed by content -->
                     <div class="self-start sm:self-auto sm:shrink-0 sm:flex sm:justify-end">

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -216,7 +216,8 @@
                               size="small"
                               severity="primary"
                               label="Claim"
-                              [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                              [disabled]="formationMutationRowKeys().has(item.rowKey) || item.formationCanWrite === false"
+                              [tooltip]="item.formationCanWrite === false ? 'You need write access to this project to claim this item.' : undefined"
                               (onClick)="onClaimFormationItem(item)"
                               data-testid="dashboard-pending-actions-formation-claim" />
                           }
@@ -226,7 +227,8 @@
                               severity="secondary"
                               [outlined]="true"
                               label="Block…"
-                              [disabled]="formationMutationRowKeys().has(item.rowKey)"
+                              [disabled]="formationMutationRowKeys().has(item.rowKey) || item.formationCanWrite === false"
+                              [tooltip]="item.formationCanWrite === false ? 'You need write access to this project to block this item.' : undefined"
                               (onClick)="onBlockFormationItemRequested(item)"
                               data-testid="dashboard-pending-actions-formation-block" />
                           }
@@ -294,7 +296,8 @@
         (castVoteRequested)="castVoteRequested.emit($event)"
         (acceptInvitationRequested)="onAcceptInvitation($event)"
         (declineInvitationRequested)="onDeclineInvitation($event)"
-        (formationItemRequested)="formationItemRequested.emit($event)" />
+        (formationItemRequested)="formationItemRequested.emit($event)"
+        (formationItemMutated)="actionClick.emit($event)" />
     }
   </section>
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -286,7 +286,7 @@
       }
 
       <lfx-pending-actions-drawer
-        [pendingActions]="pendingActions()"
+        [pendingActions]="visibleActionsUnlimited()"
         [(visible)]="drawerVisible"
         (actionCompleted)="onDrawerActionCompleted()"
         (castVoteRequested)="castVoteRequested.emit($event)"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -211,7 +211,7 @@
                         </div>
                       } @else if (item.isFormationItem) {
                         <div class="flex items-center gap-2">
-                          @if (item.formationItemStatus === 'not_started') {
+                          @if (item.formationItemAction !== 'status_only' && item.formationItemStatus === 'not_started') {
                             <lfx-button
                               size="small"
                               severity="primary"
@@ -221,7 +221,7 @@
                               (onClick)="onClaimFormationItem(item)"
                               data-testid="dashboard-pending-actions-formation-claim" />
                           }
-                          @if (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress') {
+                          @if (item.formationItemAction !== 'status_only' && (item.formationItemStatus === 'not_started' || item.formationItemStatus === 'in_progress')) {
                             <lfx-button
                               size="small"
                               severity="secondary"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -350,7 +350,6 @@ export class PendingActionsComponent {
       .subscribe({
         next: () => {
           this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
-          this.formationService.invalidateMyFormationWork();
           this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
           this.actionClick.emit(item);
         },
@@ -397,7 +396,6 @@ export class PendingActionsComponent {
         .subscribe({
           next: () => {
             this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
-            this.formationService.invalidateMyFormationWork();
             this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
             this.actionClick.emit(item);
           },

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -37,6 +37,7 @@ import { take, timer } from 'rxjs';
 
 import type {
   DecoratedPendingAction,
+  FormationItemOpenRequest,
   Meeting,
   MeetingRsvp,
   PendingActionItem,
@@ -99,7 +100,7 @@ export class PendingActionsComponent {
   // Emits {projectUid, itemKey} when a FormationItem row's Open (or Block with note's underlying
   // item) needs the existing formation-item-drawer (GH-1956) — the parent dashboard hosts
   // `dashboard-formation-item-drawer-host` and opens it on this event.
-  public readonly formationItemRequested = output<{ projectUid: string; itemKey: string }>();
+  public readonly formationItemRequested = output<FormationItemOpenRequest>();
 
   protected readonly drawerVisible = model<boolean>(false);
 
@@ -413,7 +414,7 @@ export class PendingActionsComponent {
     const projectUid = item.formationProjectUid;
     const itemKey = item.formationItemKey;
     if (!projectUid || !itemKey) return;
-    this.formationItemRequested.emit({ projectUid, itemKey });
+    this.formationItemRequested.emit({ projectUid, itemKey, canWrite: item.formationCanWrite });
   }
 
   protected openDrawer(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -11,6 +11,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { ToastMessageComponent } from '@components/toast-message/toast-message.component';
 import {
+  FORMATION_ENABLED_FLAG,
   PENDING_ACTION_BUTTON_ICON,
   PENDING_ACTION_EMPTY_GRACE_MS,
   PENDING_ACTION_FADE_OUT_MS,
@@ -19,6 +20,7 @@ import {
   VOTE_INLINE_BALLOT_MAX_COMMENT_PROMPTS,
 } from '@lfx-one/shared/constants';
 import { PollType } from '@lfx-one/shared/enums';
+import { FeatureFlagService } from '@services/feature-flag.service';
 import { MeetingService } from '@services/meeting.service';
 import { VoteService } from '@services/vote.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
@@ -79,9 +81,14 @@ export class PendingActionsComponent {
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
+  private readonly featureFlagService = inject(FeatureFlagService);
 
   protected readonly buttonIcons = PENDING_ACTION_BUTTON_ICON;
   protected readonly typeLabels = PENDING_ACTION_LABEL;
+  /** GH-1956 — mirrors the flag gate on `lfx-my-formations-card` / the "In formation" tile so a
+   *  user with the flag off never sees FormationItem rows here either, even though the server
+   *  aggregator itself is unflagged (see `FORMATION_ENABLED_FLAG`'s doc comment). */
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
 
   public readonly pendingActions = input.required<PendingActionItem[]>();
   public readonly displayLimit = input<number>(2);
@@ -677,7 +684,11 @@ export class PendingActionsComponent {
       const pinned = new Set<string>();
       this.completingRowKeys().forEach((k) => pinned.add(k));
       this.swappingRowKeys().forEach((k) => pinned.add(k));
+      const formationEnabled = this.formationFlagEnabled();
       return this.pendingActions().filter((item) => {
+        if (item.type === 'FormationItem' && !formationEnabled) {
+          return false;
+        }
         if (item.type === 'Invitation' && !!item.inviteUid && resolvedInvites.has(item.inviteUid)) {
           return false;
         }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -350,6 +350,7 @@ export class PendingActionsComponent {
       .subscribe({
         next: () => {
           this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.formationService.invalidateMyFormationWork();
           this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
           this.actionClick.emit(item);
         },
@@ -396,6 +397,7 @@ export class PendingActionsComponent {
         .subscribe({
           next: () => {
             this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+            this.formationService.invalidateMyFormationWork();
             this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
             this.actionClick.emit(item);
           },

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -25,12 +25,24 @@ import { HiddenActionsService } from '@shared/services/hidden-actions.service';
 import { getEntityCommands, invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationAcceptFlowService } from '@shared/services/invitation-accept-flow.service';
 import { InvitationService } from '@shared/services/invitation.service';
+import { FormationService } from '@shared/services/formation.service';
+import { ReasonPromptDialogComponent } from '@components/reason-prompt-dialog/reason-prompt-dialog.component';
 import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { ToastModule } from 'primeng/toast';
-import { timer } from 'rxjs';
+import { take, timer } from 'rxjs';
 
-import type { DecoratedPendingAction, Meeting, MeetingRsvp, PendingActionItem, PendingDecline, RsvpResponse, Vote } from '@lfx-one/shared/interfaces';
+import type {
+  DecoratedPendingAction,
+  Meeting,
+  MeetingRsvp,
+  PendingActionItem,
+  PendingDecline,
+  ReasonPromptDialogResult,
+  RsvpResponse,
+  Vote,
+} from '@lfx-one/shared/interfaces';
 
 /** Deferred-undo window (ms) before an optimistic decline is committed upstream. */
 const INVITE_DECLINE_UNDO_MS = 5000;
@@ -52,6 +64,7 @@ const INVITE_UNDO_TOAST_KEY = 'pending-actions-undo';
     ToastModule,
     RouterLink,
   ],
+  providers: [DialogService],
   templateUrl: './pending-actions.component.html',
   styleUrl: './pending-actions.component.scss',
 })
@@ -61,6 +74,8 @@ export class PendingActionsComponent {
   private readonly voteService = inject(VoteService);
   private readonly invitationService = inject(InvitationService);
   private readonly invitationAcceptFlow = inject(InvitationAcceptFlowService);
+  private readonly formationService = inject(FormationService);
+  private readonly dialogService = inject(DialogService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
@@ -74,6 +89,10 @@ export class PendingActionsComponent {
   public readonly actionClick = output<PendingActionItem>();
   // Emits the voteUid when a Vote pending-action needs the cast drawer (multi-question or ranked poll).
   public readonly castVoteRequested = output<string>();
+  // Emits {projectUid, itemKey} when a FormationItem row's Open (or Block with note's underlying
+  // item) needs the existing formation-item-drawer (GH-1956) — the parent dashboard hosts
+  // `dashboard-formation-item-drawer-host` and opens it on this event.
+  public readonly formationItemRequested = output<{ projectUid: string; itemKey: string }>();
 
   protected readonly drawerVisible = model<boolean>(false);
 
@@ -89,6 +108,9 @@ export class PendingActionsComponent {
   private readonly loadingMeetingUids = signal<ReadonlySet<string>>(new Set());
   private readonly loadingVoteUids = signal<ReadonlySet<string>>(new Set());
   private readonly failedMeetingUids = signal<ReadonlySet<string>>(new Set());
+  // Rows with an in-flight Claim (or Block with note) mutation — disables the row's buttons so a
+  // second click can't fire a duplicate PATCH while the first is still in flight.
+  protected readonly formationMutationRowKeys = signal<ReadonlySet<string>>(new Set());
 
   // The decline currently inside its deferred-undo window — drives the Undo affordance in the toast. Null when no decline is pending.
   protected readonly pendingDecline = signal<PendingDecline | null>(null);
@@ -300,6 +322,91 @@ export class PendingActionsComponent {
     this.invitationService.unmarkResolved(pending.inviteUid);
     this.pendingDecline.set(null);
     this.messageService.clear(INVITE_UNDO_TOAST_KEY);
+  }
+
+  // Claim a formation checklist item assigned to the caller (GH-1956): not_started -> in_progress,
+  // no note. The row stays on the list afterward (only done/skipped items drop off) — a successful
+  // claim just re-fetches pending actions so the row's status/actions catch up, mirroring how
+  // handleRsvpSubmit/handleVoteSubmitted refresh via actionClick rather than mutating the row locally.
+  protected onClaimFormationItem(item: DecoratedPendingAction): void {
+    const projectUid = item.formationProjectUid;
+    const itemKey = item.formationItemKey;
+    if (!projectUid || !itemKey) return;
+
+    const rowKey = this.getRowKey(item);
+    if (this.formationMutationRowKeys().has(rowKey)) return;
+    this.formationMutationRowKeys.update((s) => new Set(s).add(rowKey));
+
+    this.formationService
+      .updateFormationItemStatus(projectUid, itemKey, 'in_progress')
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Claimed', detail: `You claimed "${item.text}"`, life: 5000 });
+          this.actionClick.emit(item);
+        },
+        error: () => {
+          this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+          this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't claim — try again.", life: 5000 });
+        },
+      });
+  }
+
+  /**
+   * Block with note (GH-1956): the item drawer has no block-with-reason control of its own — the
+   * only place `blocked` is reachable today is `formation-checklist-section.component.ts`'s
+   * status-menu "Mark blocked…", a required-reason confirm dialog against the same plain
+   * `updateFormationItemStatus(..., 'blocked', reason)` endpoint. This mirrors that pattern rather
+   * than opening the drawer, whose own "note" field (`editForm.notes`) is a general free-text field
+   * unrelated to a status transition. `formationItemRequested` (opening the drawer) is reserved for
+   * the row's separate **Open** action.
+   */
+  protected onBlockFormationItemRequested(item: DecoratedPendingAction): void {
+    const projectUid = item.formationProjectUid;
+    const itemKey = item.formationItemKey;
+    if (!projectUid || !itemKey) return;
+
+    const rowKey = this.getRowKey(item);
+    const ref = this.dialogService.open(ReasonPromptDialogComponent, {
+      header: 'Mark blocked',
+      width: '480px',
+      modal: true,
+      data: {
+        prompt: `Marking "${item.text}" blocked requires a reason. This is logged in the item's history.`,
+        placeholder: 'What is blocking this item?',
+        confirmLabel: 'Mark blocked',
+      },
+    });
+
+    ref?.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((result: ReasonPromptDialogResult | undefined) => {
+      if (!result?.reason || this.formationMutationRowKeys().has(rowKey)) return;
+      this.formationMutationRowKeys.update((s) => new Set(s).add(rowKey));
+
+      this.formationService
+        .updateFormationItemStatus(projectUid, itemKey, 'blocked', result.reason)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: () => {
+            this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+            this.messageService.add({ key: 'pending-actions-toast', severity: 'success', summary: 'Marked blocked', life: 5000 });
+            this.actionClick.emit(item);
+          },
+          error: () => {
+            this.formationMutationRowKeys.update((s) => this.removeFromSet(s, rowKey));
+            this.messageService.add({ key: 'pending-actions-toast', severity: 'error', summary: "Couldn't mark this item blocked — try again.", life: 5000 });
+          },
+        });
+    });
+  }
+
+  // Open (GH-1956): opens the existing formation-item-drawer via the parent-hosted
+  // dashboard-formation-item-drawer-host, same precedent as castVoteRequested/dashboard-cast-drawer-host.
+  protected onOpenFormationItem(item: DecoratedPendingAction): void {
+    const projectUid = item.formationProjectUid;
+    const itemKey = item.formationItemKey;
+    if (!projectUid || !itemKey) return;
+    this.formationItemRequested.emit({ projectUid, itemKey });
   }
 
   protected openDrawer(): void {
@@ -530,6 +637,12 @@ export class PendingActionsComponent {
     if (item.voteUid) {
       return `${item.type}-${item.voteUid}`;
     }
+    if (item.briefActionUid) {
+      return `${item.type}-${item.briefActionUid}`;
+    }
+    if (item.formationItemUid) {
+      return `${item.type}-${item.formationItemUid}`;
+    }
     const base = `${item.type}-${item.badge}-${item.text}`;
     return item.buttonLink ? `${base}|${item.buttonLink}` : base;
   }
@@ -599,6 +712,7 @@ export class PendingActionsComponent {
         // Require committeeUid too — the invitation branch builds a routerLink to the group
         // and calls accept/decline with it, so a row missing it would render /groups/undefined.
         const isInvitation = item.type === 'Invitation' && !!item.inviteUid && !!item.committeeUid;
+        const isFormationItem = item.type === 'FormationItem' && !!item.formationProjectUid && !!item.formationItemKey;
         const inviteGroupName = item.inviteGroupName ?? item.badge;
         // Canonical tier-prefixed view link (GH-1566): the invited group's own `inviteIsFoundation`
         // picks /foundation vs /project; rows without tier data keep the flat /groups/:uid fallback.
@@ -621,6 +735,7 @@ export class PendingActionsComponent {
           isVoteInlineExpanded,
           voteUsesDrawer: voteUsesDrawerVal,
           isInvitation,
+          isFormationItem,
           acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
           declineAriaLabel: `Decline invite to ${inviteGroupName}`,
           inviteViewCommands,

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -152,6 +152,9 @@
                 <div class="flex flex-col gap-0.5">
                   <p class="text-xl font-medium text-gray-900">{{ formationCount() }}</p>
                   <p class="text-sm font-normal text-gray-900">In formation</p>
+                  @if (formationAnnouncementLabel()) {
+                    <p class="text-xs text-gray-500" data-testid="multi-persona-formation-tile-announcement">{{ formationAnnouncementLabel() }}</p>
+                  }
                 </div>
               </div>
             }
@@ -256,4 +259,4 @@
 <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="handleVoteSubmitted()" />
 
 <!-- Formation item drawer launched from a FormationItem pending action's Open action (GH-1956). -->
-<lfx-dashboard-formation-item-drawer-host #formationDrawerHost />
+<lfx-dashboard-formation-item-drawer-host #formationDrawerHost (itemMutated)="handleActionClick()" />

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -42,7 +42,11 @@
       </section>
     } @else {
       @defer (on idle) {
-        <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" (castVoteRequested)="castDrawerHost.open($event)" />
+        <lfx-pending-actions
+          [pendingActions]="pendingActions()"
+          (actionClick)="handleActionClick()"
+          (castVoteRequested)="castDrawerHost.open($event)"
+          (formationItemRequested)="formationDrawerHost.open($event)" />
       } @placeholder {
         <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-placeholder">
           <div class="mb-4 flex h-8 items-center gap-2">
@@ -55,6 +59,13 @@
           </div>
         </section>
       }
+    }
+
+    <!-- My formations (GH-1956) -->
+    @defer (on idle) {
+      <lfx-my-formations-card />
+    } @placeholder {
+      <p-skeleton width="100%" height="6rem" borderRadius="16px" />
     }
 
     <!-- My Foundations and Projects Section -->
@@ -73,9 +84,10 @@
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
           <div
             class="grid w-full grid-cols-1 divide-y sm:divide-y-0 sm:divide-x divide-gray-200"
-            [class.sm:grid-cols-4]="hasFoundations() && hasProjects()"
-            [class.sm:grid-cols-3]="hasFoundations() !== hasProjects()"
-            [class.sm:grid-cols-2]="!hasFoundations() && !hasProjects()">
+            [class.sm:grid-cols-2]="summaryStatsTileCount() === 2"
+            [class.sm:grid-cols-3]="summaryStatsTileCount() === 3"
+            [class.sm:grid-cols-4]="summaryStatsTileCount() === 4"
+            [class.sm:grid-cols-5]="summaryStatsTileCount() === 5">
             @if (hasFoundations()) {
               <div class="flex items-center gap-3 p-4">
                 <div class="flex items-center justify-center w-11 h-11 rounded-full bg-purple-100 text-purple-600 flex-shrink-0">
@@ -130,6 +142,17 @@
                 <p class="text-sm font-normal text-gray-900">Meetings This Week</p>
               </div>
             </div>
+            @if (formationTileVisible()) {
+              <div class="flex items-center gap-3 p-4" data-testid="multi-persona-formation-tile">
+                <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-50 text-blue-600 flex-shrink-0">
+                  <i class="fa-light fa-diagram-project text-xl"></i>
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <p class="text-xl font-medium text-gray-900">{{ formationCount() }}</p>
+                  <p class="text-sm font-normal text-gray-900">In formation</p>
+                </div>
+              </div>
+            }
           </div>
         </lfx-card>
       </div>
@@ -229,3 +252,6 @@
 
 <!-- Inline ballot cast drawer launched from a Vote pending action — same drawer used on /votes. -->
 <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="handleVoteSubmitted()" />
+
+<!-- Formation item drawer launched from a FormationItem pending action's Open action (GH-1956). -->
+<lfx-dashboard-formation-item-drawer-host #formationDrawerHost />

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -62,10 +62,12 @@
     }
 
     <!-- My formations (GH-1956) -->
-    @defer (on idle) {
-      <lfx-my-formations-card />
-    } @placeholder {
-      <p-skeleton width="100%" height="6rem" borderRadius="16px" />
+    @if (formationFlagEnabled()) {
+      @defer (on idle) {
+        <lfx-my-formations-card />
+      } @placeholder {
+        <p-skeleton width="100%" height="6rem" borderRadius="16px" />
+      }
     }
 
     <!-- My Foundations and Projects Section -->

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -122,7 +122,9 @@ export class MultiPersonaDashboardComponent {
   // so it vanishes along with `lfx-my-formations-card` once the caller's last formation goes Active.
   protected readonly formationTileLoading = signal(true);
   protected readonly formationCount: Signal<number> = this.initFormationCount();
-  protected readonly formationTileVisible: Signal<boolean> = computed(() => this.formationFlagEnabled() && !this.formationTileLoading() && this.formationCount() > 0);
+  protected readonly formationTileVisible: Signal<boolean> = computed(
+    () => this.formationFlagEnabled() && !this.formationTileLoading() && this.formationCount() > 0
+  );
   // Tile count for the summary-stat strip — 2 fixed tiles (Surveys, Meetings) plus whichever of
   // Foundations / Projects / In formation are visible, so the row always divides evenly. Template
   // binds this to literal `sm:grid-cols-N` classes (not a computed string) so Tailwind's content

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -292,7 +292,10 @@ export class MultiPersonaDashboardComponent {
     return toSignal(
       this.formationService.getMyFormationWork().pipe(
         map((response) => response.formations.length),
-        catchError(() => of(0)),
+        catchError((error: unknown) => {
+          console.error('[MultiPersonaDashboard] Failed to load formation work', error);
+          return of(0);
+        }),
         tap(() => this.formationTileLoading.set(false))
       ),
       { initialValue: 0 }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -19,11 +19,13 @@ import {
   ProjectContext,
   Meeting,
 } from '@lfx-one/shared/interfaces';
-import { PERSONA_PRIORITY, ROLE_PRIORITY, VOTING_STATUS_PRIORITY } from '@lfx-one/shared/constants';
+import { FORMATION_ENABLED_FLAG, PERSONA_PRIORITY, ROLE_PRIORITY, VOTING_STATUS_PRIORITY } from '@lfx-one/shared/constants';
 import { SurveyStatus } from '@lfx-one/shared/enums';
 import { getActiveOccurrences, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 
 import { AnalyticsService } from '@services/analytics.service';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { FormationService } from '@services/formation.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -36,12 +38,23 @@ import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap,
 import { CardComponent } from '@components/card/card.component';
 import { TableComponent } from '@components/table/table.component';
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
+import { DashboardFormationItemDrawerHostComponent } from '../components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component';
+import { MyFormationsCardComponent } from '../components/my-formations-card/my-formations-card.component';
 import { MyMeetingsComponent } from '../components/my-meetings/my-meetings.component';
 import { PendingActionsComponent } from '../components/pending-actions/pending-actions.component';
 
 @Component({
   selector: 'lfx-multi-persona-dashboard',
-  imports: [SkeletonModule, MyMeetingsComponent, PendingActionsComponent, CardComponent, TableComponent, DashboardCastDrawerHostComponent],
+  imports: [
+    SkeletonModule,
+    MyMeetingsComponent,
+    PendingActionsComponent,
+    MyFormationsCardComponent,
+    CardComponent,
+    TableComponent,
+    DashboardCastDrawerHostComponent,
+    DashboardFormationItemDrawerHostComponent,
+  ],
   templateUrl: './multi-persona-dashboard.component.html',
   styleUrl: './multi-persona-dashboard.component.scss',
 })
@@ -51,9 +64,13 @@ export class MultiPersonaDashboardComponent {
   private readonly surveyService = inject(SurveyService);
   private readonly userService = inject(UserService);
   private readonly projectService = inject(ProjectService);
+  private readonly formationService = inject(FormationService);
+  private readonly featureFlagService = inject(FeatureFlagService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly lensService = inject(LensService);
   private readonly router = inject(Router);
+
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined);
 
@@ -100,6 +117,19 @@ export class MultiPersonaDashboardComponent {
   });
   protected readonly pendingActionsLoading = signal(true);
   protected readonly pendingActions: Signal<PendingActionItem[]> = this.initPendingActions();
+  // "In formation" tile (GH-1956) — its own independent-loading signal per the section's per-tile
+  // convention; only visible once the flag is on and the caller actually has a formation to show,
+  // so it vanishes along with `lfx-my-formations-card` once the caller's last formation goes Active.
+  protected readonly formationTileLoading = signal(true);
+  protected readonly formationCount: Signal<number> = this.initFormationCount();
+  protected readonly formationTileVisible: Signal<boolean> = computed(() => this.formationFlagEnabled() && !this.formationTileLoading() && this.formationCount() > 0);
+  // Tile count for the summary-stat strip — 2 fixed tiles (Surveys, Meetings) plus whichever of
+  // Foundations / Projects / In formation are visible, so the row always divides evenly. Template
+  // binds this to literal `sm:grid-cols-N` classes (not a computed string) so Tailwind's content
+  // scanner still finds them.
+  protected readonly summaryStatsTileCount: Signal<number> = computed(
+    () => 2 + (this.hasFoundations() ? 1 : 0) + (this.hasProjects() ? 1 : 0) + (this.formationTileVisible() ? 1 : 0)
+  );
 
   public constructor() {
     // Fetch enriched persona projects so role-group lists show project names instead of slugs.
@@ -255,6 +285,17 @@ export class MultiPersonaDashboardComponent {
         tap(() => this.pendingActionsLoading.set(false))
       ),
       { initialValue: [] }
+    );
+  }
+
+  private initFormationCount(): Signal<number> {
+    return toSignal(
+      this.formationService.getMyFormationWork().pipe(
+        map((response) => response.formations.length),
+        catchError(() => of(0)),
+        tap(() => this.formationTileLoading.set(false))
+      ),
+      { initialValue: 0 }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -33,7 +33,7 @@ import { ProjectService } from '@services/project.service';
 import { SurveyService } from '@services/survey.service';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, take, tap } from 'rxjs';
 
 import { CardComponent } from '@components/card/card.component';
 import { TableComponent } from '@components/table/table.component';
@@ -288,14 +288,21 @@ export class MultiPersonaDashboardComponent {
     );
   }
 
+  // Gated on the flag so a disabled flag never issues the request — only the rendering was gated before.
   private initFormationCount(): Signal<number> {
     return toSignal(
-      this.formationService.getMyFormationWork().pipe(
-        map((response) => response.formations.length),
-        catchError((error: unknown) => {
-          console.error('[MultiPersonaDashboard] Failed to load formation work', error);
-          return of(0);
-        }),
+      toObservable(this.formationFlagEnabled).pipe(
+        filter(Boolean),
+        take(1),
+        switchMap(() =>
+          this.formationService.getMyFormationWork().pipe(
+            map((response) => response.formations.length),
+            catchError((error: unknown) => {
+              console.error('[MultiPersonaDashboard] Failed to load formation work', error);
+              return of(0);
+            })
+          )
+        ),
         tap(() => this.formationTileLoading.set(false))
       ),
       { initialValue: 0 }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -11,6 +11,7 @@ import {
   EnrichedPersonaProject,
   FoundationHealthScoreDistributionResponse,
   MultiFoundationSummaryResponse,
+  MyFormationWorkResponse,
   PastMeeting,
   PendingActionItem,
   PerFoundationAnalytics,
@@ -21,7 +22,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { FORMATION_ENABLED_FLAG, PERSONA_PRIORITY, ROLE_PRIORITY, VOTING_STATUS_PRIORITY } from '@lfx-one/shared/constants';
 import { SurveyStatus } from '@lfx-one/shared/enums';
-import { getActiveOccurrences, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { formatFormationAnnouncementLabel, getActiveOccurrences, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 
 import { AnalyticsService } from '@services/analytics.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
@@ -121,7 +122,18 @@ export class MultiPersonaDashboardComponent {
   // convention; only visible once the flag is on and the caller actually has a formation to show,
   // so it vanishes along with `lfx-my-formations-card` once the caller's last formation goes Active.
   protected readonly formationTileLoading = signal(true);
-  protected readonly formationCount: Signal<number> = this.initFormationCount();
+  protected readonly formationWork: Signal<MyFormationWorkResponse | null> = this.initFormationWork();
+  protected readonly formationCount: Signal<number> = computed(() => this.formationWork()?.formations.length ?? 0);
+  // The go-live date/countdown (GH-1956 issue body: the tile carries "count, go-live date,
+  // countdown") supplied by whichever formation is soonest to go live — the announcement date is
+  // the one piece of information that's actionable regardless of how many formations the caller has.
+  protected readonly formationAnnouncementLabel: Signal<string | null> = computed(() => {
+    const formations = this.formationWork()?.formations ?? [];
+    const dates = formations.map((f) => f.announcement_date).filter((d): d is string => !!d);
+    if (dates.length === 0) return null;
+    const soonest = dates.reduce((earliest, current) => (current < earliest ? current : earliest));
+    return formatFormationAnnouncementLabel(soonest);
+  });
   protected readonly formationTileVisible: Signal<boolean> = computed(
     () => this.formationFlagEnabled() && !this.formationTileLoading() && this.formationCount() > 0
   );
@@ -291,23 +303,22 @@ export class MultiPersonaDashboardComponent {
   }
 
   // Gated on the flag so a disabled flag never issues the request — only the rendering was gated before.
-  private initFormationCount(): Signal<number> {
+  private initFormationWork(): Signal<MyFormationWorkResponse | null> {
     return toSignal(
       toObservable(this.formationFlagEnabled).pipe(
         filter(Boolean),
         take(1),
         switchMap(() =>
           this.formationService.getMyFormationWork().pipe(
-            map((response) => response.formations.length),
             catchError((error: unknown) => {
               console.error('[MultiPersonaDashboard] Failed to load formation work', error);
-              return of(0);
+              return of(null);
             })
           )
         ),
         tap(() => this.formationTileLoading.set(false))
       ),
-      { initialValue: 0 }
+      { initialValue: null }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
@@ -136,4 +136,4 @@
 <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="handleVoteSubmitted()" />
 
 <!-- Formation item drawer launched from a FormationItem pending action's Open action (GH-1956). -->
-<lfx-dashboard-formation-item-drawer-host #formationDrawerHost />
+<lfx-dashboard-formation-item-drawer-host #formationDrawerHost (itemMutated)="handleActionClick()" />

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
@@ -50,10 +50,12 @@
     }
 
     <!-- My formations (GH-1956) -->
-    @defer (on idle) {
-      <lfx-my-formations-card />
-    } @placeholder {
-      <p-skeleton width="100%" height="6rem" borderRadius="16px" />
+    @if (formationFlagEnabled()) {
+      @defer (on idle) {
+        <lfx-my-formations-card />
+      } @placeholder {
+        <p-skeleton width="100%" height="6rem" borderRadius="16px" />
+      }
     }
 
     <!-- Board/ED: Foundation Health | Contributor/Maintainer: Recent Progress -->

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
@@ -30,7 +30,11 @@
 
     <!-- Pending Actions (always second) -->
     @defer (on idle) {
-      <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" (castVoteRequested)="castDrawerHost.open($event)" />
+      <lfx-pending-actions
+        [pendingActions]="pendingActions()"
+        (actionClick)="handleActionClick()"
+        (castVoteRequested)="castDrawerHost.open($event)"
+        (formationItemRequested)="formationDrawerHost.open($event)" />
     } @placeholder {
       <section class="flex flex-col flex-1" data-testid="user-dashboard-pending-actions-placeholder">
         <div class="flex items-center justify-between mb-4 px-2 h-8">
@@ -43,6 +47,13 @@
           <p-skeleton width="100%" height="140px" />
         </div>
       </section>
+    }
+
+    <!-- My formations (GH-1956) -->
+    @defer (on idle) {
+      <lfx-my-formations-card />
+    } @placeholder {
+      <p-skeleton width="100%" height="6rem" borderRadius="16px" />
     }
 
     <!-- Board/ED: Foundation Health | Contributor/Maintainer: Recent Progress -->
@@ -121,3 +132,6 @@
 
 <!-- Inline ballot cast drawer launched from a Vote pending action — same drawer used on /votes. -->
 <lfx-dashboard-cast-drawer-host #castDrawerHost (voteSubmitted)="handleVoteSubmitted()" />
+
+<!-- Formation item drawer launched from a FormationItem pending action's Open action (GH-1956). -->
+<lfx-dashboard-formation-item-drawer-host #formationDrawerHost />

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
@@ -11,14 +11,25 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { BehaviorSubject, catchError, of, switchMap } from 'rxjs';
 
 import { DashboardCastDrawerHostComponent } from '../components/dashboard-cast-drawer-host/dashboard-cast-drawer-host.component';
+import { DashboardFormationItemDrawerHostComponent } from '../components/dashboard-formation-item-drawer-host/dashboard-formation-item-drawer-host.component';
 import { FoundationHealthComponent } from '../components/foundation-health/foundation-health.component';
+import { MyFormationsCardComponent } from '../components/my-formations-card/my-formations-card.component';
 import { MyMeetingsComponent } from '../components/my-meetings/my-meetings.component';
 import { PendingActionsComponent } from '../components/pending-actions/pending-actions.component';
 import { RecentProgressComponent } from '../components/recent-progress/recent-progress.component';
 
 @Component({
   selector: 'lfx-user-dashboard',
-  imports: [FoundationHealthComponent, RecentProgressComponent, PendingActionsComponent, MyMeetingsComponent, SkeletonModule, DashboardCastDrawerHostComponent],
+  imports: [
+    FoundationHealthComponent,
+    RecentProgressComponent,
+    PendingActionsComponent,
+    MyFormationsCardComponent,
+    MyMeetingsComponent,
+    SkeletonModule,
+    DashboardCastDrawerHostComponent,
+    DashboardFormationItemDrawerHostComponent,
+  ],
   templateUrl: './user-dashboard.component.html',
   styleUrl: './user-dashboard.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
@@ -3,8 +3,10 @@
 
 import { Component, computed, inject, Signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FORMATION_ENABLED_FLAG } from '@lfx-one/shared/constants';
 import { PendingActionItem } from '@lfx-one/shared/interfaces';
 import { isBoardScopedPersona } from '@lfx-one/shared/utils';
+import { FeatureFlagService } from '@services/feature-flag.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -34,11 +36,13 @@ import { RecentProgressComponent } from '../components/recent-progress/recent-pr
   styleUrl: './user-dashboard.component.scss',
 })
 export class UserDashboardComponent {
+  private readonly featureFlagService = inject(FeatureFlagService);
   private readonly personaService = inject(PersonaService);
   private readonly projectService = inject(ProjectService);
 
   public readonly refresh$ = new BehaviorSubject<void>(undefined);
 
+  protected readonly formationFlagEnabled = this.featureFlagService.getBooleanFlag(FORMATION_ENABLED_FLAG, false);
   protected readonly isBoardScoped = computed(() => isBoardScopedPersona(this.personaService.currentPersona()));
   protected readonly activityRoleLabel = computed(() => {
     const persona = this.personaService.currentPersona();

--- a/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
@@ -142,14 +142,51 @@ describe('FormationService', () => {
     expect(replayed).toEqual({ formations: [], items: [], data_source: 'fixture' });
   });
 
-  it('invalidateMyFormationWork() drops the cache so the next subscriber re-fetches', () => {
-    service.getMyFormationWork().subscribe();
+  it('invalidateMyFormationWork() pushes a fresh response to an already-live subscriber', () => {
+    const received: unknown[] = [];
+    service.getMyFormationWork().subscribe((response) => received.push(response));
     http.expectOne('/api/user/formation-work').flush({ formations: [], items: [], data_source: 'fixture' });
 
     service.invalidateMyFormationWork();
+    http.expectOne('/api/user/formation-work').flush({ formations: [{ formation_uid: 'f-1' }], items: [], data_source: 'fixture' });
 
+    expect(received).toEqual([
+      { formations: [], items: [], data_source: 'fixture' },
+      { formations: [{ formation_uid: 'f-1' }], items: [], data_source: 'fixture' },
+    ]);
+  });
+
+  it('getMyFormationWork() falls back to an empty response and stays subscribable after a failed fetch', () => {
+    const received: unknown[] = [];
+    service.getMyFormationWork().subscribe((response) => received.push(response));
+    http.expectOne('/api/user/formation-work').error(new ProgressEvent('error'));
+
+    service.invalidateMyFormationWork();
+    http.expectOne('/api/user/formation-work').flush({ formations: [{ formation_uid: 'f-1' }], items: [], data_source: 'fixture' });
+
+    expect(received).toEqual([
+      { formations: [], items: [], data_source: 'fixture' },
+      { formations: [{ formation_uid: 'f-1' }], items: [], data_source: 'fixture' },
+    ]);
+  });
+
+  it('a mutation method invalidates my-formation-work on success', () => {
     service.getMyFormationWork().subscribe();
-    const req = http.expectOne('/api/user/formation-work');
-    req.flush({ formations: [], items: [], data_source: 'fixture' });
+    http.expectOne('/api/user/formation-work').flush({ formations: [], items: [], data_source: 'fixture' });
+
+    service.completeFormationItem('project-1', 'item-1').subscribe();
+    http.expectOne('/api/formations/project-1/items/item-1/complete').flush({});
+
+    http.expectOne('/api/user/formation-work').flush({ formations: [], items: [], data_source: 'fixture' });
+  });
+
+  it('a mutation method does not invalidate my-formation-work when the request errors', () => {
+    service.getMyFormationWork().subscribe();
+    http.expectOne('/api/user/formation-work').flush({ formations: [], items: [], data_source: 'fixture' });
+
+    service.completeFormationItem('project-1', 'item-1').subscribe({ error: () => undefined });
+    http.expectOne('/api/formations/project-1/items/item-1/complete').error(new ProgressEvent('error'));
+
+    http.expectNone('/api/user/formation-work');
   });
 });

--- a/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
@@ -122,4 +122,34 @@ describe('FormationService', () => {
     expect(filtered.request.params.get('search')).toBe('alliance');
     filtered.flush({});
   });
+
+  it('getMyFormationWork shares one GET across concurrent subscribers', () => {
+    service.getMyFormationWork().subscribe();
+    service.getMyFormationWork().subscribe();
+
+    const req = http.expectOne('/api/user/formation-work');
+    expect(req.request.method).toBe('GET');
+    req.flush({ formations: [], items: [], data_source: 'fixture' });
+  });
+
+  it('getMyFormationWork replays the cached response to a later subscriber without a second GET', () => {
+    service.getMyFormationWork().subscribe();
+    http.expectOne('/api/user/formation-work').flush({ formations: [], items: [], data_source: 'fixture' });
+
+    let replayed: unknown;
+    service.getMyFormationWork().subscribe((response) => (replayed = response));
+    http.expectNone('/api/user/formation-work');
+    expect(replayed).toEqual({ formations: [], items: [], data_source: 'fixture' });
+  });
+
+  it('invalidateMyFormationWork() drops the cache so the next subscriber re-fetches', () => {
+    service.getMyFormationWork().subscribe();
+    http.expectOne('/api/user/formation-work').flush({ formations: [], items: [], data_source: 'fixture' });
+
+    service.invalidateMyFormationWork();
+
+    service.getMyFormationWork().subscribe();
+    const req = http.expectOne('/api/user/formation-work');
+    req.flush({ formations: [], items: [], data_source: 'fixture' });
+  });
 });

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -10,6 +10,7 @@ import type {
   FormationItemStatus,
   FormationSubStage,
   FormationsQueueResponse,
+  MyFormationWorkResponse,
 } from '@lfx-one/shared/interfaces';
 import { Observable, take } from 'rxjs';
 
@@ -75,5 +76,10 @@ export class FormationService {
     if (subStage) params = params.set('sub_stage', subStage);
     if (search) params = params.set('search', search);
     return this.http.get<FormationsQueueResponse>('/api/formations', { params });
+  }
+
+  /** GH-1956 Me lens — formations with at least one checklist item assigned to the caller. */
+  public getMyFormationWork(): Observable<MyFormationWorkResponse> {
+    return this.http.get<MyFormationWorkResponse>('/api/user/formation-work');
   }
 }

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -83,13 +83,20 @@ export class FormationService {
    * GH-1956 Me lens — formations with at least one checklist item assigned to the caller.
    * `my-formations-card` and the multi-persona "In formation" tile both call this independently on
    * the same dashboard; `shareReplay` collapses that into one HTTP request per navigation instead of
-   * two. Not a `signal`/store cache — `refCount: true` drops the buffered response and re-fetches once
-   * every subscriber has unsubscribed (e.g. after navigating away and back).
+   * two. Because the source `HttpClient` observable completes, RxJS's `refCount` reset never fires
+   * (it's gated on `!hasCompleted`) — the response stays cached for the app's lifetime until
+   * `invalidateMyFormationWork()` is called explicitly, which callers do after any mutation that
+   * changes formation item status (claim/skip/complete).
    */
   public getMyFormationWork(): Observable<MyFormationWorkResponse> {
     if (!this.myFormationWork$) {
       this.myFormationWork$ = this.http.get<MyFormationWorkResponse>('/api/user/formation-work').pipe(shareReplay({ bufferSize: 1, refCount: true }));
     }
     return this.myFormationWork$;
+  }
+
+  /** Drops the cached `getMyFormationWork()` response so the next subscriber re-fetches. Call after any formation item mutation. */
+  public invalidateMyFormationWork(): void {
+    this.myFormationWork$ = null;
   }
 }

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -12,7 +12,7 @@ import type {
   FormationsQueueResponse,
   MyFormationWorkResponse,
 } from '@lfx-one/shared/interfaces';
-import { BehaviorSubject, Observable, shareReplay, switchMap, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, Observable, of, shareReplay, switchMap, take, tap } from 'rxjs';
 
 /** Builds the `/api/formations/:projectUid/items/:itemKey` base path shared by every item route (GH-2267 Phase 2). */
 function itemPath(projectUid: string, itemKey: string): string {
@@ -30,7 +30,18 @@ export class FormationService {
   // keeps receiving the next emission instead of being stuck on an already-completed HTTP source.
   private readonly refreshMyFormationWork$ = new BehaviorSubject<void>(undefined);
   private readonly myFormationWork$: Observable<MyFormationWorkResponse> = this.refreshMyFormationWork$.pipe(
-    switchMap(() => this.http.get<MyFormationWorkResponse>('/api/user/formation-work')),
+    switchMap(() =>
+      this.http.get<MyFormationWorkResponse>('/api/user/formation-work').pipe(
+        // Fallback lives here, inside the switchMap, not in a consumer-level `catchError` — a
+        // fallback out there would convert to a completing observable and permanently detach that
+        // subscriber from later `invalidateMyFormationWork()` emissions. Emitting the fallback from
+        // the shared stream itself keeps it alive indefinitely.
+        catchError((error: unknown) => {
+          console.error('[FormationService] Failed to load my-formation-work', error);
+          return of<MyFormationWorkResponse>({ formations: [], items: [], data_source: 'fixture' });
+        })
+      )
+    ),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
@@ -43,22 +54,32 @@ export class FormationService {
   }
 
   public completeFormationItem(projectUid: string, itemKey: string, notes?: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/complete`, { notes }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/complete`, { notes }).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   public skipFormationItem(projectUid: string, itemKey: string, reason: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/skip`, { reason }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/skip`, { reason }).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   public requestFormationItem(projectUid: string, itemKey: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/request`, {}).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/request`, {}).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   /** The three "plain" status transitions (not_started / in_progress / blocked) — completion and skip keep their own dedicated endpoints. */
   public updateFormationItemStatus(projectUid: string, itemKey: string, status: FormationItemStatus, note?: string): Observable<FormationItem> {
-    return this.http
-      .patch<FormationItem>(`${itemPath(projectUid, itemKey)}/status`, { status, note })
-      .pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/status`, { status, note }).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   public updateFormationItem(
@@ -66,22 +87,34 @@ export class FormationService {
     itemKey: string,
     patch: { notes?: string; owner_username?: string; due_date?: string | null }
   ): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(itemPath(projectUid, itemKey), patch).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.patch<FormationItem>(itemPath(projectUid, itemKey), patch).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   /** New in GH-2267 Phase 2 — mirrors upstream's `accept` action; see `formationService.acceptFormationItem` (server) for the gating detail. */
   public acceptFormationItem(projectUid: string, itemKey: string, note?: string): Observable<FormationItem> {
-    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/accept`, { note }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/accept`, { note }).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   /** New in GH-2267 Phase 2 — `note` is required upstream (minLength 1); the BFF/service enforce it, this method just forwards it. */
   public rejectFormationItem(projectUid: string, itemKey: string, note: string): Observable<FormationItem> {
-    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reject`, { note }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reject`, { note }).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   /** New in GH-2267 Phase 2 — reverses a done/skipped/awaiting-acceptance item back to in_progress. */
   public reopenFormationItem(projectUid: string, itemKey: string, note?: string): Observable<FormationItem> {
-    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reopen`, { note }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reopen`, { note }).pipe(
+      tap(() => this.invalidateMyFormationWork()),
+      take(1)
+    );
   }
 
   public getFormationsQueue(subStage?: FormationSubStage, search?: string): Observable<FormationsQueueResponse> {
@@ -94,11 +127,12 @@ export class FormationService {
   /**
    * GH-1956 Me lens — formations with at least one checklist item assigned to the caller.
    * `my-formations-card` and the multi-persona "In formation" tile both call this independently on
-   * the same dashboard; `shareReplay` collapses that into one HTTP request per navigation instead of
-   * two. The source is `refreshMyFormationWork$`, not the bare `HttpClient` call, so
-   * `invalidateMyFormationWork()` (wired into every status-changing mutation above, plus the item
-   * drawer's completion/skip paths) re-runs the fetch and pushes the new response straight to
-   * whichever card/tile is already on screen — no re-navigation needed.
+   * the same dashboard; `shareReplay({ refCount: true })` collapses that into one HTTP request per
+   * navigation instead of two, and tears the subscription down (re-fetching on the next subscribe)
+   * once the last consumer unsubscribes. The source is `refreshMyFormationWork$`, not the bare
+   * `HttpClient` call, so `invalidateMyFormationWork()` (wired into every status-changing mutation
+   * above, plus the item drawer's completion/skip paths) re-runs the fetch and pushes the new
+   * response straight to whichever card/tile is already on screen — no re-navigation needed.
    */
   public getMyFormationWork(): Observable<MyFormationWorkResponse> {
     return this.myFormationWork$;

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -12,7 +12,7 @@ import type {
   FormationsQueueResponse,
   MyFormationWorkResponse,
 } from '@lfx-one/shared/interfaces';
-import { Observable, take } from 'rxjs';
+import { Observable, shareReplay, take } from 'rxjs';
 
 /** Builds the `/api/formations/:projectUid/items/:itemKey` base path shared by every item route (GH-2267 Phase 2). */
 function itemPath(projectUid: string, itemKey: string): string {
@@ -22,6 +22,7 @@ function itemPath(projectUid: string, itemKey: string): string {
 @Injectable({ providedIn: 'root' })
 export class FormationService {
   private readonly http = inject(HttpClient);
+  private myFormationWork$: Observable<MyFormationWorkResponse> | null = null;
 
   public getProjectFormation(projectSlug: string): Observable<FormationChecklistResponse> {
     return this.http.get<FormationChecklistResponse>(`/api/projects/${encodeURIComponent(projectSlug)}/formation`);
@@ -78,8 +79,17 @@ export class FormationService {
     return this.http.get<FormationsQueueResponse>('/api/formations', { params });
   }
 
-  /** GH-1956 Me lens — formations with at least one checklist item assigned to the caller. */
+  /**
+   * GH-1956 Me lens — formations with at least one checklist item assigned to the caller.
+   * `my-formations-card` and the multi-persona "In formation" tile both call this independently on
+   * the same dashboard; `shareReplay` collapses that into one HTTP request per navigation instead of
+   * two. Not a `signal`/store cache — `refCount: true` drops the buffered response and re-fetches once
+   * every subscriber has unsubscribed (e.g. after navigating away and back).
+   */
   public getMyFormationWork(): Observable<MyFormationWorkResponse> {
-    return this.http.get<MyFormationWorkResponse>('/api/user/formation-work');
+    if (!this.myFormationWork$) {
+      this.myFormationWork$ = this.http.get<MyFormationWorkResponse>('/api/user/formation-work').pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    }
+    return this.myFormationWork$;
   }
 }

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -12,7 +12,7 @@ import type {
   FormationsQueueResponse,
   MyFormationWorkResponse,
 } from '@lfx-one/shared/interfaces';
-import { Observable, shareReplay, take } from 'rxjs';
+import { BehaviorSubject, Observable, shareReplay, switchMap, take, tap } from 'rxjs';
 
 /** Builds the `/api/formations/:projectUid/items/:itemKey` base path shared by every item route (GH-2267 Phase 2). */
 function itemPath(projectUid: string, itemKey: string): string {
@@ -22,7 +22,17 @@ function itemPath(projectUid: string, itemKey: string): string {
 @Injectable({ providedIn: 'root' })
 export class FormationService {
   private readonly http = inject(HttpClient);
-  private myFormationWork$: Observable<MyFormationWorkResponse> | null = null;
+
+  // Bumping this re-runs the `switchMap` below and pushes the fresh response to every live
+  // `getMyFormationWork()` subscriber — not just new ones. A `BehaviorSubject` (vs. nulling the
+  // cached observable) is required for that: it never completes, so `shareReplay`'s `refCount`
+  // reset is gated on `!hasCompleted` per RxJS's `share` operator and a live subscription simply
+  // keeps receiving the next emission instead of being stuck on an already-completed HTTP source.
+  private readonly refreshMyFormationWork$ = new BehaviorSubject<void>(undefined);
+  private readonly myFormationWork$: Observable<MyFormationWorkResponse> = this.refreshMyFormationWork$.pipe(
+    switchMap(() => this.http.get<MyFormationWorkResponse>('/api/user/formation-work')),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
 
   public getProjectFormation(projectSlug: string): Observable<FormationChecklistResponse> {
     return this.http.get<FormationChecklistResponse>(`/api/projects/${encodeURIComponent(projectSlug)}/formation`);
@@ -33,20 +43,22 @@ export class FormationService {
   }
 
   public completeFormationItem(projectUid: string, itemKey: string, notes?: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/complete`, { notes }).pipe(take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/complete`, { notes }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   public skipFormationItem(projectUid: string, itemKey: string, reason: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/skip`, { reason }).pipe(take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/skip`, { reason }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   public requestFormationItem(projectUid: string, itemKey: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/request`, {}).pipe(take(1));
+    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/request`, {}).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   /** The three "plain" status transitions (not_started / in_progress / blocked) — completion and skip keep their own dedicated endpoints. */
   public updateFormationItemStatus(projectUid: string, itemKey: string, status: FormationItemStatus, note?: string): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(`${itemPath(projectUid, itemKey)}/status`, { status, note }).pipe(take(1));
+    return this.http
+      .patch<FormationItem>(`${itemPath(projectUid, itemKey)}/status`, { status, note })
+      .pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   public updateFormationItem(
@@ -54,22 +66,22 @@ export class FormationService {
     itemKey: string,
     patch: { notes?: string; owner_username?: string; due_date?: string | null }
   ): Observable<FormationItem> {
-    return this.http.patch<FormationItem>(itemPath(projectUid, itemKey), patch).pipe(take(1));
+    return this.http.patch<FormationItem>(itemPath(projectUid, itemKey), patch).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   /** New in GH-2267 Phase 2 — mirrors upstream's `accept` action; see `formationService.acceptFormationItem` (server) for the gating detail. */
   public acceptFormationItem(projectUid: string, itemKey: string, note?: string): Observable<FormationItem> {
-    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/accept`, { note }).pipe(take(1));
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/accept`, { note }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   /** New in GH-2267 Phase 2 — `note` is required upstream (minLength 1); the BFF/service enforce it, this method just forwards it. */
   public rejectFormationItem(projectUid: string, itemKey: string, note: string): Observable<FormationItem> {
-    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reject`, { note }).pipe(take(1));
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reject`, { note }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   /** New in GH-2267 Phase 2 — reverses a done/skipped/awaiting-acceptance item back to in_progress. */
   public reopenFormationItem(projectUid: string, itemKey: string, note?: string): Observable<FormationItem> {
-    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reopen`, { note }).pipe(take(1));
+    return this.http.post<FormationItem>(`${itemPath(projectUid, itemKey)}/reopen`, { note }).pipe(tap(() => this.invalidateMyFormationWork()), take(1));
   }
 
   public getFormationsQueue(subStage?: FormationSubStage, search?: string): Observable<FormationsQueueResponse> {
@@ -83,20 +95,17 @@ export class FormationService {
    * GH-1956 Me lens — formations with at least one checklist item assigned to the caller.
    * `my-formations-card` and the multi-persona "In formation" tile both call this independently on
    * the same dashboard; `shareReplay` collapses that into one HTTP request per navigation instead of
-   * two. Because the source `HttpClient` observable completes, RxJS's `refCount` reset never fires
-   * (it's gated on `!hasCompleted`) — the response stays cached for the app's lifetime until
-   * `invalidateMyFormationWork()` is called explicitly, which callers do after any mutation that
-   * changes formation item status (claim/skip/complete).
+   * two. The source is `refreshMyFormationWork$`, not the bare `HttpClient` call, so
+   * `invalidateMyFormationWork()` (wired into every status-changing mutation above, plus the item
+   * drawer's completion/skip paths) re-runs the fetch and pushes the new response straight to
+   * whichever card/tile is already on screen — no re-navigation needed.
    */
   public getMyFormationWork(): Observable<MyFormationWorkResponse> {
-    if (!this.myFormationWork$) {
-      this.myFormationWork$ = this.http.get<MyFormationWorkResponse>('/api/user/formation-work').pipe(shareReplay({ bufferSize: 1, refCount: true }));
-    }
     return this.myFormationWork$;
   }
 
-  /** Drops the cached `getMyFormationWork()` response so the next subscriber re-fetches. Call after any formation item mutation. */
+  /** Re-fetches `getMyFormationWork()` and republishes it to every live subscriber. Called automatically by the mutation methods above. */
   public invalidateMyFormationWork(): void {
-    this.myFormationWork$ = null;
+    this.refreshMyFormationWork$.next();
   }
 }

--- a/apps/lfx-one/src/app/shared/services/hidden-actions.service.ts
+++ b/apps/lfx-one/src/app/shared/services/hidden-actions.service.ts
@@ -71,7 +71,7 @@ export class HiddenActionsService {
     return this.cookieService.check(`${this.cookiePrefix}${hash}`) || this.cookieService.check(`${this.dismissCookiePrefix}${hash}`);
   }
 
-  // Prefer intrinsic IDs (meetingUid, voteUid, briefActionUid) so same-text siblings never collide; fall back to type+badge+text+buttonLink for legacy action shapes without one.
+  // Prefer intrinsic IDs (meetingUid, voteUid, briefActionUid, formationItemUid) so same-text siblings never collide; fall back to type+badge+text+buttonLink for legacy action shapes without one.
   private getActionIdentifier(item: PendingActionItem): string {
     if (item.meetingUid) {
       return `${item.type}-${item.meetingUid}-${item.occurrenceId ?? ''}`;
@@ -81,6 +81,9 @@ export class HiddenActionsService {
     }
     if (item.briefActionUid) {
       return `${item.type}-${item.briefActionUid}`;
+    }
+    if (item.formationItemUid) {
+      return `${item.type}-${item.formationItemUid}`;
     }
     const base = `${item.type}-${item.badge}-${item.text}`;
     return item.buttonLink ? `${base}|${item.buttonLink}` : base;

--- a/apps/lfx-one/src/server/controllers/formation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/formation.controller.ts
@@ -8,6 +8,8 @@ import { NextFunction, Request, Response } from 'express';
 import { validateItemKeyParameter, validateUidParameter } from '../helpers/validation.helper';
 import { formationService } from '../services/formation.service';
 import { logger } from '../services/logger.service';
+import { getUsernameFromAuth } from '../utils/auth-helper';
+import { ServiceValidationError } from '../errors';
 
 export const getProjectFormation = async (req: Request, res: Response, next: NextFunction) => {
   const { slug } = req.params;
@@ -229,6 +231,34 @@ export const getFormationsQueue = async (req: Request, res: Response, next: Next
   try {
     const result = await formationService.getFormationsQueue(req, subStage, search);
     logger.success(req, 'get_formations_queue', startTime, { row_count: result.rows.length });
+    return res.json(result);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+/**
+ * `GET /api/user/formation-work` (GH-1956, Me lens) — self-scoped, so no `requireAuditor` gate
+ * unlike `getFormationsQueue`, which is LF-root auditor-gated and unusable for a partner's own view.
+ */
+export const getMyFormationWork = async (req: Request, res: Response, next: NextFunction) => {
+  const startTime = logger.startOperation(req, 'get_my_formation_work');
+
+  try {
+    const username = await getUsernameFromAuth(req);
+    if (!username) {
+      return next(
+        ServiceValidationError.forField('user_id', 'User authentication required', {
+          operation: 'get_my_formation_work',
+          service: 'formation_controller',
+          path: req.path,
+        })
+      );
+    }
+
+    const result = await formationService.getMyFormationWork(req, username);
+    res.set('Cache-Control', 'private, no-cache');
+    logger.success(req, 'get_my_formation_work', startTime, { formation_count: result.formations.length, item_count: result.items.length });
     return res.json(result);
   } catch (error) {
     return next(error);

--- a/apps/lfx-one/src/server/controllers/formation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/formation.controller.ts
@@ -9,7 +9,7 @@ import { validateItemKeyParameter, validateUidParameter } from '../helpers/valid
 import { formationService } from '../services/formation.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
-import { ServiceValidationError } from '../errors';
+import { AuthenticationError } from '../errors';
 
 export const getProjectFormation = async (req: Request, res: Response, next: NextFunction) => {
   const { slug } = req.params;
@@ -247,13 +247,7 @@ export const getMyFormationWork = async (req: Request, res: Response, next: Next
   try {
     const username = await getUsernameFromAuth(req);
     if (!username) {
-      return next(
-        ServiceValidationError.forField('user_id', 'User authentication required', {
-          operation: 'get_my_formation_work',
-          service: 'formation_controller',
-          path: req.path,
-        })
-      );
+      return next(new AuthenticationError('User authentication required', { operation: 'get_my_formation_work' }));
     }
 
     const result = await formationService.getMyFormationWork(req, username);

--- a/apps/lfx-one/src/server/routes/user.route.ts
+++ b/apps/lfx-one/src/server/routes/user.route.ts
@@ -4,12 +4,16 @@
 import { Router } from 'express';
 
 import { UserController } from '../controllers/user.controller';
+import { getMyFormationWork } from '../controllers/formation.controller';
 
 const router = Router();
 const userController = new UserController();
 
 // GET /api/user/pending-actions - Get all pending actions for the authenticated user
 router.get('/pending-actions', (req, res, next) => userController.getPendingActions(req, res, next));
+
+// GET /api/user/formation-work - Formation checklist items assigned to the caller (GH-1956, Me lens)
+router.get('/formation-work', getMyFormationWork);
 
 // GET /api/user/pending-invitations - Get the authenticated user's pending committee invitations
 router.get('/pending-invitations', (req, res, next) => userController.getPendingInvitations(req, res, next));

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -924,6 +924,7 @@ describe('FormationService', () => {
     // formation (~30% chance per item). Assertions below scope to the target formation/item uid
     // rather than asserting on the response's total length, so they don't flake on that overlap.
     it('groups a caller-assigned open item into both the formation summary and the items list', async () => {
+      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started', is_gating: true });
       seedFormation(formationRow, [item]);
@@ -935,10 +936,25 @@ describe('FormationService', () => {
       const formation = result.formations.find((f) => f.formation_uid === formationRow.uid);
       expect(formation).toMatchObject({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 });
       const returnedItem = result.items.find((i) => i.item_uid === item.uid);
-      expect(returnedItem).toMatchObject({ item_uid: item.uid, status: 'not_started', is_gating: true });
+      expect(returnedItem).toMatchObject({ item_uid: item.uid, status: 'not_started', is_gating: true, can_write: true });
+    });
+
+    it('sets can_write false for an item on a project the caller can only read, not write (auditor-only assignee)', async () => {
+      getProjectById.mockResolvedValue({ writer: false });
+      const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started' });
+      seedFormation(formationRow, [item]);
+      const username = findProbeUsername(item.uid, true);
+
+      const result = await service.getMyFormationWork(buildReq(), username);
+
+      const returnedItem = result.items.find((i) => i.item_uid === item.uid);
+      expect(returnedItem?.can_write).toBe(false);
+      expect(getProjectById).toHaveBeenCalledWith(expect.anything(), formationRow.parent_project_uid, true);
     });
 
     it('excludes done/skipped assigned items from the items list but still counts them in the formation summary', async () => {
+      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'done' });
       seedFormation(formationRow, [item]);
@@ -954,6 +970,7 @@ describe('FormationService', () => {
     });
 
     it('retains an awaiting_acceptance item in the items list (assignee never sets status, GH-1956 decision 3)', async () => {
+      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'awaiting_acceptance' });
       seedFormation(formationRow, [item]);
@@ -968,6 +985,7 @@ describe('FormationService', () => {
     });
 
     it('omits a formation with no item assigned to the caller', async () => {
+      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started' });
       seedFormation(formationRow, [item]);

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -5,7 +5,7 @@ import '@angular/compiler';
 
 import crypto from 'crypto';
 
-import type { Formation, FormationItem, QueryServiceResponse, UpstreamFormationChecklist, UpstreamFormationItem } from '@lfx-one/shared/interfaces';
+import type { Formation, FormationItem, Project, QueryServiceResponse, UpstreamFormationChecklist, UpstreamFormationItem } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +15,7 @@ import { ServiceValidationError } from '../errors/service-validation.error';
 
 const getProjectById = vi.fn();
 const getProjectIdBySlug = vi.fn();
+const getProjects = vi.fn();
 const canComplete = vi.fn();
 const natsRequest = vi.fn();
 const proxyRequest = vi.fn();
@@ -24,6 +25,7 @@ vi.mock('./project.service', () => ({
   ProjectService: class {
     public getProjectById = getProjectById;
     public getProjectIdBySlug = getProjectIdBySlug;
+    public getProjects = getProjects;
   },
 }));
 vi.mock('./microservice-proxy.service', () => ({
@@ -149,6 +151,23 @@ function findProbeUsername(itemUid: string, assigned: boolean): string {
   throw new Error(`Could not find a probe username with assigned=${assigned} for item ${itemUid}`);
 }
 
+/**
+ * `getMyFormationWork` sources its project list from `ProjectService.getProjects`, not
+ * `getProjectById` (GH-1956) — this builds the caller-accessible project row that stands in for a
+ * `STATIC_QUEUE_FORMATIONS` entry so `formation:${project.uid}` resolves the already-seeded
+ * formation instead of triggering the lazy-generate branch.
+ */
+function buildCallerProject(formationRow: Formation & { uid: string }, writer: boolean): Project {
+  return {
+    uid: formationRow.parent_project_uid,
+    slug: formationRow.parent_project_slug,
+    name: formationRow.parent_project_name,
+    parent_uid: formationRow.parent_uid ?? '',
+    stage: 'Formation - Engaged',
+    writer,
+  } as Project;
+}
+
 /** Seeds a formation + item and returns both, for tests that don't care about the specific uids. */
 function seedItem(itemOverrides: Partial<FormationItem> = {}): { formation: Formation & { uid: string }; item: FormationItem } {
   const formation = buildFormation();
@@ -164,6 +183,7 @@ describe('FormationService', () => {
     resetFormationStoreForTests();
     getProjectById.mockReset();
     getProjectIdBySlug.mockReset();
+    getProjects.mockReset();
     canComplete.mockReset();
     vi.mocked(logger.info).mockClear();
     natsRequest.mockReset();
@@ -924,8 +944,8 @@ describe('FormationService', () => {
     // formation (~30% chance per item). Assertions below scope to the target formation/item uid
     // rather than asserting on the response's total length, so they don't flake on that overlap.
     it('groups a caller-assigned open item into both the formation summary and the items list', async () => {
-      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      getProjects.mockResolvedValue([buildCallerProject(formationRow, true)]);
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started', is_gating: true });
       seedFormation(formationRow, [item]);
       const username = findProbeUsername(item.uid, true);
@@ -940,8 +960,8 @@ describe('FormationService', () => {
     });
 
     it('sets can_write false for an item on a project the caller can only read, not write (auditor-only assignee)', async () => {
-      getProjectById.mockResolvedValue({ writer: false });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      getProjects.mockResolvedValue([buildCallerProject(formationRow, false)]);
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started' });
       seedFormation(formationRow, [item]);
       const username = findProbeUsername(item.uid, true);
@@ -950,12 +970,12 @@ describe('FormationService', () => {
 
       const returnedItem = result.items.find((i) => i.item_uid === item.uid);
       expect(returnedItem?.can_write).toBe(false);
-      expect(getProjectById).toHaveBeenCalledWith(expect.anything(), formationRow.parent_project_uid, true);
+      expect(getProjects).toHaveBeenCalledWith(expect.anything());
     });
 
     it('excludes done/skipped assigned items from the items list but still counts them in the formation summary', async () => {
-      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      getProjects.mockResolvedValue([buildCallerProject(formationRow, true)]);
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'done' });
       seedFormation(formationRow, [item]);
       const username = findProbeUsername(item.uid, true);
@@ -970,8 +990,8 @@ describe('FormationService', () => {
     });
 
     it('retains an awaiting_acceptance item in the items list (assignee never sets status, GH-1956 decision 3)', async () => {
-      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      getProjects.mockResolvedValue([buildCallerProject(formationRow, true)]);
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'awaiting_acceptance' });
       seedFormation(formationRow, [item]);
       const username = findProbeUsername(item.uid, true);
@@ -985,8 +1005,8 @@ describe('FormationService', () => {
     });
 
     it('omits a formation with no item assigned to the caller', async () => {
-      getProjectById.mockResolvedValue({ writer: true });
       const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      getProjects.mockResolvedValue([buildCallerProject(formationRow, true)]);
       const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started' });
       seedFormation(formationRow, [item]);
       const username = findProbeUsername(item.uid, false);

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -970,7 +970,7 @@ describe('FormationService', () => {
 
       const returnedItem = result.items.find((i) => i.item_uid === item.uid);
       expect(returnedItem?.can_write).toBe(false);
-      expect(getProjects).toHaveBeenCalledWith(expect.anything(), {}, true);
+      expect(getProjects).toHaveBeenCalledWith(expect.anything(), { cel_filter: 'data.stage.startsWith("Formation - ")' }, true);
     });
 
     it('excludes done/skipped assigned items from the items list but still counts them in the formation summary', async () => {
@@ -1017,6 +1017,18 @@ describe('FormationService', () => {
       expect(result.items.find((i) => i.item_uid === item.uid)).toBeUndefined();
     });
 
+    it('strips an auth-provider prefix before hashing, so a raw sub claim assigns the same items as the plain username (copilot review, PR #2309)', async () => {
+      const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      getProjects.mockResolvedValue([buildCallerProject(formationRow, true)]);
+      const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started' });
+      seedFormation(formationRow, [item]);
+      const username = findProbeUsername(item.uid, true);
+
+      const result = await service.getMyFormationWork(buildReq(), `auth0|${username}`);
+
+      expect(result.items.find((i) => i.item_uid === item.uid)).toBeDefined();
+    });
+
     it('returns an empty result on the live branch rather than fabricating fixture rows', async () => {
       isFormationServiceLive.mockReturnValue(true);
 
@@ -1031,7 +1043,7 @@ describe('FormationService', () => {
       const result = await service.getMyFormationWork(buildReq(), 'any-user');
 
       expect(result).toEqual({ formations: [], items: [], data_source: 'fixture' });
-      expect(getProjects).toHaveBeenCalledWith(expect.anything(), {}, true);
+      expect(getProjects).toHaveBeenCalledWith(expect.anything(), { cel_filter: 'data.stage.startsWith("Formation - ")' }, true);
     });
   });
 });

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -970,7 +970,7 @@ describe('FormationService', () => {
 
       const returnedItem = result.items.find((i) => i.item_uid === item.uid);
       expect(returnedItem?.can_write).toBe(false);
-      expect(getProjects).toHaveBeenCalledWith(expect.anything());
+      expect(getProjects).toHaveBeenCalledWith(expect.anything(), {}, true);
     });
 
     it('excludes done/skipped assigned items from the items list but still counts them in the formation summary', async () => {
@@ -1023,6 +1023,15 @@ describe('FormationService', () => {
       const result = await service.getMyFormationWork(buildReq(), 'any-user');
 
       expect(result).toEqual({ formations: [], items: [], data_source: 'live' });
+    });
+
+    it('returns an empty result rather than a partial one when getProjects fails partway through paging', async () => {
+      getProjects.mockRejectedValue(new Error('query-service pagination failed'));
+
+      const result = await service.getMyFormationWork(buildReq(), 'any-user');
+
+      expect(result).toEqual({ formations: [], items: [], data_source: 'fixture' });
+      expect(getProjects).toHaveBeenCalledWith(expect.anything(), {}, true);
     });
   });
 });

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -3,6 +3,8 @@
 
 import '@angular/compiler';
 
+import crypto from 'crypto';
+
 import type { Formation, FormationItem, QueryServiceResponse, UpstreamFormationChecklist, UpstreamFormationItem } from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
@@ -126,6 +128,25 @@ function buildItem(formationUid: string, overrides: Partial<FormationItem> = {})
 
 function buildReq(): Request {
   return { path: '/api/formations/x/items/y' } as unknown as Request;
+}
+
+/**
+ * Mirrors `FormationService.isAssignedToCaller`'s SHA-256-seeded threshold exactly (the method
+ * itself is private, so tests can't call it directly) — used to find a probe username that either
+ * is or isn't assigned a given item uid, so `getMyFormationWork` tests are deterministic instead of
+ * depending on whichever real username happens to hash under 0.3 for a given fixture item.
+ */
+function isAssignedFixture(username: string, itemUid: string): boolean {
+  const digest = crypto.createHash('sha256').update(`${username}:${itemUid}`).digest();
+  return digest.readUInt32BE(0) / 0xffffffff < 0.3;
+}
+
+function findProbeUsername(itemUid: string, assigned: boolean): string {
+  for (let i = 0; i < 10000; i++) {
+    const candidate = `probe-${i}`;
+    if (isAssignedFixture(candidate, itemUid) === assigned) return candidate;
+  }
+  throw new Error(`Could not find a probe username with assigned=${assigned} for item ${itemUid}`);
 }
 
 /** Seeds a formation + item and returns both, for tests that don't care about the specific uids. */
@@ -892,6 +913,78 @@ describe('FormationService', () => {
       expect(result.rows).toHaveLength(1);
       expect(result.rows[0].project_uid).toBe('live-project-1');
       expect(result.tiles.total).toBe(1);
+    });
+  });
+
+  describe('getMyFormationWork (GH-1956)', () => {
+    // getMyFormationWork walks every STATIC_QUEUE_FORMATIONS row, lazily generating + seeding
+    // items for whichever ones this test file hasn't already visited (mirrors getProjectFormation's
+    // lazy-seed). The probe username picked below is only guaranteed for our own seeded item's uid
+    // — it may incidentally also assign one of those auto-generated items on an unrelated static
+    // formation (~30% chance per item). Assertions below scope to the target formation/item uid
+    // rather than asserting on the response's total length, so they don't flake on that overlap.
+    it('groups a caller-assigned open item into both the formation summary and the items list', async () => {
+      const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started', is_gating: true });
+      seedFormation(formationRow, [item]);
+      const username = findProbeUsername(item.uid, true);
+
+      const result = await service.getMyFormationWork(buildReq(), username);
+
+      expect(result.data_source).toBe('fixture');
+      const formation = result.formations.find((f) => f.formation_uid === formationRow.uid);
+      expect(formation).toMatchObject({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 });
+      const returnedItem = result.items.find((i) => i.item_uid === item.uid);
+      expect(returnedItem).toMatchObject({ item_uid: item.uid, status: 'not_started', is_gating: true });
+    });
+
+    it('excludes done/skipped assigned items from the items list but still counts them in the formation summary', async () => {
+      const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'done' });
+      seedFormation(formationRow, [item]);
+      const username = findProbeUsername(item.uid, true);
+
+      const result = await service.getMyFormationWork(buildReq(), username);
+
+      // The formation still surfaces — "at least one item assigned" doesn't require the item to
+      // still be open — but the done item itself never appears in the Pending Actions row list.
+      const formation = result.formations.find((f) => f.formation_uid === formationRow.uid);
+      expect(formation).toMatchObject({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 1 });
+      expect(result.items.find((i) => i.item_uid === item.uid)).toBeUndefined();
+    });
+
+    it('retains an awaiting_acceptance item in the items list (assignee never sets status, GH-1956 decision 3)', async () => {
+      const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'awaiting_acceptance' });
+      seedFormation(formationRow, [item]);
+      const username = findProbeUsername(item.uid, true);
+
+      const result = await service.getMyFormationWork(buildReq(), username);
+
+      const returnedItem = result.items.find((i) => i.item_uid === item.uid);
+      expect(returnedItem?.status).toBe('awaiting_acceptance');
+      const formation = result.formations.find((f) => f.formation_uid === formationRow.uid);
+      expect(formation).toMatchObject({ assigned_to_do: 0, assigned_with_team: 1, assigned_done: 0 });
+    });
+
+    it('omits a formation with no item assigned to the caller', async () => {
+      const formationRow = STATIC_QUEUE_FORMATIONS[0];
+      const item = buildItem(formationRow.uid, { project_uid: formationRow.parent_project_uid, status: 'not_started' });
+      seedFormation(formationRow, [item]);
+      const username = findProbeUsername(item.uid, false);
+
+      const result = await service.getMyFormationWork(buildReq(), username);
+
+      expect(result.formations.find((f) => f.formation_uid === formationRow.uid)).toBeUndefined();
+      expect(result.items.find((i) => i.item_uid === item.uid)).toBeUndefined();
+    });
+
+    it('returns an empty result on the live branch rather than fabricating fixture rows', async () => {
+      isFormationServiceLive.mockReturnValue(true);
+
+      const result = await service.getMyFormationWork(buildReq(), 'any-user');
+
+      expect(result).toEqual({ formations: [], items: [], data_source: 'live' });
     });
   });
 });

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -30,7 +30,7 @@ import { generateMockFormation, SEEDED_FORMATION_TEMPLATE, STATIC_QUEUE_FORMATIO
 import { mapUpstreamFormationItem } from '../helpers/formation-mapper.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { collapseRootParentUid, resolveRootProjectUid } from '../helpers/root-project.helper';
-import { getEffectiveUsername } from '../utils/auth-helper';
+import { getEffectiveUsername, stripAuthPrefix } from '../utils/auth-helper';
 import { formationItemAccessService } from './formation-item-access.service';
 import {
   appendActivity,
@@ -624,6 +624,15 @@ export class FormationService {
   public async getMyFormationWork(req: Request, username: string): Promise<MyFormationWorkResponse> {
     logger.debug(req, 'get_my_formation_work', 'Fetching formation work assigned to caller');
 
+    // Normalized here rather than trusted from the caller (copilot review, PR #2309): the
+    // `/api/user/formation-work` controller passes the raw `getUsernameFromAuth` value (no prefix
+    // stripped), while `getUserPendingActions`'s Me-lens aggregation already strips it before
+    // calling this method. For an identity like "auth0|alice" the two callers would otherwise hash
+    // different strings in `isAssignedToCaller` below and disagree on which formations are assigned
+    // to the same signed-in user. Stripping unconditionally here makes both callers agree regardless
+    // of what they pass in.
+    const normalizedUsername = stripAuthPrefix(username);
+
     if (isFormationServiceLive()) {
       // TODO(#1957): swap for a real read against the item index once it ships (see the interface
       // doc comment above). Returning empty rather than fabricating fixture rows under a live flag
@@ -651,9 +660,18 @@ export class FormationService {
     // rendered; this caller instead uses the result to decide which formations exist for the
     // caller at all, so silent truncation would drop assigned formations/Pending Actions with no
     // signal). Caught below for the same honest-empty degradation the live branch above uses.
+    // cel_filter narrows to Formation-stage projects before getProjects's own addAccessToResources
+    // FGA batch check runs (dealako review, PR #2309) — the query-service contract documents
+    // cel_filter as applied in-process "after OpenSearch, before access control checks", so this
+    // shrinks the set the batch check has to cover even though it can't shrink the underlying
+    // OpenSearch pagination itself (cel_filter is post-query there). Mirrors isFormationStageGate's
+    // own prefix match ('Formation - ') rather than an exact stage list, for the same reason that
+    // util documents: a new Formation sub-stage added upstream still matches. The client-side
+    // isFormationStageGate filter below is kept as an unconditional backstop, not a substitute —
+    // same pattern already used for filters_all in committee-activity.service.ts's notes_added leg.
     let callerProjects: Project[];
     try {
-      callerProjects = await this.projectService.getProjects(req, {}, true);
+      callerProjects = await this.projectService.getProjects(req, { cel_filter: 'data.stage.startsWith("Formation - ")' }, true);
     } catch (error) {
       logger.warning(req, 'get_my_formation_work', 'Failed to fetch caller projects, returning empty', { err: error });
       return { formations: [], items: [], data_source: 'fixture' };
@@ -682,7 +700,7 @@ export class FormationService {
         formationItems = getStoredItemsForFormation(formationRow.uid);
       }
 
-      const assignedItems = formationItems.filter((item) => FormationService.isAssignedToCaller(username, item));
+      const assignedItems = formationItems.filter((item) => FormationService.isAssignedToCaller(normalizedUsername, item));
       if (assignedItems.length === 0) continue;
 
       // Same check `assertItemProjectWriteAccess` runs before actually allowing the mutation — an

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -11,13 +11,17 @@ import type {
   FormationQueueRow,
   FormationsQueueResponse,
   FormationSubStage,
+  MyFormationItemRow,
+  MyFormationSummary,
+  MyFormationWorkResponse,
   Project,
   UpstreamFormationChecklist,
   UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
 import { FORMATION_QUEUE_SUB_STAGES } from '@lfx-one/shared/constants';
 import { QueryServiceResponse } from '@lfx-one/shared/interfaces';
-import { deriveFormationEntityType, isFormationStageGate } from '@lfx-one/shared/utils';
+import { deriveFormationEntityType, isAssignedItemOpen, isFormationStageGate, summarizeMyFormationItems } from '@lfx-one/shared/utils';
+import crypto from 'crypto';
 import { Request } from 'express';
 
 import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError, ConflictError } from '../errors';
@@ -610,6 +614,100 @@ export class FormationService {
   }
 
   /**
+   * GH-1956 Me lens: "My formations" = every formation with at least one checklist item assigned to
+   * the caller (decision 2 in the ticket's third comment — a direct-grant-only definition can't be
+   * satisfied by the permission model, since it can't distinguish a direct grant from one inherited
+   * via a parent project or `lf-staff`/`lf-contractor`). The item index this needs ("which items are
+   * assigned to me", one access-filtered query with an assignee filter) doesn't exist upstream yet —
+   * see {@link MyFormationItemRow}'s doc comment.
+   */
+  public async getMyFormationWork(req: Request, username: string): Promise<MyFormationWorkResponse> {
+    logger.debug(req, 'get_my_formation_work', 'Fetching formation work assigned to caller', { username });
+
+    if (isFormationServiceLive()) {
+      // TODO(#1957): swap for a real read against the item index once it ships (see the interface
+      // doc comment above). Returning empty rather than fabricating fixture rows under a live flag
+      // is the honest degradation — the card/tile simply don't render until the index exists.
+      logger.warning(req, 'get_my_formation_work', 'Live formation-work read not supported upstream yet, returning empty', { username });
+      return { formations: [], items: [], data_source: 'live' };
+    }
+
+    const formations: MyFormationSummary[] = [];
+    const items: MyFormationItemRow[] = [];
+
+    for (const staticRow of STATIC_QUEUE_FORMATIONS) {
+      // Formation.uid is optional only because the checklist read can't source it (see its doc
+      // comment) — every STATIC_QUEUE_FORMATIONS row (and anything seeded over it) sets it
+      // explicitly, so it's always present here; same narrowing as `toQueueRow`'s `formationUid`.
+      const formationRow = (getStoredFormation(staticRow.uid) ?? staticRow) as Formation & { uid: string };
+      let formationItems = getStoredItemsForFormation(formationRow.uid);
+      if (formationItems.length === 0) {
+        // Never visited via getProjectFormation — generate + seed exactly as that path does, so a
+        // claim made from this response's rows is visible on the project's own checklist afterward
+        // (and vice versa; see formation-store.service.ts's `seedFormation`, which no-ops if the
+        // formation/items are already present). Only `.items` is used below — `formationRow` already
+        // carries STATIC_QUEUE_FORMATIONS's curated fields (blocking_item_title, gating counts,
+        // subtitle), which a freshly generated Formation object would overwrite with placeholders.
+        const generated = generateMockFormation({
+          projectUid: formationRow.parent_project_uid,
+          projectSlug: formationRow.parent_project_slug,
+          projectName: formationRow.parent_project_name,
+          parentProjectUid: formationRow.parent_uid,
+          stage: undefined,
+        });
+        seedFormation(formationRow, generated.items);
+        formationItems = getStoredItemsForFormation(formationRow.uid);
+      }
+
+      const assignedItems = formationItems.filter((item) => FormationService.isAssignedToCaller(username, item));
+      if (assignedItems.length === 0) continue;
+
+      const doneOrSkipped = (item: FormationItem): boolean => item.status === 'done' || item.status === 'skipped';
+      const gatingItems = formationItems.filter((item) => item.is_gating);
+
+      formations.push({
+        formation_uid: formationRow.uid,
+        project_uid: formationRow.parent_project_uid,
+        project_slug: formationRow.parent_project_slug,
+        project_name: formationRow.parent_project_name,
+        sub_stage: formationRow.sub_stage,
+        announcement_date: formationRow.announcement_date,
+        ...summarizeMyFormationItems(assignedItems),
+        items_done: formationItems.filter(doneOrSkipped).length,
+        items_total: formationItems.length,
+        gating_done: gatingItems.filter(doneOrSkipped).length,
+        gating_total: gatingItems.length,
+        blocking_item_title: formationRow.blocking_item_title,
+      });
+
+      for (const item of assignedItems.filter((assignedItem) => isAssignedItemOpen(assignedItem.status))) {
+        items.push({
+          item_uid: item.uid,
+          template_item_key: item.template_item_key,
+          project_uid: item.project_uid,
+          project_slug: formationRow.parent_project_slug,
+          project_name: formationRow.parent_project_name,
+          title: item.title,
+          status: item.status,
+          is_gating: item.is_gating,
+          due_date: item.due_date,
+          action: item.action,
+          action_href: item.action_href,
+          version: item.version,
+        });
+      }
+    }
+
+    logger.debug(req, 'get_my_formation_work', 'Returning fixture formation work', {
+      username,
+      formation_count: formations.length,
+      item_count: items.length,
+    });
+
+    return { formations, items, data_source: 'fixture' };
+  }
+
+  /**
    * Live branch of {@link getFormationsQueue} — the indexer's `formation` projection already
    * matches `FormationQueueRow`'s shape verbatim (GH-2267 plan gap 2), so no per-row mapper is
    * needed, only ROOT collapse and the subStage/search filters the fixture branch also applies.
@@ -659,6 +757,19 @@ export class FormationService {
     const tiles = this.buildQueueTilesFromRows(normalizedRows);
 
     return { tiles, rows, data_source: 'live' };
+  }
+  /**
+   * Deterministic SHA-256-seeded "is this item assigned to the caller" check (never `Math.random()`)
+   * — a fixture item's real `owner` is drawn from a synthetic staff pool
+   * (`formation-fixture.helper.ts`'s `SYNTHETIC_STAFF`) that never matches a real signed-in username,
+   * so GH-1956 assignment is derived independently of `owner` rather than gated on it. ~30% of a
+   * caller's items land in their own queue — enough to populate "My formations" for demo purposes
+   * without every formation landing on every caller, satisfying the ticket's acceptance criterion
+   * that a staff member does not see every formation here.
+   */
+  private static isAssignedToCaller(username: string, item: FormationItem): boolean {
+    const digest = crypto.createHash('sha256').update(`${username}:${item.uid}`).digest();
+    return digest.readUInt32BE(0) / 0xffffffff < 0.3;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -665,8 +665,19 @@ export class FormationService {
       // Same check `assertItemProjectWriteAccess` runs before actually allowing the mutation — an
       // `auditor`-only assignee is a valid GH-1956 assignee (decision 1: partner contacts are
       // invited as `auditor` or `writer`) but Claim/Block would 403 for them; see `can_write`'s
-      // doc comment on `MyFormationItemRow`.
-      const canWrite = (await this.projectService.getProjectById(req, formationRow.parent_project_uid, true)).writer === true;
+      // doc comment on `MyFormationItemRow`. Caught rather than awaited bare: this talks to the live
+      // project service even on the fixture branch, and one formation's 404/upstream error must not
+      // abort the whole response — default to false (Claim/Block disabled) and keep going.
+      const canWrite = await this.projectService
+        .getProjectById(req, formationRow.parent_project_uid, true)
+        .then((project) => project.writer === true)
+        .catch((error) => {
+          logger.warning(req, 'get_my_formation_work', 'Failed to resolve write access; defaulting to read-only', {
+            project_uid: formationRow.parent_project_uid,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return false;
+        });
 
       const doneOrSkipped = (item: FormationItem): boolean => item.status === 'done' || item.status === 'skipped';
       const gatingItems = formationItems.filter((item) => item.is_gating);

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -662,6 +662,12 @@ export class FormationService {
       const assignedItems = formationItems.filter((item) => FormationService.isAssignedToCaller(username, item));
       if (assignedItems.length === 0) continue;
 
+      // Same check `assertItemProjectWriteAccess` runs before actually allowing the mutation — an
+      // `auditor`-only assignee is a valid GH-1956 assignee (decision 1: partner contacts are
+      // invited as `auditor` or `writer`) but Claim/Block would 403 for them; see `can_write`'s
+      // doc comment on `MyFormationItemRow`.
+      const canWrite = (await this.projectService.getProjectById(req, formationRow.parent_project_uid, true)).writer === true;
+
       const doneOrSkipped = (item: FormationItem): boolean => item.status === 'done' || item.status === 'skipped';
       const gatingItems = formationItems.filter((item) => item.is_gating);
 
@@ -673,7 +679,8 @@ export class FormationService {
         sub_stage: formationRow.sub_stage,
         announcement_date: formationRow.announcement_date,
         ...summarizeMyFormationItems(assignedItems),
-        items_done: formationItems.filter(doneOrSkipped).length,
+        // Only true completion counts here — unlike `gating_done` below, a skipped item is not done.
+        items_done: formationItems.filter((item) => item.status === 'done').length,
         items_total: formationItems.length,
         gating_done: gatingItems.filter(doneOrSkipped).length,
         gating_total: gatingItems.length,
@@ -694,6 +701,7 @@ export class FormationService {
           action: item.action,
           action_href: item.action_href,
           version: item.version,
+          can_write: canWrite,
         });
       }
     }
@@ -765,6 +773,13 @@ export class FormationService {
    * caller's items land in their own queue — enough to populate "My formations" for demo purposes
    * without every formation landing on every caller, satisfying the ticket's acceptance criterion
    * that a staff member does not see every formation here.
+   *
+   * TODO(#1957): purely a function of `username`/`item.uid` — it does not check that the caller
+   * actually has any role on `item`'s project. That's safe only because the fixture branch is
+   * synthetic data with no real entitlements to leak. When the live assignment source lands, it
+   * must gate on a real project-access check (e.g. `assertItemProjectAccess`) before including an
+   * item, not just swap this hash for a real assignee lookup — otherwise a caller could see items
+   * on a project they can't actually access.
    */
   private static isAssignedToCaller(username: string, item: FormationItem): boolean {
     const digest = crypto.createHash('sha256').update(`${username}:${item.uid}`).digest();

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -635,27 +635,38 @@ export class FormationService {
     const formations: MyFormationSummary[] = [];
     const items: MyFormationItemRow[] = [];
 
-    for (const staticRow of STATIC_QUEUE_FORMATIONS) {
-      // Formation.uid is optional only because the checklist read can't source it (see its doc
-      // comment) — every STATIC_QUEUE_FORMATIONS row (and anything seeded over it) sets it
-      // explicitly, so it's always present here; same narrowing as `toQueueRow`'s `formationUid`.
-      const formationRow = (getStoredFormation(staticRow.uid) ?? staticRow) as Formation & { uid: string };
-      let formationItems = getStoredItemsForFormation(formationRow.uid);
-      if (formationItems.length === 0) {
+    // Built from the caller's own real accessible projects (via getProjects's access-scoped
+    // /query/resources read), not STATIC_QUEUE_FORMATIONS' synthetic queue-project-* rows. The
+    // queue rows exist only to populate the staff Formations queue with a fixed demo set — using
+    // them here meant `getProjectById` could never resolve `parent_project_uid` (it isn't a real
+    // project), so `can_write` silently defaulted to read-only for every row and Open/Claim
+    // resolved a different item store than the one `getProjectFormation(projectSlug)` seeds for
+    // that same project. Sourcing from real formation-stage projects the caller can already read
+    // keeps this response, the checklist page, and the write-access check all pointed at the same
+    // project uid and the same seeded item store.
+    const rootUid = await resolveRootProjectUid(req, this.natsService);
+    const callerProjects = await this.projectService.getProjects(req);
+    const formationProjects = callerProjects.filter((project) => isFormationStageGate(project.stage));
+
+    for (const project of formationProjects) {
+      const formationUid = `formation:${project.uid}`;
+      let formationRow = getStoredFormation(formationUid) as (Formation & { uid: string }) | undefined;
+      let formationItems = formationRow ? getStoredItemsForFormation(formationRow.uid) : [];
+      if (!formationRow || formationItems.length === 0) {
         // Never visited via getProjectFormation — generate + seed exactly as that path does, so a
         // claim made from this response's rows is visible on the project's own checklist afterward
         // (and vice versa; see formation-store.service.ts's `seedFormation`, which no-ops if the
-        // formation/items are already present). Only `.items` is used below — `formationRow` already
-        // carries STATIC_QUEUE_FORMATIONS's curated fields (blocking_item_title, gating counts,
-        // subtitle), which a freshly generated Formation object would overwrite with placeholders.
+        // formation/items are already present).
+        const collapsedParentUid = collapseRootParentUid(project.parent_uid || null, rootUid) ?? null;
         const generated = generateMockFormation({
-          projectUid: formationRow.parent_project_uid,
-          projectSlug: formationRow.parent_project_slug,
-          projectName: formationRow.parent_project_name,
-          parentProjectUid: formationRow.parent_uid,
-          stage: undefined,
+          projectUid: project.uid,
+          projectSlug: project.slug,
+          projectName: project.name,
+          parentProjectUid: collapsedParentUid,
+          stage: project.stage,
         });
-        seedFormation(formationRow, generated.items);
+        seedFormation(generated.formation, generated.items);
+        formationRow = (getStoredFormation(generated.formation.uid) as (Formation & { uid: string }) | undefined) ?? generated.formation;
         formationItems = getStoredItemsForFormation(formationRow.uid);
       }
 
@@ -665,19 +676,11 @@ export class FormationService {
       // Same check `assertItemProjectWriteAccess` runs before actually allowing the mutation — an
       // `auditor`-only assignee is a valid GH-1956 assignee (decision 1: partner contacts are
       // invited as `auditor` or `writer`) but Claim/Block would 403 for them; see `can_write`'s
-      // doc comment on `MyFormationItemRow`. Caught rather than awaited bare: this talks to the live
-      // project service even on the fixture branch, and one formation's 404/upstream error must not
-      // abort the whole response — default to false (Claim/Block disabled) and keep going.
-      const canWrite = await this.projectService
-        .getProjectById(req, formationRow.parent_project_uid, true)
-        .then((project) => project.writer === true)
-        .catch((error) => {
-          logger.warning(req, 'get_my_formation_work', 'Failed to resolve write access; defaulting to read-only', {
-            project_uid: formationRow.parent_project_uid,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return false;
-        });
+      // doc comment on `MyFormationItemRow`. Read directly off `project.writer` — `getProjects`
+      // already ran the access check for every row above, so there's no second network round trip
+      // (and no per-formation failure mode to catch: an upstream error here would already have
+      // failed the whole `getProjects` call, consistent with every other real-project read).
+      const canWrite = project.writer === true;
 
       const doneOrSkipped = (item: FormationItem): boolean => item.status === 'done' || item.status === 'skipped';
       const gatingItems = formationItems.filter((item) => item.is_gating);

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -622,13 +622,13 @@ export class FormationService {
    * see {@link MyFormationItemRow}'s doc comment.
    */
   public async getMyFormationWork(req: Request, username: string): Promise<MyFormationWorkResponse> {
-    logger.debug(req, 'get_my_formation_work', 'Fetching formation work assigned to caller', { username });
+    logger.debug(req, 'get_my_formation_work', 'Fetching formation work assigned to caller');
 
     if (isFormationServiceLive()) {
       // TODO(#1957): swap for a real read against the item index once it ships (see the interface
       // doc comment above). Returning empty rather than fabricating fixture rows under a live flag
       // is the honest degradation — the card/tile simply don't render until the index exists.
-      logger.warning(req, 'get_my_formation_work', 'Live formation-work read not supported upstream yet, returning empty', { username });
+      logger.warning(req, 'get_my_formation_work', 'Live formation-work read not supported upstream yet, returning empty');
       return { formations: [], items: [], data_source: 'live' };
     }
 
@@ -699,7 +699,6 @@ export class FormationService {
     }
 
     logger.debug(req, 'get_my_formation_work', 'Returning fixture formation work', {
-      username,
       formation_count: formations.length,
       item_count: items.length,
     });

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -645,7 +645,19 @@ export class FormationService {
     // keeps this response, the checklist page, and the write-access check all pointed at the same
     // project uid and the same seeded item store.
     const rootUid = await resolveRootProjectUid(req, this.natsService);
-    const callerProjects = await this.projectService.getProjects(req);
+    // failOnPartial: true — a paged failure here must not build a "successful" response from a
+    // prefix of the caller's real projects (copilot review, PR #2309: getProjects's own default is
+    // lenient because most callers show a project list where a partial page just means fewer rows
+    // rendered; this caller instead uses the result to decide which formations exist for the
+    // caller at all, so silent truncation would drop assigned formations/Pending Actions with no
+    // signal). Caught below for the same honest-empty degradation the live branch above uses.
+    let callerProjects: Project[];
+    try {
+      callerProjects = await this.projectService.getProjects(req, {}, true);
+    } catch (error) {
+      logger.warning(req, 'get_my_formation_work', 'Failed to fetch caller projects, returning empty', { err: error });
+      return { formations: [], items: [], data_source: 'fixture' };
+    }
     const formationProjects = callerProjects.filter((project) => isFormationStageGate(project.stage));
 
     for (const project of formationProjects) {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -302,9 +302,14 @@ export class ProjectService {
 
   /**
    * Fetches all projects based on query parameters
+   * @param failOnPartial When true, a pagination failure throws instead of silently returning a
+   *   truncated list — see {@link fetchAllProjectsFiltered}. Defaults false, matching every
+   *   existing caller's "degrade gracefully" expectation; pass true when the caller would
+   *   otherwise build a false-successful response from a prefix of the real project set (e.g.
+   *   `getMyFormationWork`, review thread on GH-1956/PR #2309).
    */
-  public async getProjects(req: Request, query: Record<string, any> = {}): Promise<Project[]> {
-    const filtered = await this.fetchAllProjectsFiltered(req, query);
+  public async getProjects(req: Request, query: Record<string, any> = {}, failOnPartial: boolean = false): Promise<Project[]> {
+    const filtered = await this.fetchAllProjectsFiltered(req, query, failOnPartial);
 
     // Add writer access field to all projects
     return await this.accessCheckService.addAccessToResources(req, filtered, 'project');

--- a/apps/lfx-one/src/server/services/user.service.spec.ts
+++ b/apps/lfx-one/src/server/services/user.service.spec.ts
@@ -19,11 +19,12 @@ import {
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { proxyRequest, getPendingActionSurveys, getMyPendingInvitations, getUsernameFromAuth } = vi.hoisted(() => ({
+const { proxyRequest, getPendingActionSurveys, getMyPendingInvitations, getUsernameFromAuth, getMyFormationWork } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   getPendingActionSurveys: vi.fn(),
   getMyPendingInvitations: vi.fn(),
   getUsernameFromAuth: vi.fn(),
+  getMyFormationWork: vi.fn(),
 }));
 
 // Stub the constructor collaborators (NATS, Snowflake, etc.) so `new UserService()` is cheap and
@@ -46,6 +47,9 @@ vi.mock('./committee.service', () => ({
   CommitteeService: class {
     public getMyPendingInvitations = getMyPendingInvitations;
   },
+}));
+vi.mock('./formation.service', () => ({
+  formationService: { getMyFormationWork },
 }));
 vi.mock('../utils/auth-helper', () => ({
   getUsernameFromAuth,
@@ -383,10 +387,12 @@ describe('UserService.getPendingActions RSVP gating (GH-1951)', () => {
     getPendingActionSurveys.mockReset();
     getMyPendingInvitations.mockReset();
     getUsernameFromAuth.mockReset();
+    getMyFormationWork.mockReset();
 
     getPendingActionSurveys.mockResolvedValue([]);
     getMyPendingInvitations.mockResolvedValue([]);
     getUsernameFromAuth.mockResolvedValue('testuser');
+    getMyFormationWork.mockResolvedValue({ formations: [], items: [], data_source: 'fixture' });
 
     service = new UserService();
   });
@@ -460,6 +466,85 @@ describe('UserService.getPendingActions RSVP gating (GH-1951)', () => {
     expect(actions.some((action) => action.type === 'Agenda')).toBe(true);
     expect(queriedTypes()).not.toContain('v1_meeting_registrant');
     expect(queriedTypes()).not.toContain('v1_meeting_rsvp');
+  });
+});
+
+describe('UserService.getPendingActions formation items (GH-1956)', () => {
+  const req = {} as unknown as Request;
+  const email = 'assignee@example.com';
+
+  const formationRow = {
+    item_uid: 'item-1',
+    template_item_key: 'legal-review',
+    project_uid: 'project-1',
+    project_slug: 'acme-project',
+    project_name: 'Acme Project',
+    title: 'Complete legal review',
+    status: 'not_started',
+    is_gating: true,
+    due_date: null,
+    action: 'manual',
+    action_href: null,
+    version: 1,
+  };
+
+  let service: UserService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    getPendingActionSurveys.mockReset();
+    getMyPendingInvitations.mockReset();
+    getUsernameFromAuth.mockReset();
+    getMyFormationWork.mockReset();
+
+    proxyRequest.mockImplementation(() => queryPage([]));
+    getPendingActionSurveys.mockResolvedValue([]);
+    getMyPendingInvitations.mockResolvedValue([]);
+    getUsernameFromAuth.mockResolvedValue('testuser');
+    getMyFormationWork.mockResolvedValue({ formations: [], items: [formationRow], data_source: 'fixture' });
+
+    service = new UserService();
+  });
+
+  it('includes formation item actions, placed immediately after invitations, on the unscoped Me-lens path', async () => {
+    getMyPendingInvitations.mockResolvedValue([{ uid: 'invite-1', committee_uid: 'c-1', committee_name: 'Board' }]);
+
+    const actions = await service.getPendingActions(req, undefined, email, undefined);
+
+    expect(getMyFormationWork).toHaveBeenCalledWith(req, 'testuser');
+    const types = actions.map((a) => a.type);
+    const invitationIndex = types.indexOf('Invitation');
+    const formationIndex = types.indexOf('FormationItem');
+    expect(formationIndex).toBeGreaterThan(-1);
+    expect(formationIndex).toBe(invitationIndex + 1);
+
+    const formationAction = actions[formationIndex];
+    expect(formationAction).toMatchObject({
+      formationItemUid: 'item-1',
+      formationProjectUid: 'project-1',
+      buttonText: 'Claim',
+    });
+  });
+
+  it('does not call getMyFormationWork on a project/foundation-lens request', async () => {
+    await service.getPendingActions(req, 'project-1', email, 'acme-project');
+    expect(getMyFormationWork).not.toHaveBeenCalled();
+  });
+
+  it('degrades to no formation actions when the source errors, without failing the whole aggregation', async () => {
+    getMyFormationWork.mockRejectedValue(new Error('boom'));
+
+    const actions = await service.getPendingActions(req, undefined, email, undefined);
+
+    expect(actions.some((a) => a.type === 'FormationItem')).toBe(false);
+  });
+
+  it('skips the call when no username can be resolved from auth', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+
+    await service.getPendingActions(req, undefined, email, undefined);
+
+    expect(getMyFormationWork).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -25,6 +25,7 @@ import {
   MeetingOccurrence,
   MeetingRegistrant,
   MeetingRsvp,
+  MyFormationItemRow,
   PastMeeting,
   PastMeetingParticipant,
   PendingActionItem,
@@ -45,6 +46,7 @@ import {
   Vote,
 } from '@lfx-one/shared/interfaces';
 import {
+  buildFormationItemActions,
   buildInvitationActions,
   codePointLength,
   getCurrentOrNextOccurrence,
@@ -66,6 +68,7 @@ import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { CommitteeService } from './committee.service';
+import { formationService } from './formation.service';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -1306,7 +1309,7 @@ export class UserService {
     // Phase 1: surveys, meetings, pending votes, and (Me-lens only) invitations are independent —
     // issue them in parallel. Each source has its own `.catch` returning [] so one flaky source
     // can't wipe the whole list.
-    const [surveys, meetings, pendingVotes, pendingInvitations] = await Promise.all([
+    const [surveys, meetings, pendingVotes, pendingInvitations, formationItems] = await Promise.all([
       this.projectService.getPendingActionSurveys(email, projectSlug).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch surveys for pending actions', { err: error });
         return [];
@@ -1328,12 +1331,26 @@ export class UserService {
             return [] as PendingInvitation[];
           })
         : Promise.resolve([] as PendingInvitation[]),
+
+      // Formation checklist work assigned to the caller only belongs on the unscoped Me-lens path
+      // (GH-1956) — same rationale as pending invitations above. `username` may be null when the
+      // auth context can't resolve one; formation work has nothing to key off of in that case.
+      isMeLens && username
+        ? formationService
+            .getMyFormationWork(req, username)
+            .then((result) => result.items)
+            .catch((error) => {
+              logger.warning(req, 'get_user_pending_actions', 'Failed to fetch formation work for pending actions', { err: error });
+              return [] as MyFormationItemRow[];
+            })
+        : Promise.resolve([] as MyFormationItemRow[]),
     ]);
 
     const inWindowMeetings = this.filterMeetingsInWindow(meetings);
     const meetingActions = this.transformMeetingsToActions(inWindowMeetings);
     const voteActions = this.transformVotesToActions(pendingVotes);
     const invitationActions = this.transformInvitationsToActions(pendingInvitations);
+    const formationItemActions = this.transformFormationItemsToActions(formationItems);
 
     // Phase 2: RSVP + registrant lookups only pay off when at least one in-window meeting
     // collects LFX RSVPs. Pre-feature series still produce Review Agenda actions, but they
@@ -1357,11 +1374,12 @@ export class UserService {
     }
 
     // Order by actionability: pending invitations are the most actionable (someone is waiting on
-    // the user to join) and only ever appear on the Me lens, so they lead. RSVPs and votes have
-    // closing windows next. Surveys are time-bounded by their cutoff. Review Agenda is
-    // informational (read-before-meeting) and goes last — with the 5-item display cap, plentiful
-    // meetings shouldn't crowd out the rows the user actually has to respond to.
-    return [...invitationActions, ...rsvpActions, ...voteActions, ...surveys, ...meetingActions];
+    // the user to join) and only ever appear on the Me lens, so they lead. Formation checklist
+    // items come next — assigned work with a due date is more actionable than an RSVP (GH-1956).
+    // RSVPs and votes have closing windows next. Surveys are time-bounded by their cutoff. Review
+    // Agenda is informational (read-before-meeting) and goes last — with the 5-item display cap,
+    // plentiful meetings shouldn't crowd out the rows the user actually has to respond to.
+    return [...invitationActions, ...formationItemActions, ...rsvpActions, ...voteActions, ...surveys, ...meetingActions];
   }
 
   /**
@@ -1602,6 +1620,18 @@ export class UserService {
    */
   private transformInvitationsToActions(invitations: PendingInvitation[]): PendingActionItem[] {
     return buildInvitationActions(invitations);
+  }
+
+  /**
+   * Transform formation checklist items assigned to the caller into pending action rows (GH-1956,
+   * Me lens only). `formationService.getMyFormationWork` already filters to open items
+   * (`isAssignedItemOpen` — never `done`/`skipped`) and to the calling username, so this is a
+   * straight structural mapping; the row shape itself lives in the shared package
+   * (`buildFormationItemActions`) so it's unit-testable without standing up Express, mirroring
+   * `transformInvitationsToActions` above.
+   */
+  private transformFormationItemsToActions(items: MyFormationItemRow[]): PendingActionItem[] {
+    return buildFormationItemActions(items);
   }
 
   /**

--- a/packages/shared/src/constants/pending-action.constants.ts
+++ b/packages/shared/src/constants/pending-action.constants.ts
@@ -16,6 +16,7 @@ export const PENDING_ACTION_SEVERITY: Record<PendingActionType, TagSeverity> = {
   Submitted: 'success', // green — completed survey/feedback acknowledgement, distinguishes from pending Survey
   Invitation: 'success', // green — matches the design's green invite pill
   BriefAction: 'secondary', // gray — AI-suggested follow-up, not a deadline-bound obligation
+  FormationItem: 'warn', // amber — assigned checklist work, matches RSVP/Survey's action-needed tone
 };
 
 /** Per-type CTA button icon — conveys the action rather than the category. */
@@ -27,6 +28,7 @@ export const PENDING_ACTION_BUTTON_ICON: Record<PendingActionType, string> = {
   Submitted: 'fa-light fa-circle-check',
   Invitation: 'fa-light fa-user-plus',
   BriefAction: 'fa-light fa-list-check',
+  FormationItem: 'fa-light fa-diagram-project',
 };
 
 /** Human-friendly display labels for the pending-action category tag. */
@@ -38,6 +40,7 @@ export const PENDING_ACTION_LABEL: Record<PendingActionType, string> = {
   Submitted: 'Submitted',
   Invitation: 'Invitation',
   BriefAction: 'From Weekly Brief',
+  FormationItem: 'Formation',
 };
 
 /**

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -644,6 +644,8 @@ export interface DrawerActionRow extends PendingActionItem {
   acceptAriaLabel: string;
   /** Precomputed `aria-label` for the Decline control ("Decline invite to {inviteGroupName}") — built in TS so the template never calls a method. */
   declineAriaLabel: string;
+  /** True when the action is a formation checklist item (GH-1956); renders Claim / Block… / Open instead of the generic CTA. */
+  isFormationItem: boolean;
 }
 
 /** Lighter pending-action row used by committee-overview's static list — adds a stable `@for ... track` key. */

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -4,6 +4,7 @@
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
 
 import type { CommitteeOrganizationReference } from './committee.interface';
+import type { FormationItemStatus } from './formation.interface';
 import type { Meeting } from './meeting.interface';
 import type { Vote } from './poll.interface';
 
@@ -521,7 +522,7 @@ export interface ProgressItemWithChart extends ProgressItem {
  * Pending-action row discriminator. String union (not enum) so it round-trips through JSON
  * without value-vs-key reverse-mapping footguns.
  */
-export type PendingActionType = 'RSVP' | 'Vote' | 'Survey' | 'Agenda' | 'Submitted' | 'Invitation' | 'BriefAction';
+export type PendingActionType = 'RSVP' | 'Vote' | 'Survey' | 'Agenda' | 'Submitted' | 'Invitation' | 'BriefAction' | 'FormationItem';
 
 /**
  * Pending action item for task list
@@ -568,6 +569,16 @@ export interface PendingActionItem {
   inviteRequiresOrganization?: boolean;
   /** Weekly-brief action-item UID (set on BriefAction action types). Gives HiddenActionsService's identifier scheme a stable per-item key instead of falling back to type+badge+text. */
   briefActionUid?: string;
+  /** Project uid the formation item belongs to (set on FormationItem action types). Paired with `formationItemKey` to address the Claim/Block-with-note mutation and open the item drawer. */
+  formationProjectUid?: string;
+  /** `template_item_key` — the write address, together with `formationProjectUid` (set on FormationItem action types). */
+  formationItemKey?: string;
+  /** Formation item uid (set on FormationItem action types). Gives HiddenActionsService's identifier scheme, and `getRowKey`, a stable per-item key. */
+  formationItemUid?: string;
+  /** Current status (set on FormationItem action types) — drives whether the row still offers Claim (only when `not_started`). */
+  formationItemStatus?: FormationItemStatus;
+  /** Whether the item is gating (set on FormationItem action types) — drives the "Required for Active" marker. */
+  formationIsGating?: boolean;
 }
 
 /**
@@ -609,6 +620,8 @@ export interface DecoratedPendingAction extends PendingActionItem {
   inviteViewCommands: string[] | null;
   /** Precomputed `?project=` query params for the invitation view link; null when no project slug resolved. */
   inviteViewQueryParams: { project: string } | null;
+  /** True when the action is a FormationItem (GH-1956) — drives the inline Claim button and the "Required for Active" marker. */
+  isFormationItem: boolean;
 }
 
 /** Pending action row for the right-side drawer — adds inline-RSVP flags and per-row meeting-fetch state. */

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -4,7 +4,7 @@
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
 
 import type { CommitteeOrganizationReference } from './committee.interface';
-import type { FormationItemStatus } from './formation.interface';
+import type { FormationItemAction, FormationItemStatus } from './formation.interface';
 import type { Meeting } from './meeting.interface';
 import type { Vote } from './poll.interface';
 
@@ -580,12 +580,33 @@ export interface PendingActionItem {
   /** Whether the item is gating (set on FormationItem action types) — drives the "Required for Active" marker. */
   formationIsGating?: boolean;
   /**
+   * The item's action kind (set on FormationItem action types) — `assertItemProjectWriteAccess`
+   * aside, `FormationService.updateFormationItemStatus` rejects every manual status transition for
+   * `status_only` items regardless of write access, so Claim/Block must never render for them; the
+   * row falls back to Open/the link only.
+   */
+  formationItemAction?: FormationItemAction;
+  /**
    * Whether the caller has project `writer` access (set on FormationItem action types) —
    * Claim/Block both hard-require `project.writer` server-side (`assertItemProjectWriteAccess`),
    * so an `auditor`-only assignee would otherwise see an actionable button that always 403s.
    * Drives whether the row's Claim/Block controls render as clickable vs. disabled-with-tooltip.
    */
   formationCanWrite?: boolean;
+}
+
+/**
+ * Payload emitted when a Pending Actions row's Open action requests the shared
+ * `formation-item-drawer` (GH-1956) — carried from `pending-actions`/`pending-actions-drawer` through
+ * `dashboard-formation-item-drawer-host.open()`. `canWrite` mirrors `PendingActionItem.formationCanWrite`
+ * so the host can render the drawer's Mark complete/Save/Skip controls read-only for an auditor-only
+ * assignee — those mutations hard-require project `writer` server-side, and the drawer's own
+ * `can_complete` gate does not account for that (it only encodes the gating-item LF-staff check).
+ */
+export interface FormationItemOpenRequest {
+  projectUid: string;
+  itemKey: string;
+  canWrite?: boolean;
 }
 
 /**

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -579,6 +579,13 @@ export interface PendingActionItem {
   formationItemStatus?: FormationItemStatus;
   /** Whether the item is gating (set on FormationItem action types) — drives the "Required for Active" marker. */
   formationIsGating?: boolean;
+  /**
+   * Whether the caller has project `writer` access (set on FormationItem action types) —
+   * Claim/Block both hard-require `project.writer` server-side (`assertItemProjectWriteAccess`),
+   * so an `auditor`-only assignee would otherwise see an actionable button that always 403s.
+   * Drives whether the row's Claim/Block controls render as clickable vs. disabled-with-tooltip.
+   */
+  formationCanWrite?: boolean;
 }
 
 /**

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -393,3 +393,61 @@ export interface FormationItemMapContext {
   projectUid: string;
   projectSlug: string;
 }
+
+/**
+ * One checklist item assigned to the caller, across every project they can read (GH-1956). Answers
+ * "which items are assigned to me", which no upstream endpoint offers yet — the item index the Me
+ * lens needs (one access-filtered query with an assignee filter) does not exist upstream (#1957).
+ * `data_source: 'live'` on {@link MyFormationWorkResponse} therefore always returns `items: []`
+ * rather than fabricating rows; this shape is what the eventual index response maps onto 1:1.
+ */
+export interface MyFormationItemRow {
+  item_uid: string;
+  /** The write address, together with {@link MyFormationItemRow.project_uid} — see `FormationItem.template_item_key`'s doc comment. */
+  template_item_key: string;
+  project_uid: string;
+  project_slug: string;
+  project_name: string;
+  title: string;
+  /** Never `'done'` | `'skipped'` — filtered upstream of this shape by `isAssignedItemOpen`. */
+  status: FormationItemStatus;
+  /** Drives the "Required for Active" marker on the Pending Actions row. */
+  is_gating: boolean;
+  due_date: string | null;
+  action: FormationItemAction;
+  action_href: string | null;
+  /** `If-Match` token for the Claim / Block-with-note mutation. */
+  version: number;
+}
+
+/**
+ * One formation the caller has at least one assigned item on (GH-1956's "My formations" = projects
+ * with at least one item assigned to me — the direct-grant definition in the issue body is not
+ * satisfiable, see the ticket's third comment). Maps onto the already-live formation projection
+ * ({@link FormationQueueRow}) filtered to documents whose `assignees` contains the caller — derived
+ * server-side today, unlike {@link MyFormationItemRow}, so the client shape doesn't change on swap.
+ */
+export interface MyFormationSummary {
+  formation_uid: string;
+  project_uid: string;
+  project_slug: string;
+  project_name: string;
+  sub_stage: FormationSubStage;
+  announcement_date: string | null;
+  /** The three "My formations" subtitle buckets — see `formatMyFormationSubtitle`. */
+  assigned_to_do: number;
+  assigned_with_team: number;
+  assigned_done: number;
+  items_done: number;
+  items_total: number;
+  gating_done: number;
+  gating_total: number;
+  blocking_item_title: string | null;
+}
+
+/** Response body for `GET /api/user/formation-work` (GH-1956, Me lens only). */
+export interface MyFormationWorkResponse {
+  formations: MyFormationSummary[];
+  items: MyFormationItemRow[];
+  data_source: 'fixture' | 'live';
+}

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -418,6 +418,14 @@ export interface MyFormationItemRow {
   action_href: string | null;
   /** `If-Match` token for the Claim / Block-with-note mutation. */
   version: number;
+  /**
+   * Whether the caller has `writer` on {@link MyFormationItemRow.project_uid} — Claim/Block both
+   * call `updateFormationItemStatus`, which hard-requires `project.writer` via
+   * `assertItemProjectWriteAccess` (an `auditor`-only assignee is a valid GH-1956 assignee but has
+   * no write access and would otherwise see an actionable button that always 403s). Drives whether
+   * `buildFormationItemActions` renders the row's action as clickable.
+   */
+  can_write: boolean;
 }
 
 /**
@@ -434,10 +442,13 @@ export interface MyFormationSummary {
   project_name: string;
   sub_stage: FormationSubStage;
   announcement_date: string | null;
-  /** The three "My formations" subtitle buckets — see `formatMyFormationSubtitle`. */
+  /** The "My formations" subtitle buckets — see `formatMyFormationSubtitle`. */
   assigned_to_do: number;
   assigned_with_team: number;
   assigned_done: number;
+  /** Skipped is kept out of `assigned_done` — skipping is an escape hatch for a gate the project can't complete, not completion. */
+  assigned_skipped: number;
+  /** Counts only `status === 'done'` — a skipped item is not done, unlike `gating_done`'s readiness sense below. */
   items_done: number;
   items_total: number;
   gating_done: number;

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -451,3 +451,15 @@ export interface MyFormationWorkResponse {
   items: MyFormationItemRow[];
   data_source: 'fixture' | 'live';
 }
+
+/**
+ * `MyFormationSummary` decorated with pre-derived display fields for `my-formations-card` — mirrors
+ * `DecoratedPendingAction` in `components.interface.ts`. Templates may only read signals/computed
+ * values, never call a method, so `subtitle`/`progressPercent`/`announcementLabel` must be computed
+ * once per row up front rather than via template-called functions.
+ */
+export interface DecoratedMyFormation extends MyFormationSummary {
+  subtitle: string;
+  progressPercent: number;
+  announcementLabel: string | null;
+}

--- a/packages/shared/src/utils/formation-me.utils.spec.ts
+++ b/packages/shared/src/utils/formation-me.utils.spec.ts
@@ -21,6 +21,7 @@ const formationItemRow = (overrides: Partial<MyFormationItemRow> = {}): MyFormat
   action: 'manual',
   action_href: null,
   version: 1,
+  can_write: true,
   ...overrides,
 });
 
@@ -40,39 +41,55 @@ describe('isAssignedItemOpen', () => {
 
 describe('summarizeMyFormationItems', () => {
   it('buckets a single not_started item as to-do (GH-1956 N=1)', () => {
-    expect(summarizeMyFormationItems(items('not_started'))).toEqual({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 });
+    expect(summarizeMyFormationItems(items('not_started'))).toEqual({
+      assigned_to_do: 1,
+      assigned_with_team: 0,
+      assigned_done: 0,
+      assigned_skipped: 0,
+    });
   });
 
   it('buckets across three formations worth of items', () => {
     const result = summarizeMyFormationItems(items('not_started', 'in_progress', 'blocked', 'awaiting_acceptance', 'done', 'skipped'));
-    expect(result).toEqual({ assigned_to_do: 3, assigned_with_team: 1, assigned_done: 2 });
+    expect(result).toEqual({ assigned_to_do: 3, assigned_with_team: 1, assigned_done: 1, assigned_skipped: 1 });
   });
 
   it('counts a claimed (in_progress) item as to-do, not done and not with the formation team', () => {
     const result = summarizeMyFormationItems(items('in_progress'));
-    expect(result).toEqual({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 });
+    expect(result).toEqual({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0, assigned_skipped: 0 });
   });
 
-  it('returns all zeros for a formation whose assigned items are all done/skipped', () => {
-    expect(summarizeMyFormationItems(items('done', 'skipped'))).toEqual({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 2 });
+  it('returns skipped counted separately from done, not folded together', () => {
+    expect(summarizeMyFormationItems(items('done', 'skipped'))).toEqual({
+      assigned_to_do: 0,
+      assigned_with_team: 0,
+      assigned_done: 1,
+      assigned_skipped: 1,
+    });
   });
 });
 
 describe('formatMyFormationSubtitle', () => {
-  it('renders all three buckets joined with middle dots', () => {
-    expect(formatMyFormationSubtitle({ assigned_to_do: 2, assigned_with_team: 1, assigned_done: 1 })).toBe('2 to do · 1 with formation team · 1 done');
+  it('renders all four buckets joined with middle dots', () => {
+    expect(formatMyFormationSubtitle({ assigned_to_do: 2, assigned_with_team: 1, assigned_done: 1, assigned_skipped: 1 })).toBe(
+      '2 to do · 1 with formation team · 1 done · 1 skipped'
+    );
   });
 
   it('drops zero-count buckets instead of padding with "0 done"', () => {
-    expect(formatMyFormationSubtitle({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 })).toBe('1 to do');
+    expect(formatMyFormationSubtitle({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0, assigned_skipped: 0 })).toBe('1 to do');
   });
 
   it('reads correctly at N=1 for the with-team bucket alone', () => {
-    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 1, assigned_done: 0 })).toBe('1 with formation team');
+    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 1, assigned_done: 0, assigned_skipped: 0 })).toBe('1 with formation team');
+  });
+
+  it('keeps skipped its own segment rather than folding it into done', () => {
+    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 0, assigned_skipped: 1 })).toBe('1 skipped');
   });
 
   it('returns an empty string when every bucket is zero', () => {
-    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 0 })).toBe('');
+    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 0, assigned_skipped: 0 })).toBe('');
   });
 });
 
@@ -114,5 +131,13 @@ describe('buildFormationItemActions', () => {
 
   it('returns an empty array for no items', () => {
     expect(buildFormationItemActions([])).toEqual([]);
+  });
+
+  it('threads can_write through as formationCanWrite unchanged', () => {
+    const [writable] = buildFormationItemActions([formationItemRow({ can_write: true })]);
+    expect(writable.formationCanWrite).toBe(true);
+
+    const [readOnly] = buildFormationItemActions([formationItemRow({ can_write: false })]);
+    expect(readOnly.formationCanWrite).toBe(false);
   });
 });

--- a/packages/shared/src/utils/formation-me.utils.spec.ts
+++ b/packages/shared/src/utils/formation-me.utils.spec.ts
@@ -1,0 +1,118 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import type { FormationItemStatus, MyFormationItemRow } from '../interfaces/formation.interface';
+import { buildFormationItemActions, formatMyFormationSubtitle, isAssignedItemOpen, summarizeMyFormationItems } from './formation-me.utils';
+
+const items = (...statuses: FormationItemStatus[]): { status: FormationItemStatus }[] => statuses.map((status) => ({ status }));
+
+const formationItemRow = (overrides: Partial<MyFormationItemRow> = {}): MyFormationItemRow => ({
+  item_uid: 'item-1',
+  template_item_key: 'legal-review',
+  project_uid: 'project-1',
+  project_slug: 'acme-project',
+  project_name: 'Acme Project',
+  title: 'Complete legal review',
+  status: 'not_started',
+  is_gating: true,
+  due_date: null,
+  action: 'manual',
+  action_href: null,
+  version: 1,
+  ...overrides,
+});
+
+describe('isAssignedItemOpen', () => {
+  it('excludes done and skipped', () => {
+    expect(isAssignedItemOpen('done')).toBe(false);
+    expect(isAssignedItemOpen('skipped')).toBe(false);
+  });
+
+  it('keeps every other status, including awaiting_acceptance', () => {
+    expect(isAssignedItemOpen('not_started')).toBe(true);
+    expect(isAssignedItemOpen('in_progress')).toBe(true);
+    expect(isAssignedItemOpen('blocked')).toBe(true);
+    expect(isAssignedItemOpen('awaiting_acceptance')).toBe(true);
+  });
+});
+
+describe('summarizeMyFormationItems', () => {
+  it('buckets a single not_started item as to-do (GH-1956 N=1)', () => {
+    expect(summarizeMyFormationItems(items('not_started'))).toEqual({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 });
+  });
+
+  it('buckets across three formations worth of items', () => {
+    const result = summarizeMyFormationItems(items('not_started', 'in_progress', 'blocked', 'awaiting_acceptance', 'done', 'skipped'));
+    expect(result).toEqual({ assigned_to_do: 3, assigned_with_team: 1, assigned_done: 2 });
+  });
+
+  it('counts a claimed (in_progress) item as to-do, not done and not with the formation team', () => {
+    const result = summarizeMyFormationItems(items('in_progress'));
+    expect(result).toEqual({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 });
+  });
+
+  it('returns all zeros for a formation whose assigned items are all done/skipped', () => {
+    expect(summarizeMyFormationItems(items('done', 'skipped'))).toEqual({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 2 });
+  });
+});
+
+describe('formatMyFormationSubtitle', () => {
+  it('renders all three buckets joined with middle dots', () => {
+    expect(formatMyFormationSubtitle({ assigned_to_do: 2, assigned_with_team: 1, assigned_done: 1 })).toBe('2 to do · 1 with formation team · 1 done');
+  });
+
+  it('drops zero-count buckets instead of padding with "0 done"', () => {
+    expect(formatMyFormationSubtitle({ assigned_to_do: 1, assigned_with_team: 0, assigned_done: 0 })).toBe('1 to do');
+  });
+
+  it('reads correctly at N=1 for the with-team bucket alone', () => {
+    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 1, assigned_done: 0 })).toBe('1 with formation team');
+  });
+
+  it('returns an empty string when every bucket is zero', () => {
+    expect(formatMyFormationSubtitle({ assigned_to_do: 0, assigned_with_team: 0, assigned_done: 0 })).toBe('');
+  });
+});
+
+describe('buildFormationItemActions', () => {
+  it('maps a single item to a FormationItem row with the formation-specific fields', () => {
+    const [action] = buildFormationItemActions([formationItemRow()]);
+    expect(action).toMatchObject({
+      type: 'FormationItem',
+      badge: 'Acme Project',
+      text: 'Complete legal review',
+      buttonText: 'Claim',
+      formationProjectUid: 'project-1',
+      formationItemKey: 'legal-review',
+      formationItemUid: 'item-1',
+      formationItemStatus: 'not_started',
+      formationIsGating: true,
+    });
+  });
+
+  it('never emits a "Mark done" button text, even for an awaiting_acceptance row (GH-1956 decision 3)', () => {
+    const [action] = buildFormationItemActions([formationItemRow({ status: 'awaiting_acceptance' })]);
+    expect(action.buttonText).toBe('Claim');
+    expect(action.buttonText.toLowerCase()).not.toContain('done');
+  });
+
+  it('omits date when due_date is null and sets it when present', () => {
+    const [withoutDate] = buildFormationItemActions([formationItemRow({ due_date: null })]);
+    expect(withoutDate.date).toBeUndefined();
+
+    const [withDate] = buildFormationItemActions([formationItemRow({ due_date: '2026-10-01' })]);
+    expect(withDate.date).toBe('2026-10-01');
+  });
+
+  it('preserves row order and count across multiple items', () => {
+    const rows = [formationItemRow({ item_uid: 'item-1' }), formationItemRow({ item_uid: 'item-2' }), formationItemRow({ item_uid: 'item-3' })];
+    const actions = buildFormationItemActions(rows);
+    expect(actions.map((a) => a.formationItemUid)).toEqual(['item-1', 'item-2', 'item-3']);
+  });
+
+  it('returns an empty array for no items', () => {
+    expect(buildFormationItemActions([])).toEqual([]);
+  });
+});

--- a/packages/shared/src/utils/formation-me.utils.ts
+++ b/packages/shared/src/utils/formation-me.utils.ts
@@ -79,6 +79,11 @@ export function formatMyFormationSubtitle(summary: MyFormationBucketCounts): str
  * hard-require it server-side via `assertItemProjectWriteAccess`; without this flag such a caller
  * would see an actionable button that always 403s). The template renders Claim/Block
  * disabled-with-tooltip when false.
+ *
+ * `formationItemAction` carries `item.action` through unchanged (copilot review: `status_only`
+ * items are rejected unconditionally by `FormationService.updateFormationItemStatus`, independent
+ * of write access — the template must render only Open/the link, never Claim/Block, when this is
+ * `'status_only'`).
  */
 export function buildFormationItemActions(items: MyFormationItemRow[]): PendingActionItem[] {
   return items.map((item) => ({
@@ -96,5 +101,6 @@ export function buildFormationItemActions(items: MyFormationItemRow[]): PendingA
     formationItemStatus: item.status,
     formationIsGating: item.is_gating,
     formationCanWrite: item.can_write,
+    formationItemAction: item.action,
   }));
 }

--- a/packages/shared/src/utils/formation-me.utils.ts
+++ b/packages/shared/src/utils/formation-me.utils.ts
@@ -1,0 +1,87 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_SEVERITY } from '../constants/pending-action.constants';
+import type { PendingActionItem } from '../interfaces/components.interface';
+import type { FormationItemStatus, MyFormationItemRow, MyFormationSummary } from '../interfaces/formation.interface';
+
+/** The three "My formations" subtitle buckets, keyed by project — see {@link MyFormationSummary}. */
+export type MyFormationBucketCounts = Pick<MyFormationSummary, 'assigned_to_do' | 'assigned_with_team' | 'assigned_done'>;
+
+/**
+ * True for every {@link FormationItemStatus} that still belongs on the caller's Pending Actions
+ * list — i.e. every status except the two terminal ones. `awaiting_acceptance` stays open: the
+ * assignee's own work is done, but the row still surfaces so they can see the item is waiting on
+ * the formation team (GH-1956 decision 3 — the assignee never sets a status themselves, so nothing
+ * here transitions an item to `done`).
+ */
+export function isAssignedItemOpen(status: FormationItemStatus): boolean {
+  return status !== 'done' && status !== 'skipped';
+}
+
+/**
+ * Buckets a caller's assigned items on one formation into the three "My formations" subtitle
+ * counts (GH-1956). Takes every item assigned to the caller on the formation — not just the open
+ * ones {@link isAssignedItemOpen} keeps for the Pending Actions response — so `assigned_done` has
+ * something to count; `MyFormationWorkResponse.items` only ever carries the open subset.
+ */
+export function summarizeMyFormationItems(items: { status: FormationItemStatus }[]): MyFormationBucketCounts {
+  let assignedToDo = 0;
+  let assignedWithTeam = 0;
+  let assignedDone = 0;
+
+  for (const item of items) {
+    if (item.status === 'awaiting_acceptance') {
+      assignedWithTeam += 1;
+    } else if (item.status === 'done' || item.status === 'skipped') {
+      assignedDone += 1;
+    } else {
+      // not_started | in_progress | blocked
+      assignedToDo += 1;
+    }
+  }
+
+  return { assigned_to_do: assignedToDo, assigned_with_team: assignedWithTeam, assigned_done: assignedDone };
+}
+
+/**
+ * `2 to do · 1 with formation team · 1 done` (GH-1956 decision "subtitle copy") — zero-count
+ * buckets are dropped entirely rather than rendered as "0 done", so a formation with nothing yet
+ * completed reads `2 to do · 1 with formation team`, not a padded three-part string.
+ */
+export function formatMyFormationSubtitle(summary: MyFormationBucketCounts): string {
+  const parts: string[] = [];
+  if (summary.assigned_to_do > 0) parts.push(`${summary.assigned_to_do} to do`);
+  if (summary.assigned_with_team > 0) parts.push(`${summary.assigned_with_team} with formation team`);
+  if (summary.assigned_done > 0) parts.push(`${summary.assigned_done} done`);
+  return parts.join(' · ');
+}
+
+/**
+ * Pure mapping from `MyFormationWorkResponse.items` to Pending Actions rows (GH-1956) — mirrors
+ * `buildInvitationActions`'s split (server aggregator stays a thin caller, the row shape is
+ * unit-testable here without standing up Express). Ordering (formation rows placed immediately
+ * after invitations) is the caller's concern, not this function's.
+ *
+ * No "Mark done" button ever appears — GH-1956 decision 3: the assignee doesn't set status. The
+ * row always offers Claim / Block with note / Open; `buttonText` stays "Claim" even for an
+ * `awaiting_acceptance` row (the template disables/relabels it client-side once claimed, keyed off
+ * `formationItemStatus`), since it is the assignee's one inline action and not a status label.
+ */
+export function buildFormationItemActions(items: MyFormationItemRow[]): PendingActionItem[] {
+  return items.map((item) => ({
+    type: 'FormationItem',
+    badge: item.project_name,
+    text: item.title,
+    icon: PENDING_ACTION_BUTTON_ICON.FormationItem,
+    severity: PENDING_ACTION_SEVERITY.FormationItem,
+    buttonText: 'Claim',
+    buttonLink: item.action_href ?? undefined,
+    ...(item.due_date ? { date: item.due_date } : {}),
+    formationProjectUid: item.project_uid,
+    formationItemKey: item.template_item_key,
+    formationItemUid: item.item_uid,
+    formationItemStatus: item.status,
+    formationIsGating: item.is_gating,
+  }));
+}

--- a/packages/shared/src/utils/formation-me.utils.ts
+++ b/packages/shared/src/utils/formation-me.utils.ts
@@ -5,8 +5,8 @@ import { PENDING_ACTION_BUTTON_ICON, PENDING_ACTION_SEVERITY } from '../constant
 import type { PendingActionItem } from '../interfaces/components.interface';
 import type { FormationItemStatus, MyFormationItemRow, MyFormationSummary } from '../interfaces/formation.interface';
 
-/** The three "My formations" subtitle buckets, keyed by project — see {@link MyFormationSummary}. */
-export type MyFormationBucketCounts = Pick<MyFormationSummary, 'assigned_to_do' | 'assigned_with_team' | 'assigned_done'>;
+/** The "My formations" subtitle buckets, keyed by project — see {@link MyFormationSummary}. */
+export type MyFormationBucketCounts = Pick<MyFormationSummary, 'assigned_to_do' | 'assigned_with_team' | 'assigned_done' | 'assigned_skipped'>;
 
 /**
  * True for every {@link FormationItemStatus} that still belongs on the caller's Pending Actions
@@ -29,31 +29,37 @@ export function summarizeMyFormationItems(items: { status: FormationItemStatus }
   let assignedToDo = 0;
   let assignedWithTeam = 0;
   let assignedDone = 0;
+  let assignedSkipped = 0;
 
   for (const item of items) {
     if (item.status === 'awaiting_acceptance') {
       assignedWithTeam += 1;
-    } else if (item.status === 'done' || item.status === 'skipped') {
+    } else if (item.status === 'done') {
       assignedDone += 1;
+    } else if (item.status === 'skipped') {
+      assignedSkipped += 1;
     } else {
       // not_started | in_progress | blocked
       assignedToDo += 1;
     }
   }
 
-  return { assigned_to_do: assignedToDo, assigned_with_team: assignedWithTeam, assigned_done: assignedDone };
+  return { assigned_to_do: assignedToDo, assigned_with_team: assignedWithTeam, assigned_done: assignedDone, assigned_skipped: assignedSkipped };
 }
 
 /**
- * `2 to do · 1 with formation team · 1 done` (GH-1956 decision "subtitle copy") — zero-count
- * buckets are dropped entirely rather than rendered as "0 done", so a formation with nothing yet
- * completed reads `2 to do · 1 with formation team`, not a padded three-part string.
+ * `2 to do · 1 with formation team · 1 done · 1 skipped` (GH-1956 decision "subtitle copy") —
+ * zero-count buckets are dropped entirely rather than rendered as "0 done", so a formation with
+ * nothing yet completed reads `2 to do · 1 with formation team`, not a padded string. Skipped is
+ * its own segment, not folded into "done" — skipping is the escape hatch for a gate the project
+ * can't complete (see `formation-checklist.utils.ts`'s readiness summary), not completion.
  */
 export function formatMyFormationSubtitle(summary: MyFormationBucketCounts): string {
   const parts: string[] = [];
   if (summary.assigned_to_do > 0) parts.push(`${summary.assigned_to_do} to do`);
   if (summary.assigned_with_team > 0) parts.push(`${summary.assigned_with_team} with formation team`);
   if (summary.assigned_done > 0) parts.push(`${summary.assigned_done} done`);
+  if (summary.assigned_skipped > 0) parts.push(`${summary.assigned_skipped} skipped`);
   return parts.join(' · ');
 }
 
@@ -67,6 +73,12 @@ export function formatMyFormationSubtitle(summary: MyFormationBucketCounts): str
  * row always offers Claim / Block with note / Open; `buttonText` stays "Claim" even for an
  * `awaiting_acceptance` row (the template disables/relabels it client-side once claimed, keyed off
  * `formationItemStatus`), since it is the assignee's one inline action and not a status label.
+ *
+ * `formationCanWrite` carries `item.can_write` through unchanged (GH-1956 review: an `auditor`-only
+ * assignee — a valid assignee per decision 1 — has no project write access, and Claim/Block both
+ * hard-require it server-side via `assertItemProjectWriteAccess`; without this flag such a caller
+ * would see an actionable button that always 403s). The template renders Claim/Block
+ * disabled-with-tooltip when false.
  */
 export function buildFormationItemActions(items: MyFormationItemRow[]): PendingActionItem[] {
   return items.map((item) => ({
@@ -83,5 +95,6 @@ export function buildFormationItemActions(items: MyFormationItemRow[]): PendingA
     formationItemUid: item.item_uid,
     formationItemStatus: item.status,
     formationIsGating: item.is_gating,
+    formationCanWrite: item.can_write,
   }));
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -74,4 +74,5 @@ export * from './social-listening-filter.utils';
 export * from './formation.utils';
 export * from './project-stage.utils';
 export * from './formation-checklist.utils';
+export * from './formation-me.utils';
 export * from './health-metrics-overview.utils';


### PR DESCRIPTION
## Summary

Me lens now surfaces formation work assigned to the signed-in user:

- **"My formations" card** on both `multi-persona-dashboard` and `user-dashboard` — one row per project with at least one checklist item assigned to the caller, subtitle bucketed `N to do · N with formation team · N done`, progress bar, gating count, announcement date, blocking item.
- **"In formation" tile** on `multi-persona-dashboard` only (the only Me-lens dashboard with a tile strip).
- **Formation rows in Pending Actions** (both the inline list and its drawer) with **Claim / Block… / Open** actions — no "Mark done"; the assignee doesn't set status, only claims, blocks with a reason, or opens the full item drawer.
- **Dashboard-level drawer host** (`dashboard-formation-item-drawer-host`) reusing the existing `formation-item-drawer` for Block/Open/Skip, wired for both dashboards.

Everything ships behind `FORMATION_ENABLED_FLAG`. Built against a fixture in the agreed shape — the upstream per-item formation index doesn't exist yet; the live branch returns an empty result with `data_source: 'live'` rather than fabricate rows (mirrors `getProjectFormation`'s TODO(#1957) pattern).

## Deliberate deviations / notes for reviewers

- **No `deriveAllowedLenses`/`lens.utils.ts` change** — per #1956's decision thread, a partner already reaches Project Lens via their project grant; no formation-specific grant needed. `lens.utils.spec.ts` is unmodified — there's nothing new there to test under this definition.
- **No derived assignment label** — under the assignment-based definition, every row is by construction "assigned to me"; a per-row label would say nothing. Called out rather than invented.
- **Two commits became eight** — the plan's "split into two commits for a clean two-PR split" target grew because of two full-branch review passes (findings + re-verification) plus a couple of small fixes discovered while wiring the dashboard drawer host outputs (`itemUpdated`/`writeStarted`/`writeEnded` were unbound, leaving `mutationInFlight` a fake alias for `skipInFlight`) and a Block-button status-gating gap in the main Pending Actions list. All commits are signed/DCO'd; see `git log` for the breakdown if a split is wanted.
- **Diff is ~1579 lines**, over the 1000-line target in `.claude/rules/commit-workflow.md` — flagged as a NIT by `/lfx-self-serve-pr-readiness`, not a blocker; the feature (shared types, BFF endpoint, card, tile, Pending Actions rows, drawer host, tests) doesn't split cleanly along a smaller natural seam without re-reviewing partial state.
- **The main Pending Actions list's generic Dismiss control still applies to formation rows unchanged** (deliberate, per the original plan — "formation rows inherit it unchanged, exactly as the ticket asks"). The **drawer's** Dismiss control, by contrast, now explicitly excludes formation rows (`!item.isFormationItem`) since they're owned by Claim/Block/Open, not a generic dismiss — this asymmetry between the main list and the drawer is intentional, scoped to a full-branch review finding on the drawer specifically.
- **No e2e/manual browser verification in this sandbox** — `TEST_USERNAME`/`TEST_PASSWORD` aren't available here. `yarn check-types`, `yarn lint:check`, `./check-headers.sh`, `yarn test` (142 files / 2442 tests), and `yarn build` all pass locally; e2e specs were added per the plan but not run against a live server from this environment.

## Test plan

- [x] `yarn check-types && yarn lint:check && ./check-headers.sh && yarn test && yarn build`
- [x] `/lfx-self-serve-pr-readiness` — READY WITH CHANGES (branch renamed `feat/GH-1956-me-lens-formation` → `feat/issue-1956` to match convention; diff-size NIT acknowledged above)
- [x] `/preflight` — all checks pass
- [ ] Manual verification in a running environment: card/tile at N=1 and N=3, both disappearing at N=0, a claimed item staying in Pending Actions as "with formation team" (not done), Claim/Block/Open with no Mark-done, claim-from-row reflected on the project's checklist page

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)