### PR TITLE
fix(meetings): allowlist upstream and public registrant payloads

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -6,7 +6,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
-import { MeetingRegistrant, User } from '@lfx-one/shared/interfaces';
+import { PublicMeetingRegistrationResponse, User } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { extractErrorMessage } from '@shared/utils/http-error.utils';
@@ -82,7 +82,7 @@ export class PublicRegistrationModalComponent {
           ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })
         .subscribe({
-          next: (registrant: MeetingRegistrant) => {
+          next: (registrant: PublicMeetingRegistrationResponse) => {
             this.submitting.set(false);
             this.messageService.add({
               severity: 'success',

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -42,6 +42,7 @@ import {
   PresignAttachmentResponse,
   PublicMeetingOccurrencesResponse,
   PublicMeetingProject,
+  PublicMeetingRegistrationResponse,
   PublicPastMeetingResponse,
   PublicProjectMeetingsResponse,
   QueryServiceCountResponse,
@@ -728,8 +729,13 @@ export class MeetingService {
     );
   }
 
-  public registerForPublicMeeting(registrantData: CreateMeetingRegistrantRequest): Observable<MeetingRegistrant> {
-    return this.http.post<MeetingRegistrant>('/public/api/meetings/register', registrantData).pipe(
+  /*
+   * Typed off what the endpoint actually returns, not off the row it was built from: the public
+   * response is an allowlisted subset (`toSelfRegistrationResponse`), and typing it as a full
+   * `MeetingRegistrant` invited a caller to read a field the wire never carried.
+   */
+  public registerForPublicMeeting(registrantData: CreateMeetingRegistrantRequest): Observable<PublicMeetingRegistrationResponse> {
+    return this.http.post<PublicMeetingRegistrationResponse>('/public/api/meetings/register', registrantData).pipe(
       take(1),
       catchError((error) => {
         console.error(`Failed to register for public meeting ${registrantData.meeting_id}:`, error);

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -4,11 +4,13 @@
 import { CreateMeetingRegistrantRequest, UpdateMeetingRegistrantRequest } from '@lfx-one/shared/interfaces';
 
 /**
- * Registrant fields the outbound mapper drops whatever their value is.
+ * Registrant fields the outbound mapper never forwards, whatever their value is.
  *
  * Only `meeting_id` today: the meeting is addressed by the path, so ITX has no field to put it in.
- * A key here can never reach upstream, which is why `MeetingController.hasRegistrantChanges` treats
- * one as no change at all rather than as a change whose value happens to be nullish.
+ * A key here can never reach upstream — it is absent from
+ * {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS} and has no rename to carry it — which is why
+ * `MeetingController.hasRegistrantChanges` treats one as no change at all rather than as a change
+ * whose value happens to be nullish.
  */
 export const UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS = ['meeting_id'] as const satisfies readonly (keyof CreateMeetingRegistrantRequest &
   keyof UpdateMeetingRegistrantRequest)[];
@@ -22,10 +24,11 @@ export const UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS = ['meeting_id'] as const s
  * unrenamed key is dropped upstream behind a 201.
  *
  * A map rather than a list of names because `MeetingService.toUpstreamRegistrantBody` has to do two
- * things with each of these — delete the app-side key and re-emit the value under the upstream one —
- * and those were previously written out in two places. A fourth key added to a bare list would have
- * been deleted from the outbound body and then never re-emitted: silent data loss, no type error.
- * Here one entry drives both halves.
+ * things with each of these — keep the app-side key out of the outbound body and re-emit the value
+ * under the upstream one — and those were previously written out in two places. A fourth key added
+ * to a bare list would have been withheld from the outbound body and then never re-emitted: silent
+ * data loss, no type error. Here one entry drives both halves, and the same entry is what excludes
+ * the app-side name from {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS}.
  *
  * `MeetingController.hasRegistrantChanges` reads the key side to decide whether an update actually
  * asks for anything: a nullish value on one of these is omitted rather than renamed, so
@@ -41,9 +44,9 @@ export const RENAMED_REGISTRANT_KEYS = {
 /**
  * The app-side names of {@link RENAMED_REGISTRANT_KEYS}.
  *
- * "Nullish-dropped" is about what reaches upstream, not about the outbound body: the app-side key is
- * always deleted from it. What the value decides is whether it is re-emitted under the upstream name
- * — a nullish one is not, so the pair leaves nothing behind, and that is the case
+ * "Nullish-dropped" is about what reaches upstream, not about the outbound body: the app-side key
+ * never appears in it either way. What the value decides is whether it is re-emitted under the
+ * upstream name — a nullish one is not, so the pair leaves nothing behind, and that is the case
  * `MeetingController.hasRegistrantChanges` has to treat as no change at all.
  */
 export const NULLISH_DROPPED_REGISTRANT_KEYS = Object.keys(RENAMED_REGISTRANT_KEYS) as (keyof typeof RENAMED_REGISTRANT_KEYS)[];
@@ -75,7 +78,8 @@ export const NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS = ['job_title', 'username'] a
  *
  * The two halves get there differently — {@link NULLISH_DROPPED_REGISTRANT_KEYS} are dropped
  * because the rename that would carry them upstream is skipped, {@link
- * NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS} are deleted from the body outright — but the consequence
+ * NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS} are allowed through by name but skipped on `null` — but
+ * the consequence
  * is identical, and it is the consequence `MeetingController.hasRegistrantChanges` has to count:
  * a `null` on any of these makes the outbound body no larger, so counting it as a change forwards
  * the empty `PUT` that guard exists to reject.
@@ -85,12 +89,65 @@ export const NULLISH_OMITTED_REGISTRANT_KEYS = [...NULLISH_DROPPED_REGISTRANT_KE
 /**
  * Every registrant field the app carries but ITX does not accept under that name.
  *
- * `MeetingService.toUpstreamRegistrantBody` deletes all of them from the outbound body. Composed
- * from the two halves above rather than written out again, so the mapper and the
- * `hasRegistrantChanges` guard cannot disagree about which keys exist: adding a key to either half
- * updates the delete loop, the upstream re-emit, and the guard in the same edit. Both halves are
+ * `MeetingService.toUpstreamRegistrantBody` forwards none of them under that name: this list is
+ * what {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP} excludes from the allowlist, so a key here is
+ * one the mapper is required *not* to declare. Composed from the two halves above rather than
+ * written out again, so the mapper and the `hasRegistrantChanges` guard cannot disagree about which
+ * keys exist: adding a key to either half updates the allowlist's exclusion, the upstream re-emit,
+ * and the guard in the same edit. Both halves are
  * keyed on the *intersection* of the two request interfaces rather than a union — a union only rejects a key once
  * it is gone from both, so renaming it on one of them would still compile while the delete quietly
  * stopped matching.
  */
 export const APP_ONLY_REGISTRANT_KEYS = [...UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS, ...NULLISH_DROPPED_REGISTRANT_KEYS] as const;
+
+/**
+ * Every registrant key the outbound mapper forwards upstream under its own name.
+ *
+ * `MeetingService.toUpstreamRegistrantBody` picks these out of the submitted body rather than
+ * copying the body wholesale and deleting what it recognises. The two shapes look equivalent for a
+ * body that matches its declared type, and are not for one that doesn't: the registrant routes carry
+ * no express-validator, `req.body` is untyped JSON, and both batch controllers spread it, so a client
+ * can name any key it likes. Under a denylist an unlisted key — `uid` being the one that matters —
+ * reached upstream unexamined; under this allowlist it is simply absent from the outbound body.
+ *
+ * Written as the keys of a `satisfies Record<—, true>` so the check runs in both directions: a
+ * misspelt or removed field is rejected, *and* a field added to either request interface fails to
+ * compile until it is listed here. That second half is the point — an allowlist's failure mode is
+ * silent omission, and the deletion lists above already showed what an unenforced list costs.
+ *
+ * Keyed on the *union* of the two request interfaces, unlike {@link APP_ONLY_REGISTRANT_KEYS} and
+ * the lists it is built from. Those describe keys that must vanish, so they take the intersection —
+ * a union would let a rename on one interface silently stop matching. This one describes keys that
+ * must survive, and a key that exists on only one of the two shapes still has to be accounted for,
+ * so the union is the exhaustive set. `committee_uid` is create-only and `linkedin_profile`
+ * update-only; both are listed for that reason.
+ *
+ * `linkedin_profile` is forwarded even though Goa discards it — it isn't declared upstream under
+ * any name. Listing it keeps the outbound body byte-identical to what the denylist produced and
+ * states the app's intent, so the day upstream declares the field it starts working without a
+ * second edit. See {@link UpdateMeetingRegistrantRequest} for the tracking note.
+ */
+const UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP = {
+  email: true,
+  first_name: true,
+  last_name: true,
+  host: true,
+  job_title: true,
+  username: true,
+  committee_uid: true,
+  linkedin_profile: true,
+} as const satisfies Record<
+  Exclude<keyof CreateMeetingRegistrantRequest | keyof UpdateMeetingRegistrantRequest, (typeof APP_ONLY_REGISTRANT_KEYS)[number]>,
+  true
+>;
+
+/**
+ * The key list of {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP}, in declaration order.
+ *
+ * Same shape as {@link NULLISH_DROPPED_REGISTRANT_KEYS}: the map carries the exhaustiveness check,
+ * this is what the mapper iterates.
+ */
+export const UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS = Object.keys(
+  UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP
+) as (keyof typeof UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP)[];

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -517,11 +517,17 @@ describe('MeetingController', () => {
       // forwards an empty write.
       ['sends only a committee_uid', [{ uid: 'reg-1', changes: { committee_uid: V1_COMMITTEE_SFID } }]],
       // The three keys below survive `stripCommitteeUid` but not `toUpstreamRegistrantBody`:
-      // `meeting_id` is deleted outright, and the renamed fields are dropped when nullish. Counting
-      // raw keys let all three through the guard and into the empty `PUT` it exists to reject.
+      // `meeting_id` is absent from its allowlist, and the renamed fields are dropped when nullish.
+      // Counting raw keys let all three through the guard and into the empty `PUT` it exists to
+      // reject.
       ['sends only a meeting_id', [{ uid: 'reg-1', changes: { meeting_id: MEETING_ID } }]],
       ['sends only a null org_name', [{ uid: 'reg-1', changes: { org_name: null } }]],
       ['sends only nullish renamed fields', [{ uid: 'reg-1', changes: { org_name: null, avatar_url: undefined, occurrence_id: null } }]],
+      // Undeclared keys are the case the allowlist added: `req.body` is untyped JSON, so a client
+      // can name anything. Under the old denylist the mapper forwarded whatever it didn't recognise
+      // and this guard counted it, so `{ uid: 'other' }` produced a `PUT` carrying a client-chosen
+      // identity. Now neither list contains the key and both agree it changes nothing.
+      ['sends only keys no request shape declares', [{ uid: 'reg-1', changes: { uid: 'other', totally_made_up: 'x' } }]],
     ])('rejects an entry that %s instead of forwarding an empty write', async (_label, body) => {
       const req = buildReq({ body });
 
@@ -614,6 +620,36 @@ describe('MeetingController', () => {
 
       expect(next).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith([registrant]);
+    });
+
+    // `getCommitteeById` is a committee-service read gated on the caller being a committee reader,
+    // so an organizer who is not one gets nothing back from it. The meeting's own committee entry
+    // already carries the name (`getMeetingById` resolves it off the query service), which is what
+    // keeps the "via [Group]" chip rendering for them.
+    it('names the group from the meeting when the caller cannot read the committee itself', async () => {
+      meetingSvc.getMeetingById.mockResolvedValue({ uid: MEETING_ID, committees: [{ uid: V2_COMMITTEE_UID, name: 'TAC' }] });
+      committeeSvc.getCommitteeById.mockRejectedValue(new Error('forbidden'));
+      const res = buildRes();
+
+      await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ committee_name: 'TAC' })]);
+    });
+
+    // The fallback is a name only. Role, voting status and appointment come off the committee's
+    // member records, and those stay gated on the caller's own token — a chip that says which group
+    // someone came in with is not a licence to read that group's roster.
+    it('leaves the member-level committee fields empty for that same caller', async () => {
+      meetingSvc.getMeetingById.mockResolvedValue({ uid: MEETING_ID, committees: [{ uid: V2_COMMITTEE_UID, name: 'TAC' }] });
+      committeeSvc.getCommitteeById.mockRejectedValue(new Error('forbidden'));
+      committeeSvc.getCommitteeMembers.mockRejectedValue(new Error('forbidden'));
+      const res = buildRes();
+
+      await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(res.json).toHaveBeenCalledWith([
+        expect.objectContaining({ committee_name: 'TAC', committee_role: null, committee_voting_status: null, committee_appointed_by: null }),
+      ]);
     });
   });
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -14,6 +14,7 @@ import {
   CreateMeetingRsvpRequest,
   GenerateAgendaResponse,
   Meeting,
+  MeetingCommittee,
   MeetingRegistrant,
   PresignAttachmentRequest,
   UpdateMeetingAttachmentRequest,
@@ -23,7 +24,7 @@ import {
 import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
-import { NULLISH_OMITTED_REGISTRANT_KEYS, UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS } from '../constants';
+import { NULLISH_DROPPED_REGISTRANT_KEYS, NULLISH_OMITTED_REGISTRANT_KEYS, UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS } from '../constants';
 import { resolveCommitteeV2UidMappings, resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
 import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
 import {
@@ -1882,6 +1883,15 @@ export class MeetingController {
     // Build lookup maps keyed by v2 committee UID
     const committeeMap = new Map<string, Committee | null>();
     committees.forEach(({ uid, committee }) => committeeMap.set(uid, committee));
+    // The meeting's own committee entries, which already carry a resolved `name`: `getMeetingById`
+    // fills them from `getCommitteeNameMap`, a query-service read, while `getCommitteeById` above is
+    // a committee-service read gated on the caller being a committee reader. An organizer who is not
+    // one gets `null` from that fetch, and without this fallback the "via [Group]" chip silently
+    // stops rendering for them. Swapping in an M2M token here instead would also hand them the
+    // member-level role, voting status and appointment below, which their own token says they may
+    // not read — the name is the only part of this that is already theirs.
+    const meetingCommitteeMap = new Map<string, MeetingCommittee>();
+    meetingCommittees.forEach((committee) => meetingCommitteeMap.set(committee.uid, committee));
     const memberMap = new Map<string, CommitteeMember[]>();
     membersByCommittee.forEach(({ uid, members }) => memberMap.set(uid, members));
 
@@ -1911,7 +1921,7 @@ export class MeetingController {
         // same field carries two identifier spaces depending on which direction it was travelling.
         committee_uid: v2Uid,
         // Committee details
-        committee_name: committee?.name || null,
+        committee_name: committee?.name || meetingCommitteeMap.get(v2Uid)?.name || null,
         committee_category: committee?.category || null,
         // Member details
         committee_role: member?.role?.name || null,
@@ -1948,11 +1958,12 @@ export class MeetingController {
    * Drops a runtime `committee_uid` from a registrant update body.
    *
    * `UpdateMeetingRegistrantRequest` declares no such field, but that is a compile-time guarantee
-   * only: `req.body` is untyped JSON and `toUpstreamRegistrantBody` forwards every key it doesn't
-   * recognize, so an extra one here would reach upstream — which derives `type: 'committee'` from
-   * whatever SFID it receives. That would route around the meeting-scoped allowlist the create path
-   * enforces, using the edit endpoint instead. Attribution is set when a guest is added and never
-   * edited, so stripping costs nothing.
+   * only: `req.body` is untyped JSON. `committee_uid` *is* on `toUpstreamRegistrantBody`'s allowlist
+   * — `CreateMeetingRegistrantRequest` declares it, and the allowlist is keyed on the union of the
+   * two request shapes — so an extra one here would be forwarded verbatim to upstream, which
+   * derives `type: 'committee'` from whatever SFID it receives. That would route around the
+   * meeting-scoped allowlist the create path enforces, using the edit endpoint instead. Attribution
+   * is set when a guest is added and never edited, so stripping costs nothing.
    *
    * Generic over the body shape so both callers get their own type back: the update path keeps
    * `UpdateMeetingRegistrantRequest` for the spread, and `hasRegistrantChanges` — which reads straight
@@ -1979,20 +1990,22 @@ export class MeetingController {
    * rather than counted — `Object.keys('ab')` is `['0', '1']`, which would otherwise pass as two
    * changes.
    *
-   * The count is taken over the keys that survive the outbound mapper, not over the raw ones,
-   * because every key the mapper drops is a key that cannot reach upstream:
+   * The count is taken over the keys that reach upstream, not over the raw ones, because a key the
+   * mapper never forwards cannot make the `PUT` do anything:
    * - `committee_uid` — `stripCommitteeUid` removes it here, before the body is forwarded.
-   * - {@link UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS} — `toUpstreamRegistrantBody` deletes these
-   *   whatever their value is.
-   * - {@link NULLISH_OMITTED_REGISTRANT_KEYS} — a `null` on one of these contributes nothing to the
-   *   outbound body: the mapper skips the rename for the renamed three, and deletes the two ITX
-   *   declares non-nullable under their own name.
+   * - Anything absent from both {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS} and
+   *   {@link NULLISH_DROPPED_REGISTRANT_KEYS} — `toUpstreamRegistrantBody` builds the outbound body
+   *   out of those two lists alone, so `meeting_id`, and any key a client invents, is simply absent.
+   * - {@link NULLISH_OMITTED_REGISTRANT_KEYS} on a nullish value — the mapper skips the rename for
+   *   the renamed three and skips the copy for the two ITX declares non-nullable under their own
+   *   name, so the outbound body is no larger for having received them.
    *
    * Counting the raw keys instead let `{ "meeting_id": "M1" }` and `{ "org_name": null }` through
-   * the guard and straight into the empty `PUT` it exists to prevent. The two lists are the same
-   * ones `toUpstreamRegistrantBody`'s delete loop reads — it consumes their union as
-   * `APP_ONLY_REGISTRANT_KEYS` — so a key added to either half reaches the mapper and this guard in
-   * one edit, and neither can be updated without the other.
+   * the guard and straight into the empty `PUT` it exists to prevent. The two membership lists are
+   * exactly the two the mapper's own loops iterate, so a key added to either reaches the mapper and
+   * this guard in one edit and neither can be updated without the other — and because the mapper
+   * is an allowlist, a key nobody has declared fails this test by default rather than by someone
+   * remembering to deny it.
    */
   private static hasRegistrantChanges(changes: unknown): boolean {
     if (typeof changes !== 'object' || changes === null || Array.isArray(changes)) {
@@ -2002,9 +2015,13 @@ export class MeetingController {
     const stripped = MeetingController.stripCommitteeUid(changes as Record<string, unknown>);
 
     return Object.entries(stripped).some(([key, value]) => {
-      // Widened for the lookups only: both arrays are typed by their registrant key unions, so
-      // `includes` won't accept an arbitrary string, and the keys here come off untyped JSON.
-      if ((UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS as readonly string[]).includes(key)) {
+      // Widened for the lookups only: every one of these arrays is typed by its registrant key
+      // union, so `includes` won't accept an arbitrary string, and the keys here come off untyped
+      // JSON. The two membership tests mirror the mapper's two loops, in the same order.
+      const reachesUpstream =
+        (UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS as readonly string[]).includes(key) || (NULLISH_DROPPED_REGISTRANT_KEYS as readonly string[]).includes(key);
+
+      if (!reachesUpstream) {
         return false;
       }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -69,7 +69,14 @@ vi.mock('@lfx-one/shared/utils', async () => ({
 }));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
-vi.mock('@lfx-one/shared/constants', () => ({
+vi.mock('@lfx-one/shared/constants', async () => ({
+  // The real allowlist rather than a hand-copy, on the same reasoning as `joinAsSentenceList`
+  // below: a duplicate here would let the leak test further down go green against a list the
+  // controller no longer uses. `meeting-registrant.constants.ts` has no runtime imports of its own
+  // (its only import is type-only), so this pulls in none of the aliased barrel graph the mock
+  // exists to avoid.
+  PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS: (await import('../../../../../packages/shared/src/constants/meeting-registrant.constants'))
+    .PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS,
   HOST_KEY_EARLY_MINUTES: 70,
   HOST_KEY_LATE_MINUTES: 40,
   MEETING_PASSWORD_HEADER: 'x-meeting-password',
@@ -800,6 +807,39 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-01T00:00:00Z',
     });
+  });
+
+  /*
+   * The allowlist is the whole defence on this route, and it is one line to widen. This asserts the
+   * consequence rather than the list: nothing upstream attaches about *other* people, and nothing
+   * the registrant is not entitled to assert about themselves, reaches an anonymous caller — so
+   * adding any of these keys to `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS` fails here instead of
+   * shipping.
+   */
+  it('never lets a roster field reach an anonymous caller, whatever upstream attached', async () => {
+    const leakable = {
+      username: 'alice.liddell',
+      committee_uid: 'committee-9',
+      committee_name: 'Technical Steering',
+      type: 'committee',
+      invite_accepted: true,
+      attended: true,
+      org_is_member: true,
+      org_is_project_member: true,
+      created_by: { username: 'roster-admin', email: 'admin@acme-motors.example', name: 'Roster Admin' },
+      updated_by: { username: 'roster-admin', email: 'admin@acme-motors.example', name: 'Roster Admin' },
+      rsvp: { status: 'yes' },
+    };
+    meetingSvc.addMeetingRegistrantSelf.mockResolvedValue({ uid: 'reg-1', meeting_id: MEETING_ID, ...leakable });
+    const { req, res, next } = buildRegisterReq(true);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    const body = res.json.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(['meeting_id', 'uid']);
+    for (const key of Object.keys(leakable)) {
+      expect(body).not.toHaveProperty(key);
+    }
   });
 
   it('omits a field the write response never carried rather than stating it as undefined', async () => {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
-import { MEETING_PASSWORD_HEADER, PUBLIC_REGISTRATION_FIELD_LABELS, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import {
+  MEETING_PASSWORD_HEADER,
+  PUBLIC_REGISTRATION_FIELD_LABELS,
+  PUBLIC_REGISTRATION_FIELD_MAX_LENGTH,
+  PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS,
+  ROOT_PROJECT_SLUG,
+} from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   CreateMeetingRegistrantRequest,
@@ -11,6 +17,7 @@ import {
   Project,
   PublicMeetingOccurrencesResponse,
   PublicMeetingProject,
+  PublicMeetingRegistrationResponse,
 } from '@lfx-one/shared/interfaces';
 import { joinAsSentenceList, truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
@@ -742,24 +749,14 @@ export class PublicMeetingController {
    * `fromUpstreamRegistrant` is careful to preserve. The in-app caller
    * (`PublicRegistrationModalComponent`) reads none of these fields; it forwards a `registered: true`
    * flag and discards the row, so narrowing costs the UI nothing.
+   *
+   * The allowlist and the return type both come from `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`, so the
+   * client cannot go on typing this as a full `MeetingRegistrant` while the wire carries twelve keys.
    */
-  private toSelfRegistrationResponse(registrant: MeetingRegistrant): Partial<MeetingRegistrant> {
-    const fields = [
-      'uid',
-      'meeting_id',
-      'email',
-      'first_name',
-      'last_name',
-      'host',
-      'job_title',
-      'org_name',
-      'occurrence_id',
-      'avatar_url',
-      'created_at',
-      'updated_at',
-    ] as const satisfies readonly (keyof MeetingRegistrant)[];
-
-    return Object.fromEntries(fields.filter((field) => registrant[field] !== undefined).map((field) => [field, registrant[field]]));
+  private toSelfRegistrationResponse(registrant: MeetingRegistrant): PublicMeetingRegistrationResponse {
+    return Object.fromEntries(
+      PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS.filter((field) => registrant[field] !== undefined).map((field) => [field, registrant[field]])
+    );
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1,7 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { Meeting, MeetingRegistrant, MeetingRsvp, MeetingUserInfo, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import type {
+  CreateMeetingRegistrantRequest,
+  Meeting,
+  MeetingRegistrant,
+  MeetingRsvp,
+  MeetingUserInfo,
+  QueryServiceResponse,
+  UpdateMeetingRegistrantRequest,
+} from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
@@ -1087,6 +1095,28 @@ describe('MeetingService registrant write payloads', () => {
     });
 
     expect(result).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
+    // The identity is the routed one, not the body's. `uid` isn't in the update body at all and
+    // `MeetingRegistrant` declares it required, so an unasserted fallback could drop it and still
+    // type-check; `meeting_id` is in the body, and the routed meeting is the authoritative one.
+    expect(result).toMatchObject({ uid: 'reg-1', meeting_id: 'meeting-1' });
+  });
+
+  // The routed identity is written after the spread for the same reason the create fallback's is:
+  // the batch endpoint reads `changes` straight off `req.body`, so a client can name a `uid` and a
+  // `meeting_id` of its own. Spread last, they would overwrite the ones the request actually routed
+  // on and be echoed back as the updated registrant's identity.
+  it('does not let a body-supplied identity override the routed one in the update fallback', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'other-meeting',
+      uid: 'other-registrant',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+    } as UpdateMeetingRegistrantRequest & { uid: string });
+
+    expect(result).toMatchObject({ uid: 'reg-1', meeting_id: 'meeting-1' });
   });
 
   // Where upstream did answer, its body is the whole answer: merging the request underneath it would
@@ -1127,6 +1157,45 @@ describe('MeetingService registrant write payloads', () => {
 
     expect(result).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
     expect(result.uid).toBe('');
+  });
+
+  // `registrantData` comes from `req.body` and the create route carries no express-validator, so a
+  // client can name a `uid`. Spread over the placeholder it would be echoed back as the created
+  // registrant's identity — a UID upstream never minted, presented as though it had, and falsy
+  // checks like `if (registrant.uid)` would route past the read-back that exists to find the real
+  // one.
+  it('does not let a body-supplied uid stand in for the one upstream never minted', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.addMeetingRegistrant(req, {
+      meeting_id: 'meeting-1',
+      uid: 'client-chosen',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+    } as CreateMeetingRegistrantRequest & { uid: string });
+
+    expect(result.uid).toBe('');
+  });
+
+  // The outbound mapper is an allowlist, not a copy-with-deletions. `req.body` is untyped JSON and
+  // both batch controllers spread it, so a key no request shape declares used to be forwarded
+  // unexamined — `uid` being the one that matters, since ITX derives the registrant's identity from
+  // the path and an extra body key is exactly the kind of thing a proxy should not be relaying.
+  it('forwards no key that neither request shape declares', async () => {
+    await service.addMeetingRegistrant(req, {
+      meeting_id: 'meeting-1',
+      uid: 'client-chosen',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      totally_made_up: 'x',
+    } as CreateMeetingRegistrantRequest & { uid: string; totally_made_up: string });
+
+    expect(bodyOf()).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
+    for (const key of ['uid', 'totally_made_up', 'meeting_id']) {
+      expect(bodyOf()).not.toHaveProperty(key);
+    }
   });
 
   // Self-registration is the path a registrant drives from the public meeting page, so the same

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -56,7 +56,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError, AuthorizationError, ServiceValidationError } from '../errors';
 import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
 import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from '../helpers/meeting-rsvp.helper';
-import { APP_ONLY_REGISTRANT_KEYS, NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS, RENAMED_REGISTRANT_KEYS } from '../constants';
+import { NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS, RENAMED_REGISTRANT_KEYS, UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS } from '../constants';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { encodePathSegment } from '../helpers/url-validation';
@@ -2280,7 +2280,14 @@ export class MeetingService {
   }
 
   /**
-   * Renames the three registrant fields whose app-side names differ from the upstream ITX contract.
+   * Builds the ITX registrant body from a submitted create or update payload.
+   *
+   * An allowlist — {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS} plus the renamed three below —
+   * rather than a copy of the body with the app-only keys deleted. The parameter type says what a
+   * well-behaved caller sends, not what arrives: `req.body` is untyped JSON and both batch
+   * controllers spread it, so under a denylist any key the app had no opinion about — `uid` above
+   * all — reached upstream unexamined. Goa ignores keys it doesn't declare, which bounds the blast
+   * radius but does not make forwarding them correct.
    *
    * `CreateItxRegistrantRequestBody` (reused verbatim for the PUT) declares `org`, `profile_picture`
    * and `occurrence`; the app's read model — which comes from the v1 query-service index, not from
@@ -2288,8 +2295,8 @@ export class MeetingService {
    * doesn't declare, so without this rename the organization an organizer types, the avatar, and a
    * single-occurrence invite were all dropped on the way upstream, behind a 201.
    *
-   * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
-   * caller has already used it to build the URL.
+   * `meeting_id` is absent from the allowlist for the same reason it isn't declared upstream: it's
+   * the path parameter, and the caller has already used it to build the URL.
    *
    * A `null` on one of the three renamed fields is omitted rather than renamed.
    * `UpdateMeetingRegistrantRequest` uses `null` to erase a stored value, but all three targets are
@@ -2301,8 +2308,9 @@ export class MeetingService {
    *
    * {@link NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS} gets the same treatment for the same reason,
    * without the rename: `job_title` and `username` are declared upstream under the app's own name and
-   * are equally non-nullable, and `getChangedFields` nulls them too. `linkedin_profile` is left
-   * alone — it isn't declared upstream at all, so Goa discards the key rather than the value.
+   * are equally non-nullable, and `getChangedFields` nulls them too — so a `null` on either is
+   * skipped even though the key itself is allowed through. `linkedin_profile` is left alone: it
+   * isn't declared upstream at all, so Goa discards the key rather than the value.
    *
    * Cost: clearing an organization on an edit leaves the stored value in place. It did before this
    * rename too, so nothing regresses — but it stays unfixed until upstream states how these fields are
@@ -2310,32 +2318,43 @@ export class MeetingService {
    * ("blank = all occurrences"), so a wrong guess silently rescopes an invite.
    */
   private toUpstreamRegistrantBody(body: CreateMeetingRegistrantRequest | UpdateMeetingRegistrantRequest): Record<string, unknown> {
-    const upstream: Record<string, unknown> = { ...body };
+    // Spread rather than cast: the declared parameter types are interfaces with no index
+    // signature, and the runtime object is exactly what a client posted, extra keys included.
+    const submitted: Record<string, unknown> = { ...body };
+    const upstream: Record<string, unknown> = {};
 
-    // Shared with `MeetingController.hasRegistrantChanges`, which has to know exactly which keys
-    // vanish here to tell an empty update apart from a real one — see the constant's own docs for
-    // why it's keyed on the intersection of the two request interfaces.
-    for (const appOnlyKey of APP_ONLY_REGISTRANT_KEYS) {
-      delete upstream[appOnlyKey];
+    // Built up key by key rather than spread-and-deleted. The declared parameter type is a
+    // compile-time guarantee only — the registrant routes carry no express-validator and both batch
+    // controllers spread `req.body` — so a client can name any key it likes, and a denylist forwarded
+    // every one it didn't recognise. Shared with `MeetingController.hasRegistrantChanges`, which has
+    // to know exactly which keys survive here to tell an empty update apart from a real one.
+    for (const passthroughKey of UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS) {
+      const value = submitted[passthroughKey];
+
+      // Absent stays absent: a key the caller never sent must not appear upstream as `undefined`,
+      // which `getChangedFields` would otherwise turn into a declared-but-empty field.
+      if (value === undefined) {
+        continue;
+      }
+
+      // These keep their own name, so there is no rename to skip — the `null` has to be left out
+      // outright. The field is declared non-nullable upstream, and `getChangedFields` nulls it on
+      // an ordinary edit.
+      if (value === null && (NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS as readonly string[]).includes(passthroughKey)) {
+        continue;
+      }
+
+      upstream[passthroughKey] = value;
     }
 
-    // Driven off the same map the delete loop's second half is derived from, so a key can't be
-    // deleted here and then forgotten on the way back in — which would be silent data loss with no
-    // type error to catch it.
+    // Driven off the same map {@link APP_ONLY_REGISTRANT_KEYS}' second half is derived from, so a key
+    // can't be excluded from the allowlist above and then forgotten on the way back in — which would
+    // be silent data loss with no type error to catch it.
     for (const [appKey, upstreamKey] of Object.entries(RENAMED_REGISTRANT_KEYS)) {
-      const value = body[appKey as keyof typeof body];
+      const value = submitted[appKey];
 
       if (value != null) {
         upstream[upstreamKey] = value;
-      }
-    }
-
-    // These keep their own name, so there is no rename to skip — the `null` has to be deleted
-    // outright. Same reason as above: the field is declared non-nullable upstream, and
-    // `getChangedFields` nulls it on an ordinary edit.
-    for (const nonNullableKey of NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS) {
-      if (upstream[nonNullableKey] == null) {
-        delete upstream[nonNullableKey];
       }
     }
 
@@ -2396,8 +2415,14 @@ export class MeetingService {
    * would otherwise claim a field the object doesn't carry; an empty string is falsy, so a caller's
    * `if (registrant.uid)` still routes to the read-back, whereas an absent one would reach a template
    * or a URL segment as the literal `"undefined"`.
+   *
+   * It is written *after* the spread, not before it. `registrantData` comes from `req.body`, so a
+   * client that names a `uid` of its own would otherwise have it win over the empty one and be
+   * echoed back as the created registrant's identity — a UID upstream never minted, presented as
+   * though it had. Same ordering rule as `updateMeetingRegistrant`'s fallback, where the routed
+   * `uid` and `meeting_id` are written last for the same reason.
    */
   private static registrantFromSubmittedPayload(registrantData: CreateMeetingRegistrantRequest): MeetingRegistrant {
-    return { uid: '', ...registrantData } as MeetingRegistrant;
+    return { ...registrantData, uid: '' } as MeetingRegistrant;
   }
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -13,6 +13,7 @@ export * from './countries.constants';
 export * from './file-upload.constants';
 export * from './font-sizes.constants';
 export * from './meeting.constants';
+export * from './meeting-registrant.constants';
 export * from './persona.constants';
 export * from './server.constants';
 export * from './states.constants';

--- a/packages/shared/src/constants/meeting-registrant.constants.ts
+++ b/packages/shared/src/constants/meeting-registrant.constants.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { MeetingRegistrant } from '../interfaces/meeting.interface';
+
+/**
+ * The only registrant fields a public self-registration response carries back to the caller.
+ * @description An allowlist, so a column added to the upstream registrant row later has to be named
+ * here before an unauthenticated caller can see it. Shared rather than local to the controller
+ * because the client types the same response off it — a server-side narrowing the client still typed
+ * as a full `MeetingRegistrant` is how a caller ends up reading a field the wire never carried. The
+ * derived response type is `PublicMeetingRegistrationResponse` (`meeting.interface.ts`).
+ *
+ * Its own file rather than `meeting.constants.ts` so it stays a runtime leaf — the only import here
+ * is type-only, which lets a spec that mocks the constants barrel pull the real list in by relative
+ * path instead of hand-copying it.
+ */
+export const PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS = [
+  'uid',
+  'meeting_id',
+  'email',
+  'first_name',
+  'last_name',
+  'host',
+  'job_title',
+  'org_name',
+  'occurrence_id',
+  'avatar_url',
+  'created_at',
+  'updated_at',
+] as const satisfies readonly (keyof MeetingRegistrant)[];

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { MEETING_ALLOWED_VOTING_STATUSES } from '../constants/committees.constants';
+import type { PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS } from '../constants/meeting-registrant.constants';
 import type { MEETING_COMPOSER_SECTIONS, PAST_MEETING_SORT, MEETING_FEATURE_BY_KEY } from '../constants/meeting.constants';
 import type { ArtifactVisibility, MeetingType, MeetingVisibility, RecurrenceType, CancelOnCommitteeRemoval } from '../enums';
 import type { TagSeverity } from './components.interface';
@@ -638,6 +639,16 @@ export interface MeetingRegistrant {
   /** Registrant's RSVP (only included when include_rsvp=true) */
   rsvp?: MeetingRsvp | null;
 }
+
+/**
+ * What a public self-registration (`POST /public/api/meetings/register`) actually returns.
+ * @description Narrower than `MeetingRegistrant`: the endpoint answers unauthenticated callers, so it
+ * replies with an allowlist of the registrant's own record rather than the whole upstream row
+ * (`PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`). Every key is optional because the response omits a key
+ * upstream did not return rather than stating it as `undefined` — "the write response didn't say" and
+ * "upstream stored nothing" are different answers, and only omission preserves the distinction.
+ */
+export type PublicMeetingRegistrationResponse = Partial<Pick<MeetingRegistrant, (typeof PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS)[number]>>;
 
 /**
  * Request payload for creating a meeting registrant


### PR DESCRIPTION
## What

Server-side half of the automated-review sweep across this stack. Three payload shapes were built by deleting keys from whatever a client posted; all three are now built by picking from an explicit allowlist.

- **`toUpstreamRegistrantBody`** picks from `UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP`, an `as const satisfies Record<..., true>` map. The registrant routes carry no express-validator and both batch controllers spread `req.body`, so the old denylist forwarded every key it didn't recognise. Because the map is bidirectional, adding a field to `CreateMeetingRegistrantRequest` / `UpdateMeetingRegistrantRequest` without deciding whether it goes upstream now fails to compile.
- **`toSelfRegistrationResponse`** picks from the new shared `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`, so a field added upstream later cannot leak out of the anonymous self-registration endpoint. `PublicMeetingRegistrationResponse` is derived from that list; the spec imports the real constant by relative path and holds a mutation-verified leak test.
- **`registrantFromSubmittedPayload`** no longer claims a `uid` it doesn't have.
- **`enrichCommitteeRegistrants`** falls back to the committee name already carried on the meeting when the per-committee lookup is denied. cursor suggested swapping in an M2M token instead — that would have over-shared member role, voting status and appointment, which are gated; the committee *name* is not.

## How

`UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS` and `NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS` are kept separate on purpose: the latter names the fields `getChangedFields` nulls on an ordinary edit but that upstream declares non-nullable, so a `null` on those is skipped rather than forwarded. Folding them together would have silently dropped `job_title` / `username` writes.

`MeetingController.hasRegistrantChanges` and `stripCommitteeUid` were rewritten against the same allowlist, since they have to know exactly which keys survive to tell an empty update apart from a real one.

## Verification

`./check-headers.sh`, `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build`, `yarn workspace lfx-one run test:server` (118 files / 3279 tests), `yarn workspace lfx-one run test:app` (155 files / 2787 tests) — all green at this commit in isolation, not just at the tip of the stack.

## Related

Slice 23 of the `#1451` composer stack, based on #2312.

Refs #1451
