### PR TITLE
test(meetings): close the review's remaining coverage gaps

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
@@ -446,5 +446,20 @@ describe('MeetingComposerHostComponent', () => {
       expect(formService.form()).toBe(form);
       expect(formService.form().get('title')?.value).toBe('Quarterly sync');
     });
+
+    // The dialog's own `visibleChange` closes the composer, and unmounting the dialog is exactly
+    // what the handoff does. If that ever routes through `close()`, the drawer the organizer just
+    // asked for never appears — so the open state is asserted separately from the form state.
+    it('leaves the composer open so the drawer can take over', async () => {
+      composer.open({ mode: 'create', projectUid: 'project-1', variant: 'quick' });
+      await flush();
+      formService.form().patchValue({ title: 'Quarterly sync', startDate: new Date('2026-11-04T00:00:00Z'), startTime: '10:00' });
+
+      component['onSwitchToAdvanced']();
+      await flush();
+
+      expect(composer.isOpen()).toBe(true);
+      expect(formService.form().get('startTime')?.value).toBe('10:00');
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
@@ -24,6 +24,7 @@ import { QuickCreateDialogComponent } from './quick-create-dialog.component';
 describe('QuickCreateDialogComponent', () => {
   let fixture: ComponentFixture<QuickCreateDialogComponent>;
   let formService: MeetingComposerFormService;
+  let composer: MeetingComposerService;
 
   const selectType = (meetingType: MeetingType): void => {
     formService.form().get('meeting_type')?.setValue(meetingType);
@@ -44,7 +45,8 @@ describe('QuickCreateDialogComponent', () => {
     });
     TestBed.overrideComponent(QuickCreateDialogComponent, { set: { template: '', imports: [] } });
 
-    TestBed.inject(MeetingComposerService).open({ mode: 'create', projectUid: 'project-1' });
+    composer = TestBed.inject(MeetingComposerService);
+    composer.open({ mode: 'create', projectUid: 'project-1' });
     formService = TestBed.inject(MeetingComposerFormService);
     formService.initialize({ mode: 'create', projectUid: 'project-1' });
 
@@ -113,5 +115,89 @@ describe('QuickCreateDialogComponent', () => {
 
     expect(valueOf('title')).not.toBe(boardTitle);
     expect(valueOf('title')).toBeTruthy();
+  });
+  // Duration is the one seeded control whose template value is usually thrown away: every type but
+  // Maintainers estimates a span no chip offers, and seeding one of those would drop this surface into
+  // the custom-minutes input it deliberately never shows. Both halves of that guard are pinned below,
+  // each starting from a chip the seeding has to visibly overwrite or visibly leave alone.
+  it('seeds a template estimate that sits on the chip scale', () => {
+    formService.setDuration(30);
+
+    selectType(MeetingType.MAINTAINERS);
+
+    expect(formService.effectiveDuration()).toBe(60);
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(true);
+  });
+
+  it('leaves the duration alone when the template estimate is off the chip scale', () => {
+    formService.setDuration(30);
+
+    // Technical's first template estimates 70 minutes, which no chip offers.
+    selectType(MeetingType.TECHNICAL);
+
+    expect(formService.effectiveDuration()).toBe(30);
+    expect(valueOf('duration')).not.toBe('custom');
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(false);
+  });
+
+  // The value clears back to the same default it was seeded from, so the hint is the only thing that
+  // moves — and the hint is the whole point: it claims the number came from the type.
+  it('takes the duration hint back out when the organizer switches to Other', () => {
+    selectType(MeetingType.MAINTAINERS);
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(true);
+
+    selectType(MeetingType.OTHER);
+
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(false);
+  });
+
+  it('keeps a duration the organizer set themselves', () => {
+    formService.setDuration(120);
+    formService.form().get('duration')?.markAsDirty();
+
+    selectType(MeetingType.MAINTAINERS);
+
+    expect(formService.effectiveDuration()).toBe(120);
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(false);
+  });
+
+  it('closes the composer when the organizer dismisses the dialog', () => {
+    composer.open({ mode: 'create', projectUid: 'project-1', variant: 'quick' });
+
+    fixture.componentInstance['onVisibleChange'](false);
+
+    expect(composer.isOpen()).toBe(false);
+  });
+
+  // The handoff to the drawer unmounts this dialog. An unmount that still routed through `close()`
+  // would take the composer down with it, so the organizer would ask for the advanced surface and get
+  // an empty screen — hence the variant guard rather than a bare `close()`.
+  it('leaves the composer open when the dialog closes behind the drawer handoff', () => {
+    composer.open({ mode: 'create', projectUid: 'project-1', variant: 'quick' });
+    composer.switchToAdvanced();
+
+    fixture.componentInstance['onVisibleChange'](false);
+
+    expect(composer.isOpen()).toBe(true);
+  });
+
+  // Both footer actions are announcements, not the action itself: saving and surface-switching each
+  // need the composer service and the form service held together, which only the host does.
+  it('announces create rather than saving from the dialog', () => {
+    const emitted = vi.fn();
+    fixture.componentInstance.create.subscribe(emitted);
+
+    fixture.componentInstance['onCreate']();
+
+    expect(emitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces the drawer handoff rather than performing it', () => {
+    const emitted = vi.fn();
+    fixture.componentInstance.switchToAdvanced.subscribe(emitted);
+
+    fixture.componentInstance['onSwitchToAdvanced']();
+
+    expect(emitted).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,8 +8,8 @@ import {
   CreateMeetingRegistrantRequest,
   MeetingOccurrenceSummary,
   MeetingRegistrant,
-  PublicMeetingOccurrencesResponse,
   Project,
+  PublicMeetingOccurrencesResponse,
   PublicMeetingProject,
 } from '@lfx-one/shared/interfaces';
 import { joinAsSentenceList, truncateToUtf16Units } from '@lfx-one/shared/utils';

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -256,6 +256,22 @@ describe('AiService.generateMeetingAgenda', () => {
     expect(timeoutSpy).toHaveBeenCalledWith(AI_REQUEST_CONFIG.TIMEOUT_MS);
   });
 
+  // The caller-facing message is deliberately generic, so `cause` is the only thing carrying the
+  // upstream detail. A future edit that drops the options bag would keep this suite green without
+  // this assertion, and the real failure would vanish from every handler that inspects the cause.
+  it('keeps the upstream failure reachable through error.cause', async () => {
+    const { MeetingType } = await import('@lfx-one/shared/enums');
+    fetchMock.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized', text: async () => '{"error":"Invalid API key"}' } as unknown as Response);
+
+    const failure = await service
+      .generateMeetingAgenda(req, { meetingType: MeetingType.MAINTAINERS, title: 'Sanity check', projectName: 'Debug Project' })
+      .then(() => null)
+      .catch((error: Error) => error);
+
+    expect(failure?.message).toBe('Failed to generate meeting agenda');
+    expect((failure?.cause as Error | undefined)?.message).toMatch(/401 Unauthorized.*Invalid API key/);
+  });
+
   // GH-1464: the helper is reachable before Details & Access is filled in, so `buildPrompt` has to
   // omit each absent descriptor rather than emit an "undefined" clause the model would read as text.
   describe('prompt shape with partial descriptors', () => {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1214,3 +1214,64 @@ describe('MeetingService registrant write payloads', () => {
     }
   });
 });
+
+/**
+ * `encodePathSegment` guards every registrant path, but the guard is one call away from being
+ * reverted to raw interpolation and nothing here would have gone red. These cases pin the
+ * behaviour at the call sites rather than only on the helper: a slash or a space has to arrive
+ * upstream percent-encoded, and a dot-only segment has to be refused outright before the request
+ * is built, so `..` can never walk the ITX path.
+ */
+describe('MeetingService registrant paths reject hostile identifiers', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    proxyRequest.mockResolvedValue({});
+    service = new MeetingService();
+  });
+
+  const pathOf = (): string => proxyRequest.mock.calls[0][2] as string;
+
+  it('encodes a slash and a space in the create path', async () => {
+    await service.addMeetingRegistrant(req, { meeting_id: 'mtg/1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    expect(pathOf()).toBe('/itx/meetings/mtg%2F1/registrants');
+  });
+
+  it('encodes both identifiers in the update path', async () => {
+    await service.updateMeetingRegistrant(req, 'mtg 1', 'reg/1', { meeting_id: 'mtg 1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    expect(pathOf()).toBe('/itx/meetings/mtg%201/registrants/reg%2F1');
+  });
+
+  it('encodes both identifiers in the delete path', async () => {
+    await service.deleteMeetingRegistrant(req, 'mtg/1', 'reg 1');
+
+    expect(pathOf()).toBe('/itx/meetings/mtg%2F1/registrants/reg%201');
+  });
+
+  it('encodes both identifiers in the resend path', async () => {
+    await service.resendMeetingInvitation(req, 'mtg/1', 'reg/1');
+
+    expect(pathOf()).toBe('/itx/meetings/mtg%2F1/registrants/reg%2F1/resend');
+  });
+
+  it('encodes the meeting id in the self-registration path', async () => {
+    await service.addMeetingRegistrantSelf(req, 'mtg/1', { meeting_id: 'mtg/1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    expect(pathOf()).toBe('/itx/meetings/mtg%2F1/registrants/self');
+  });
+
+  it.each([['..'], ['.']])('refuses a %s meeting id before any request goes out', async (hostile) => {
+    await expect(service.addMeetingRegistrant(req, { meeting_id: hostile, email: 'a@example.com', first_name: 'A', last_name: 'B' })).rejects.toThrow();
+
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([['..'], ['.']])('refuses a %s registrant id before any request goes out', async (hostile) => {
+    await expect(service.deleteMeetingRegistrant(req, 'mtg-1', hostile)).rejects.toThrow();
+
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> **Final PR in the stack.** Base: `fix/issue-1451-privacy-and-composer-gaps` (#2310). Review this one last.

## What

Closes the last findings from @dealako's second review pass that the earlier slices had **not** actually answered, plus the partial gaps where the production fix had landed but nothing pinned it.

Two commits:

**`style(meetings): order the public meeting controller imports`** — `Project` sat out of alphabetical order in the shared-interfaces import of `public-meeting.controller.ts`. One line, no behaviour change.

**`test(meetings): close the review's remaining coverage gaps`** — four test gaps:

| Gap | What the test now pins |
|---|---|
| `MeetingService` registrant paths | Five cases prove a slash or a space reaches `proxyRequest` percent-encoded (create / update / delete / resend / self-registration); four prove a `.` or `..` identifier is refused **before** any request is built. |
| `AiService.generateMeetingAgenda` | The caller-facing message is deliberately generic, so `cause` is the only thing carrying the upstream detail. Dropping the options bag now fails a test. |
| `QuickCreateDialogComponent` | Duration seeding on **both** halves of the chip-scale guard, the dismiss-versus-handoff branch of `onVisibleChange`, and the two footer outputs. 6 tests → 14. |
| `MeetingComposerHostComponent` | The quick-to-drawer handoff asserts `composer.isOpen()` separately from the form state. |

## Why these are tests rather than fixes

The production behaviour in all four rows was already correct at the branch tip — the review's point was that nothing would have caught a regression. So each assertion was **mutation-checked** against the exact branch it guards:

- Reverting two `encodePathSegment(...)` call sites in `meeting.service.ts` to raw interpolation → exactly the 7 relevant new cases fail, 81 pass.
- Removing `{ cause: error }` from the `generateMeetingAgenda` throw → exactly 1 new test fails, 38 pass.
- Removing the chip-scale guard and the `isQuickCreate()` guard → exactly the 2 intended new tests fail, 12 pass.
- Removing the duration seeding itself → exactly the other 2 intended new tests fail, 12 pass.

Each mutation was then reverted and the suite re-confirmed green.

## Verification

```
./check-headers.sh   License check passed (8902 files)
yarn format:check    All matched files use Prettier code style!
yarn lint:check      0 errors (1 pre-existing warning, unrelated)
yarn check-types     2 tasks successful
yarn build           2 tasks successful
test:app             155 files / 2787 tests passed
test:server          118 files / 3272 tests passed
```

Refs #1451
