### PR TITLE
fix(composer): close remaining bot review findings in the composer

### DIFF
--- a/.claude/rules/development-rules.md
+++ b/.claude/rules/development-rules.md
@@ -39,7 +39,8 @@ If you already have a working branch, ensure it's rebased on the latest `main` b
 
 **M2M tokens represent the application, not a user.** They should be used only for:
 
-- **Public-facing endpoints where no user session exists** (e.g. public meeting pages or public meeting registration)
+- **Public-facing endpoints where no user session exists** (e.g. the anonymous reads behind a public meeting page — the meeting itself, its occurrences, a past meeting, a join URL)
+  - Being mounted under `/public/api` is not the test; having no session is. `POST /public/api/meetings/register` sits on that surface and still requires a session and the caller's own bearer token, because it registers the caller **as themselves** and upstream reads their identity off their token. It uses an M2M token only for the meeting lookup that decides whether the meeting is public and unrestricted — the privileged-upstream-call case below, not this one
 - **Explicit privileged upstream calls** from an authenticated route, _after_ the route has validated the user's access/authorization in-app, and only for the specific upstream request that requires application-level credentials (e.g. certain meeting registrant or invitation checks)
 
 In the authenticated-route case, always:

--- a/apps/lfx-one/e2e/project-context-deep-link.spec.ts
+++ b/apps/lfx-one/e2e/project-context-deep-link.spec.ts
@@ -785,11 +785,33 @@ test.describe('Meeting edit load failure (GH-2037)', () => {
     });
 
     // Toast first: it fires synchronously with the eject and expires (default p-toast life)
-    // before a URL-first assertion would observe it.
-    await expect(page.locator('.p-toast')).toContainText('Meeting not found or you do not have permission to access it', {
-      timeout: PAGE_LOAD_TIMEOUT,
-    });
+    // before a drawer-first assertion would observe it.
+    await expect(page.locator('.p-toast')).toContainText('Meeting not found', { timeout: PAGE_LOAD_TIMEOUT });
+    // The eject itself. The URL alone proves nothing here: the composer route redirects to the
+    // meetings list before the detail request for every status, so a 500 lands on this same URL
+    // with the drawer still standing over it. What separates AC-2 from AC-1 is that the drawer is
+    // gone — no edit form for a meeting that does not exist, and no inline error state either.
+    await expect(page.getByTestId('meeting-composer-header')).toHaveCount(0, { timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-load-error')).toHaveCount(0);
     await expect(page).toHaveURL(/\/meetings(\?|$)/, { timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('a 403 keeps the drawer and says the access is missing, not the meeting (AC-2 boundary)', async ({ page }) => {
+    await stubMeetingEditDetailError(page, 403);
+
+    await gotoSpa(page, `/project/meetings/${MOCK_MEETING_UID}/edit`, {
+      uid: OTHER_PROJECT_UID,
+      slug: OTHER_PROJECT_SLUG,
+      name: 'Other Project',
+      foundation: false,
+    });
+
+    // The permanent-but-present case, which is neither AC. Ejecting on it and calling the meeting
+    // missing is the same mislabelling #2037 was filed about, pointed the other way, so the drawer
+    // stays and states the real reason - with no Try again, which would only fail identically.
+    await expect(page.getByTestId('meeting-composer-load-error')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('meeting-composer-load-error')).toContainText("You don't have permission to edit this meeting");
+    await expect(page.getByTestId('meeting-composer-load-retry')).toHaveCount(0);
   });
 
   test('non-ED writer persona: a transient probe failure redirects to the project overview (guard fail-closed)', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -47,6 +47,7 @@ import {
   findPendingInvitationForCommittee,
   invitationRequiresOrganization,
 } from '@lfx-one/shared/utils';
+import { MeetingComposerService } from '@app/modules/meetings/meeting-composer/meeting-composer.service';
 import { CommitteeService } from '@services/committee.service';
 import { CommitteeJoinApplicationSessionService } from '@services/committee-join-application-session.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
@@ -153,6 +154,7 @@ export class CommitteeViewComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly mailingListService = inject(MailingListService);
   private readonly meetingService = inject(MeetingService);
+  private readonly composer = inject(MeetingComposerService);
   private readonly messageService = inject(MessageService);
   private readonly dialogService = inject(DialogService);
   private readonly userService = inject(UserService);
@@ -1461,14 +1463,22 @@ export class CommitteeViewComponent {
   }
 
   private initUpcomingMeetings(): Signal<Meeting[]> {
+    const committeeUid$ = toObservable(this.committee).pipe(
+      filter((c): c is Committee => !!c?.uid),
+      map((c) => c.uid),
+      // A refresh (e.g. a description save) re-emits a new Committee object with the same uid —
+      // skip the redundant meetings round-trip when the id itself hasn't changed.
+      distinctUntilChanged()
+    );
+
+    // The composer opens as a drawer over this page and closes back onto it instead of navigating, so
+    // this list is what the organizer looks at straight after creating or editing a meeting from the
+    // Meetings tab. `combineLatest` needs both sources before it emits, so the counter's replayed
+    // value is folded into the first fetch rather than doubling it — including on a mount that comes
+    // after earlier saves, where the replay is already non-zero.
     return toSignal(
-      toObservable(this.committee).pipe(
-        filter((c): c is Committee => !!c?.uid),
-        map((c) => c.uid),
-        // A refresh (e.g. a description save) re-emits a new Committee object with the same uid —
-        // skip the redundant meetings round-trip when the id itself hasn't changed.
-        distinctUntilChanged(),
-        switchMap((uid) => {
+      combineLatest([committeeUid$, toObservable(this.composer.saveCount)]).pipe(
+        switchMap(([uid]) => {
           this.meetingsLoading.set(true);
           // Not skip_registrants: this list is now shared with the Meetings tab, which needs
           // full registrant data on each meeting (see committee-meetings.component.ts).

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
@@ -12,10 +12,14 @@
         <!-- A button for a link that opens something in place, an anchor for one that navigates, so
              nothing about the element promises a destination it doesn't have. -->
         @if (link.command; as command) {
+          <!-- `aria-expanded` only where `hasPopup` is set: on a button that opens nothing it would
+               claim a disclosure state that never changes. Every popup link here opens the create
+               menu below, which is the only popup this section owns. -->
           <button
             type="button"
             (click)="command($event)"
             [attr.aria-haspopup]="link.hasPopup ?? null"
+            [attr.aria-expanded]="link.hasPopup ? createMeetingMenu.isOpen() : null"
             class="flex items-center gap-2 text-sm text-primary hover:underline"
             [attr.data-testid]="'dashboard-quicklink-' + link.testId">
             <i [class]="link.icon" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.spec.ts
@@ -6,12 +6,11 @@ import { TestBed } from '@angular/core/testing';
 import { Meeting } from '@lfx-one/shared/interfaces';
 import { MeetingComposerService } from '@app/modules/meetings/meeting-composer/meeting-composer.service';
 import { MeetingService } from '@services/meeting.service';
-import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
-import { Observable, of, Subject } from 'rxjs';
+import { Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingCardComponent } from './meeting-card.component';
@@ -19,16 +18,18 @@ import { MeetingCardComponent } from './meeting-card.component';
 const MEETING = { id: 'meeting-1', project_uid: 'project-1', project_slug: 'acme', organizer: true } as Meeting;
 
 /**
- * Covers the write-access probe the edit button runs before opening the composer.
+ * Covers the edit-permission re-check the edit button runs before opening the composer.
  * @description `meeting().organizer` is a snapshot of what the list payload said when the card
  * rendered, so an organizer whose access was revoked since then still sees an edit button. Opening
  * the composer on that stale flag walks the organizer through a whole edit that upstream will reject
- * on save, so the card re-asks before opening.
+ * on save, so the card re-asks before opening — of the meeting itself, which is the object the API's
+ * own guard is evaluated against. No `ProjectContextService` is provided below, so a probe that went
+ * back to project permissions instead would fail to inject rather than quietly pass.
  */
 describe('MeetingCardComponent — edit-access re-check', () => {
   let composerOpen: ReturnType<typeof vi.fn>;
   let toastAdd: ReturnType<typeof vi.fn>;
-  let writeAccess: ReturnType<typeof vi.fn>;
+  let getMeetingDetail: ReturnType<typeof vi.fn>;
 
   /** Mounts the card over `meeting` with an empty template — this suite exercises the handler, not the markup. */
   async function mount(meeting: Meeting = MEETING): Promise<MeetingCardComponent> {
@@ -36,7 +37,6 @@ describe('MeetingCardComponent — edit-access re-check', () => {
       providers: [
         { provide: UserService, useValue: { user: signal(null), authenticated: signal(false) } },
         { provide: ProjectService, useValue: { project: signal(null) } },
-        { provide: ProjectContextService, useValue: { meetingWriteAccessFor: writeAccess } },
         { provide: MeetingComposerService, useValue: { open: composerOpen } },
         { provide: MessageService, useValue: { add: toastAdd } },
         { provide: ConfirmationService, useValue: {} },
@@ -44,6 +44,7 @@ describe('MeetingCardComponent — edit-access re-check', () => {
         {
           provide: MeetingService,
           useValue: {
+            getMeetingDetail,
             getMeetingAttachments: vi.fn().mockReturnValue(of([])),
             getPastMeetingAttachments: vi.fn().mockReturnValue(of([])),
             getPublicMeetingJoinUrl: vi.fn().mockReturnValue(of({ link: '' })),
@@ -67,21 +68,22 @@ describe('MeetingCardComponent — edit-access re-check', () => {
   beforeEach(() => {
     composerOpen = vi.fn();
     toastAdd = vi.fn();
-    writeAccess = vi.fn().mockReturnValue(of(true));
+    getMeetingDetail = vi.fn().mockReturnValue(of({ ...MEETING, organizer: true }));
   });
 
-  it('opens the composer once the probe confirms write access', async () => {
+  it('opens the composer once a fresh read still reports the viewer as organizer', async () => {
     const component = await mount();
 
     component.onEditMeeting();
 
-    expect(writeAccess).toHaveBeenCalledWith('acme');
+    // `skipCache` is the whole point: the cached payload is the one the stale flag came from.
+    expect(getMeetingDetail).toHaveBeenCalledWith('meeting-1', { skipCache: true });
     expect(composerOpen).toHaveBeenCalledWith({ mode: 'edit', meetingUid: 'meeting-1', projectUid: 'project-1' });
     expect(toastAdd).not.toHaveBeenCalled();
   });
 
   it('refuses to open the composer for an organizer whose access has since been revoked', async () => {
-    writeAccess.mockReturnValue(of(false));
+    getMeetingDetail.mockReturnValue(of({ ...MEETING, organizer: false }));
     const component = await mount();
 
     component.onEditMeeting();
@@ -92,21 +94,32 @@ describe('MeetingCardComponent — edit-access re-check', () => {
     expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn', summary: 'Editing unavailable' }));
   });
 
-  it('does not probe at all when the meeting carries no project reference', async () => {
+  it('opens for an organizer the meeting grants but no project permission would', async () => {
+    // A committee writer inherits `organizer` on the meeting while holding nothing at project level.
+    // Re-deriving the answer from the project denied exactly this person an edit the API allows.
+    getMeetingDetail.mockReturnValue(of({ id: 'meeting-1', organizer: true } as Meeting));
     const component = await mount({ id: 'meeting-1', organizer: true } as Meeting);
 
     component.onEditMeeting();
 
-    // `meetingWriteAccessFor` needs a slug or uid to ask about; without one there is nothing to check
-    // and the composer would open on an unverified flag.
-    expect(writeAccess).not.toHaveBeenCalled();
+    expect(composerOpen).toHaveBeenCalledWith({ mode: 'edit', meetingUid: 'meeting-1', projectUid: undefined });
+    expect(toastAdd).not.toHaveBeenCalled();
+  });
+
+  it('says the check failed rather than claiming the permission was revoked', async () => {
+    getMeetingDetail.mockReturnValue(throwError(() => new Error('network')));
+    const component = await mount();
+
+    component.onEditMeeting();
+
     expect(composerOpen).not.toHaveBeenCalled();
-    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn' }));
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn', summary: 'Could not open the editor' }));
+    expect(component.checkingEditAccess()).toBe(false);
   });
 
   it('holds the button disabled for the length of the probe and ignores a second click', async () => {
-    const probe = new Subject<boolean>();
-    writeAccess.mockReturnValue(probe as unknown as Observable<boolean>);
+    const probe = new Subject<Meeting>();
+    getMeetingDetail.mockReturnValue(probe as unknown as Observable<Meeting>);
     const component = await mount();
 
     component.onEditMeeting();
@@ -116,9 +129,9 @@ describe('MeetingCardComponent — edit-access re-check', () => {
     // A second click while the first probe is in flight must not queue a second request — otherwise
     // two composers race to open over the same meeting.
     component.onEditMeeting();
-    expect(writeAccess).toHaveBeenCalledTimes(1);
+    expect(getMeetingDetail).toHaveBeenCalledTimes(1);
 
-    probe.next(true);
+    probe.next({ ...MEETING, organizer: true });
     probe.complete();
 
     expect(component.checkingEditAccess()).toBe(false);
@@ -126,7 +139,7 @@ describe('MeetingCardComponent — edit-access re-check', () => {
   });
 
   it('releases the button after a denied probe so the organizer can retry', async () => {
-    writeAccess.mockReturnValue(of(false));
+    getMeetingDetail.mockReturnValue(of({ ...MEETING, organizer: false }));
     const component = await mount();
 
     component.onEditMeeting();

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -73,7 +73,6 @@ import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { MeetingService } from '@services/meeting.service';
-import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { AnimateOnScrollModule } from 'primeng/animateonscroll';
@@ -122,7 +121,6 @@ export class MeetingCardComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly clipboard = inject(Clipboard);
   private readonly userService = inject(UserService);
-  private readonly projectContext = inject(ProjectContextService);
   private readonly composer = inject(MeetingComposerService);
 
   private readonly destroyRef = inject(DestroyRef);
@@ -281,11 +279,20 @@ export class MeetingCardComponent implements OnInit {
   }
 
   /**
-   * Re-checks meeting write access before opening the composer in edit mode.
+   * Re-checks edit permission on the meeting itself before opening the composer in edit mode.
    * @description `meeting().organizer` is whatever the list payload said when the card first rendered,
    * so an organizer whose access was revoked since then keeps an edit button until the page reloads.
-   * Same fresh writer -> meeting-coordinator probe the group meetings list makes before scheduling: the
-   * save would fail upstream regardless, but the composer should not open onto work that cannot land.
+   * The re-check asks the meeting detail for a fresh `organizer` rather than re-deriving the answer
+   * from the parent project: the permission model inherits `organizer` from Project Writer, Project
+   * Meeting Coordinator *and* Committee Writer, so a committee writer legitimately holds it while
+   * holding nothing at project level, and the API's own guard is evaluated against the meeting
+   * (`docs/architecture/frontend/permission-persona-navigation-model-preread.md:128-143`). Rebuilding
+   * that inheritance out of project permissions is the documented anti-pattern, and it would deny an
+   * edit upstream allows.
+   *
+   * `skipCache: true` is what makes this a re-check at all — the detail cache would otherwise replay
+   * whatever a previous read left behind. It also primes the entry the composer reads next, so the
+   * probe costs the edit flow no extra round trip.
    */
   public onEditMeeting(): void {
     if (this.checkingEditAccess()) {
@@ -293,32 +300,30 @@ export class MeetingCardComponent implements OnInit {
     }
 
     const meeting = this.meeting();
-    const projectRef = meeting.project_slug || meeting.project_uid;
-
-    if (!projectRef) {
-      this.denyEdit();
-      return;
-    }
 
     this.checkingEditAccess.set(true);
-    // `meetingWriteAccessFor` already folds its own failures into `false`, so there is no error branch.
-    this.projectContext
-      .meetingWriteAccessFor(projectRef)
+    this.meetingService
+      .getMeetingDetail(meeting.id, { skipCache: true })
       .pipe(
         finalize(() => this.checkingEditAccess.set(false)),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((canEdit) => {
-        if (!canEdit) {
-          this.denyEdit();
-          return;
-        }
+      .subscribe({
+        next: (fresh) => {
+          if (fresh.organizer !== true) {
+            this.denyEdit();
+            return;
+          }
 
-        this.composer.open({
-          mode: 'edit',
-          meetingUid: meeting.id,
-          projectUid: meeting.project_uid,
-        });
+          this.composer.open({
+            mode: 'edit',
+            meetingUid: meeting.id,
+            projectUid: meeting.project_uid,
+          });
+        },
+        // A probe that could not run is not a revoked permission, and saying it was sends the
+        // organizer looking for an access problem they do not have.
+        error: () => this.warnEditCheckUnavailable(),
       });
   }
 
@@ -867,6 +872,14 @@ export class MeetingCardComponent implements OnInit {
       severity: 'warn',
       summary: 'Editing unavailable',
       detail: 'You no longer have permission to edit this meeting.',
+    });
+  }
+
+  private warnEditCheckUnavailable(): void {
+    this.messageService.add({
+      severity: 'warn',
+      summary: 'Could not open the editor',
+      detail: 'We could not check your access to this meeting. Please try again.',
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -3,6 +3,7 @@
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 import { NgClass } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
   Component,
   computed,
@@ -321,9 +322,7 @@ export class MeetingCardComponent implements OnInit {
             projectUid: meeting.project_uid,
           });
         },
-        // A probe that could not run is not a revoked permission, and saying it was sends the
-        // organizer looking for an access problem they do not have.
-        error: () => this.warnEditCheckUnavailable(),
+        error: (error: unknown) => this.reportEditProbeFailure(error),
       });
   }
 
@@ -873,6 +872,35 @@ export class MeetingCardComponent implements OnInit {
       summary: 'Editing unavailable',
       detail: 'You no longer have permission to edit this meeting.',
     });
+  }
+
+  /**
+   * Says which of the three things went wrong, rather than always offering a retry.
+   * @description The probe's own failure modes are not interchangeable. A 403 is the access loss
+   * this re-check exists to catch, and a 404 means the card is showing a meeting somebody already
+   * deleted — both are permanent, so inviting another attempt just fails again. Everything else — a
+   * 5xx, a dropped connection — really is a probe that could not run, and calling that a revoked
+   * permission sends the organizer looking for an access problem they do not have. Mirrors the split
+   * the composer's own load path makes on the same two statuses.
+   */
+  private reportEditProbeFailure(error: unknown): void {
+    const status = error instanceof HttpErrorResponse ? error.status : null;
+
+    if (status === 403) {
+      this.denyEdit();
+      return;
+    }
+
+    if (status === 404) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Editing unavailable',
+        detail: 'This meeting no longer exists.',
+      });
+      return;
+    }
+
+    this.warnEditCheckUnavailable();
   }
 
   private warnEditCheckUnavailable(): void {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.spec.ts
@@ -109,4 +109,50 @@ describe('MeetingCommitteeManagerComponent — committee member emissions', () =
     // answer, and withholding it would strand group guests the organizer has just deselected.
     expect(emissions).toEqual([[]]);
   });
+
+  /*
+   * Reopening an edit composer over a meeting that already has groups. The manager is rebuilt from
+   * scratch every time the Guests section is entered, and each mount starts with an empty member
+   * list and an outstanding fetch — the same shape as a meeting with no groups at all. The gate has
+   * to hold across the whole of that window, not just its first tick: an `[]` anywhere before the
+   * roster lands is read by the composer as "these groups have no members" and queues every saved
+   * group guest for deletion.
+   */
+  it('never announces an empty roster while reopening over saved groups', async () => {
+    const board = new Subject<CommitteeMember[]>();
+    const { emissions, fixture } = await mount([{ uid: BOARD.uid } as MeetingCommittee], { [BOARD.uid]: board });
+
+    // Change detection runs repeatedly while the drawer is open, and `selectedCommitteeIds` is set
+    // from the parent's committees as well as from the multiselect, so the gate is asked more than
+    // once per mount.
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    board.next([member(BOARD.uid, 'chair@example.com')]);
+    board.complete();
+    await fixture.whenStable();
+
+    expect(emissions.filter((entry) => entry.length === 0)).toEqual([]);
+    expect(emissions.map((entry) => entry.map((m) => m.email))).toEqual([['chair@example.com']]);
+  });
+
+  /*
+   * The gate is per-fetch, not once-per-lifetime. Deselecting every group is an answer and has to
+   * reach the composer, or the guests those groups contributed stay invited with nothing selected;
+   * selecting one again reopens the question and must go quiet until the new fetch settles.
+   */
+  it('re-arms when the selection changes after the first roster has landed', async () => {
+    const board = new Subject<CommitteeMember[]>();
+    const { component, emissions, fixture } = await mount([{ uid: BOARD.uid } as MeetingCommittee], { [BOARD.uid]: board });
+
+    board.next([member(BOARD.uid, 'chair@example.com')]);
+    board.complete();
+    await fixture.whenStable();
+    expect(emissions).toHaveLength(1);
+
+    component.committeeForm.get('committees')?.setValue([]);
+    await fixture.whenStable();
+    expect(emissions).toEqual([[expect.objectContaining({ email: 'chair@example.com' })], []]);
+  });
 });

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -53,6 +53,12 @@ export class MeetingCommitteeManagerComponent {
    * only after the parent's committees have actually been applied (until then the empty list is a
    * mount-time artifact); and a failed fetch is never emitted, since "no members" and "we couldn't
    * ask" are indistinguishable in the result but opposite in consequence.
+   *
+   * What the gate cannot tell apart is an empty selection from a parent that has none and one from a
+   * parent that has not resolved its own yet — both arrive as `[]` on the same input. So the parent
+   * owns that half: mount this component only once its selection is known. Both callers do, by
+   * reading `selectedCommittees` off the form control the composer populates, and by rendering the
+   * Guests section only after an edit-mode load has settled.
    */
   private membersResolved = false;
   private selectionApplied = false;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
@@ -89,7 +89,7 @@
     [rows]="rows()"
     [maxlength]="agendaMaxLength"
     [ariaDescribedBy]="agendaDescribedBy()"
-    [attr.aria-invalid]="agendaTooLong() ? 'true' : null"
+    [invalid]="agendaTooLong()"
     [attr.data-testid]="inputId() + '-textarea'" />
 
   <div class="flex items-center justify-between gap-2">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.html
@@ -80,10 +80,13 @@
     </div>
   </p-popover>
 
+  <!-- `inputId`, not `id`: both land on the inner `<textarea>` today, but `inputId` is the input
+       `TextareaComponent` documents for exactly this pairing, so the `<label for>` above cannot be
+       broken by a later change that gives `id` a different meaning on the wrapper. -->
   <lfx-textarea
     [form]="form()"
     control="description"
-    [id]="inputId()"
+    [inputId]="inputId()"
     placeholder="Enter meeting agenda and key discussion points"
     [styleClass]="textareaClass()"
     [rows]="rows()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/composer-agenda-field.component.spec.ts
@@ -5,7 +5,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { AbstractControl } from '@angular/forms';
 import { DEFAULT_DURATION, MAX_CUSTOM_DURATION, MEETING_AGENDA_PROMPT_MAX_LENGTH, MIN_CUSTOM_DURATION } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
-import type { MeetingTemplate } from '@lfx-one/shared/interfaces';
+import type { GenerateAgendaResponse, MeetingTemplate } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
@@ -13,7 +13,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { Popover } from 'primeng/popover';
-import { of } from 'rxjs';
+import { type Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ComposerAgendaFieldComponent } from './composer-agenda-field.component';
@@ -327,6 +327,131 @@ describe('ComposerAgendaFieldComponent — popovers and the estimated duration',
       applyEstimate(MAX_CUSTOM_DURATION + 1);
 
       expect(popover.hide).toHaveBeenCalled();
+    });
+  });
+});
+
+/**
+ * The two ways a generation ends without landing a draft: one the server refuses, and one that answers
+ * after the composer has moved on. Neither has a control of its own reporting it — the section is
+ * destroyed on every rail change and the whole host on every successful save, so an in-flight request
+ * routinely outlives the form it was asked for. A late write would land on whatever form is mounted by
+ * then: the next section the organizer opened, or the blank one behind the next create.
+ */
+describe('ComposerAgendaFieldComponent \u2014 a generation that never lands', () => {
+  let fixture: ComponentFixture<ComposerAgendaFieldComponent>;
+  let component: ComposerAgendaFieldComponent;
+  let formService: MeetingComposerFormService;
+  let messageAdd: ReturnType<typeof vi.fn>;
+  let response: Observable<GenerateAgendaResponse>;
+
+  const popover = { hide: vi.fn() };
+  const generate = (): void => component['onGenerateAgenda'](popover as unknown as Popover);
+  const toastsOfSeverity = (severity: string): unknown[] => messageAdd.mock.calls.filter(([message]) => message.severity === severity);
+
+  beforeEach(async () => {
+    messageAdd = vi.fn();
+    popover.hide = vi.fn();
+    response = of({ agenda: 'Roll call', estimatedDuration: 30 });
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: messageAdd } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: { generateAgenda: vi.fn(() => response) } },
+        { provide: ProjectContextService, useValue: { activeContext: () => null, activeContextUid: () => null } },
+        { provide: PersonaService, useValue: { currentPersona: () => null } },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerAgendaFieldComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerAgendaFieldComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    formService.form().get('title')?.setValue('Quarterly review');
+    await fixture.whenStable();
+  });
+
+  describe('when the request fails', () => {
+    beforeEach(() => {
+      // `MeetingService.generateAgenda` logs and re-throws, so the component sees a plain error.
+      response = throwError(() => new Error('upstream refused'));
+    });
+
+    it('says the generation failed', () => {
+      generate();
+
+      expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Generation failed' }));
+      expect(toastsOfSeverity('success')).toHaveLength(0);
+    });
+
+    it('leaves the agenda alone rather than writing an empty draft over it', () => {
+      formService.form().get('description')?.setValue('1. Roll call');
+
+      generate();
+
+      expect(formService.form().get('description')?.value).toBe('1. Roll call');
+    });
+
+    it('keeps the helper open so the goal the organizer typed is still there to retry with', () => {
+      generate();
+
+      expect(popover.hide).not.toHaveBeenCalled();
+    });
+
+    it('puts the Generate button back, so a failure is not a dead end', () => {
+      generate();
+
+      // `finalize` rather than the success handler, which a failure never reaches.
+      expect(component['isGeneratingAgenda']()).toBe(false);
+    });
+
+    it('swallows the error instead of tearing the subscription down as unhandled', () => {
+      expect(() => generate()).not.toThrow();
+    });
+  });
+
+  describe('when the answer arrives after the section is gone', () => {
+    let late: Subject<GenerateAgendaResponse>;
+
+    beforeEach(() => {
+      late = new Subject<GenerateAgendaResponse>();
+      response = late;
+    });
+
+    it('drops the draft rather than writing it into a form the organizer has moved on from', () => {
+      generate();
+      const description = formService.form().get('description');
+      fixture.destroy();
+
+      late.next({ agenda: 'Roll call', estimatedDuration: 30 });
+
+      expect(description?.value).toBe('');
+      expect(description?.dirty).toBe(false);
+      expect(toastsOfSeverity('success')).toHaveLength(0);
+    });
+
+    it('drops a late duration too, so the next meeting does not inherit this estimate', () => {
+      generate();
+      fixture.destroy();
+
+      late.next({ agenda: 'Roll call', estimatedDuration: 30 });
+
+      expect(formService.effectiveDuration()).toBe(DEFAULT_DURATION);
+    });
+
+    it('unsubscribes, so nothing is left listening for a response that may never come', () => {
+      generate();
+      expect(late.observed).toBe(true);
+
+      fixture.destroy();
+
+      expect(late.observed).toBe(false);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -1029,6 +1029,31 @@ describe('MeetingComposerFormService — group reconciliation after a failed gue
     expect(service.registrantUpdates().toAdd).toEqual([]);
   });
 
+  // The banner stays up while the organizer keeps working, so the selection the retry has to honour
+  // is their latest one. Returning without replacing the buffered snapshot replays whichever group
+  // was in flight when the load failed: members of a group they have since dropped get invited, and
+  // the group they picked afterwards is missed entirely.
+  it('reconciles the latest group selection, not the one made before the load failed', () => {
+    const groupMember = (committeeUid: string, email: string): CommitteeMember =>
+      ({
+        uid: `member-${email}`,
+        committee_uid: committeeUid,
+        email,
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      }) as CommitteeMember;
+
+    service.syncCommitteeMembers([groupMember('committee-board', 'chair@example.com')]);
+    service.syncCommitteeMembers([groupMember('committee-tac', 'tac-chair@example.com')]);
+
+    getMeetingRegistrants.mockReturnValue(of([] as MeetingRegistrant[]));
+    service.retryLoadMeeting();
+
+    expect(service.guests().map((guest) => guest.email)).toEqual(['tac-chair@example.com']);
+  });
+
   it('hydrates the saved guests as already persisted once the retry succeeds', () => {
     getMeetingRegistrants.mockReturnValue(of([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]));
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -1227,24 +1227,29 @@ describe('MeetingComposerFormService \u2014 edit-mode hydration', () => {
     expect(service.isSectionValid('details-access')).toBe(true);
   });
 
-  it('folds a group member added mid-load into the saved row that arrives for them', () => {
+  it('holds a group selected mid-load back rather than queueing its members as new', () => {
     const registrants = new Subject<MeetingRegistrant[]>();
     const service = openEdit({}, registrants);
 
-    // Selecting a group while the guest fetch is still open queues its members as `new`; the
-    // deliberate case mismatch is what an upstream row and a committee record actually differ by.
+    // Mid-flight the guest list is still empty, so reconciling here would read an already-registered
+    // member as uninvited. A save that beat the fetch would then invite them a second time. The
+    // snapshot is held instead, and nothing is queued in the meantime.
     service.syncCommitteeMembers([boardMember('Chair@Example.com')]);
-    expect(service.guests()).toHaveLength(1);
 
+    expect(service.guests()).toEqual([]);
+    expect(service.registrantUpdates().toAdd).toEqual([]);
+
+    // The deliberate case mismatch is what an upstream row and a committee record actually differ by.
     registrants.next([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]);
 
-    // One person, one row: without the dedupe the save would invite an already-registered guest again.
+    // One person, one row, and it is the saved one — the held snapshot is replayed against the real
+    // list, which is the whole point of holding it.
     expect(service.guests()).toHaveLength(1);
     expect(service.guests()[0]).toMatchObject({ uid: 'registrant-1', state: 'existing' });
     expect(service.registrantUpdates().toAdd).toEqual([]);
   });
 
-  it('keeps a mid-load guest the fetch does not know about', () => {
+  it('applies a group selected mid-load once the fetch has landed', () => {
     const registrants = new Subject<MeetingRegistrant[]>();
     const service = openEdit({}, registrants);
 
@@ -1252,9 +1257,28 @@ describe('MeetingComposerFormService \u2014 edit-mode hydration', () => {
 
     registrants.next([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]);
 
-    // The dedupe must not swallow work done during the fetch, and the pending row keeps its place
-    // ahead of the saved ones so the organizer can still see what they just added.
-    expect(service.guests().map((guest) => guest.email)).toEqual(['newcomer@example.com', 'chair@example.com']);
+    // Holding the snapshot must not lose it: a member no saved row covers still has to be invited.
+    // They land after the saved rows rather than ahead of them, because the group is now applied on
+    // the far side of the fetch instead of racing it.
+    expect(service.guests().map((guest) => guest.email)).toEqual(['chair@example.com', 'newcomer@example.com']);
+    expect(service.guests()[1]).toMatchObject({ state: 'new', type: 'committee' });
+  });
+
+  /*
+   * Holding group emissions closes the group half of the mid-load race, not the whole of it: the
+   * organizer can still type a guest in by hand while the fetch is open, and that row has no second
+   * chance to be replayed. `mergeLoadedGuests` is what keeps it, and keeps it in front, so the person
+   * they just added does not appear to have been swallowed by rows that arrived afterwards.
+   */
+  it('keeps a hand-added mid-load guest ahead of the saved rows', () => {
+    const registrants = new Subject<MeetingRegistrant[]>();
+    const service = openEdit({}, registrants);
+
+    service.updateGuests((current) => [...current, { ...service.newGuestDefaults(), email: 'typed@example.com' }]);
+
+    registrants.next([{ uid: 'registrant-1', email: 'chair@example.com' } as MeetingRegistrant]);
+
+    expect(service.guests().map((guest) => guest.email)).toEqual(['typed@example.com', 'chair@example.com']);
     expect(service.guests()[0]).toMatchObject({ state: 'new' });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -22,6 +22,7 @@ import { Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerService } from './meeting-composer.service';
 
 /**
  * Covers the submit pipeline's generation guard — the composer host outlives every open, so a save
@@ -428,6 +429,7 @@ describe('MeetingComposerFormService — load retry', () => {
   let getMeeting: ReturnType<typeof vi.fn>;
   let getMeetingRegistrants: ReturnType<typeof vi.fn>;
   let messageAdd: ReturnType<typeof vi.fn>;
+  let closeComposer: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     getMeeting = vi.fn().mockReturnValue(throwError(() => new Error('not found')));
@@ -452,6 +454,9 @@ describe('MeetingComposerFormService — load retry', () => {
     });
 
     service = TestBed.inject(MeetingComposerFormService);
+    // Spied, not stubbed: the real close still runs, so a test that closes the composer leaves the
+    // same state behind as the drawer does.
+    closeComposer = vi.spyOn(TestBed.inject(MeetingComposerService), 'close');
   });
 
   it('re-fetches the meeting after a failed edit-mode load', () => {
@@ -578,19 +583,36 @@ describe('MeetingComposerFormService — load retry', () => {
     expect(getMeeting).toHaveBeenCalledTimes(2);
   });
 
-  it.each([404, 403])('treats a %i as denied, says so once, and refuses the retry', (status) => {
-    getMeeting.mockReturnValue(throwError(() => new HttpErrorResponse({ status })));
+  it('treats a 403 as denied, keeps the drawer, and refuses the retry', () => {
+    getMeeting.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 403 })));
 
     service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
 
     expect(service.meetingLoadFailure()).toBe('denied');
-    expect(messageAdd).toHaveBeenCalledWith(
-      expect.objectContaining({ severity: 'error', detail: 'Meeting not found or you do not have permission to access it' })
-    );
+    // The drawer's own panel carries the reason, and the meeting is still there: a toast saying
+    // "not found" over it is the mislabelling #2037 was filed about, pointed the other way.
+    expect(messageAdd).not.toHaveBeenCalled();
+    expect(closeComposer).not.toHaveBeenCalled();
 
     service.retryLoadMeeting();
 
     expect(getMeeting).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * #2037's second criterion: a meeting that genuinely does not exist still says so and returns the
+   * organizer to the meetings list. The composer route redirects there and opens over it, so the
+   * drawer closing is what that return consists of - left open it is an edit form for nothing, and
+   * the list it covers is the one place the organizer can act.
+   */
+  it('closes the composer on a 404 and names the meeting missing, rather than describing a failure', () => {
+    getMeeting.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    expect(closeComposer).toHaveBeenCalledTimes(1);
+    expect(service.meetingLoadFailure()).toBeNull();
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Meeting not found' }));
   });
 
   it('refuses to submit an edit form that never hydrated', () => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -470,7 +470,16 @@ describe('MeetingComposerFormService — load retry', () => {
   it('asks for committee enrichment when loading the guest list', () => {
     service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
 
-    expect(getMeetingRegistrants).toHaveBeenCalledWith('meeting-1', false, undefined, false, undefined, true);
+    expect(getMeetingRegistrants).toHaveBeenCalledWith('meeting-1', false, undefined, true, undefined, true);
+  });
+
+  it('fails the guest load rather than accepting a truncated page', () => {
+    // A partial page reads as "these people are not registered yet", and the organizer's next act
+    // is to invite them again — duplicate invites to guests who already have one. The retry banner
+    // is the honest answer, and the `catchError` below already raises it.
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    expect(getMeetingRegistrants.mock.calls[0][3]).toBe(true);
   });
 
   it('leaves a guest list that loaded fine alone on retry', () => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -126,10 +126,11 @@ export class MeetingComposerFormService {
   public readonly loading = signal<boolean>(false);
   /**
    * How the edit-mode fetch failed, or `null` when it hasn't.
-   * @description Two outcomes, not one: a 404/403 is permanent, so the drawer explains and stops
-   * there, while anything else keeps its Retry. A single boolean offered "Try again" on a deleted
-   * meeting and labelled a 500 "not found" — the pair of mistakes #2037 fixed on the page this
-   * composer replaced.
+   * @description Two outcomes, not one: a 403 is permanent, so the drawer explains and stops there,
+   * while anything else keeps its Retry. A single boolean offered "Try again" on a meeting no retry
+   * could reach and labelled a 500 "not found" — the pair of mistakes #2037 fixed on the page this
+   * composer replaced. A 404 reaches neither state: it closes the composer instead, so there is no
+   * drawer left to describe it.
    */
   public readonly meetingLoadFailure = signal<MeetingComposerLoadFailure | null>(null);
   /** Whether the edit-mode fetch failed, so the drawer can say so instead of showing an empty form. */
@@ -439,7 +440,7 @@ export class MeetingComposerFormService {
   public retryLoadMeeting(): void {
     const meetingUid = this.meetingId();
 
-    // `denied` never retries: the 404/403 that produced it will produce it again, and the drawer
+    // `denied` never retries: the 403 that produced it will produce it again, and the drawer
     // doesn't render the action for it. Guarded here too so a caller can't route around that.
     if (!this.isEditMode() || !meetingUid || this.loading() || this.meetingLoadFailure() === 'denied') {
       return;
@@ -1023,24 +1024,31 @@ export class MeetingComposerFormService {
         },
         error: (error: unknown) => {
           console.error('Error getting meeting:', error);
-          // 404/403 is the permanent pair: the meeting is gone, or write access went away
-          // mid-session and no retry here can restore it. Everything else — a 5xx, a dropped
-          // connection — is worth another attempt, and saying "not found" about it would send the
-          // organizer looking for a meeting that is still there.
-          const denied = error instanceof HttpErrorResponse && (error.status === 404 || error.status === 403);
+          const status = error instanceof HttpErrorResponse ? error.status : null;
 
-          this.meetingLoadFailure.set(denied ? 'denied' : 'retryable');
-
-          // The toast is transient, so the drawer keeps its own state either way — otherwise the
-          // organizer is left with an empty form and a disabled Save and nothing saying why. Only
-          // the permanent case gets a toast on top: the retryable one has an action on screen.
-          if (denied) {
+          // A 404 is the one outcome that still ejects. There is no meeting to edit, so a drawer
+          // left standing over the list is a form for something that does not exist — and #2037's
+          // second criterion is that a genuinely missing meeting says so and returns the organizer
+          // to the meetings list. The composer route already redirected there underneath, so
+          // closing is what lands them on it; the toast carries the message the drawer no longer can.
+          if (status === 404) {
+            this.composer.close();
             this.messageService.add({
               severity: 'error',
               summary: 'Error',
-              detail: 'Meeting not found or you do not have permission to access it',
+              detail: 'Meeting not found',
             });
+
+            return;
           }
+
+          // A 403 is permanent too — access went away and no retry here can restore it — but the
+          // meeting is still there, and announcing it as missing is the other half of the
+          // mislabelling #2037 fixed. It keeps the drawer, which states the real reason and offers
+          // no Try again. Everything else — a 5xx, a dropped connection — is worth another attempt,
+          // and the drawer keeps its own state for that too: otherwise the organizer is left with
+          // an empty form and a disabled Save and nothing saying why.
+          this.meetingLoadFailure.set(status === 403 ? 'denied' : 'retryable');
         },
       });
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -1060,9 +1060,13 @@ export class MeetingComposerFormService {
     this.guestsLoadFailed.set(false);
 
     this.meetingService
+      // fail_on_partial: a truncated page reads as "these people are not registered yet", and the
+      // organizer's next act is to invite them again — duplicate invites to guests who already have
+      // one. An error is the honest answer, and this component already has somewhere to put it: the
+      // `catchError` below raises `guestsLoadFailed`, which renders the retry banner.
       // include_committee: the Guests rows render a "via [Group]" chip, which needs the committee
       // metadata the plain projection omits.
-      .getMeetingRegistrants(meetingUid, false, undefined, false, undefined, true)
+      .getMeetingRegistrants(meetingUid, false, undefined, true, undefined, true)
       .pipe(
         take(1),
         catchError((error: unknown) => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -690,7 +690,13 @@ export class MeetingComposerFormService {
     // them as `state: 'new'`, so saving would re-invite people who are already registered. Skip the
     // pass entirely until a retry populates the list — the section already surfaces the failure and
     // offers "Try again", and the group selection is re-applied once that succeeds.
+    //
+    // Buffer rather than drop: the banner is up for as long as the organizer keeps working, and the
+    // groups they pick while it is up are the ones the retry has to reconcile. Returning without
+    // replacing the snapshot would replay whichever selection happened to be in flight when the load
+    // failed — inviting members of a group they have since dropped, and omitting the one they added.
     if (this.guestsLoadFailed()) {
+      this.deferredCommitteeMembers = members;
       return;
     }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -246,6 +246,14 @@ export class MeetingComposerFormService {
    */
   private guestsLoadGeneration = 0;
 
+  /**
+   * The newest group-member snapshot that arrived while the saved guests were still loading.
+   * @description Only the newest is worth keeping: reconciliation is a full pass over the selection,
+   * so an older snapshot has nothing to add once a later one has landed. Cleared by `resetState` and
+   * consumed once the load settles.
+   */
+  private deferredCommitteeMembers: CommitteeMember[] | null = null;
+
   public constructor() {
     this.destroyRef.onDestroy(() => {
       this.formSubscriptions.unsubscribe();
@@ -277,6 +285,7 @@ export class MeetingComposerFormService {
     this.guestsLoading.set(false);
     this.guestsLoadFailed.set(false);
     this.suppressedGuestEmails.set(new Set());
+    this.deferredCommitteeMembers = null;
     this.committeeContext.set(null);
     this.hydratedOwner.set(null);
     this.ownerManualEntry.set(false);
@@ -344,6 +353,7 @@ export class MeetingComposerFormService {
           form.get('title')?.value &&
           form.get('title')?.valid &&
           form.get('meeting_type')?.value &&
+          form.get('meeting_type')?.valid &&
           // Optional field, so `?? true` rather than `.valid`: absent means nothing to block on. Only a
           // hand-typed organizer email can fail it, and the error only renders in manual-entry mode.
           (form.get('ownerEmail')?.valid ?? true)
@@ -564,12 +574,12 @@ export class MeetingComposerFormService {
         // A stale failure still gets reported, but worded so the user doesn't read it as their current
         // draft failing and hit Save again — that would duplicate the meeting.
         const isStale = generation !== this.generation;
+        const pastVerb = wasEditMode ? 'updated' : 'created';
+        const verb = wasEditMode ? 'update' : 'create';
         this.messageService.add({
           severity: 'error',
           summary: 'Error',
-          detail: isStale
-            ? `An earlier meeting could not be ${wasEditMode ? 'updated' : 'created'}. Your current draft is unaffected.`
-            : `Failed to ${wasEditMode ? 'update' : 'create'} meeting. Please try again.`,
+          detail: isStale ? `An earlier meeting could not be ${pastVerb}. Your current draft is unaffected.` : `Failed to ${verb} meeting. Please try again.`,
         });
         return EMPTY;
       }),
@@ -684,6 +694,69 @@ export class MeetingComposerFormService {
       return;
     }
 
+    // Same hazard one step earlier: mid-flight, `guests()` is still empty but nothing has failed yet,
+    // so every group member reads as uninvited and is queued as `state: 'new'`. `mergeLoadedGuests`
+    // drops those rows once the fetch lands, but a save that beats the fetch would re-invite people
+    // who are already registered. Hold the snapshot instead and reconcile against the real list.
+    if (this.guestsLoading()) {
+      this.deferredCommitteeMembers = members;
+      return;
+    }
+
+    this.reconcileCommitteeMembers(members);
+  }
+
+  /** Fields shared by every locally-added guest; `created_at` / `updated_at` are stamped upstream. */
+  public newGuestDefaults(): MeetingRegistrantWithState {
+    return {
+      uid: '',
+      meeting_id: this.meetingId() ?? '',
+      occurrence_id: null,
+      email: '',
+      first_name: '',
+      last_name: '',
+      job_title: null,
+      org_name: null,
+      host: false,
+      org_is_member: false,
+      org_is_project_member: false,
+      avatar_url: null,
+      username: null,
+      linkedin_profile: null,
+      created_at: '',
+      updated_at: '',
+      type: 'direct',
+      invite_accepted: null,
+      attended: null,
+      state: 'new',
+      tempId: generateTempId(),
+    };
+  }
+
+  /**
+   * Minutes the form currently resolves to, whichever of the two duration controls holds it.
+   * @description `customDuration` starts out as an empty string and holds whatever the numeric input
+   * produces, so it is coerced rather than cast.
+   */
+  public effectiveDuration(): number | null {
+    const duration = this.form().get('duration')?.value as number | 'custom' | null;
+
+    if (duration !== 'custom') {
+      return duration ?? null;
+    }
+
+    const customDuration = Number(this.form().get('customDuration')?.value);
+
+    return Number.isFinite(customDuration) && customDuration > 0 ? customDuration : null;
+  }
+
+  /**
+   * The reconciliation itself, with the "is the guest list trustworthy yet" guards already answered.
+   * @description Split out so the deferred replay can run it directly: `take(1)` hands the loaded
+   * guests to the subscriber before it completes, so `finalize` has not yet flipped `guestsLoading`
+   * back to false and `syncCommitteeMembers` would defer the same snapshot forever.
+   */
+  private reconcileCommitteeMembers(members: CommitteeMember[]): void {
     const memberByEmail = new Map<string, CommitteeMember>();
     members.forEach((member) => {
       if (member.email) {
@@ -740,50 +813,6 @@ export class MeetingComposerFormService {
 
       return [...reconciled, ...additions];
     });
-  }
-
-  /** Fields shared by every locally-added guest; `created_at` / `updated_at` are stamped upstream. */
-  public newGuestDefaults(): MeetingRegistrantWithState {
-    return {
-      uid: '',
-      meeting_id: this.meetingId() ?? '',
-      occurrence_id: null,
-      email: '',
-      first_name: '',
-      last_name: '',
-      job_title: null,
-      org_name: null,
-      host: false,
-      org_is_member: false,
-      org_is_project_member: false,
-      avatar_url: null,
-      username: null,
-      linkedin_profile: null,
-      created_at: '',
-      updated_at: '',
-      type: 'direct',
-      invite_accepted: null,
-      attended: null,
-      state: 'new',
-      tempId: generateTempId(),
-    };
-  }
-
-  /**
-   * Minutes the form currently resolves to, whichever of the two duration controls holds it.
-   * @description `customDuration` starts out as an empty string and holds whatever the numeric input
-   * produces, so it is coerced rather than cast.
-   */
-  public effectiveDuration(): number | null {
-    const duration = this.form().get('duration')?.value as number | 'custom' | null;
-
-    if (duration !== 'custom') {
-      return duration ?? null;
-    }
-
-    const customDuration = Number(this.form().get('customDuration')?.value);
-
-    return Number.isFinite(customDuration) && customDuration > 0 ? customDuration : null;
   }
 
   private toGroupGuest(member: CommitteeMember): MeetingRegistrantWithState {
@@ -1101,6 +1130,17 @@ export class MeetingComposerFormService {
         }
 
         this.setGuests(this.mergeLoadedGuests(loaded));
+
+        // Straight to `reconcileCommitteeMembers`, not back through `syncCommitteeMembers`: `take(1)`
+        // hands the value to this subscriber before it completes, so `finalize` has not yet flipped
+        // `guestsLoading` back to false and the public entry point would buffer the same snapshot again.
+        // Only on success. A failed load leaves the snapshot buffered so the retry reconciles it
+        // against the real list rather than against the empty one `catchError` substituted.
+        const deferred = this.deferredCommitteeMembers;
+        if (deferred && !this.guestsLoadFailed()) {
+          this.deferredCommitteeMembers = null;
+          this.reconcileCommitteeMembers(deferred);
+        }
       });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -87,11 +87,16 @@
          own vertical padding instead, so the rule between them runs the full height rather than stopping short
          of the header and footer. -->
     <div class="flex h-full min-h-0 gap-6">
-      <!-- Rail and preview are `lg`-only; below that the compact chip row further down takes over section navigation (GH-1462).
+      <!-- Rail and preview appear from 820px up; below that the compact chip row further down takes over
+           section navigation. 820px is the threshold #1462 names, and it is not one of this repo's Tailwind
+           breakpoints (`lg` is 1024px), so it is written as an arbitrary variant rather than rounded to the
+           nearest named one — rounding up would leave the rail collapsed across the whole 820–1023px band
+           the issue asks it to occupy.
            The column is hidden when the edit-mode fetch failed: there is no form behind the rail, so every row
            would report empty and clicking one would swap a section the organizer can't see. -->
       @if (!formService.meetingLoadFailed()) {
-        <div class="hidden w-[286px] shrink-0 flex-col gap-4 overflow-y-auto py-5 lg:flex lg:border-r lg:border-gray-200 lg:pr-6">
+        <div
+          class="hidden w-[286px] shrink-0 flex-col gap-4 overflow-y-auto py-5 min-[820px]:flex min-[820px]:border-r min-[820px]:border-gray-200 min-[820px]:pr-6">
           <lfx-meeting-composer-rail />
 
           @if (!isEditMode()) {
@@ -141,7 +146,7 @@
           <!-- Negative top/margin cancel the column's own `py-5`: the bar covers that band whether it is
                stuck or not, so content never scrolls through a gap above it. -->
           <div
-            class="sticky -top-5 z-10 -mt-5 flex flex-col gap-2 border-b border-gray-200 bg-white pb-3 pt-5 lg:hidden"
+            class="sticky -top-5 z-10 -mt-5 flex flex-col gap-2 border-b border-gray-200 bg-white pb-3 pt-5 min-[820px]:hidden"
             data-testid="meeting-composer-compact-progress">
             <div class="flex items-center gap-2">
               @if (!isEditMode()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -106,16 +106,18 @@
         <p class="py-5 text-sm text-gray-500" data-testid="meeting-composer-loading">Loading meeting…</p>
       } @else if (formService.meetingLoadFailure(); as loadFailure) {
         <!-- Without this the failed fetch leaves an empty form and a disabled Save with nothing saying why.
-             The two outcomes read differently on purpose: a 404/403 will fail the same way every time, so it
+             The two outcomes read differently on purpose: a 403 will fail the same way every time, so it
              gets no Retry, while everything else keeps one rather than being mislabelled "not found".
              That second branch covers a 500, a 401 and a status 0 alike, and nothing in the response
              separates them, so the copy claims only that the request did not complete — whether the meeting
-             still exists and whether the server was ever reached are for the retry to find out. -->
+             still exists and whether the server was ever reached are for the retry to find out.
+             A 404 reaches neither branch: the composer closes on it, so the meetings list underneath is
+             what the organizer is left on, with the not-found toast over it. -->
         <div class="flex min-w-0 flex-1 flex-col items-start gap-3 py-5" data-testid="meeting-composer-load-error">
           @if (loadFailure === 'denied') {
             <div class="flex flex-col gap-1">
-              <span class="text-sm font-semibold text-gray-900">Couldn't load this meeting</span>
-              <span class="text-sm text-gray-600">It may have been deleted, or you may not have permission to edit it.</span>
+              <span class="text-sm font-semibold text-gray-900">You don't have permission to edit this meeting</span>
+              <span class="text-sm text-gray-600">The meeting is still there — your access to change it isn't. Ask an organizer to grant it.</span>
             </div>
           } @else {
             <div class="flex flex-col gap-1">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -107,7 +107,10 @@
       } @else if (formService.meetingLoadFailure(); as loadFailure) {
         <!-- Without this the failed fetch leaves an empty form and a disabled Save with nothing saying why.
              The two outcomes read differently on purpose: a 404/403 will fail the same way every time, so it
-             gets no Retry, while a server error keeps one rather than being mislabelled "not found". -->
+             gets no Retry, while everything else keeps one rather than being mislabelled "not found".
+             That second branch covers a 500, a 401 and a status 0 alike, and nothing in the response
+             separates them, so the copy claims only that the request did not complete — whether the meeting
+             still exists and whether the server was ever reached are for the retry to find out. -->
         <div class="flex min-w-0 flex-1 flex-col items-start gap-3 py-5" data-testid="meeting-composer-load-error">
           @if (loadFailure === 'denied') {
             <div class="flex flex-col gap-1">
@@ -117,7 +120,7 @@
           } @else {
             <div class="flex flex-col gap-1">
               <span class="text-sm font-semibold text-gray-900">Something went wrong loading this meeting</span>
-              <span class="text-sm text-gray-600">The meeting is still there — the request didn't get through.</span>
+              <span class="text-sm text-gray-600">We couldn't complete the request. Try again — if it keeps failing, reload the page.</span>
             </div>
 
             <lfx-button

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
@@ -8,6 +8,7 @@ import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY } from '@lfx-one/
 import type { Meeting } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
+import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
@@ -32,6 +33,8 @@ describe('MeetingComposerHostComponent', () => {
   let formService: MeetingComposerFormService;
   let messageService: { add: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn> };
   let canWriteMeetings: WritableSignal<boolean>;
+  let activeContextUid: WritableSignal<string>;
+  let currentPersona: WritableSignal<string>;
   let meetingWriteAccessFor: ReturnType<typeof vi.fn>;
 
   const createdMeeting = { id: 'meeting-1', title: 'Weekly sync' } as Meeting;
@@ -70,6 +73,8 @@ describe('MeetingComposerHostComponent', () => {
   beforeEach(async () => {
     messageService = { add: vi.fn(), clear: vi.fn() };
     canWriteMeetings = signal(true);
+    activeContextUid = signal('project-1');
+    currentPersona = signal('maintainer');
     meetingWriteAccessFor = vi.fn().mockReturnValue(of(true));
 
     TestBed.configureTestingModule({
@@ -85,9 +90,13 @@ describe('MeetingComposerHostComponent', () => {
             getMeetingDetail: vi.fn(() => of(null)),
           },
         },
-        // `canWriteMeetings` is fed to `toObservable`, so it has to be a real signal rather than a plain
-        // getter. The host reads no other write-access signal off this service.
-        { provide: ProjectContextService, useValue: { canWriteMeetings, activeContextUid: () => 'project-1', meetingWriteAccessFor } },
+        // `canWriteMeetings` and `activeContextUid` are read inside a computed that feeds `toObservable`,
+        // so both have to be real signals rather than plain getters. The host reads no other
+        // write-access signal off this service.
+        { provide: ProjectContextService, useValue: { canWriteMeetings, activeContextUid, meetingWriteAccessFor } },
+        // The real service reads a cookie and an HTTP endpoint in its constructor; the host only ever
+        // asks it which persona is active.
+        { provide: PersonaService, useValue: { currentPersona } },
         // Only reached by the project-context fallback, which never runs while no meeting is loaded.
         { provide: ProjectService, useValue: {} },
         { provide: Router, useValue: { events: new Subject(), url: '/meetings', parseUrl: () => ({ queryParams: {} }) } },
@@ -209,6 +218,33 @@ describe('MeetingComposerHostComponent', () => {
 
       expect(composer.isOpen()).toBe(true);
     });
+
+    it('leaves the composer open when the write-access answer changes with the project it answers for', async () => {
+      // `syncEntityProjectContext` moves the context to the meeting's own project on a context-less
+      // edit link. The new project answers the write question for itself, so a true -> false across
+      // that move is a different question, not a lost grant — a committee writer editing a group
+      // meeting, or anyone admitted on one project and editing a meeting in another, reaches false
+      // here on an edit `writerGuard` had just admitted.
+      await openCreate();
+
+      activeContextUid.set('project-2');
+      canWriteMeetings.set(false);
+      await flush();
+
+      expect(composer.isOpen()).toBe(true);
+    });
+
+    it('leaves an executive director in the composer when the same project reports no write access', async () => {
+      // `writerGuard` admits the ED persona outright, with no FGA check, so this signal never speaks
+      // for them — the same exemption `evictOnWriteAccessLoss` makes.
+      currentPersona.set('executive-director');
+      await openCreate();
+
+      canWriteMeetings.set(false);
+      await flush();
+
+      expect(composer.isOpen()).toBe(true);
+    });
   });
 
   describe('submit gating', () => {
@@ -265,7 +301,9 @@ describe('MeetingComposerHostComponent', () => {
         detail: 'Weekly sync',
         sticky: true,
         closable: true,
-        data: { meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1', projectUid: null },
+        // 'project-1' rather than null: the response echoed no `project_uid`, so the toast falls back
+        // to the uid the save was written against — here the one `openCreate()` opened with.
+        data: { meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1', projectUid: 'project-1' },
       });
       // A meeting with no password carries no navigation state at all, so the link is a plain route.
       expect(lastToast().data.meetingLinkState).toBeUndefined();
@@ -427,6 +465,46 @@ describe('MeetingComposerHostComponent', () => {
 
       expect(meetingWriteAccessFor).not.toHaveBeenCalled();
       expect(component['editFromToastBlockedReason']()).toBeNull();
+    });
+
+    it('falls back to the project the save was written against when the response omits it', async () => {
+      // A create response that does not echo `project_uid` back used to leave the toast with no
+      // project at all, so Edit fell through to the ambient answer — the exact question this
+      // block exists because it gets wrong. `effectiveProjectUid()` is the uid `prepareMeetingData()`
+      // wrote with, so the probe asks about the project the meeting is actually in.
+      composer.open({ mode: 'create', projectUid: 'other-project' });
+      await flush();
+
+      announce('');
+
+      expect(meetingWriteAccessFor).toHaveBeenCalledWith('other-project');
+    });
+
+    it('ignores a probe response that a newer create has already superseded', () => {
+      // Two creates in a row: the first project's answer can land after the second toast replaced
+      // it. Applying it would speak for a meeting it was never asked about.
+      const stale = new Subject<boolean>();
+      meetingWriteAccessFor.mockReturnValueOnce(stale).mockReturnValueOnce(of(true));
+
+      announce('stale-project');
+      announce('fresh-project');
+      stale.next(false);
+      stale.complete();
+
+      expect(component['editFromToastBlockedReason']()).toBeNull();
+    });
+
+    it('leaves the newer toast checking when a superseded probe answers', () => {
+      const stale = new Subject<boolean>();
+      const fresh = new Subject<boolean>();
+      meetingWriteAccessFor.mockReturnValueOnce(stale).mockReturnValueOnce(fresh);
+
+      announce('stale-project');
+      announce('fresh-project');
+      stale.next(true);
+      stale.complete();
+
+      expect(component['editFromToastBlockedReason']()).toBe('Checking your access to that project');
     });
   });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.spec.ts
@@ -1,12 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { signal, type WritableSignal } from '@angular/core';
+import { computed, signal, type WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY } from '@lfx-one/shared/constants';
-import type { Meeting } from '@lfx-one/shared/interfaces';
+import type { Meeting, MeetingWriteAccess } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
+import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -32,10 +33,9 @@ describe('MeetingComposerHostComponent', () => {
   let composer: MeetingComposerService;
   let formService: MeetingComposerFormService;
   let messageService: { add: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn> };
-  let canWriteMeetings: WritableSignal<boolean>;
-  let activeContextUid: WritableSignal<string>;
+  let meetingWriteAccess: WritableSignal<MeetingWriteAccess>;
   let currentPersona: WritableSignal<string>;
-  let meetingWriteAccessFor: ReturnType<typeof vi.fn>;
+  let clearContextLens: ReturnType<typeof vi.fn>;
 
   const createdMeeting = { id: 'meeting-1', title: 'Weekly sync' } as Meeting;
 
@@ -69,13 +69,13 @@ describe('MeetingComposerHostComponent', () => {
   };
 
   const lastToast = () => messageService.add.mock.calls[messageService.add.mock.calls.length - 1][0];
+  const setWriteAccess = (patch: Partial<MeetingWriteAccess>) => meetingWriteAccess.update((current) => ({ ...current, ...patch }));
 
   beforeEach(async () => {
     messageService = { add: vi.fn(), clear: vi.fn() };
-    canWriteMeetings = signal(true);
-    activeContextUid = signal('project-1');
+    meetingWriteAccess = signal<MeetingWriteAccess>({ contextUid: 'project-1', canWrite: true });
     currentPersona = signal('maintainer');
-    meetingWriteAccessFor = vi.fn().mockReturnValue(of(true));
+    clearContextLens = vi.fn();
 
     TestBed.configureTestingModule({
       providers: [
@@ -90,15 +90,26 @@ describe('MeetingComposerHostComponent', () => {
             getMeetingDetail: vi.fn(() => of(null)),
           },
         },
-        // `canWriteMeetings` and `activeContextUid` are read inside a computed that feeds `toObservable`,
-        // so both have to be real signals rather than plain getters. The host reads no other
-        // write-access signal off this service.
-        { provide: ProjectContextService, useValue: { canWriteMeetings, activeContextUid, meetingWriteAccessFor } },
+        // `meetingWriteAccess` feeds `toObservable`, so it has to be a real signal rather than a
+        // plain getter. It is the source here, with the two loose signals derived off it exactly as
+        // the real service derives them — composing it the other way round would let a test stage a
+        // uid and an answer separately, which is the state the pairing exists to make unreachable.
+        {
+          provide: ProjectContextService,
+          useValue: {
+            meetingWriteAccess,
+            canWriteMeetings: computed(() => meetingWriteAccess().canWrite),
+            activeContextUid: computed(() => meetingWriteAccess().contextUid),
+          },
+        },
         // The real service reads a cookie and an HTTP endpoint in its constructor; the host only ever
         // asks it which persona is active.
         { provide: PersonaService, useValue: { currentPersona } },
         // Only reached by the project-context fallback, which never runs while no meeting is loaded.
         { provide: ProjectService, useValue: {} },
+        // The create picker's lens override is the only one the host ends; the real service reads
+        // cookies and the router to work out a lens nothing here asks it for.
+        { provide: LensService, useValue: { clearContextLens } },
         { provide: Router, useValue: { events: new Subject(), url: '/meetings', parseUrl: () => ({ queryParams: {} }) } },
       ],
     });
@@ -196,10 +207,34 @@ describe('MeetingComposerHostComponent', () => {
       expect(composer.isOpen()).toBe(true);
     });
 
+    /**
+     * The create picker can open this composer with a lens override standing in `LensService` — a
+     * deliberate persona bypass, scoped to one flow, that every other branch of the picker ends by
+     * navigating. This branch never navigates, so closing the overlay is the only end it gets.
+     */
+    it('ends the create picker lens override when the composer closes', async () => {
+      await openCreate();
+      expect(clearContextLens).not.toHaveBeenCalled();
+
+      component['onVisibleChange'](false);
+      await flush();
+
+      expect(clearContextLens).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the override alone while the composer is still open', async () => {
+      await openCreate();
+      await flush();
+
+      // Nothing has ended yet: clearing here would drop the very override the picker set to make
+      // this composer read the project it was opened against.
+      expect(clearContextLens).not.toHaveBeenCalled();
+    });
+
     it('closes an open composer when write access is lost', async () => {
       await openCreate();
 
-      canWriteMeetings.set(false);
+      setWriteAccess({ canWrite: false });
       await flush();
 
       expect(composer.isOpen()).toBe(false);
@@ -209,11 +244,11 @@ describe('MeetingComposerHostComponent', () => {
       // `canWriteMeetings` starts false in production and stays false while the grants request is
       // unresolved, so a deep-linked open would be closed under the organizer if any false counted
       // rather than only a true -> false. Drop to false before opening to reach that state.
-      canWriteMeetings.set(false);
+      setWriteAccess({ canWrite: false });
       await flush();
       await openCreate();
 
-      canWriteMeetings.set(true);
+      setWriteAccess({ canWrite: true });
       await flush();
 
       expect(composer.isOpen()).toBe(true);
@@ -227,23 +262,26 @@ describe('MeetingComposerHostComponent', () => {
       // here on an edit `writerGuard` had just admitted.
       await openCreate();
 
-      activeContextUid.set('project-2');
-      canWriteMeetings.set(false);
+      meetingWriteAccess.set({ contextUid: 'project-2', canWrite: false });
       await flush();
 
       expect(composer.isOpen()).toBe(true);
     });
 
-    it('leaves an executive director in the composer when the same project reports no write access', async () => {
-      // `writerGuard` admits the ED persona outright, with no FGA check, so this signal never speaks
-      // for them — the same exemption `evictOnWriteAccessLoss` makes.
+    it('closes on an executive director too, because the loss it saw was a real one', async () => {
+      // No persona exemption here, unlike `evictOnWriteAccessLoss`. That helper fires on the first
+      // false after boot, which an executive director admitted by `writerGuard`'s FGA-less fast path
+      // produces with no grant ever having existed, so it has to exempt them. This pipe needs a
+      // pairwise true -> false, which that same ED never reaches: with no grant the signal never
+      // says true, and there is no transition. Reaching here means the grant was there and is gone,
+      // and the upstream save has stopped accepting it whatever persona is on screen.
       currentPersona.set('executive-director');
       await openCreate();
 
-      canWriteMeetings.set(false);
+      setWriteAccess({ canWrite: false });
       await flush();
 
-      expect(composer.isOpen()).toBe(true);
+      expect(composer.isOpen()).toBe(false);
     });
   });
 
@@ -301,9 +339,7 @@ describe('MeetingComposerHostComponent', () => {
         detail: 'Weekly sync',
         sticky: true,
         closable: true,
-        // 'project-1' rather than null: the response echoed no `project_uid`, so the toast falls back
-        // to the uid the save was written against — here the one `openCreate()` opened with.
-        data: { meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1', projectUid: 'project-1' },
+        data: { meetingUid: 'meeting-1', meetingTitle: 'Weekly sync', meetingUrl: '/meetings/meeting-1' },
       });
       // A meeting with no password carries no navigation state at all, so the link is a plain route.
       expect(lastToast().data.meetingLinkState).toBeUndefined();
@@ -387,10 +423,14 @@ describe('MeetingComposerHostComponent', () => {
       expect(component['editFromToastBlockedReason']()).toBeNull();
     });
 
-    it('refuses once meeting-write access is gone', () => {
-      canWriteMeetings.set(false);
+    it('still offers the reopen when the ambient project reports no meeting-write access', () => {
+      // The organizer of a group meeting is frequently not a writer or meeting coordinator on the
+      // project they happen to be looking at, and `createMeeting` wrote them into the meeting's
+      // own `organizers` regardless. Asking the project-level question here denied people the
+      // meeting they had just made; the meeting-scoped answer lives on the path this action opens.
+      setWriteAccess({ canWrite: false });
 
-      expect(component['editFromToastBlockedReason']()).toBe('You no longer have write access');
+      expect(component['editFromToastBlockedReason']()).toBeNull();
     });
 
     it('does nothing when the action is blocked', async () => {
@@ -400,7 +440,6 @@ describe('MeetingComposerHostComponent', () => {
         meetingUid: 'meeting-1',
         meetingTitle: 'Weekly sync',
         meetingUrl: '/meetings/meeting-1',
-        projectUid: null,
       });
 
       // Reopening here would silently discard the draft in the open composer.
@@ -412,99 +451,10 @@ describe('MeetingComposerHostComponent', () => {
         meetingUid: 'meeting-1',
         meetingTitle: 'Weekly sync',
         meetingUrl: '/meetings/meeting-1',
-        projectUid: null,
       });
 
       expect(messageService.clear).toHaveBeenCalledWith(MEETING_COMPOSER_TOAST_KEY);
       expect(composer.context()).toEqual({ mode: 'edit', meetingUid: 'meeting-1' });
-    });
-  });
-
-  /**
-   * A group-scoped create saves into the project it was handed, not the one the organizer is
-   * looking at, and the toast outlives that open. Asking whether they may write meetings *here*
-   * is then the wrong question — it can offer an Edit that fails, or withhold one that would work.
-   */
-  describe('editing a meeting created in another project', () => {
-    const announce = (projectUid: string | undefined): void => {
-      component['announceCreatedMeeting']({ ...createdMeeting, project_uid: projectUid } as Meeting);
-    };
-
-    it('asks about the project the meeting actually landed in', () => {
-      announce('other-project');
-
-      expect(meetingWriteAccessFor).toHaveBeenCalledWith('other-project');
-    });
-
-    it('refuses the reopen when that project is not writable', () => {
-      meetingWriteAccessFor.mockReturnValue(of(false));
-
-      announce('other-project');
-
-      expect(component['editFromToastBlockedReason']()).toBe('You do not have write access to that project');
-    });
-
-    it('says the check is running rather than guessing from the ambient project', () => {
-      meetingWriteAccessFor.mockReturnValue(new Subject<boolean>());
-
-      announce('other-project');
-
-      expect(component['editFromToastBlockedReason']()).toBe('Checking your access to that project');
-    });
-
-    it('allows the reopen on the answer for that project, not the ambient one', () => {
-      canWriteMeetings.set(false);
-
-      announce('other-project');
-
-      expect(component['editFromToastBlockedReason']()).toBeNull();
-    });
-
-    it('does not re-ask for a meeting created in the project already on screen', () => {
-      announce('project-1');
-
-      expect(meetingWriteAccessFor).not.toHaveBeenCalled();
-      expect(component['editFromToastBlockedReason']()).toBeNull();
-    });
-
-    it('falls back to the project the save was written against when the response omits it', async () => {
-      // A create response that does not echo `project_uid` back used to leave the toast with no
-      // project at all, so Edit fell through to the ambient answer — the exact question this
-      // block exists because it gets wrong. `effectiveProjectUid()` is the uid `prepareMeetingData()`
-      // wrote with, so the probe asks about the project the meeting is actually in.
-      composer.open({ mode: 'create', projectUid: 'other-project' });
-      await flush();
-
-      announce('');
-
-      expect(meetingWriteAccessFor).toHaveBeenCalledWith('other-project');
-    });
-
-    it('ignores a probe response that a newer create has already superseded', () => {
-      // Two creates in a row: the first project's answer can land after the second toast replaced
-      // it. Applying it would speak for a meeting it was never asked about.
-      const stale = new Subject<boolean>();
-      meetingWriteAccessFor.mockReturnValueOnce(stale).mockReturnValueOnce(of(true));
-
-      announce('stale-project');
-      announce('fresh-project');
-      stale.next(false);
-      stale.complete();
-
-      expect(component['editFromToastBlockedReason']()).toBeNull();
-    });
-
-    it('leaves the newer toast checking when a superseded probe answers', () => {
-      const stale = new Subject<boolean>();
-      const fresh = new Subject<boolean>();
-      meetingWriteAccessFor.mockReturnValueOnce(stale).mockReturnValueOnce(fresh);
-
-      announce('stale-project');
-      announce('fresh-project');
-      stale.next(true);
-      stale.complete();
-
-      expect(component['editFromToastBlockedReason']()).toBe('Checking your access to that project');
     });
   });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, signal, type Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_POSITION } from '@lfx-one/shared/constants';
 import type { EntityWithProject, Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
+import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
-import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
@@ -63,7 +63,7 @@ export class MeetingComposerHostComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
   private readonly meetingService = inject(MeetingService);
-  private readonly personaService = inject(PersonaService);
+  private readonly lensService = inject(LensService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -139,26 +139,10 @@ export class MeetingComposerHostComponent {
     return this.sections.some((section) => this.formService.sectionNeedsAttention(section, visited));
   });
   /**
-   * Meeting-authoring permission for the project the toast's meeting belongs to.
-   * @description `null` means "no separate answer" — either the meeting landed in the active project,
-   * where the ambient signal already applies, or no toast is up. Only a cross-project create asks.
-   */
-  private readonly toastProjectWriteAccess = signal<boolean | null>(null);
-  /** Whether that cross-project probe is still in flight, so Edit can say so rather than guess. */
-  private readonly toastProjectWriteAccessLoading = signal<boolean>(false);
-  /**
-   * Which probe the signals above belong to.
-   * @description Only the newest toast is on screen, but its probe is an in-flight request that a
-   * newer create cannot cancel. Two creates in a row against different projects race: the first
-   * response can land after the second probe started and answer the second toast with the first
-   * project's verdict — enabling Edit on a meeting the organizer cannot reopen, or disabling it on
-   * one they can. A response is applied only while it is still the current generation's.
-   */
-  private toastProjectProbe = 0;
-  /**
    * Why the toast's Edit action can't act, or `null` when it can.
-   * @description Doubles as the enabled check. Reopening while another meeting is part-way through the
-   * composer would discard that draft, and reopening after write access was lost would only fail on save.
+   * @description One question only: reopening while another meeting is part-way through the composer
+   * would discard that draft. Permission is deliberately not asked here — see
+   * {@link initEditFromToastBlockedReason}.
    */
   protected readonly editFromToastBlockedReason: Signal<string | null> = this.initEditFromToastBlockedReason();
   /**
@@ -188,23 +172,41 @@ export class MeetingComposerHostComponent {
     // nothing about the grant this composer was opened under: a committee writer editing a group
     // meeting, or anyone admitted on one project and editing a meeting in another, would be shut out
     // of an edit `writerGuard` had just admitted. Only a loss within one project is a loss.
-    const meetingWriteAccessByContext = computed(() => ({
-      contextUid: this.projectContextService.activeContextUid(),
-      canWrite: this.projectContextService.canWriteMeetings(),
-    }));
-
-    toObservable(meetingWriteAccessByContext)
+    // Read as the service's own paired signal, not recomposed here from `activeContextUid()` and
+    // `canWriteMeetings()`: those two move at different times, so for one tick after a context
+    // change the old project's verdict wears the new project's uid and the comparison below reads
+    // a cross-project move as a revocation.
+    //
+    // No persona exemption rides along. `evictOnWriteAccessLoss` carries one because it fires on the
+    // first false after boot, which an executive director admitted by `writerGuard`'s FGA-less fast
+    // path produces without ever having been granted anything. This is a pairwise true -> false, so
+    // that ED never reaches it: with no grant the signal never emits true, and there is no
+    // transition. What is left is an ED whose grant demonstrably existed and is now gone — a real
+    // revocation, and closing is the right answer to it. Personas shape presentation, not access
+    // (docs/architecture/frontend/permission-persona-navigation-model-preread.md), so exempting one
+    // here would only hold someone in a composer whose save upstream has already stopped accepting.
+    toObservable(this.projectContextService.meetingWriteAccess)
       .pipe(
         pairwise(),
-        // Executive directors are exempt for the reason `evictOnWriteAccessLoss` exempts them:
-        // `writerGuard` admits the persona outright, with no FGA check, so this signal's false is
-        // not an answer about them. The persona is cookie-seeded in `PersonaService`'s constructor,
-        // so the value read here is the one the guard read at navigation time.
-        filter(() => this.personaService.currentPersona() !== 'executive-director'),
         filter(([before, after]) => before.contextUid === after.contextUid && before.canWrite && !after.canWrite && this.composer.isOpen()),
         takeUntilDestroyed()
       )
       .subscribe(() => this.composer.close());
+
+    // The create picker aligns the ambient lens to the picked target with `setContextLens`, whose
+    // persona bypass is meant to last one flow and self-clears on that flow's terminal Router
+    // event. The meeting branch has none — it raises this overlay in place instead of navigating —
+    // so the overlay's own end is what has to end the override. Unconditional because the clear
+    // is a no-op when nothing set one, and because the picker is the only caller: every other
+    // branch of it navigates, and that navigation has already cleared its own override by the
+    // time anything gets here.
+    toObservable(this.composer.isOpen)
+      .pipe(
+        pairwise(),
+        filter(([wasOpen, isOpen]) => wasOpen && !isOpen),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.lensService.clearContextLens());
 
     // Derive the project context from the meeting being edited so a context-less edit link
     // (/project/meetings/:id/edit) lands in the meeting's project, not the cookie-restored
@@ -332,65 +334,21 @@ export class MeetingComposerHostComponent {
     });
   }
 
-  private initEditFromToastBlockedReason(): Signal<string | null> {
-    return computed(() => {
-      if (this.composer.isOpen()) {
-        return 'Close the open composer first';
-      }
-
-      if (this.toastProjectWriteAccessLoading()) {
-        return 'Checking your access to that project';
-      }
-
-      // A meeting created into another project — a group-scoped create carries its own `projectUid`
-      // — is not covered by the ambient answer, which is about wherever the organizer is standing
-      // now. When the probe below produced a verdict for that project, it wins.
-      const projectAccess = this.toastProjectWriteAccess();
-
-      if (projectAccess !== null) {
-        return projectAccess ? null : 'You do not have write access to that project';
-      }
-
-      // Meeting-authoring permission, not writer-only: a meeting coordinator creates meetings without
-      // being a project writer, and `canWrite()` would deny them the edit action on the meeting this
-      // toast is announcing. Same signal the dashboard gates the create action on.
-      return this.projectContextService.canWriteMeetings() ? null : 'You no longer have write access';
-    });
-  }
-
   /**
-   * Resolves meeting-authoring permission for the project a just-created meeting landed in.
-   * @description Skipped entirely for the common case: when the meeting belongs to the active
-   * project the ambient `canWriteMeetings()` already answers, and it stays live as the session
-   * changes, which a one-shot probe would not. A cross-project create is the case the ambient
-   * signal gets wrong, and the only one worth two extra requests.
+   * The one thing that can stop the toast's Edit action: a composer already open on something else.
+   * @description No permission leg, deliberately. This toast only exists because a create just
+   * succeeded, and `MeetingService.createMeeting` writes the caller into the meeting's `organizers`,
+   * so the person looking at it holds the meeting's own organizer permission by construction. Every
+   * project-level answer available here asks a different question and gets it wrong in both
+   * directions: a committee writer who created a group meeting is not a project writer or meeting
+   * coordinator, so the ambient signal denies them a meeting they organize, while an organizer who
+   * has since switched context is judged against a project their meeting was never in. The
+   * meeting-scoped check that is actually authoritative lives on the path this action opens — a
+   * revoked reopen 403s and lands on the composer's own "you don't have permission" panel, which
+   * says more than a disabled button with a tooltip ever did.
    */
-  private resolveToastProjectWriteAccess(projectUid: string | null): void {
-    const probe = ++this.toastProjectProbe;
-
-    this.toastProjectWriteAccess.set(null);
-    this.toastProjectWriteAccessLoading.set(false);
-
-    if (!projectUid || projectUid === this.projectContextService.activeContextUid()) {
-      return;
-    }
-
-    this.toastProjectWriteAccessLoading.set(true);
-
-    this.projectContextService
-      .meetingWriteAccessFor(projectUid)
-      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
-      .subscribe((canWrite) => {
-        // A superseded probe writes nothing at all: the newer call already reset both signals to
-        // the state its own toast needs, and clearing the loading flag here would tell the newer
-        // toast its own request had finished.
-        if (probe !== this.toastProjectProbe) {
-          return;
-        }
-
-        this.toastProjectWriteAccess.set(canWrite);
-        this.toastProjectWriteAccessLoading.set(false);
-      });
+  private initEditFromToastBlockedReason(): Signal<string | null> {
+    return computed(() => (this.composer.isOpen() ? 'Close the open composer first' : null));
   }
 
   /**
@@ -409,12 +367,6 @@ export class MeetingComposerHostComponent {
       meetingUid: meeting.id,
       meetingTitle: meeting.title ?? 'Untitled meeting',
       meetingUrl: `/meetings/${meeting.id}`,
-      // `||` not `??`: the field is typed required but arrives empty from a create response that
-      // did not echo it back, and an empty uid is no project rather than a project named "".
-      // `effectiveProjectUid()` is the fallback rather than the ambient context directly: it is the
-      // same resolution `prepareMeetingData()` wrote the meeting with, so the Edit action asks about
-      // the project the save actually targeted. Read before `close()` tears the form state down.
-      projectUid: meeting.project_uid || this.formService.effectiveProjectUid() || null,
       // The join page rejects a private or restricted meeting without its password and redirects to
       // `/meetings/not-found`, which every BOARD meeting would hit since those are forced private.
       // Carried as router state rather than a query param so the password never reaches the address
@@ -423,10 +375,6 @@ export class MeetingComposerHostComponent {
       // client-side navigation, which is the only journey this link is for.
       ...(meeting.password ? { meetingLinkState: { password: meeting.password } } : {}),
     };
-
-    // The Edit action asks whether this meeting may be reopened, which is a question about the
-    // project it was saved into — not about wherever the organizer happens to be standing.
-    this.resolveToastProjectWriteAccess(data.projectUid);
 
     // Only the newest sticky toast survives. Without a lifetime nothing retires these on its own, so
     // creating several meetings in a row stacked permanent multi-line toasts up over the content the

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -9,6 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_POSITION } from '@lfx-one/shared/constants';
 import type { EntityWithProject, Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
 import { MeetingService } from '@services/meeting.service';
+import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
@@ -62,6 +63,7 @@ export class MeetingComposerHostComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly projectService = inject(ProjectService);
   private readonly meetingService = inject(MeetingService);
+  private readonly personaService = inject(PersonaService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -145,6 +147,15 @@ export class MeetingComposerHostComponent {
   /** Whether that cross-project probe is still in flight, so Edit can say so rather than guess. */
   private readonly toastProjectWriteAccessLoading = signal<boolean>(false);
   /**
+   * Which probe the signals above belong to.
+   * @description Only the newest toast is on screen, but its probe is an in-flight request that a
+   * newer create cannot cancel. Two creates in a row against different projects race: the first
+   * response can land after the second probe started and answer the second toast with the first
+   * project's verdict — enabling Edit on a meeting the organizer cannot reopen, or disabling it on
+   * one they can. A response is applied only while it is still the current generation's.
+   */
+  private toastProjectProbe = 0;
+  /**
    * Why the toast's Edit action can't act, or `null` when it can.
    * @description Doubles as the enabled check. Reopening while another meeting is part-way through the
    * composer would discard that draft, and reopening after write access was lost would only fail on save.
@@ -169,12 +180,28 @@ export class MeetingComposerHostComponent {
     // accepts — reads as false on it throughout and would never produce the transition below anyway.
     // Only a true -> false transition counts: it starts false and reports false while the grants
     // request is unresolved, so reacting to any false would close a composer opened from a deep link
-    // before access ever resolved. A project switch holds the previous value rather than emitting a
-    // transient false, so the guard doesn't fire on navigation either.
-    toObservable(this.projectContextService.canWriteMeetings)
+    // before access ever resolved.
+    //
+    // The context uid rides along because the answer is per-project, and `syncEntityProjectContext`
+    // below deliberately moves the context to the meeting's own project on a context-less edit link.
+    // That move re-asks the question about a different project, so a true -> false across it says
+    // nothing about the grant this composer was opened under: a committee writer editing a group
+    // meeting, or anyone admitted on one project and editing a meeting in another, would be shut out
+    // of an edit `writerGuard` had just admitted. Only a loss within one project is a loss.
+    const meetingWriteAccessByContext = computed(() => ({
+      contextUid: this.projectContextService.activeContextUid(),
+      canWrite: this.projectContextService.canWriteMeetings(),
+    }));
+
+    toObservable(meetingWriteAccessByContext)
       .pipe(
         pairwise(),
-        filter(([hadWriteAccess, canWrite]) => hadWriteAccess && !canWrite && this.composer.isOpen()),
+        // Executive directors are exempt for the reason `evictOnWriteAccessLoss` exempts them:
+        // `writerGuard` admits the persona outright, with no FGA check, so this signal's false is
+        // not an answer about them. The persona is cookie-seeded in `PersonaService`'s constructor,
+        // so the value read here is the one the guard read at navigation time.
+        filter(() => this.personaService.currentPersona() !== 'executive-director'),
+        filter(([before, after]) => before.contextUid === after.contextUid && before.canWrite && !after.canWrite && this.composer.isOpen()),
         takeUntilDestroyed()
       )
       .subscribe(() => this.composer.close());
@@ -339,6 +366,8 @@ export class MeetingComposerHostComponent {
    * signal gets wrong, and the only one worth two extra requests.
    */
   private resolveToastProjectWriteAccess(projectUid: string | null): void {
+    const probe = ++this.toastProjectProbe;
+
     this.toastProjectWriteAccess.set(null);
     this.toastProjectWriteAccessLoading.set(false);
 
@@ -352,6 +381,13 @@ export class MeetingComposerHostComponent {
       .meetingWriteAccessFor(projectUid)
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe((canWrite) => {
+        // A superseded probe writes nothing at all: the newer call already reset both signals to
+        // the state its own toast needs, and clearing the loading flag here would tell the newer
+        // toast its own request had finished.
+        if (probe !== this.toastProjectProbe) {
+          return;
+        }
+
         this.toastProjectWriteAccess.set(canWrite);
         this.toastProjectWriteAccessLoading.set(false);
       });
@@ -375,7 +411,10 @@ export class MeetingComposerHostComponent {
       meetingUrl: `/meetings/${meeting.id}`,
       // `||` not `??`: the field is typed required but arrives empty from a create response that
       // did not echo it back, and an empty uid is no project rather than a project named "".
-      projectUid: meeting.project_uid || null,
+      // `effectiveProjectUid()` is the fallback rather than the ambient context directly: it is the
+      // same resolution `prepareMeetingData()` wrote the meeting with, so the Edit action asks about
+      // the project the save actually targeted. Read before `close()` tears the form state down.
+      projectUid: meeting.project_uid || this.formService.effectiveProjectUid() || null,
       // The join page rejects a private or restricted meeting without its password and redirects to
       // `/meetings/not-found`, which every BOARD meeting would hit since those are forced private.
       // Carried as router state rather than a query param so the password never reaches the address

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.spec.ts
@@ -26,12 +26,14 @@ import { MeetingComposerService } from './meeting-composer.service';
  * Covers the preview's "has the organizer actually answered this?" gating.
  *
  * Every row here is a claim about a decision the organizer made, so the interesting cases are the ones
- * where a control holds a value nobody chose: `startDate`, `platform`, `visibility` and the recurrence
- * cadence all open pre-filled or default, and echoing those straight back would present the composer's
- * own defaults as the organizer's answers. Each gated row is therefore asserted twice — once before its
- * section has been visited and once after — because an ungated implementation still passes the second
- * half on its own. The un-gated rows (title, type, features, guests) are pinned in the same way, since
- * the asymmetry between the two groups is deliberate and not obvious from either one alone.
+ * where a control holds a value nobody chose. `platform` opens pre-filled and "does not repeat" is what
+ * an untouched recurrence card says, so echoing either straight back would present the composer's own
+ * defaults as the organizer's answers; both are asserted twice — once before their section has been
+ * visited and once after — because an ungated implementation still passes the second half on its own.
+ * Every other row, `startDate` and a chosen cadence included, answers on its value alone and is pinned
+ * without a visit, because the quick-create dialog hands those over without ever opening the drawer's
+ * schedule section. The asymmetry between the two groups is deliberate and not obvious from either one
+ * alone.
  */
 describe('MeetingComposerPreviewComponent', () => {
   let fixture: ComponentFixture<MeetingComposerPreviewComponent>;
@@ -93,12 +95,21 @@ describe('MeetingComposerPreviewComponent', () => {
   });
 
   describe('date chip and when line', () => {
-    it('holds the placeholder marks while Date & Schedule is unvisited, whatever the control holds', () => {
-      set('startDate', START_DATE);
+    it('holds the placeholder marks while no date has been picked', () => {
       set('startTime', '10:00 AM');
 
       expect(dateChip()).toEqual({ day: '··', month: '—' });
       expect(whenSummary()).toBeNull();
+    });
+
+    // The schedule controls are left empty now, so a date is an answer wherever it came from. A
+    // quick-create handoff lands one on the form having visited only Details & Access, and gating this
+    // row on the drawer's schedule section dropped it back out of the panel.
+    it('renders a date carried in from quick create, with the schedule section never visited', () => {
+      set('startDate', START_DATE);
+
+      expect(dateChip()).toEqual({ day: '5', month: 'MAR' });
+      expect(whenSummary()).toBe('Mar 5, 2026');
     });
 
     it('renders the picked date once the organizer has seen the section', () => {
@@ -185,11 +196,7 @@ describe('MeetingComposerPreviewComponent', () => {
   });
 
   describe('recurrence row', () => {
-    it('stays unset while Date & Schedule is unvisited, even for a meeting already marked recurring', () => {
-      set('isRecurring', true);
-      set('recurrenceType', 'daily');
-      set('startDate', START_DATE);
-
+    it('stays unset while Date & Schedule is unvisited and nothing has been marked recurring', () => {
       expect(recurrenceLabel()).toBeNull();
     });
 
@@ -197,6 +204,16 @@ describe('MeetingComposerPreviewComponent', () => {
       visit('date-schedule');
 
       expect(recurrenceLabel()).toBe('Does not repeat');
+    });
+
+    // Same handoff as the date chip above: the quick-create dialog has its own recurring card, and a
+    // cadence picked there is not the composer stating a default back at anyone.
+    it('summarises a cadence carried in from quick create, with the schedule section never visited', () => {
+      set('isRecurring', true);
+      set('recurrenceType', 'daily');
+      set('startDate', START_DATE);
+
+      expect(recurrenceLabel()).toBe('Daily');
     });
 
     it('summarises the chosen cadence', () => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-preview.component.ts
@@ -15,10 +15,10 @@ import { MeetingComposerService } from './meeting-composer.service';
  * Live preview of the meeting being created (GH-1459).
  * @description Create mode only — in edit mode the meeting already exists and the sections themselves
  * show its saved state. Rows carry no field labels: an icon plus the chosen value, or a bar while the
- * value is still unknown. Several controls are pre-filled with defaults, so a row only resolves once
- * its owning section has been visited (or, for recurrence, is complete) — until then it shows the bar
- * rather than presenting a default as a choice the organizer made. Details & Access is where the
- * composer opens, so its rows resolve as soon as they have a value.
+ * value is still unknown. A row shows the bar rather than presenting one of the composer's own defaults
+ * as a choice the organizer made, which for `platform` — the one control that still opens pre-filled —
+ * means waiting until its section has been visited. Every other row resolves on its value alone, so a
+ * quick-create handoff carries its answers straight into the panel.
  */
 @Component({
   selector: 'lfx-meeting-composer-preview',
@@ -113,23 +113,22 @@ export class MeetingComposerPreviewComponent {
   }
 
   /**
-   * Recurrence row, or `null` while Date & Schedule is unvisited.
-   * @description "Does not repeat" is a real answer, but only once the organizer has actually seen the
-   * section — showing it against an untouched one would be stating the default back at them. Gated on
-   * having been visited, like the start date and the platform rows above, rather than on the section
-   * being valid: the recurrence controls are answered independently of the date and time, so a schedule
-   * that is merely unfinished should not blank a cadence the organizer has already chosen.
+   * Recurrence row: the chosen cadence, `Does not repeat` once Date & Schedule has been visited, or
+   * `null`.
+   * @description Only the "Does not repeat" half is gated on visitation. It is a real answer, but it is
+   * also what an untouched form says, so against a section the organizer has never opened it would be
+   * stating the default back at them. A cadence they actually picked is not the default and needs no
+   * gate — it can arrive from the quick-create dialog, whose recurring card never visits the drawer's
+   * schedule section. The gate is visitation rather than section validity because the recurrence
+   * controls are answered independently of the date and time, so a schedule that is merely unfinished
+   * should not blank a cadence already chosen.
    */
   private initRecurrenceLabel(): Signal<string | null> {
     return computed(() => {
       this.formService.revision();
 
-      if (!this.composer.visitedSections().has('date-schedule')) {
-        return null;
-      }
-
       if (this.controlValue('isRecurring') !== true) {
-        return 'Does not repeat';
+        return this.composer.visitedSections().has('date-schedule') ? 'Does not repeat' : null;
       }
 
       const recurrence = this.formService.recurrencePayload();
@@ -181,12 +180,14 @@ export class MeetingComposerPreviewComponent {
     });
   }
 
-  /** Start date, or `null` while Date & Schedule is unvisited — the control opens pre-filled with a default. */
+  /**
+   * Start date, or `null` while it is unanswered or unparseable.
+   * @description Ungated. The schedule controls used to open seeded a week out, so a value there did not
+   * mean the organizer had picked one and the row waited on the section being visited; they are left
+   * empty now, so a value is an answer wherever it came from — including the quick-create dialog, which
+   * hands its date over without ever visiting the drawer's schedule section.
+   */
   private startDate(): Date | null {
-    if (!this.composer.visitedSections().has('date-schedule')) {
-      return null;
-    }
-
     const value = this.controlValue('startDate');
 
     return value instanceof Date && !Number.isNaN(value.getTime()) ? value : null;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.spec.ts
@@ -133,8 +133,16 @@ describe('MeetingComposerRailComponent', () => {
       formService.form().get('title')?.setValue('');
 
       // Visited sections stay reachable up to the break, so the organizer can walk back to the field
-      // that broke — but nothing past it opens, even though `platform-features` was visited.
-      expect(reachableIds()).toEqual(['details-access']);
+      // that broke — but nothing past it opens. `date-schedule` is the proof: visited, still valid,
+      // and locked anyway because it sits past the section that went empty.
+      expect(row('date-schedule').reachable).toBe(false);
+      expect(row('guests').reachable).toBe(false);
+
+      // `platform-features` is the exception, and only because it is the pane on screen. Locking the
+      // row for the section the organizer is standing in renders a padlock over content they are
+      // already looking at, which reads as "you cannot be here". Clicking it is a no-op either way.
+      expect(reachableIds()).toEqual(['details-access', 'platform-features']);
+      expect(row('platform-features').active).toBe(true);
     });
 
     it('marks a section complete only after it has been visited', () => {
@@ -210,7 +218,7 @@ describe('MeetingComposerRailComponent', () => {
   /**
    * The compact chip row's `afterRenderEffect`, which scrolls the active chip into view.
    *
-   * `lg:hidden` is a CSS breakpoint, so at desktop widths the chip row is still in the DOM and the
+   * `min-[820px]:hidden` is a CSS breakpoint, so at desktop widths the chip row is still in the DOM and the
    * component's query still finds the chip — the only thing separating "collapsed and visible" from
    * "present but hidden" is whether the element has been laid out. Getting that wrong is invisible in
    * the collapsed layout the feature was built for and yanks the desktop composer's scroll position
@@ -267,7 +275,7 @@ describe('MeetingComposerRailComponent', () => {
     });
 
     it('leaves the scroll position alone when the chip row is in the DOM but not laid out', () => {
-      // What `lg:hidden` produces: the query still finds the chip, and `getClientRects()` is empty for
+      // What `min-[820px]:hidden` produces: the query still finds the chip, and `getClientRects()` is empty for
       // anything `display: none`. Scrolling here would move the page behind a row nobody can see.
       setLaidOut(false);
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-rail.component.ts
@@ -66,9 +66,9 @@ export class MeetingComposerRailComponent {
 
         const chip = this.elementRef.nativeElement.querySelector<HTMLElement>('[data-active-chip]');
 
-        // `lg:hidden` is a CSS breakpoint, not an input, so this component has no signal that says
-        // whether its own chip row is on screen — at `lg` and up the row is still in the DOM and this
-        // query still finds the chip. `getClientRects()` is empty for anything `display: none`, which
+        // `min-[820px]:hidden` is a CSS breakpoint, not an input, so this component has no signal that
+        // says whether its own chip row is on screen — at 820px and up the row is still in the DOM and
+        // this query still finds the chip. `getClientRects()` is empty for anything `display: none`, which
         // is the one reliable read of "laid out" available here.
         return chip?.getClientRects().length ? chip : null;
       },
@@ -98,8 +98,11 @@ export class MeetingComposerRailComponent {
       // A section only reads as done once the organizer has actually been there: Date & Schedule validates
       // straight out of the box from its defaults, and a check mark on a section nobody has opened yet
       // claims work that didn't happen.
-      const isComplete = (section: MeetingComposerSection): boolean =>
-        visited.has(section.id) && (section.required ? (validById.get(section.id) ?? false) : true);
+      // Validity is checked for optional sections too. "Optional" means the organizer may leave it
+      // empty, not that anything they type there is acceptable — an optional section holding an
+      // invalid value (a malformed link, an over-long agenda) still blocks the save, and a check mark
+      // over it points them away from the thing they have to fix.
+      const isComplete = (section: MeetingComposerSection): boolean => visited.has(section.id) && (validById.get(section.id) ?? false);
       // Create mode advances one section at a time, so the frontier is the section right after the
       // furthest one visited. Edit mode has no order to respect.
       const frontier = sections.reduce((furthest, section, index) => (visited.has(section.id) ? index : furthest), 0) + 1;
@@ -118,7 +121,10 @@ export class MeetingComposerRailComponent {
           complete: isComplete(section) && !active,
           // Shared with the compact badge in the host, so the two can't disagree about what needs fixing.
           needsAttention: this.formService.sectionNeedsAttention(section, visited),
-          reachable: isEditMode || (index <= blockedAt && (visited.has(section.id) || index <= frontier)),
+          // `active ||`: the section the organizer is standing in is reachable by definition. Without
+          // it, an active section past `blockedAt` — reached before its predecessor went invalid —
+          // renders as locked, which reads as "you cannot be here" about the pane on screen.
+          reachable: active || isEditMode || (index <= blockedAt && (visited.has(section.id) || index <= frontier)),
           isLast: index === sections.length - 1,
         };
       });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -34,7 +34,9 @@ export class MeetingComposerService {
    * Increments once per successful save.
    * @description Saving no longer navigates, so the page underneath the composer would otherwise keep
    * showing a list that predates the meeting the toast just announced. Surfaces that render meetings
-   * refresh off this rather than off `isOpen`, which also fires on a cancelled open.
+   * refresh off this rather than off `isOpen`, which also fires on a cancelled open. Both surfaces the
+   * composer opens over read it: the meetings dashboard and the committee Meetings tab (through
+   * `CommitteeViewComponent`, which owns that tab's fetch).
    */
   private readonly _saveCount = signal(0);
   public readonly saveCount = this._saveCount.asReadonly();
@@ -75,10 +77,10 @@ export class MeetingComposerService {
    * carries on with the same subscriptions.
    *
    * The dialog's sections carry over as visited. `visitedSections` means "the organizer has seen this",
-   * and they have — the drawer is only a second view of a fill already in progress. Left unset, the
-   * preview blanks the date the organizer just picked (it hides `startDate` until Date & Schedule is
-   * visited, since that control opens pre-filled with a default) and the rail shows four sections they
-   * have already been through as untouched.
+   * and they have — the drawer is only a second view of a fill already in progress. Left unset, the rail
+   * shows four sections they have already been through as untouched, and the preview withholds the rows
+   * it gates on visitation rather than on a value — the recurrence card would stop reading "Does not
+   * repeat" for a dialog the organizer had just declined to make recurring.
    */
   public switchToAdvanced(): void {
     this._variant.set('drawer');

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-create-menu.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-create-menu.component.html
@@ -19,6 +19,7 @@
   [popup]="true"
   appendTo="body"
   (onShow)="onShow()"
+  (onHide)="onHide()"
   styleClass="mt-1.5 w-[22rem] max-w-[calc(100vw-16px)] p-1.5 [&_.p-menu-list]:gap-0 [&_.p-menu-list]:p-0 [&_.p-menu-submenu-label]:p-2 [&_.p-menu-separator]:my-1.5">
   <ng-template #submenuheader let-item>
     <span class="text-[0.6875rem] font-semibold uppercase tracking-wide text-gray-500">{{ item.label }}</span>
@@ -33,7 +34,7 @@
       </span>
       <span class="flex min-w-0 flex-col gap-0.5">
         <span class="text-sm font-medium text-gray-900">{{ item.label }}</span>
-        <span class="whitespace-normal text-xs leading-snug text-gray-400">{{ item.description }}</span>
+        <span class="whitespace-normal text-xs leading-snug text-gray-500">{{ item.description }}</span>
       </span>
     </div>
   </ng-template>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-create-menu.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-create-menu.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, input, PLATFORM_ID, Signal, viewChild } from '@angular/core';
+import { Component, computed, inject, input, PLATFORM_ID, signal, Signal, viewChild } from '@angular/core';
 import { MenuComponent } from '@components/menu/menu.component';
 import { MeetingType } from '@lfx-one/shared/enums';
 import { MeetingCreateMenuAlign, MeetingCreateMenuRow } from '@lfx-one/shared/interfaces';
@@ -59,6 +59,16 @@ export class MeetingCreateMenuComponent {
    */
   protected readonly createMenuItems: Signal<MenuItem[]> = this.initCreateMenuItems();
 
+  /**
+   * Whether the panel is showing, for a trigger that has to announce its disclosure state.
+   * @description The trigger is a menu button, so it carries `aria-haspopup` and a bound
+   * `aria-expanded` — without the second one assistive technology says a menu exists but never says
+   * it opened. Tracked here rather than in each owner because the panel closes on its own (an
+   * outside click, Escape, or a row's command), and only this component sees those.
+   */
+  private readonly _isOpen = signal(false);
+  public readonly isOpen = this._isOpen.asReadonly();
+
   /** Smallest gap left between the popup and either viewport edge, in px. */
   private readonly viewportGutter = 8;
 
@@ -90,6 +100,8 @@ export class MeetingCreateMenuComponent {
    * coordinates, hence the scroll offset.
    */
   protected onShow(): void {
+    this._isOpen.set(true);
+
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
@@ -112,6 +124,11 @@ export class MeetingCreateMenuComponent {
 
       panel.style.left = `${window.scrollX + this.alignedLeft(trigger.getBoundingClientRect(), panel.offsetWidth)}px`;
     });
+  }
+
+  /** Mirrors every way the panel can close — an outside click, Escape, or a row's command. */
+  protected onHide(): void {
+    this._isOpen.set(false);
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -44,8 +44,11 @@
 
   <!-- 3/5 + 2/5 rather than an even split: the left column carries the long-form fields (title, agenda,
        access) while the right one only holds the schedule controls. -->
-  <div class="grid grid-cols-1 gap-5 lg:grid-cols-5 lg:gap-x-8" data-testid="quick-create-body">
-    <div class="flex min-w-0 flex-col gap-4 lg:col-span-3">
+  <!-- 820px, not `lg`: #1462 puts the single-column collapse under roughly 820px, and this repo's `lg`
+       is 1024px, so the named breakpoint would keep the dialog stacked across a 200px band that has room
+       for both columns. -->
+  <div class="grid grid-cols-1 gap-5 min-[820px]:grid-cols-5 min-[820px]:gap-x-8" data-testid="quick-create-body">
+    <div class="flex min-w-0 flex-col gap-4 min-[820px]:col-span-3">
       <!-- Type leads the form here rather than sitting inside the section: picking it is what seeds the
            rest of the dialog, so it reads as chips above the fields it fills in. -->
       <div class="flex flex-col gap-1.5">
@@ -95,9 +98,9 @@
     </div>
 
     <!-- The rule only exists once the two columns sit side by side; stacked, the row gap separates them. -->
-    <div class="flex min-w-0 flex-col gap-4 lg:col-span-2 lg:border-l lg:border-gray-200 lg:pl-8">
-      <!-- Its own hint rather than sharing the title's: only a template whose estimate lands on the chip
-           scale seeds duration at all, so the two go quiet independently -->
+    <div class="flex min-w-0 flex-col gap-4 min-[820px]:col-span-2 min-[820px]:border-l min-[820px]:border-gray-200 min-[820px]:pl-8">
+      <!-- Its own hint rather than sharing the title's: the two seed independently, and an edit to
+           either one stops only that hint -->
       <lfx-composer-date-schedule
         [form]="formService.form()"
         [showHeading]="false"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
@@ -116,10 +116,9 @@ describe('QuickCreateDialogComponent', () => {
     expect(valueOf('title')).not.toBe(boardTitle);
     expect(valueOf('title')).toBeTruthy();
   });
-  // Duration is the one seeded control whose template value is usually thrown away: every type but
-  // Maintainers estimates a span no chip offers, and seeding one of those would drop this surface into
-  // the custom-minutes input it deliberately never shows. Both halves of that guard are pinned below,
-  // each starting from a chip the seeding has to visibly overwrite or visibly leave alone.
+  // Duration is the seeded control the chip scale does not fit: Maintainers is the only type whose
+  // first template estimates a span a chip offers, and every other one lands on 70 minutes. Both
+  // routes are pinned below, each starting from a chip the seeding has to visibly overwrite.
   it('seeds a template estimate that sits on the chip scale', () => {
     formService.setDuration(30);
 
@@ -129,15 +128,18 @@ describe('QuickCreateDialogComponent', () => {
     expect(fixture.componentInstance['prefilledDuration']()).toBe(true);
   });
 
-  it('leaves the duration alone when the template estimate is off the chip scale', () => {
+  it('routes an off-chip template estimate into the custom-minutes input', () => {
     formService.setDuration(30);
 
-    // Technical's first template estimates 70 minutes, which no chip offers.
+    // Technical's first template estimates 70 minutes, which no chip offers. Skipping those left
+    // nearly every type sitting on the plain form default, so the estimate is seeded regardless and
+    // `setDuration` puts it where an off-chip value belongs.
     selectType(MeetingType.TECHNICAL);
 
-    expect(formService.effectiveDuration()).toBe(30);
-    expect(valueOf('duration')).not.toBe('custom');
-    expect(fixture.componentInstance['prefilledDuration']()).toBe(false);
+    expect(formService.effectiveDuration()).toBe(70);
+    expect(valueOf('duration')).toBe('custom');
+    expect(valueOf('customDuration')).toBe(70);
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(true);
   });
 
   // The value clears back to the same default it was seeded from, so the hint is the only thing that

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.spec.ts
@@ -163,6 +163,23 @@ describe('QuickCreateDialogComponent', () => {
     expect(fixture.componentInstance['prefilledDuration']()).toBe(false);
   });
 
+  // An off-chip seed leaves `duration` parked on `'custom'` and pristine, because the only control
+  // the organizer can reach in that shape is `customDuration`. Reading `duration` alone called that
+  // edit untouched and threw it away on the next type switch.
+  it('keeps custom minutes the organizer typed over an off-chip template estimate', () => {
+    selectType(MeetingType.TECHNICAL);
+    expect(valueOf('customDuration')).toBe(70);
+
+    formService.form().get('customDuration')?.setValue(95);
+    formService.form().get('customDuration')?.markAsDirty();
+
+    selectType(MeetingType.BOARD);
+
+    expect(formService.effectiveDuration()).toBe(95);
+    expect(valueOf('duration')).toBe('custom');
+    expect(fixture.componentInstance['prefilledDuration']()).toBe(false);
+  });
+
   it('closes the composer when the organizer dismisses the dialog', () => {
     composer.open({ mode: 'create', projectUid: 'project-1', variant: 'quick' });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -5,7 +5,7 @@ import { NgClass } from '@angular/common';
 import { Component, computed, inject, output, signal, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
-import { DEFAULT_DURATION, MEETING_DURATION_CHIP_OPTIONS, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
+import { DEFAULT_DURATION, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import type { CardSelectorOption, CommitteeMember, MeetingCommittee, MeetingTemplate } from '@lfx-one/shared/interfaces';
 import { getSelectableMeetingTypeOptions } from '@lfx-one/shared/utils';
@@ -58,9 +58,10 @@ export class QuickCreateDialogComponent {
    */
   public readonly switchToAdvanced = output<void>();
 
-  // What the type's template wrote, tracked per control: most templates estimate a duration off the chip
-  // scale, which `applyTypeTemplate` skips, so a single flag would keep the details hint alive on the
-  // untouched `duration` control long after the organizer rewrote the title.
+  // What the type's template wrote, tracked per control rather than as one flag: each control is
+  // seeded only while it is still pristine, so a type switch after the organizer has rewritten the
+  // title reseeds duration and agenda but not the title — and one flag would keep the hint standing
+  // over the field they typed themselves.
   private readonly seededTitle = signal(false);
   private readonly seededDuration = signal(false);
   private readonly seededAgenda = signal(false);
@@ -187,8 +188,10 @@ export class QuickCreateDialogComponent {
    * Seeds title, agenda and duration from the meeting type's first template.
    * @description Guarded on `pristine` rather than on emptiness: switching type after editing a field must
    * keep the edit, and an emptiness check would treat a prefill from the previous type as free to
-   * overwrite — leaving a Board meeting carrying the Technical template's title. Durations off the chip
-   * scale are skipped, since seeding one would drop this surface into the custom-minutes input.
+   * overwrite — leaving a Board meeting carrying the Technical template's title. The duration is seeded
+   * whatever it is: most first templates estimate 70 minutes, which is off the chip scale, so skipping
+   * those left nearly every type on the plain 60-minute form default. `setDuration` already routes an
+   * off-chip value into the custom-minutes input this dialog renders through `lfx-composer-date-schedule`.
    */
   private applyTypeTemplate(meetingType: MeetingType | null): void {
     // Take the previous type's prefill back out first, so a type whose template omits a field — or has
@@ -215,7 +218,7 @@ export class QuickCreateDialogComponent {
       seededTitle = true;
     }
 
-    if (duration?.pristine && MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === template.estimatedDuration)) {
+    if (duration?.pristine) {
       this.formService.setDuration(template.estimatedDuration);
       seededDuration = true;
     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -171,7 +171,7 @@ export class QuickCreateDialogComponent {
     return computed(() => {
       this.formService.revision();
 
-      return this.seededDuration() && !!this.formService.form().get('duration')?.pristine;
+      return this.seededDuration() && this.durationPairPristine();
     });
   }
 
@@ -184,6 +184,21 @@ export class QuickCreateDialogComponent {
   }
 
   // Other private helper methods
+  /**
+   * Whether the organizer has left the duration alone.
+   * @description The duration is two controls, not one: the chip group writes `duration`, and an
+   * off-chip value parks `'custom'` there and puts the minutes in `customDuration`. Since most first
+   * templates estimate 70 minutes, a seeded duration is usually the second shape — and then the only
+   * control the organizer can actually edit is `customDuration`, while `duration` stays pristine on
+   * `'custom'`. Reading `duration` alone would therefore call an edited custom duration untouched and
+   * overwrite it on the next type switch, which is exactly what the `pristine` guards exist to prevent.
+   */
+  private durationPairPristine(): boolean {
+    const form = this.formService.form();
+
+    return !!form.get('duration')?.pristine && !!form.get('customDuration')?.pristine;
+  }
+
   /**
    * Seeds title, agenda and duration from the meeting type's first template.
    * @description Guarded on `pristine` rather than on emptiness: switching type after editing a field must
@@ -208,7 +223,6 @@ export class QuickCreateDialogComponent {
     const form = this.formService.form();
     const title = form.get('title');
     const description = form.get('description');
-    const duration = form.get('duration');
     let seededTitle = false;
     let seededDuration = false;
     let seededAgenda = false;
@@ -218,7 +232,7 @@ export class QuickCreateDialogComponent {
       seededTitle = true;
     }
 
-    if (duration?.pristine) {
+    if (this.durationPairPristine()) {
       this.formService.setDuration(template.estimatedDuration);
       seededDuration = true;
     }
@@ -243,13 +257,12 @@ export class QuickCreateDialogComponent {
     const form = this.formService.form();
     const title = form.get('title');
     const description = form.get('description');
-    const duration = form.get('duration');
 
     if (this.seededTitle() && title?.pristine) {
       title.setValue('');
     }
 
-    if (this.seededDuration() && duration?.pristine) {
+    if (this.seededDuration() && this.durationPairPristine()) {
       this.formService.setDuration(DEFAULT_DURATION);
     }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -59,11 +59,14 @@
       aria-labelledby="composer-duration-label"
       [attr.aria-describedby]="durationHint() ? 'composer-duration-hint' : null"
       data-testid="composer-duration-chips">
+      <!-- `unselectable` stays at its wrapper default of true: PrimeNG reads it as "the selected option
+           cannot be clicked off", so a second click on the chosen chip is ignored rather than emptying a
+           required control. Early join below is the opposite case and does pass false, because its chip
+           list has no "none" entry and clearing is the only way back to no early-join window. -->
       <lfx-select-button
         [form]="form()"
         control="duration"
         [options]="durationOptions"
-        [unselectable]="false"
         [required]="true"
         [class]="chipGroupClass"
         [styleClass]="chipButtonClass" />
@@ -184,11 +187,11 @@
           <p class="text-sm text-gray-500" data-testid="composer-cadence-needs-date">Pick a start date to choose how often this meeting repeats.</p>
         } @else {
           <div role="group" aria-labelledby="composer-cadence-label" data-testid="composer-cadence-chips">
+            <!-- Required, so it keeps the wrapper's unselectable default and cannot be clicked empty. -->
             <lfx-select-button
               [form]="form()"
               control="recurrenceType"
               [options]="cadenceOptions()"
-              [unselectable]="false"
               [required]="true"
               [class]="chipGroupClass"
               [styleClass]="chipButtonClass" />

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.spec.ts
@@ -411,3 +411,91 @@ describe('ComposerDateScheduleComponent — custom duration description ids', ()
     expect(ariaInvalid()).toBeNull();
   });
 });
+
+/**
+ * Covers the chips a second click must not be able to empty, driven through the rendered DOM.
+ * @description PrimeNG reads `unselectable` backwards from its name: the setter assigns
+ * `allowEmpty = !value`, and `onOptionSelect` returns early on `selected && unselectable`, so the
+ * wrapper default of `true` is the thing that stops a second click on the chosen chip from clearing a
+ * required control. Passing `false` there compiles, reads like the safe option, and leaves `duration`
+ * and `recurrenceType` clearable with no chip to get back to — nothing validates until submit. Early
+ * join is the deliberate opposite and is asserted here too, so removing its `false` shows up as a
+ * failure rather than as a field nobody can reset.
+ */
+describe('ComposerDateScheduleComponent — chips that cannot be cleared', () => {
+  let fixture: ComponentFixture<ComposerDateScheduleComponent>;
+  let formService: MeetingComposerFormService;
+
+  /** Any Thursday will do; the cadence chips only need a start date to name a weekday from. */
+  const A_THURSDAY = new Date(2026, 0, 8);
+
+  const control = (name: string) => formService.form().get(name);
+
+  /**
+   * Clicks one chip by the label an organizer would aim at.
+   *
+   * By label rather than by `aria-pressed`: the pressed attribute comes from the inner toggle button's
+   * `ngModel`, which settles a microtask later, so a query for it reads the previous selection in a
+   * synchronous test. `SelectButton`'s own `value` comes straight from the control accessor and is
+   * current, and that is the state the guard under test reads.
+   */
+  const clickChip = (group: string, label: string): void => {
+    fixture.detectChanges();
+    const chips = Array.from(fixture.nativeElement.querySelectorAll(`[data-testid="${group}"] p-togglebutton`) as NodeListOf<HTMLElement>);
+    const chip = chips.find((candidate) => candidate.textContent?.trim() === label);
+
+    expect(chip, `no "${label}" chip in "${group}" (found ${chips.map((candidate) => candidate.textContent?.trim()).join(', ')})`).toBeDefined();
+
+    chip?.click();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: {} },
+        { provide: ProjectContextService, useValue: { activeContextUid: () => null } },
+      ],
+    });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerDateScheduleComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('keeps the duration when its chosen chip is clicked a second time', () => {
+    control('duration')?.setValue(45);
+
+    clickChip('composer-duration-chips', '45 min');
+
+    expect(control('duration')?.value).toBe(45);
+  });
+
+  it('keeps the cadence when its chosen chip is clicked a second time', () => {
+    // The cadence chips only exist once there is a start date to name a day from, and switching
+    // recurrence on is what seeds `weekly`.
+    control('startDate')?.setValue(A_THURSDAY);
+    control('isRecurring')?.setValue(true);
+
+    clickChip('composer-cadence-chips', 'Weekly on Thursday');
+
+    expect(control('recurrenceType')?.value).toBe('weekly');
+  });
+
+  it('still lets early join be cleared, because its chips have no way back to none', () => {
+    // `EARLY_JOIN_CHIP_OPTIONS` has no "no early join" entry, so clicking the chosen chip off is the
+    // only route back to an unset window.
+    control('early_join_time_minutes')?.setValue(EARLY_JOIN_CHIP_OPTIONS[0].value);
+
+    clickChip('composer-early-join-chips', EARLY_JOIN_CHIP_OPTIONS[0].label);
+
+    expect(control('early_join_time_minutes')?.value).toBeNull();
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -34,10 +34,11 @@
         <p class="text-xs text-gray-500">
           The meeting date is appended to the YouTube video title on upload, so the title must be ≤ {{ youtubeTitleLimit }} characters.
         </p>
+        <!-- Not a live region: the number changes on every keystroke, and announcing each one buries
+             the only thing that matters. The threshold state is announced below instead. -->
         <p
-          role="status"
-          aria-live="polite"
           class="text-xs"
+          data-testid="composer-title-youtube-counter"
           [ngClass]="{
             'text-gray-500': titleLength() < youtubeAmberThreshold,
             'text-amber-600': titleLength() >= youtubeAmberThreshold && titleLength() <= youtubeTitleLimit,
@@ -47,6 +48,14 @@
         </p>
       </div>
     }
+
+    <!-- Mounted unconditionally, and outside the `@if` above, so switching YouTube upload on over an
+         already-too-long title is a content change inside a live region rather than the insertion of an
+         already-populated one — insertions are not reliably announced. Empty below the warning
+         threshold: an empty region still counts as mounted, and there is nothing to say yet. -->
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true" data-testid="composer-title-youtube-announcement">
+      {{ titleLimitAnnouncement() }}
+    </p>
 
     <!-- `aria-describedby` on the input reaches the two title errors below, so each is read the next time
          the field takes focus rather than when it appears — no composer error message is in a live region

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.spec.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MAINTAINER_MEETING_TYPES, MEETING_TYPE_OPTIONS, YOUTUBE_MAX_MEETING_TITLE_LENGTH } from '@lfx-one/shared/constants';
+import {
+  MAINTAINER_MEETING_TYPES,
+  MEETING_TYPE_OPTIONS,
+  YOUTUBE_MAX_MEETING_TITLE_LENGTH,
+  YOUTUBE_MEETING_TITLE_WARNING_LENGTH,
+} from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
 import { Meeting } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
@@ -252,6 +257,109 @@ describe('ComposerDetailsAccessComponent — title description ids', () => {
     expect(maxlength()).toBe(String(YOUTUBE_MAX_MEETING_TITLE_LENGTH));
     expect(control?.value).toHaveLength(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1);
     expect(ariaInvalid()).toBe('true');
+  });
+});
+
+/**
+ * Covers what a screen reader hears as the title approaches the YouTube limit.
+ * @description The visible counter cannot be the live region: it changes on every keystroke, so it
+ * would read the running number out and bury the threshold underneath it. The announcement is a
+ * separate region, and it is mounted unconditionally — enabling YouTube upload over a title that is
+ * already too long would otherwise *insert* an already-populated region, and an insertion is not
+ * reliably announced.
+ */
+describe('ComposerDetailsAccessComponent — YouTube title limit announcement', () => {
+  let fixture: ComponentFixture<ComposerDetailsAccessComponent>;
+  let formService: MeetingComposerFormService;
+
+  const region = (): HTMLElement => {
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('[data-testid="composer-title-youtube-announcement"]') as HTMLElement;
+  };
+  const announcement = (): string => region().textContent?.trim() ?? '';
+  const counter = (): HTMLElement | null => {
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('[data-testid="composer-title-youtube-counter"]');
+  };
+  const enableUpload = (): void => formService.form().get('youtube_upload_enabled')?.setValue(true);
+  const setTitle = (length: number): void => formService.form().get('title')?.setValue('a'.repeat(length));
+
+  beforeEach(async () => {
+    configure();
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerDetailsAccessComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    await fixture.whenStable();
+  });
+
+  it('keeps the region on the page with nothing to say while uploads are off', () => {
+    setTitle(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1);
+
+    expect(region()).not.toBeNull();
+    expect(announcement()).toBe('');
+  });
+
+  it('turns enabling the upload into a content change rather than an inserted region', () => {
+    // The reported bug: the region used to live inside the `@if`, so this transition mounted it with
+    // its text already written. Holding the same node across the toggle is what makes it an update.
+    setTitle(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1);
+    const before = region();
+
+    enableUpload();
+
+    expect(region()).toBe(before);
+    expect(announcement()).toContain('over the');
+  });
+
+  it('stays silent while the title still has room to spare', () => {
+    enableUpload();
+    setTitle(YOUTUBE_MEETING_TITLE_WARNING_LENGTH - 1);
+
+    expect(announcement()).toBe('');
+  });
+
+  it('holds one sentence steady across every keystroke inside the warning band', () => {
+    enableUpload();
+    setTitle(YOUTUBE_MEETING_TITLE_WARNING_LENGTH);
+    const atThreshold = announcement();
+
+    setTitle(YOUTUBE_MEETING_TITLE_WARNING_LENGTH + 1);
+
+    expect(atThreshold).toContain('nearing');
+    expect(announcement()).toBe(atThreshold);
+  });
+
+  it('changes what it says when the limit itself is passed', () => {
+    enableUpload();
+    setTitle(YOUTUBE_MAX_MEETING_TITLE_LENGTH);
+    const atLimit = announcement();
+
+    setTitle(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1);
+
+    expect(atLimit).toContain('nearing');
+    expect(announcement()).toContain('over the');
+  });
+
+  it('goes quiet again once the title is shortened back under the warning band', () => {
+    enableUpload();
+    setTitle(YOUTUBE_MAX_MEETING_TITLE_LENGTH + 1);
+    expect(announcement()).toContain('over the');
+
+    setTitle(1);
+
+    expect(announcement()).toBe('');
+  });
+
+  it('leaves the visible counter out of the live region entirely', () => {
+    enableUpload();
+
+    const visible = counter();
+    expect(visible).not.toBeNull();
+    expect(visible?.getAttribute('aria-live')).toBeNull();
+    expect(visible?.getAttribute('role')).toBeNull();
+    expect(visible?.textContent?.trim()).toBe(`0/${YOUTUBE_MAX_MEETING_TITLE_LENGTH}`);
   });
 });
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -111,6 +111,9 @@ export class ComposerDetailsAccessComponent {
    * raises the "Go back to Details & Access" callout in Platform & features.
    */
   protected readonly titleMaxlength: Signal<number | null> = computed(() => (this.youtubeUploadEnabled() ? this.youtubeTitleLimit : null));
+  private readonly titleLimitState: Signal<'off' | 'ok' | 'approaching' | 'over'> = this.initTitleLimitState();
+  /** Carries the counter's meaning to a screen reader without reading out every keystroke. */
+  protected readonly titleLimitAnnouncement: Signal<string> = this.initTitleLimitAnnouncement();
   /**
    * Ids the title input points at through `aria-describedby`.
    * @description Built here rather than bound inline because the input takes a single attribute value:
@@ -200,6 +203,48 @@ export class ComposerDetailsAccessComponent {
     }
 
     return name || email;
+  }
+
+  /**
+   * Which side of the YouTube title thresholds the current title sits on.
+   * @description The counter beside the field re-renders on every keystroke, which is right for a
+   * number and wrong for a live region — announcing "63/70" and then "64/70" buries the one thing
+   * that changed. Reducing the length to a state first is what lets the announcement text below
+   * change only when the organizer actually crosses a threshold.
+   */
+  private initTitleLimitState(): Signal<'off' | 'ok' | 'approaching' | 'over'> {
+    return computed(() => {
+      if (!this.youtubeUploadEnabled()) {
+        return 'off';
+      }
+
+      const length = this.titleLength();
+      if (length > this.youtubeTitleLimit) {
+        return 'over';
+      }
+
+      return length >= this.youtubeAmberThreshold ? 'approaching' : 'ok';
+    });
+  }
+
+  /**
+   * Text of the visually hidden live region that sits under the title.
+   * @description Empty in both quiet states — upload off, and on with room to spare — so the region
+   * stays mounted with nothing to say rather than being inserted at the moment it has something. The
+   * two thresholds each get their own sentence, so crossing one is a content change the reader
+   * announces; typing on within a state rewrites the same string, which is not.
+   */
+  private initTitleLimitAnnouncement(): Signal<string> {
+    return computed(() => {
+      switch (this.titleLimitState()) {
+        case 'approaching':
+          return `Meeting title is nearing the ${this.youtubeTitleLimit}-character YouTube limit.`;
+        case 'over':
+          return `Meeting title is over the ${this.youtubeTitleLimit}-character YouTube limit and has to be shortened before the recording can upload.`;
+        default:
+          return '';
+      }
+    });
   }
 
   private initTitleDescribedBy(): Signal<string | null> {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
@@ -78,12 +78,20 @@
             @if (directGuestCount() > 0) {
               <span>{{ directGuestCount() }} direct guest{{ directGuestCount() === 1 ? '' : 's' }}</span>
             }
-            @if (invitedGuestCount() > 0) {
+            @if (showAcceptanceSummary()) {
               @if (groupGuestCount() > 0 || directGuestCount() > 0) {
                 <span> · </span>
               }
-              <span [title]="acceptanceBreakdown()" data-testid="composer-guests-acceptance">
-                {{ acceptedGuestCount() }} of {{ invitedGuestCount() }} accepted
+              <span
+                class="cursor-help"
+                tabindex="0"
+                [attr.aria-label]="acceptanceLabel()"
+                [pTooltip]="acceptanceBreakdown()"
+                tooltipEvent="both"
+                tooltipPosition="top"
+                tooltipStyleClass="text-xs max-w-xs"
+                data-testid="composer-guests-acceptance">
+                {{ acceptanceSummary() }}
               </span>
             }
           </span>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.html
@@ -82,8 +82,11 @@
               @if (groupGuestCount() > 0 || directGuestCount() > 0) {
                 <span> · </span>
               }
+              <!-- role="note": aria-label is prohibited on the generic role a bare span maps to, so
+                   without a role the label below is discarded rather than announced. -->
               <span
                 class="cursor-help"
+                role="note"
                 tabindex="0"
                 [attr.aria-label]="acceptanceLabel()"
                 [pTooltip]="acceptanceBreakdown()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.spec.ts
@@ -3,7 +3,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup } from '@angular/forms';
-import type { CommitteeMember, ComposerGuestRow, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
+import type { CommitteeMember, ComposerGuestRow, Meeting, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -243,6 +243,96 @@ describe('ComposerGuestsComponent', () => {
       formService.setGuests([guest('existing', true), guest('existing', false), guest('existing', null)]);
 
       expect(component['acceptanceBreakdown']()).toBe('1 accepted \u00b7 1 declined \u00b7 1 awaiting a reply');
+    });
+
+    it('hides the summary on a meeting that does not collect responses', () => {
+      // Nobody can answer, so every invited guest sits at "awaiting a reply" permanently. Showing
+      // the line would report the whole guest list as unresponsive over a question never asked.
+      formService.meeting.set({ is_invite_responses_enabled: false } as Meeting);
+      formService.setGuests([guest('existing', true), guest('existing', null)]);
+
+      expect(component['inviteResponsesEnabled']()).toBe(false);
+      expect(component['showAcceptanceSummary']()).toBe(false);
+    });
+
+    it('hides the summary in create mode, where there is no meeting to read the flag off', () => {
+      formService.setGuests([guest('existing', true)]);
+
+      expect(component['showAcceptanceSummary']()).toBe(false);
+    });
+
+    it('shows the summary once responses are on and somebody has been invited', () => {
+      formService.meeting.set({ is_invite_responses_enabled: true } as Meeting);
+      formService.setGuests([guest('existing', true), guest('new', null)]);
+
+      expect(component['showAcceptanceSummary']()).toBe(true);
+      expect(component['acceptanceSummary']()).toBe('1 of 1 accepted');
+    });
+
+    it('still hides the summary with responses on but nobody invited yet', () => {
+      formService.meeting.set({ is_invite_responses_enabled: true } as Meeting);
+      formService.setGuests([guest('new', null)]);
+
+      expect(component['showAcceptanceSummary']()).toBe(false);
+    });
+
+    it('repeats the visible line in the accessible name on the tooltip', () => {
+      // `pTooltip` renders its own element rather than a native `title`, so the breakdown reaches a
+      // screen reader only through this label — and `aria-label` replaces the span's text.
+      formService.meeting.set({ is_invite_responses_enabled: true } as Meeting);
+      formService.setGuests([guest('existing', true), guest('existing', false)]);
+
+      expect(component['acceptanceLabel']()).toBe('1 of 2 accepted \u00b7 1 accepted \u00b7 1 declined \u00b7 0 awaiting a reply');
+    });
+  });
+
+  /**
+   * Covers removal identity for a guest with neither a uid nor a tempId.
+   * @description `guestRows` keys such a row by its render index, which the mutation here has no
+   * access to — it is rebuilding the array that list is projected from. Before the object-identity
+   * arm, both keyless rows resolved to the same `undefined` key and removing either dropped both.
+   */
+  describe('removing a keyless guest', () => {
+    const keyless = (email: string, state: MeetingRegistrantWithState['state']): MeetingRegistrantWithState => ({
+      ...savedGroupGuest,
+      uid: '',
+      email,
+      type: 'direct',
+      state,
+    });
+
+    it('drops only the guest asked for when two carry no identity at all', () => {
+      const first = keyless('first@example.com', 'new');
+      const second = keyless('second@example.com', 'new');
+      formService.setGuests([first, second]);
+
+      component['onRemoveGuest'](first);
+
+      expect(formService.guests().map((entry) => entry.email)).toEqual(['second@example.com']);
+    });
+
+    it('queues only the guest asked for when both are saved upstream', () => {
+      const first = keyless('first@example.com', 'existing');
+      const second = keyless('second@example.com', 'existing');
+      formService.setGuests([first, second]);
+
+      component['onRemoveGuest'](second);
+
+      expect(formService.guests().map((entry) => [entry.email, entry.state])).toEqual([
+        ['first@example.com', 'existing'],
+        ['second@example.com', 'deleted'],
+      ]);
+    });
+
+    it('still keys on the tempId when the guest has one', () => {
+      const first = { ...keyless('first@example.com', 'new'), tempId: 'temp_1' };
+      const second = { ...keyless('second@example.com', 'new'), tempId: 'temp_2' };
+      formService.setGuests([first, second]);
+
+      // A copy, not the object in the list: the tempId is what has to match, not the reference.
+      component['onRemoveGuest']({ ...first });
+
+      expect(formService.guests().map((entry) => entry.email)).toEqual(['second@example.com']);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -8,11 +8,12 @@ import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggl
 import { UserSearchComponent } from '@components/user-search/user-search.component';
 import { SHOW_MEETING_ATTENDEES_FEATURE } from '@lfx-one/shared/constants';
 import type { ComposerGuestRow, CommitteeMember, ManualGuestDialogResult, MeetingCommittee, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
-import { avatarInitials } from '@lfx-one/shared/utils';
+import { avatarInitials, isMeetingInviteResponsesEnabled } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { controlValueSignal } from '@shared/utils/form-control-signals.util';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { TooltipModule } from 'primeng/tooltip';
 import { take } from 'rxjs';
 
 import { MeetingCommitteeManagerComponent } from '../../components/meeting-committee-manager/meeting-committee-manager.component';
@@ -27,7 +28,7 @@ import { MeetingComposerFormService } from '../meeting-composer-form.service';
  */
 @Component({
   selector: 'lfx-composer-guests',
-  imports: [FeatureToggleComponent, UserSearchComponent, MeetingCommitteeManagerComponent],
+  imports: [FeatureToggleComponent, UserSearchComponent, MeetingCommitteeManagerComponent, TooltipModule],
   templateUrl: './composer-guests.component.html',
 })
 export class ComposerGuestsComponent {
@@ -83,12 +84,38 @@ export class ComposerGuestsComponent {
    * @description The visible line answers "how many are in?" — the number issue #1457 asks for —
    * and hiding the rest keeps a stats line that already carries the group/direct split to one
    * row. The difference between a decline and a silence is what an organizer chases, though, so
-   * it is a hover away rather than gone. Same `[title]` affordance the guest rows already use
-   * for their truncated name and secondary line.
+   * it is a hover away rather than gone.
    */
   protected readonly acceptanceBreakdown: Signal<string> = computed(
     () => `${this.acceptedGuestCount()} accepted \u00b7 ${this.declinedGuestCount()} declined \u00b7 ${this.pendingGuestCount()} awaiting a reply`
   );
+
+  protected readonly acceptanceSummary: Signal<string> = computed(() => `${this.acceptedGuestCount()} of ${this.invitedGuestCount()} accepted`);
+
+  /**
+   * The visible line and the hover detail, joined for assistive tech.
+   * @description The breakdown hangs off `pTooltip`, which renders a styled element of its own —
+   * not the native `title` affordance a screen reader announces. `tooltipEvent="both"` puts it in
+   * front of a keyboard user; this label is what puts it in front of a screen-reader user, and it
+   * has to repeat the visible text because `aria-label` replaces an element's content rather than
+   * adding to it.
+   */
+  protected readonly acceptanceLabel: Signal<string> = computed(() => `${this.acceptanceSummary()} \u00b7 ${this.acceptanceBreakdown()}`);
+
+  /**
+   * Whether this meeting collects RSVPs at all.
+   * @description `invite_accepted` is only ever populated for a meeting with invite responses
+   * enabled. With the toggle off nobody can answer, so every invited guest stays "awaiting a
+   * reply" forever and the summary reads as a guest list ignoring the organizer — a number they
+   * cannot act on and did not ask for. Same gate the other RSVP surfaces apply
+   * (`meeting-card.component.ts:191`, `meeting-registrants-display.component.ts:77`). In create
+   * mode there is no meeting yet, which the util already answers `false` for, and nothing has
+   * been invited there to summarise either.
+   */
+  protected readonly inviteResponsesEnabled: Signal<boolean> = computed(() => isMeetingInviteResponsesEnabled(this.formService.meeting()));
+
+  /** The acceptance line needs both an RSVP worth reporting and somebody to report it for. */
+  protected readonly showAcceptanceSummary: Signal<boolean> = computed(() => this.inviteResponsesEnabled() && this.invitedGuestCount() > 0);
 
   /**
    * The guest list, with every derived string resolved once per change.
@@ -123,7 +150,10 @@ export class ComposerGuestsComponent {
   }
 
   protected onRemoveGuest(guest: MeetingRegistrantWithState): void {
-    const key = guest.uid || guest.tempId;
+    // Null, not `undefined`, so the reduce below can tell "no identity" apart from a key that
+    // happens to be missing on the candidate: `undefined === undefined` matched every other
+    // keyless row, and removing one such guest dropped all of them.
+    const key = guest.uid || guest.tempId || null;
 
     // A group re-emission would otherwise undo the removal — re-adding an unsaved group guest, or
     // un-deleting a saved one who is still a member of a selected group. Only group guests are
@@ -134,7 +164,13 @@ export class ComposerGuestsComponent {
 
     this.formService.updateGuests((current) =>
       current.reduce<MeetingRegistrantWithState[]>((kept, candidate) => {
-        if ((candidate.uid || candidate.tempId) !== key) {
+        // The same two rungs `guestRows` tracks by, with the same last resort: a guest carrying
+        // neither is only identifiable by reference. `guestRows` can fall back to the render index
+        // because it is keying a list it is iterating; this is mutating the array that list came
+        // from, so the object itself is the only stable handle left.
+        const isRemoved = key === null ? candidate === guest : (candidate.uid || candidate.tempId) === key;
+
+        if (!isRemoved) {
           kept.push(candidate);
           return kept;
         }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -98,7 +98,8 @@ export class ComposerGuestsComponent {
    * not the native `title` affordance a screen reader announces. `tooltipEvent="both"` puts it in
    * front of a keyboard user; this label is what puts it in front of a screen-reader user, and it
    * has to repeat the visible text because `aria-label` replaces an element's content rather than
-   * adding to it.
+   * adding to it. Reading the breakdown alone would drop the summary entirely, not de-duplicate it.
+   * The span carries `role="note"` for the same label to be honoured at all — see the template.
    */
   protected readonly acceptanceLabel: Signal<string> = computed(() => `${this.acceptanceSummary()} \u00b7 ${this.acceptanceBreakdown()}`);
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.spec.ts
@@ -139,6 +139,35 @@ describe('ComposerPlatformFeaturesComponent', () => {
 
       expect(control('reminderMinutes')?.disabled).toBe(true);
     });
+
+    /*
+     * The error paragraphs are computed off `AbstractControl.events`, and `disable()` sets `errors`
+     * to `null` without touching the value. Disabling silently therefore leaves the paragraph on
+     * screen describing an error the control has stopped carrying, over an input the organizer can
+     * no longer reach to correct it.
+     */
+    it('clears a standing minutes error when locking minutes at the maximum hour', () => {
+      control('auto_email_reminder_enabled')?.setValue(true);
+      control('reminderHours')?.setValue(MIN_EMAIL_REMINDER_HOURS);
+      control('reminderMinutes')?.setValue(75);
+      control('reminderMinutes')?.markAsTouched();
+      expect(component['reminderMinutesError']()).toBe(true);
+
+      control('reminderHours')?.setValue(MAX_EMAIL_REMINDER_HOURS);
+
+      expect(component['reminderMinutesError']()).toBe(false);
+    });
+
+    it('clears a standing hours error when the reminder is turned off', () => {
+      control('auto_email_reminder_enabled')?.setValue(true);
+      control('reminderHours')?.setValue(MAX_EMAIL_REMINDER_HOURS + 1);
+      control('reminderHours')?.markAsTouched();
+      expect(component['reminderHoursMaxError']()).toBe(true);
+
+      control('auto_email_reminder_enabled')?.setValue(false);
+
+      expect(component['reminderHoursMaxError']()).toBe(false);
+    });
   });
 
   describe('platform chips', () => {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.ts
@@ -155,14 +155,20 @@ export class ComposerPlatformFeaturesComponent {
     }
 
     if (!reminderEnabled) {
+      // The value writes stay silent — `reminderHours` feeds its own `valueChanges` subscription
+      // below and would re-enter this method. The `disable()` / `enable()` calls do emit, because
+      // disabling sets `errors` to `null` and the error paragraphs are computed off
+      // `AbstractControl.events`: suppressing that event leaves a paragraph on screen naming an
+      // error the control has stopped carrying. `syncReminderMinutesControl` returns early while
+      // the toggle is off, so the hours emission cannot loop back through here.
       hoursControl.setValue(DEFAULT_EMAIL_REMINDER_HOURS, { emitEvent: false });
-      hoursControl.disable({ emitEvent: false });
+      hoursControl.disable();
       minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
-      minutesControl.disable({ emitEvent: false });
+      minutesControl.disable();
       return;
     }
 
-    hoursControl.enable({ emitEvent: false });
+    hoursControl.enable();
     this.syncReminderMinutesControl(Number(hoursControl.value));
   }
 
@@ -173,12 +179,14 @@ export class ComposerPlatformFeaturesComponent {
       return;
     }
 
-    // Minutes stay locked at 0 while hours sits at the 24-hour maximum.
+    // Minutes stay locked at 0 while hours sits at the 24-hour maximum. Only the value write is
+    // silent; the enable/disable emits so `reminderMinutesError()` re-reads the control it is
+    // describing. Nothing subscribes to `reminderMinutes.valueChanges`, so nothing re-enters here.
     if (hours === MAX_EMAIL_REMINDER_HOURS) {
       minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
-      minutesControl.disable({ emitEvent: false });
+      minutesControl.disable();
     } else {
-      minutesControl.enable({ emitEvent: false });
+      minutesControl.enable();
     }
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.spec.ts
@@ -16,7 +16,7 @@ import { UserService } from '@services/user.service';
 import { installMatchMediaShim } from '@shared/testing/header-test-providers';
 import { MessageService } from 'primeng/api';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MeetingJoinComponent } from './meeting-join.component';
 
@@ -323,6 +323,55 @@ describe('MeetingJoinComponent', () => {
     await TestBed.inject(ApplicationRef).whenStable();
 
     expect((component as unknown as { registrants: () => MeetingRegistrant[] }).registrants()).toEqual([]);
+  });
+
+  /**
+   * Covers what the Previous/Next occurrence links are allowed to carry.
+   * @description The composer's post-create toast hands the meeting password over in router
+   * navigation state precisely so it stays out of the URL. These links are plain `href`s, so
+   * anything written into one lands in the address bar, the history entry, and the `Referer` of
+   * whatever the next page loads. A password that is already a query param here is a different
+   * case: forwarding it exposes nothing that is not exposed already.
+   */
+  describe('occurrence navigation links and the meeting password', () => {
+    const OCCURRENCE_A = { occurrence_id: 'occurrence-a', start_time: FUTURE_START_TIME, duration: 60 } as unknown as MeetingOccurrence;
+    const OCCURRENCE_B = { occurrence_id: 'occurrence-b', start_time: '2099-01-02T00:00:00.000Z', duration: 60 } as unknown as MeetingOccurrence;
+
+    const nextUrl = (component: MeetingJoinComponent): string | null =>
+      (component as unknown as { nextOccurrenceUrl: () => string | null }).nextOccurrenceUrl();
+
+    beforeEach(() => {
+      getPublicMeeting.mockReturnValue(
+        of({
+          meeting: buildMeeting({ recurrence: { type: 2, repeat_interval: 1 }, occurrences: [OCCURRENCE_A, OCCURRENCE_B] }),
+          project: buildProject(),
+        })
+      );
+    });
+
+    afterEach(() => {
+      history.replaceState({}, '');
+    });
+
+    it('keeps a password that arrived in navigation state out of the generated hrefs', async () => {
+      history.replaceState({ password: 'secret' }, '');
+
+      const component = await createComponent();
+
+      // Still authenticates the page's own fetches — the password is used, just never re-published.
+      expect(component.password()).toBe('secret');
+      expect(getPublicMeetingOccurrences).toHaveBeenCalledWith(MEETING_ID, 'secret');
+      expect(nextUrl(component)).not.toBeNull();
+      expect(nextUrl(component)).not.toContain('password');
+    });
+
+    it('still forwards a password that is already in this page url', async () => {
+      queryParamMap$.next(convertToParamMap({ password: 'secret' }));
+
+      const component = await createComponent();
+
+      expect(nextUrl(component)).toContain('password=secret');
+    });
   });
 
   // GH-2041: `meeting()` must resolve from `TransferState` at construction time (via `toSignal`'s

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -189,6 +189,13 @@ export class MeetingJoinComponent implements OnInit {
   } | null>;
   public returnTo: Signal<string | undefined>;
   public password: WritableSignal<string | null> = signal<string | null>(null);
+  /**
+   * The password only when it is already in this page's own address bar.
+   * @description Narrower than `password` on purpose: it answers "is this secret already
+   * exposed here?", which is the only thing that makes writing it into another link harmless.
+   * `buildOccurrenceUrl` reads this, never `password`.
+   */
+  private urlPassword: WritableSignal<string | null> = signal<string | null>(null);
   public canJoinMeeting: Signal<boolean>;
   public fetchedJoinUrl: Signal<string | undefined>;
   public isLoadingJoinUrl: WritableSignal<boolean> = signal<boolean>(false);
@@ -400,7 +407,7 @@ export class MeetingJoinComponent implements OnInit {
     // `initializeSeriesOccurrences()` subscribes to `meeting` immediately and would otherwise
     // read `password` before the debounced pipeline (line ~755) gets a chance to set it,
     // sending a password-gated recurring meeting's occurrences request with no password.
-    this.password.set(this.readPassword(this.activatedRoute.snapshot.queryParamMap));
+    this.applyPassword(this.activatedRoute.snapshot.queryParamMap);
 
     this.meeting = this.initializeMeeting(transferredMeeting);
     this.currentOccurrence = this.initializeCurrentOccurrence();
@@ -810,7 +817,7 @@ export class MeetingJoinComponent implements OnInit {
       debounceTime(0), // Coalesce rapid SSR hydration emissions so the fallback chain isn't canceled
       switchMap(([params, queryParams]) => {
         const meetingId = params.get('id');
-        this.password.set(this.readPassword(queryParams));
+        this.applyPassword(queryParams);
 
         if (!meetingId) {
           this.router.navigate(['/meetings/not-found']);
@@ -934,12 +941,23 @@ export class MeetingJoinComponent implements OnInit {
   // a query param writes a shared secret into the address bar, the history entry, the `Referer`
   // header of anything this page later loads, and every proxy log in between -- but the param
   // remains the shared shape everywhere else (meeting cards, copied join links), so it still wins
-  // when present. `history` is browser-only, so the state read is guarded; on the server the
-  // param is the only source.
-  private readPassword(queryParams: ParamMap): string | null {
+  // when present.
+  //
+  // The two sources are recorded separately because they are not equally safe to pass on: a param
+  // password is already in this URL, a state password is deliberately not, and only the first may
+  // be written into a link this page generates.
+  private applyPassword(queryParams: ParamMap): void {
     const fromQuery = queryParams.get('password');
-    if (fromQuery || !isPlatformBrowser(this.platformId)) {
-      return fromQuery;
+    this.urlPassword.set(fromQuery);
+    this.password.set(fromQuery || this.statePassword());
+  }
+
+  // The password the composer's post-create toast hands over in router navigation state.
+  // `history` is browser-only, so the read is guarded; on the server the query param is the only
+  // source a page has.
+  private statePassword(): string | null {
+    if (!isPlatformBrowser(this.platformId)) {
+      return null;
     }
 
     const stated = (history.state as { password?: unknown } | null)?.password;
@@ -1020,7 +1038,13 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   private buildOccurrenceUrl(seriesUid: string, occurrence: OccurrenceNavItem): string {
-    const password = this.password();
+    // `urlPassword`, not `password`: these are plain `href`s, so anything put here lands in the
+    // address bar, the history entry and the `Referer` of whatever the next page loads. Forwarding a
+    // param that is already visible here changes nothing; forwarding a password the composer handed
+    // over in navigation state would publish a secret that was deliberately kept out of the URL.
+    // A visitor who arrived that way is asked for the password on the next occurrence instead,
+    // exactly as they would be reaching that occurrence from anywhere else.
+    const password = this.urlPassword();
     const params = new URLSearchParams();
     if (password) params.set('password', password);
     // Past record: its composite id is the canonical past-meeting URL — never reconstruct from start_time

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -41,6 +41,8 @@
                   [attr.data-testid]="'meeting-create-button'"
                   label="Create Meeting"
                   size="small"
+                  ariaHasPopup="menu"
+                  [ariaExpanded]="createMenu.isOpen()"
                   (onClick)="createMenu.toggle($event)">
                   <!-- The calendar sits here rather than in `icon` because `lfx-button` takes a single
                        icon and the chevron needs it. PrimeNG renders projected content before its own

--- a/apps/lfx-one/src/app/shared/components/button/button.component.ts
+++ b/apps/lfx-one/src/app/shared/components/button/button.component.ts
@@ -4,7 +4,7 @@
 import { NgClass } from '@angular/common';
 import { Component, computed, effect, input, output } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { ButtonProps } from '@lfx-one/shared/interfaces';
+import { ButtonAriaHasPopup, ButtonProps } from '@lfx-one/shared/interfaces';
 import { resolveButtonAriaPt } from '@lfx-one/shared/utils';
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
@@ -71,6 +71,14 @@ export class ButtonComponent {
    * a plain `[attr.aria-expanded]` at the call site only reaches the host. Same `tooltip` conflict.
    */
   public readonly ariaExpanded = input<boolean | undefined>(undefined);
+  /**
+   * The kind of popup this button opens, for a trigger whose only job is to open one (e.g. the
+   * Create Meeting dropdown). Pairs with {@link ariaExpanded}: `aria-haspopup` says a menu is there,
+   * `aria-expanded` says whether it is showing, and a menu button needs both to be announced as one
+   * rather than as a plain button. Forwarded through the same `pt` passthrough, with the same
+   * `tooltip` conflict and the same anchor-branch caveat as {@link ariaExpanded}.
+   */
+  public readonly ariaHasPopup = input<ButtonAriaHasPopup | undefined>(undefined);
 
   // Navigation
   public readonly routerLink = input<string | string[] | undefined>(undefined);
@@ -89,22 +97,22 @@ export class ButtonComponent {
   public readonly tooltipPosition = input<string>('top');
 
   // Merged aria-pressed/aria-expanded `pt` for the `<p-button>` branch, hoisted to a computed so the template doesn't hand PrimeNG a fresh object per change-detection pass. `undefined` when `tooltip` is set — the Tooltip directive on this host consumes the same `pt` binding for its own `role="tooltip"` container, and the aria attributes must not leak onto it. Typed via the shared `ButtonRootPassThrough` (not PrimeNG's `ButtonPassThrough`) because the single `[pt]` binding type-checks against both `<p-button>` and `pTooltip`.
-  protected readonly ariaPt = computed(() => (this.tooltip() ? undefined : resolveButtonAriaPt(this.ariaPressed(), this.ariaExpanded())));
+  protected readonly ariaPt = computed(() => (this.tooltip() ? undefined : resolveButtonAriaPt(this.ariaPressed(), this.ariaExpanded(), this.ariaHasPopup())));
 
   public constructor() {
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       effect(() => {
-        if (this.tooltip() && (this.ariaPressed() !== undefined || this.ariaExpanded() !== undefined)) {
+        if (this.tooltip() && (this.ariaPressed() !== undefined || this.ariaExpanded() !== undefined || this.ariaHasPopup() !== undefined)) {
           console.warn(
-            '<lfx-button>: `ariaPressed`/`ariaExpanded` are ignored when `tooltip` is also set — both consume the same PrimeNG `pt` binding on this host.'
+            '<lfx-button>: `ariaPressed`/`ariaExpanded`/`ariaHasPopup` are ignored when `tooltip` is also set — both consume the same PrimeNG `pt` binding on this host.'
           );
         }
         if (this.href() && this.ariaPressed() !== undefined) {
           console.warn('<lfx-button>: `ariaPressed` is ignored on the `href` (anchor) variant — aria-pressed is invalid on role="link".');
         }
-        if (this.href() && this.ariaExpanded() !== undefined) {
+        if (this.href() && (this.ariaExpanded() !== undefined || this.ariaHasPopup() !== undefined)) {
           console.warn(
-            '<lfx-button>: `ariaExpanded` is ignored on the `href` (anchor) variant — the `pt` passthrough only applies to the `<p-button>` branch.'
+            '<lfx-button>: `ariaExpanded`/`ariaHasPopup` are ignored on the `href` (anchor) variant — the `pt` passthrough only applies to the `<p-button>` branch.'
           );
         }
       });

--- a/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.html
+++ b/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.html
@@ -40,7 +40,7 @@
           [id]="feature().key"
           [trueValue]="feature().trueValue || true"
           [falseValue]="feature().falseValue || false"
-          [ariaLabel]="feature().title"
+          [ariaLabel]="toggleAriaLabel()"
           [attr.data-testid]="'toggle-' + feature().key">
         </lfx-toggle>
       </div>

--- a/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.ts
+++ b/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, input, InputSignal } from '@angular/core';
+import { Component, computed, input, InputSignal, Signal } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ToggleComponent } from '@components/toggle/toggle.component';
 import { FeatureConfig } from '@lfx-one/shared/interfaces';
@@ -30,4 +30,17 @@ export class FeatureToggleComponent {
    * belongs to instead of against the card as a whole. `null` renders nothing.
    */
   public readonly toggleNote = input<string | null>(null);
+
+  /**
+   * The switch's accessible name, with the note folded in when there is one.
+   * @description The note is the only place the row says why a toggle cannot be turned on yet, and
+   * as plain text beside the control it never reaches a screen reader that walks the form by its
+   * controls. Naming rather than describing it, because `lfx-toggle` wraps `p-toggleSwitch`, whose
+   * only ARIA text input is `ariaLabel` — an `aria-describedby` bound out here would land on the
+   * wrapper element rather than on the input the assistive technology actually focuses.
+   */
+  protected readonly toggleAriaLabel: Signal<string> = computed(() => {
+    const note = this.toggleNote();
+    return note ? `${this.feature().title}. ${note}` : this.feature().title;
+  });
 }

--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -145,6 +145,25 @@ export class LensService {
       .subscribe(() => this.contextLensOverride.set(null));
   }
 
+  /**
+   * Drops a {@link setContextLens} override whose flow ended without navigating.
+   *
+   * The self-clear above waits on a terminal Router event, which the create picker's meeting
+   * branch never produces: the composer is an overlay raised over the page the rail was on, so
+   * nothing navigates and the override outlives the pick. It would then still be standing on the
+   * organizer's NEXT navigation — evaluated by `lensRedirectGuard` before the NavigationEnd that
+   * clears it — routing one journey under a lens their persona was never allowed.
+   * `MeetingComposerHostComponent` calls this when the composer closes, giving that branch the
+   * end-of-flow the others get from navigating. A no-op when no override stands.
+   *
+   * Only the override is dropped: `selectedLens` stays where the pick put it, and `activeLens`
+   * re-derives it through `getAllowedLensIds()` again, so a lens the persona can't hold falls
+   * back to `DEFAULT_LENS` on its own.
+   */
+  public clearContextLens(): void {
+    this.contextLensOverride.set(null);
+  }
+
   private applyLensSelection(lens: Lens): void {
     if ((lens === 'foundation' || lens === 'project') && lens !== this.navLensSelection()) {
       this.navLensSelection.set(lens);

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -421,13 +421,15 @@ export class MeetingService {
   /**
    * @param failOnPartial - If true, the request fails instead of returning a truncated roster
    *   when a later page fails server-side. Callers that rely on the complete list for
-   *   correctness (e.g. importing every registrant) should set this.
+   *   correctness (e.g. importing every registrant) should set this. A complete roster is a
+   *   privileged read, so the server authorizes it on either path — see `committeeUid` below.
    * @param committeeUid - Scopes the request to the committee "import registrants" flow, which
    *   reads a privileged roster: the server verifies the committee belongs to the same project as
    *   the meeting, and that the caller either has writer access on the committee or is a member of
    *   it when the committee is invite_only (mirroring canSendMemberInvites() client-side) — see
-   *   meeting.controller.ts. Omitting it is not an error: `failOnPartial` alone just asks the
-   *   caller's own registrant listing to be strict about a truncated page.
+   *   meeting.controller.ts. Omitting it is not an error, but it does not skip authorization
+   *   either: an unscoped `failOnPartial` is authorized as an organizer read of that meeting's
+   *   full roster (`MeetingService.getAuthorizedCompleteRegistrants`), and answers 403 otherwise.
    * @param includeCommittee - Opts into committee enrichment (`committee_name`, `committee_role`,
    *   `committee_category`, `committee_voting_status`, `committee_appointed_by`), and normalizes
    *   `committee_uid` from the upstream v1 SFID to the v2 UID. It costs the BFF a per-committee

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -733,7 +733,9 @@ export class MeetingService {
     );
   }
 
-  /*
+  /**
+   * Registers the authenticated caller for a public meeting as themselves.
+   *
    * Typed off what the endpoint actually returns, not off the row it was built from: the public
    * response is an allowlisted subset (`toSelfRegistrationResponse`), and typing it as a full
    * `MeetingRegistrant` invited a caller to read a field the wire never carried.

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -422,10 +422,12 @@ export class MeetingService {
    * @param failOnPartial - If true, the request fails instead of returning a truncated roster
    *   when a later page fails server-side. Callers that rely on the complete list for
    *   correctness (e.g. importing every registrant) should set this.
-   * @param committeeUid - Required whenever `failOnPartial` is true. The server verifies the
-   *   committee belongs to the same project as the meeting, and that the caller either has writer
-   *   access on the committee or is a member of it when the committee is invite_only (mirroring
-   *   canSendMemberInvites() client-side) — see meeting.controller.ts.
+   * @param committeeUid - Scopes the request to the committee "import registrants" flow, which
+   *   reads a privileged roster: the server verifies the committee belongs to the same project as
+   *   the meeting, and that the caller either has writer access on the committee or is a member of
+   *   it when the committee is invite_only (mirroring canSendMemberInvites() client-side) — see
+   *   meeting.controller.ts. Omitting it is not an error: `failOnPartial` alone just asks the
+   *   caller's own registrant listing to be strict about a truncated page.
    * @param includeCommittee - Opts into committee enrichment (`committee_name`, `committee_role`,
    *   `committee_category`, `committee_voting_status`, `committee_appointed_by`), and normalizes
    *   `committee_uid` from the upstream v1 SFID to the v2 UID. It costs the BFF a per-committee

--- a/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.spec.ts
@@ -316,3 +316,87 @@ describe('ProjectContextService — canWriteMeetings', () => {
     expect(service.canWriteMeetings()).toBe(true);
   });
 });
+
+/**
+ * The reason the answer is published paired with the project it answers for, rather than left to be
+ * recomposed against `activeContextUid()` at the point of use. A consumer watching for *lost* access
+ * — the meeting composer, which closes itself on one — has to tell a revoked grant apart from the
+ * context simply moving to another project, and can only do that if the uid and the verdict move
+ * together.
+ */
+describe('ProjectContextService — meetingWriteAccess pairing', () => {
+  const OTHER: ProjectContext = { uid: 'proj-2', name: 'Project Two', slug: 'project-two' };
+
+  /**
+   * One subject per probe, so each project's answer lands exactly when the test says it does.
+   * `meetingWriteAccessFor` asks twice for a project the writer relation does not cover - once
+   * plainly, then again with `meetingCoordinator` - and the two have to be answerable separately
+   * or the second probe would silently inherit the first one's reply.
+   */
+  const answers = new Map<string, Subject<Partial<Project> | null>>();
+
+  const answerFor = (slug: string, meetingCoordinator = false): Subject<Partial<Project> | null> => {
+    const key = `${slug}:${meetingCoordinator}`;
+    if (!answers.has(key)) {
+      answers.set(key, new Subject<Partial<Project> | null>());
+    }
+    return answers.get(key)!;
+  };
+
+  const setup = (): ProjectContextService => {
+    answers.clear();
+    const getProject = vi.fn((slug: string, _current?: boolean, options?: { meetingCoordinator?: boolean }) =>
+      answerFor(slug, options?.meetingCoordinator === true).asObservable()
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ProjectService, useValue: { getProject, getProjectSfid: vi.fn().mockReturnValue(of(null)) } },
+        { provide: SsrCookieService, useValue: { get: vi.fn(), set: vi.fn(), delete: vi.fn() } },
+        { provide: CookieRegistryService, useValue: { registerCookie: vi.fn(), unregisterCookie: vi.fn() } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: () => signal(false) } },
+        { provide: LensService, useValue: { activeLens: signal('project') } },
+        {
+          provide: PersonaService,
+          useValue: { isMarketingAuditor: signal(false), isCampaignManager: signal(false), marketingGrantSlug: signal(null), currentPersona: signal(null) },
+        },
+        { provide: Router, useValue: { getCurrentNavigation: () => null, parseUrl: vi.fn(), serializeUrl: vi.fn(), url: '/' } },
+        { provide: Location, useValue: { replaceState: vi.fn() } },
+        { provide: HttpClient, useValue: { get: vi.fn().mockReturnValue(of({})), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+
+    TestBed.inject(UserService).authenticated.set(true);
+    const service = TestBed.inject(ProjectContextService);
+    service.setRouteLensKind('project');
+    return service;
+  };
+
+  it('never pairs a project uid with another project\u2019s answer', () => {
+    const service = setup();
+
+    // `toObservable` publishes from an effect, so the pipeline is not subscribed to the probe until
+    // the first flush. Emitting before that tick would drop the answer on the floor.
+    service.setProject(CONTEXT, false);
+    TestBed.inject(ApplicationRef).tick();
+    answerFor(CONTEXT.slug).next({ writer: true });
+    TestBed.inject(ApplicationRef).tick();
+    expect(service.meetingWriteAccess()).toEqual({ contextUid: CONTEXT.uid, canWrite: true });
+
+    // Move the context. `activeContextUid()` follows immediately; the new project's answer is still
+    // a round trip away. Composed from those two, this instant reads as "proj-2, and you may write
+    // it" — an answer nobody gave — and the next instant as a revocation on proj-2.
+    service.setProject(OTHER, false);
+    TestBed.inject(ApplicationRef).tick();
+    expect(service.activeContextUid()).toBe(OTHER.uid);
+    expect(service.meetingWriteAccess()).toEqual({ contextUid: CONTEXT.uid, canWrite: true });
+
+    // Not a writer, so the coordinator probe follows; both have to answer before the verdict lands.
+    answerFor(OTHER.slug).next({ writer: false });
+    TestBed.inject(ApplicationRef).tick();
+    answerFor(OTHER.slug, true).next({ writer: false });
+    TestBed.inject(ApplicationRef).tick();
+    expect(service.meetingWriteAccess()).toEqual({ contextUid: OTHER.uid, canWrite: false });
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -7,7 +7,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { MARKETING_OPS_FGA_ENABLED_FLAG, SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lfx-one/shared/constants';
 import { ProjectStage } from '@lfx-one/shared/enums';
-import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
+import { MeetingWriteAccess, Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { getFormationSubStageLabel, isBoardScopedPersona, isFormationStage, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { catchError, combineLatest, filter, map, Observable, of, startWith, switchMap, tap } from 'rxjs';
@@ -140,13 +140,20 @@ export class ProjectContextService {
   public readonly activeProjectStage: Signal<string | null> = this.initActiveProjectStage();
 
   /**
-   * Meeting-authoring permission for the current active context: writer *or* meeting coordinator.
+   * Meeting-authoring permission for the current active context, paired with the context uid it was
+   * resolved against: writer *or* meeting coordinator.
    * @description Distinct from {@link canWrite}, which is writer-only. A meeting coordinator can create
    * and edit meetings without being a project writer, so gating a meeting action on `canWrite` locks out
    * a legitimate coordinator — including from the meeting they just created. Lives here rather than in
    * one dashboard so every meeting surface asks the same question.
+   *
+   * Most callers want {@link canWriteMeetings}. Read this pair only to distinguish a *revoked* grant
+   * from the active context moving to another project — see {@link MeetingWriteAccess}.
    */
-  public readonly canWriteMeetings: Signal<boolean> = this.initCanWriteMeetings();
+  public readonly meetingWriteAccess: Signal<MeetingWriteAccess> = this.initMeetingWriteAccess();
+
+  /** {@link meetingWriteAccess} without the context it was resolved against. */
+  public readonly canWriteMeetings: Signal<boolean> = computed(() => this.meetingWriteAccess().canWrite);
 
   /** Salesforce 18-char ID for the active foundation — resolves PCC deep-link targets. `null` while resolving or unavailable. */
   public readonly selectedFoundationSfid: Signal<string | null> = this.initSelectedFoundationSfid();
@@ -405,10 +412,16 @@ export class ProjectContextService {
     );
   }
 
-  private initCanWriteMeetings(): Signal<boolean> {
+  private initMeetingWriteAccess(): Signal<MeetingWriteAccess> {
     return toSignal(
       combineLatest([toObservable(this.activeContext), toObservable(this.userService.authenticated)]).pipe(
         switchMap(([ctx, authenticated]) => {
+          // The uid is carried through the pipeline rather than read back out of `activeContextUid()`
+          // so the answer and the context it answers for change in one step. Composed outside, they
+          // do not: the uid moves as soon as the context does, while the answer trails a round trip
+          // behind, and for that gap the previous project's verdict reads as the new project's.
+          const contextUid = ctx?.uid ?? '';
+
           // Anonymous/public routes have no session — /api/projects/:slug would just 401 (LFXV2-3266),
           // same as the two siblings above. It also puts the recompute back: gated on the context
           // alone this ran once per navigation and never again, so a session that settled after the
@@ -416,17 +429,17 @@ export class ProjectContextService {
           // unauthenticated result is `false` either way, via the `catchError` below; what changes is
           // that it is no longer a wasted round trip, and that it re-evaluates when the session does.
           if (!ctx?.slug || !authenticated) {
-            return of(false);
+            return of({ contextUid, canWrite: false });
           }
           // Two requests rather than one `?meeting_coordinator=true` fetch, and cheaper than it
           // looks: the plain `getProject(slug, false)` response is already in ProjectService's
           // cache on every navigation — `projectQueryParamGuard` fetches that exact key — while
           // `:mc` is a separate cache entry and so a genuine extra round trip on the SSR critical
           // path of every page.
-          return this.meetingWriteAccessFor(ctx.slug);
+          return this.meetingWriteAccessFor(ctx.slug).pipe(map((canWrite) => ({ contextUid, canWrite })));
         })
       ),
-      { initialValue: false }
+      { initialValue: { contextUid: '', canWrite: false } }
     );
   }
 

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.spec.ts
@@ -6,13 +6,13 @@ import { ApplicationRef, computed, DestroyRef, inject, signal } from '@angular/c
 import { TestBed } from '@angular/core/testing';
 import { NavigationEnd, Router } from '@angular/router';
 import { ProjectFunding, ProjectStage } from '@lfx-one/shared/enums';
-import { Project, ProjectContext } from '@lfx-one/shared/interfaces';
+import { EntityWithProject, Project, ProjectContext } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { ProjectService } from '@shared/services/project.service';
 import { of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { reconcileRouteProjectContext } from './entity-project-context.util';
+import { reconcileRouteProjectContext, syncEntityProjectContextFallback } from './entity-project-context.util';
 
 // Regression coverage for the GH-1570 route-param reconciliation's NavigationEnd re-apply
 // (PR #2224 review): a query-param-only navigation (?step=N on the newsletter edit stepper)
@@ -204,5 +204,132 @@ describe('reconcileRouteProjectContext', () => {
     expect(setFoundation).not.toHaveBeenCalled();
     expect(setProject).not.toHaveBeenCalled();
     expect(projectContextService.activeContext()?.slug).toBe('other-project');
+  });
+});
+
+/**
+ * The fallback resolver outliving the thing it was asked about. Every host that mounts it clears
+ * its entity on the way out - the meeting composer nulls `meetingEntityContext` when the drawer
+ * closes, list pages null theirs on navigation - and the lookup it kicked off is a page-context
+ * write waiting to happen. A resolution landing after that point repoints the chrome to a project
+ * the organizer already walked away from, with nothing on screen explaining why.
+ */
+describe('syncEntityProjectContextFallback - a lookup outliving its entity', () => {
+  const ENTITY_UID = 'meeting-1';
+  const PROJECT_UID = 'project-1';
+
+  // Unresolved on purpose: project_uid present, project_slug missing - the exact shape that sends
+  // the helper looking the project up instead of applying it straight from the payload.
+  const unresolvedEntity: EntityWithProject = { uid: ENTITY_UID, project_uid: PROJECT_UID };
+
+  const resolvedProject = {
+    uid: PROJECT_UID,
+    name: 'Test Project',
+    slug: 'test-project',
+    parent_uid: '',
+    logo_url: '',
+    stage: ProjectStage.Active,
+    funding: ProjectFunding.Unfunded,
+    funding_model: [],
+    legal_entity_type: '',
+  } as unknown as Project;
+
+  let entity: ReturnType<typeof signal<EntityWithProject | null>>;
+  let lookup: Subject<Project | null>;
+  let getProject: ReturnType<typeof vi.fn>;
+  let freshFetch: ReturnType<typeof vi.fn>;
+  let freshLookup: Subject<Pick<EntityWithProject, 'project_uid' | 'project_slug' | 'project_name' | 'is_foundation'> | null>;
+  let setRouteLensKindSpy: ReturnType<typeof vi.fn>;
+  let setProjectSpy: ReturnType<typeof vi.fn>;
+  let setFoundationSpy: ReturnType<typeof vi.fn>;
+  let fallbackRouter: Router;
+  let contextService: ProjectContextService;
+
+  const settle = (): Promise<void> => TestBed.inject(ApplicationRef).whenStable();
+
+  const startFallback = (options?: { withFreshFetch?: boolean }): void => {
+    TestBed.runInInjectionContext(() =>
+      syncEntityProjectContextFallback(
+        entity.asReadonly(),
+        { getProject } as unknown as ProjectService,
+        contextService,
+        fallbackRouter,
+        inject(DestroyRef),
+        options?.withFreshFetch ? { entityKind: 'meeting', freshFetch } : undefined
+      )
+    );
+  };
+
+  beforeEach(() => {
+    entity = signal<EntityWithProject | null>(unresolvedEntity);
+    lookup = new Subject<Project | null>();
+    getProject = vi.fn().mockReturnValue(lookup);
+    freshLookup = new Subject<Pick<EntityWithProject, 'project_uid' | 'project_slug' | 'project_name' | 'is_foundation'> | null>();
+    freshFetch = vi.fn().mockReturnValue(freshLookup);
+    setRouteLensKindSpy = vi.fn();
+    setProjectSpy = vi.fn();
+    setFoundationSpy = vi.fn();
+    contextService = {
+      setRouteLensKind: setRouteLensKindSpy,
+      setProject: setProjectSpy,
+      setFoundation: setFoundationSpy,
+    } as unknown as ProjectContextService;
+    fallbackRouter = {
+      events: new Subject<NavigationEnd>().asObservable(),
+      url: `/project/meetings/${ENTITY_UID}/edit`,
+      parseUrl: vi.fn().mockReturnValue({ queryParams: {} }),
+    } as unknown as Router;
+
+    TestBed.configureTestingModule({});
+  });
+
+  it('resolves the owning project of an entity whose payload carries no slug', async () => {
+    startFallback();
+    await settle();
+    lookup.next(resolvedProject);
+
+    expect(getProject).toHaveBeenCalledWith(PROJECT_UID, false);
+    expect(setRouteLensKindSpy).toHaveBeenCalledWith('project');
+    expect(setProjectSpy).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: 'test-project' }, false);
+  });
+
+  it('tears the lookup down when the entity is cleared, instead of leaving it subscribed', async () => {
+    startFallback();
+    await settle();
+    expect(lookup.observed).toBe(true);
+
+    entity.set(null);
+    await settle();
+
+    expect(lookup.observed).toBe(false);
+  });
+
+  it('does not repoint the page context with a resolution that lands after the entity is gone', async () => {
+    startFallback();
+    await settle();
+
+    entity.set(null);
+    await settle();
+    lookup.next(resolvedProject);
+
+    expect(setProjectSpy).not.toHaveBeenCalled();
+    expect(setFoundationSpy).not.toHaveBeenCalled();
+    expect(setRouteLensKindSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels the fresh-detail retry too, not just the relation-gated lookup', async () => {
+    // The second leg is nested inside the same switchMap: a null from the gated lookup hands off
+    // to the ungated detail fetch, so a cancellation has to reach through both.
+    startFallback({ withFreshFetch: true });
+    await settle();
+    lookup.next(null);
+    expect(freshLookup.observed).toBe(true);
+
+    entity.set(null);
+    await settle();
+    freshLookup.next({ project_uid: PROJECT_UID, project_slug: 'test-project', project_name: 'Test Project', is_foundation: false });
+
+    expect(freshLookup.observed).toBe(false);
+    expect(setProjectSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/entity-project-context.util.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { EntityWithProject, ProjectContext } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, isSameProjectContext } from '@lfx-one/shared/utils';
-import { catchError, distinctUntilChanged, filter, map, merge, Observable, of, switchMap } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, filter, map, merge, Observable, of, switchMap } from 'rxjs';
 
 import { ProjectContextService } from '../services/project-context.service';
 import { ProjectService } from '../services/project.service';
@@ -274,6 +274,10 @@ export function canonicalizeTierPrefix(router: Router, isFoundation: boolean, pr
  *
  * `canonicalizeRoute` mirrors the syncEntityProjectContext option: rewrite a wrong-tier URL to the
  * resolved context's tier after applying it.
+ *
+ * Clearing the entity signal cancels an in-flight lookup: hosts that unmount their entity on close
+ * (the meeting composer nulls `meetingEntityContext` when the drawer is dismissed) get the pending
+ * request torn down instead of leaving it free to repoint the page context afterwards.
  */
 export function syncEntityProjectContextFallback<T extends EntityWithProject>(
   entitySignal: Signal<T | null>,
@@ -329,8 +333,15 @@ export function syncEntityProjectContextFallback<T extends EntityWithProject>(
 
   merge(unresolvedEntity$, navigationReapply$)
     .pipe(
-      filter((entity): entity is T => !!entity?.project_uid && !entity.project_slug),
+      // The unresolved test lives INSIDE the switchMap rather than in a `filter` ahead of it, so
+      // that clearing the entity CANCELS whatever lookup is still in flight. Closing the composer
+      // (or navigating off the page) nulls the entity signal; with the test as a filter, that
+      // emission never reached the switchMap and the previous `getProject`/fresh-detail request
+      // stayed subscribed — free to repoint the page context long after the drawer was dismissed.
       switchMap((entity) => {
+        if (!entity?.project_uid || entity.project_slug) {
+          return EMPTY;
+        }
         const cached = resolvedCache.get(entity.uid);
         if (cached) {
           return of(cached);

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -68,10 +68,32 @@ export const NULLISH_DROPPED_REGISTRANT_KEYS = Object.keys(RENAMED_REGISTRANT_KE
  * none.
  *
  * `linkedin_profile` is deliberately absent: it isn't declared upstream under any name, so Goa
- * discards the whole key and its `null` never reaches a field.
+ * discards the whole key and its `null` never reaches a field. Nor does any other value it could
+ * carry, which is why it is listed unconditionally in {@link UNDECLARED_UPSTREAM_REGISTRANT_KEYS}
+ * instead of here.
  */
 export const NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS = ['job_title', 'username'] as const satisfies readonly (keyof CreateMeetingRegistrantRequest &
   keyof UpdateMeetingRegistrantRequest)[];
+
+/**
+ * Registrant fields the mapper forwards under their own name that ITX declares nowhere.
+ *
+ * Update-only, so keyed on {@link UpdateMeetingRegistrantRequest} alone rather than on the
+ * intersection the deletion lists use — `linkedin_profile` does not exist on the create shape, and
+ * an intersection would silently accept nothing.
+ *
+ * These are still forwarded: see {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS} for why the outbound
+ * body states the app's intent even where Goa drops it. What this list changes is the *counting*.
+ * A key here reaches upstream and lands on no field whatever its value, so an update carrying only
+ * one of them asks upstream for nothing — exactly the empty `PUT` that
+ * `MeetingController.hasRegistrantChanges` exists to reject, and one it used to wave through
+ * because the key was on the passthrough allowlist. Unconditional, unlike
+ * {@link NULLISH_OMITTED_REGISTRANT_KEYS}: there is no value that makes an undeclared field land.
+ *
+ * The day upstream declares one of these, deleting it here is the whole change — the forwarding is
+ * already in place.
+ */
+export const UNDECLARED_UPSTREAM_REGISTRANT_KEYS = ['linkedin_profile'] as const satisfies readonly (keyof UpdateMeetingRegistrantRequest)[];
 
 /**
  * Every registrant key whose nullish value reaches upstream as nothing at all.
@@ -126,7 +148,9 @@ export const APP_ONLY_REGISTRANT_KEYS = [...UNCONDITIONALLY_DROPPED_REGISTRANT_K
  * `linkedin_profile` is forwarded even though Goa discards it — it isn't declared upstream under
  * any name. Listing it keeps the outbound body byte-identical to what the denylist produced and
  * states the app's intent, so the day upstream declares the field it starts working without a
- * second edit. See {@link UpdateMeetingRegistrantRequest} for the tracking note.
+ * second edit. See {@link UpdateMeetingRegistrantRequest} for the tracking note. Being forwarded is
+ * not the same as doing something, though, so it is also named in
+ * {@link UNDECLARED_UPSTREAM_REGISTRANT_KEYS} and does not count as a change on its own.
  */
 const UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP = {
   email: true,

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -78,9 +78,9 @@ export const NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS = ['job_title', 'username'] a
 /**
  * Registrant fields the mapper forwards under their own name that ITX declares nowhere.
  *
- * Update-only, so keyed on {@link UpdateMeetingRegistrantRequest} alone rather than on the
- * intersection the deletion lists use — `linkedin_profile` does not exist on the create shape, and
- * an intersection would silently accept nothing.
+ * Update-only, so keyed on {@link UpdateMeetingRegistrantRequest} alone rather than on the intersection
+ * the deletion lists use — `linkedin_profile` does not exist on the create shape, and an intersection
+ * would silently accept nothing.
  *
  * These are still forwarded: see {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS} for why the outbound
  * body states the app's intent even where Goa drops it. What this list changes is the *counting*.

--- a/apps/lfx-one/src/server/constants/registrant.constants.ts
+++ b/apps/lfx-one/src/server/constants/registrant.constants.ts
@@ -98,28 +98,25 @@ export const UNDECLARED_UPSTREAM_REGISTRANT_KEYS = ['linkedin_profile'] as const
 /**
  * Every registrant key whose nullish value reaches upstream as nothing at all.
  *
- * The two halves get there differently — {@link NULLISH_DROPPED_REGISTRANT_KEYS} are dropped
- * because the rename that would carry them upstream is skipped, {@link
- * NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS} are allowed through by name but skipped on `null` — but
- * the consequence
- * is identical, and it is the consequence `MeetingController.hasRegistrantChanges` has to count:
- * a `null` on any of these makes the outbound body no larger, so counting it as a change forwards
- * the empty `PUT` that guard exists to reject.
+ * The two halves get there differently — {@link NULLISH_DROPPED_REGISTRANT_KEYS} are dropped because the rename
+ * that would carry them upstream is skipped, {@link NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS} are allowed through
+ * by name but skipped on `null` — but the consequence is identical, and it is the consequence
+ * `MeetingController.hasRegistrantChanges` has to count: a `null` on any of these makes the outbound body no
+ * larger, so counting it as a change forwards the empty `PUT` that guard exists to reject.
  */
 export const NULLISH_OMITTED_REGISTRANT_KEYS = [...NULLISH_DROPPED_REGISTRANT_KEYS, ...NON_NULLABLE_UPSTREAM_REGISTRANT_KEYS] as const;
 
 /**
  * Every registrant field the app carries but ITX does not accept under that name.
  *
- * `MeetingService.toUpstreamRegistrantBody` forwards none of them under that name: this list is
- * what {@link UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP} excludes from the allowlist, so a key here is
- * one the mapper is required *not* to declare. Composed from the two halves above rather than
- * written out again, so the mapper and the `hasRegistrantChanges` guard cannot disagree about which
- * keys exist: adding a key to either half updates the allowlist's exclusion, the upstream re-emit,
- * and the guard in the same edit. Both halves are
- * keyed on the *intersection* of the two request interfaces rather than a union — a union only rejects a key once
- * it is gone from both, so renaming it on one of them would still compile while the delete quietly
- * stopped matching.
+ * `MeetingService.toUpstreamRegistrantBody` forwards none of them under that name: this list is what {@link
+ * UPSTREAM_PASSTHROUGH_REGISTRANT_KEY_MAP} excludes from the allowlist, so a key here is one the mapper is
+ * required *not* to declare. Composed from the two halves above rather than written out again, so the mapper
+ * and the `hasRegistrantChanges` guard cannot disagree about which keys exist: adding a key to either half
+ * updates the allowlist's exclusion, the upstream re-emit, and the guard in the same edit. Both halves are
+ * keyed on the *intersection* of the two request interfaces rather than a union — a union only rejects a key
+ * once it is gone from both, so renaming it on one of them would still compile while the delete quietly stopped
+ * matching.
  */
 export const APP_ONLY_REGISTRANT_KEYS = [...UNCONDITIONALLY_DROPPED_REGISTRANT_KEYS, ...NULLISH_DROPPED_REGISTRANT_KEYS] as const;
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.delegation.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.delegation.spec.ts
@@ -11,6 +11,7 @@ const { meetingSvc, getEffectiveEmailMock, generateM2MTokenMock, addInvitedStatu
   meetingSvc: {
     getMeetingRegistrants: vi.fn(),
     getAuthorizedRegistrantsForImport: vi.fn(),
+    getAuthorizedCompleteRegistrants: vi.fn(),
     getMeetingById: vi.fn(),
     getMeetingHostKey: vi.fn(),
     getMeetingRegistrantsByEmail: vi.fn(),
@@ -90,9 +91,12 @@ function buildRes(): any {
 }
 
 // Authorization, membership, project-match, and size-cap rules are business logic tested at
-// their source — MeetingService.getAuthorizedRegistrantsForImport (meeting.service.spec.ts) —
-// per the three-file pattern (docs/reviews/backend-checklist.md). This spec covers only the
-// controller's HTTP-layer responsibility: parsing params and delegating to the right service call.
+// their source — MeetingService.getAuthorizedRegistrantsForImport and
+// getAuthorizedCompleteRegistrants (meeting.service.spec.ts) — per the three-file pattern
+// (docs/reviews/backend-checklist.md). This spec covers only the controller's HTTP-layer
+// responsibility: parsing params and delegating to the right service call. Which of the three it
+// picks is the security boundary here: routing a strict request to the unauthorized listing is how
+// the whole roster leaks, so each branch is pinned.
 describe('MeetingController.getMeetingRegistrants — delegation', () => {
   let controller: MeetingController;
 
@@ -114,20 +118,45 @@ describe('MeetingController.getMeetingRegistrants — delegation', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  // Completeness without a committee is the composer's Guests section, not the import flow. It has
-  // no privileged roster to read, so it stays on the caller's own token and only asks the normal
-  // listing to be strict about truncation. Turning that into a 403 broke the section outright.
-  it('sends a complete-roster request with no committee_uid down the normal listing, still strict', async () => {
-    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
+  // Completeness without a committee is the composer's Guests section, not the import flow — but
+  // "not the import flow" is not "no authorization". The unpaginated roster is every registrant's
+  // PII and upstream filters none of it per-user, so this must never reach the plain listing,
+  // which would hand it to any authenticated caller who can name the meeting uid.
+  it('routes a complete-roster request with no committee_uid through the authorized organizer read', async () => {
+    meetingSvc.getAuthorizedCompleteRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true' }), res, next);
 
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true);
+    expect(meetingSvc.getAuthorizedCompleteRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined);
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
     expect(meetingSvc.getAuthorizedRegistrantsForImport).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
     expect(next).not.toHaveBeenCalled();
+  });
+
+  // include_rsvp and occurrence_id are forwarded on this branch too — the authorized read is the
+  // same listing with a gate in front, not a reduced one.
+  it('forwards include_rsvp and occurrence_id on the authorized complete-roster branch', async () => {
+    meetingSvc.getAuthorizedCompleteRegistrants.mockResolvedValue([]);
+    const res = buildRes();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true', include_rsvp: 'true', occurrence_id: 'occ-1' }), res, vi.fn());
+
+    expect(meetingSvc.getAuthorizedCompleteRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, true, 'occ-1');
+  });
+
+  it('propagates a 403 from the authorized complete-roster read via next, without responding', async () => {
+    const authError = Object.assign(new Error('Not authorized'), { statusCode: 403 });
+    meetingSvc.getAuthorizedCompleteRegistrants.mockRejectedValue(authError);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true' }), res, next);
+
+    expect(next).toHaveBeenCalledWith(authError);
+    expect(res.json).not.toHaveBeenCalled();
   });
 
   it('delegates a complete-roster request to getAuthorizedRegistrantsForImport with the parsed uid and committee_uid', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.delegation.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.delegation.spec.ts
@@ -114,15 +114,20 @@ describe('MeetingController.getMeetingRegistrants — delegation', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('rejects a complete-roster request with no committee_uid, without calling either service method', async () => {
+  // Completeness without a committee is the composer's Guests section, not the import flow. It has
+  // no privileged roster to read, so it stays on the caller's own token and only asks the normal
+  // listing to be strict about truncation. Turning that into a 403 broke the section outright.
+  it('sends a complete-roster request with no committee_uid down the normal listing, still strict', async () => {
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1', email: 'a@example.com' }]);
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMeetingRegistrants(buildReq({ fail_on_partial: 'true' }), res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, true);
     expect(meetingSvc.getAuthorizedRegistrantsForImport).not.toHaveBeenCalled();
-    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1', email: 'a@example.com' }]);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('delegates a complete-roster request to getAuthorizedRegistrantsForImport with the parsed uid and committee_uid', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -528,6 +528,11 @@ describe('MeetingController', () => {
       // and this guard counted it, so `{ uid: 'other' }` produced a `PUT` carrying a client-chosen
       // identity. Now neither list contains the key and both agree it changes nothing.
       ['sends only keys no request shape declares', [{ uid: 'reg-1', changes: { uid: 'other', totally_made_up: 'x' } }]],
+      // `linkedin_profile` is the inverse case: the mapper *does* forward it, deliberately and under
+      // its own name, but ITX declares no such field, so Goa discards the key and the `PUT` applies
+      // nothing. Being on the passthrough allowlist used to be enough to clear this guard, which made
+      // it the one remaining spelling of the empty write the guard exists to reject.
+      ['sends only a linkedin_profile', [{ uid: 'reg-1', changes: { linkedin_profile: 'https://in.example/alice' } }]],
     ])('rejects an entry that %s instead of forwarding an empty write', async (_label, body) => {
       const req = buildReq({ body });
 
@@ -560,6 +565,24 @@ describe('MeetingController', () => {
 
       expect(next).not.toHaveBeenCalledWith(expect.any(FakeValidationError));
       expect(meetingSvc.updateMeetingRegistrant).toHaveBeenCalledWith(req, MEETING_ID, 'reg-1', expect.objectContaining({ org_name: 'Acme' }));
+    });
+
+    // The exclusion is about counting, not about forwarding: `linkedin_profile` still travels in the
+    // outbound body so the day ITX declares it nothing has to change. What it must not do is make an
+    // otherwise-empty update look like a change, and it must not suppress one that carries a real key
+    // alongside it.
+    it('forwards a linkedin_profile that rides along with a change that does land', async () => {
+      const req = buildReq({ body: [{ uid: 'reg-1', changes: { linkedin_profile: 'https://in.example/alice', first_name: 'Alice' } }] });
+
+      await controller.updateMeetingRegistrants(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalledWith(expect.any(FakeValidationError));
+      expect(meetingSvc.updateMeetingRegistrant).toHaveBeenCalledWith(
+        req,
+        MEETING_ID,
+        'reg-1',
+        expect.objectContaining({ first_name: 'Alice', linkedin_profile: 'https://in.example/alice' })
+      );
     });
 
     it('rejects a non-array body as a validation error rather than throwing', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -24,7 +24,12 @@ import {
 import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
-import { NULLISH_DROPPED_REGISTRANT_KEYS, NULLISH_OMITTED_REGISTRANT_KEYS, UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS } from '../constants';
+import {
+  NULLISH_DROPPED_REGISTRANT_KEYS,
+  NULLISH_OMITTED_REGISTRANT_KEYS,
+  UNDECLARED_UPSTREAM_REGISTRANT_KEYS,
+  UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS,
+} from '../constants';
 import { resolveCommitteeV2UidMappings, resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
 import { MicroserviceError, ServiceValidationError } from '../errors';
 import {
@@ -1997,6 +2002,11 @@ export class MeetingController {
    * - {@link NULLISH_OMITTED_REGISTRANT_KEYS} on a nullish value — the mapper skips the rename for
    *   the renamed three and skips the copy for the two ITX declares non-nullable under their own
    *   name, so the outbound body is no larger for having received them.
+   * - {@link UNDECLARED_UPSTREAM_REGISTRANT_KEYS} on any value — `linkedin_profile` is forwarded
+   *   under its own name deliberately, but ITX declares no such field, so Goa discards the key and
+   *   the `PUT` applies nothing. Unconditional rather than nullish-gated: no value makes an
+   *   undeclared field land. Without it `{ "linkedin_profile": "…" }` cleared this guard on the
+   *   strength of being on the passthrough allowlist and became exactly the empty write below.
    *
    * Counting the raw keys instead let `{ "meeting_id": "M1" }` and `{ "org_name": null }` through
    * the guard and straight into the empty `PUT` it exists to prevent. The two membership lists are
@@ -2019,7 +2029,9 @@ export class MeetingController {
       const reachesUpstream =
         (UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS as readonly string[]).includes(key) || (NULLISH_DROPPED_REGISTRANT_KEYS as readonly string[]).includes(key);
 
-      if (!reachesUpstream) {
+      // Reaching upstream and landing on a field are different questions, and only the second one
+      // makes the `PUT` worth sending.
+      if (!reachesUpstream || (UNDECLARED_UPSTREAM_REGISTRANT_KEYS as readonly string[]).includes(key)) {
         return false;
       }
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -419,17 +419,19 @@ export class MeetingController {
         return;
       }
 
-      // A complete roster scoped to a committee is the committee "import registrants" flow — a
-      // privileged, business-logic-heavy path (authorization, size cap), so it's delegated to
-      // MeetingService.getAuthorizedRegistrantsForImport per the three-file pattern
-      // (docs/reviews/backend-checklist.md). Every other caller goes through the normal listing on
-      // its own bearer token, which forwards fail_on_partial so a truncated upstream page surfaces
-      // as an error rather than a silently short list. That includes the composer's Guests section,
-      // which wants completeness without a committee in scope: it gets strictness, not the
-      // privileged path, and not a 403.
+      // `fail_on_partial` asks for a *complete* roster, and the upstream query-service applies no
+      // per-user grant filtering to v1_meeting_registrant — so both strict paths are authorized
+      // in MeetingService per the three-file pattern (docs/reviews/backend-checklist.md), never
+      // taken on the caller's word. Scoped to a committee it is the committee "import registrants"
+      // flow, with that flow's own rules and size cap; unscoped it is the composer's Guests
+      // section, which has to be an organizer of the meeting it is editing. Only the tolerant
+      // listing — the one that may come back short — goes straight through on the caller's own
+      // bearer token.
       let registrants: MeetingRegistrant[];
       if (failOnPartial && committeeUid) {
         registrants = await this.meetingService.getAuthorizedRegistrantsForImport(req, uid, committeeUid);
+      } else if (failOnPartial) {
+        registrants = await this.meetingService.getAuthorizedCompleteRegistrants(req, uid, includeRsvp, occurrenceId);
       } else {
         registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, failOnPartial);
       }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -26,7 +26,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { NULLISH_DROPPED_REGISTRANT_KEYS, NULLISH_OMITTED_REGISTRANT_KEYS, UPSTREAM_PASSTHROUGH_REGISTRANT_KEYS } from '../constants';
 import { resolveCommitteeV2UidMappings, resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
-import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
+import { MicroserviceError, ServiceValidationError } from '../errors';
 import {
   addInvitedStatusToMeeting,
   applyOrganizerAndHostKeyResult,
@@ -414,18 +414,16 @@ export class MeetingController {
         return;
       }
 
-      // Completeness (failOnPartial) is only ever requested by the committee "import registrants"
-      // flow — that's a privileged, business-logic-heavy path (authorization, size cap), so it's
-      // delegated to MeetingService.getAuthorizedRegistrantsForImport per the three-file pattern
-      // (docs/reviews/backend-checklist.md). The 3 partial-tolerant callers are unaffected.
+      // A complete roster scoped to a committee is the committee "import registrants" flow — a
+      // privileged, business-logic-heavy path (authorization, size cap), so it's delegated to
+      // MeetingService.getAuthorizedRegistrantsForImport per the three-file pattern
+      // (docs/reviews/backend-checklist.md). Every other caller goes through the normal listing on
+      // its own bearer token, which forwards fail_on_partial so a truncated upstream page surfaces
+      // as an error rather than a silently short list. That includes the composer's Guests section,
+      // which wants completeness without a committee in scope: it gets strictness, not the
+      // privileged path, and not a 403.
       let registrants: MeetingRegistrant[];
-      if (failOnPartial) {
-        if (!committeeUid) {
-          throw new AuthorizationError('committee_uid is required when requesting a complete registrant roster', {
-            operation: 'get_meeting_registrants',
-            service: 'meeting_controller',
-          });
-        }
+      if (failOnPartial && committeeUid) {
         registrants = await this.meetingService.getAuthorizedRegistrantsForImport(req, uid, committeeUid);
       } else {
         registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, failOnPartial);

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -811,12 +811,13 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
   /*
    * The allowlist is the whole defence on this route, and it is one line to widen. This asserts the
-   * consequence rather than the list: nothing upstream attaches about *other* people, and nothing
-   * the registrant is not entitled to assert about themselves, reaches an anonymous caller — so
-   * adding any of these keys to `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS` fails here instead of
-   * shipping.
+   * consequence rather than the list: nothing upstream attaches about *other* people, and nothing the
+   * registrant is not entitled to assert about themselves, comes back out of the write — so adding any
+   * of these keys to `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS` fails here instead of shipping. The
+   * caller is authenticated (the handler rejects anonymous requests by name, covered separately); what
+   * is being withheld is roster context about a person, not access to the endpoint.
    */
-  it('never lets a roster field reach an anonymous caller, whatever upstream attached', async () => {
+  it('never lets a roster field back out of a self-registration, whatever upstream attached', async () => {
     const leakable = {
       username: 'alice.liddell',
       committee_uid: 'committee-9',

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -6,6 +6,7 @@ import { MeetingVisibility } from '@lfx-one/shared/enums';
 import type { Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AuthenticationError } from '../errors/authentication.error';
 import type { ServiceValidationError } from '../errors/service-validation.error';
 
 const MEETING_ID = 'meeting-1111';
@@ -881,6 +882,21 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+  });
+
+  // Order matters, not just the outcome: the body checks below name the exact fields, their labels and
+  // the cap, and an anonymous caller has no business being told any of it. A request that is both
+  // unauthenticated and malformed has to come back as the authentication failure.
+  it.each([
+    ['over-length', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+    ['missing a required name', { first_name: '' }],
+  ])('answers an unauthenticated request with %s as 401 rather than describing the body', async (_label, overrides) => {
+    const { req, res, next } = buildRegisterReq(false, overrides);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
   });
 
   it('missing first_name returns validation error without calling the service', async () => {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -489,6 +489,25 @@ export class PublicMeetingController {
    * requests receive 401.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
+    // Ahead of every shape check below, so an anonymous caller is answered with "sign in" rather than
+    // walked through the field rules of a route it cannot reach. The length and required-field
+    // rejections name the exact fields, labels and cap, which is what the registration modal needs
+    // and precisely what an unauthenticated prober should not be handed.
+    //
+    // The token is checked alongside the session for the same reason it is elsewhere on this
+    // optional-auth surface: a refresh failure can leave `isAuthenticated()` true with no user token
+    // captured, and this route has to post as the caller.
+    if (!req.oidc?.isAuthenticated() || !req.bearerToken) {
+      return next(
+        new AuthenticationError('Authentication required to register for a meeting', {
+          operation: 'register_for_public_meeting',
+          service: 'public_meeting_controller',
+          path: req.path,
+        })
+      );
+    }
+
+    const userToken = req.bearerToken;
     const registrantData = this.toSelfRegistration(req.body);
     const meetingId = registrantData.meeting_id;
 
@@ -545,18 +564,6 @@ export class PublicMeetingController {
         return;
       }
 
-      if (!req.oidc?.isAuthenticated() || !req.bearerToken) {
-        return next(
-          new AuthenticationError('Authentication required to register for a meeting', {
-            operation: 'register_for_public_meeting',
-            service: 'public_meeting_controller',
-            path: req.path,
-          })
-        );
-      }
-
-      const userToken = req.bearerToken;
-
       // The missing fields are named individually in the top-level message for the same reason as the
       // length rejection above: that message is the only part of this error the registration modal
       // shows, so a generic "validation failed" here is what turns a fixable empty field into an
@@ -607,7 +614,9 @@ export class PublicMeetingController {
 
       logger.success(req, 'register_for_public_meeting', startTime, {
         meeting_id: meetingId,
-        registrant_uid: newRegistrant.uid,
+        // `?? null` because the no-body branch omits `uid` rather than inventing one, and Pino drops
+        // undefined — which would log as a success line with no `registrant_uid` field at all.
+        registrant_uid: newRegistrant.uid ?? null,
       });
 
       res.status(201).json(this.toSelfRegistrationResponse(newRegistrant));
@@ -752,8 +761,13 @@ export class PublicMeetingController {
    *
    * The allowlist and the return type both come from `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`, so the
    * client cannot go on typing this as a full `MeetingRegistrant` while the wire carries twelve keys.
+   *
+   * The parameter is a `Partial` because the service's no-body fallback is one: a write upstream
+   * acknowledged without a body knows only what was submitted, and `host`, `created_at` and
+   * `updated_at` are three of the twelve keys here that it cannot honestly answer. The `!== undefined`
+   * filter is what turns that into omission rather than a fabricated value.
    */
-  private toSelfRegistrationResponse(registrant: MeetingRegistrant): PublicMeetingRegistrationResponse {
+  private toSelfRegistrationResponse(registrant: Partial<MeetingRegistrant>): PublicMeetingRegistrationResponse {
     return Object.fromEntries(
       PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS.filter((field) => registrant[field] !== undefined).map((field) => [field, registrant[field]])
     );

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -415,6 +415,21 @@ describe('AiService.generateNewsletter', () => {
     expect(timeoutSpy).toHaveBeenCalledWith(AI_REQUEST_CONFIG.NEWSLETTER_TIMEOUT_MS);
     expect(AI_REQUEST_CONFIG.NEWSLETTER_TIMEOUT_MS).toBeGreaterThan(AI_REQUEST_CONFIG.TIMEOUT_MS);
   });
+
+  // Same reasoning as the agenda counterpart: the caller-facing message is deliberately generic, so
+  // `cause` is the only thing carrying the upstream detail, and dropping the options bag would keep
+  // this suite green without the assertion.
+  it('keeps the upstream failure reachable through error.cause', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401, statusText: 'Unauthorized', text: async () => '{"error":"Invalid API key"}' } as unknown as Response);
+
+    const failure = await service
+      .generateNewsletter(req, { rawContent: 'notes', contextType: 'project', contextName: 'Debug Project' })
+      .then(() => null)
+      .catch((error: Error) => error);
+
+    expect(failure?.message).toBe('Failed to generate newsletter');
+    expect((failure?.cause as Error | undefined)?.message).toMatch(/401 Unauthorized.*Invalid API key/);
+  });
 });
 
 describe('AiService.reconcileAttendees (GH-1672 / PCC-1452 port)', () => {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1247,13 +1247,54 @@ describe('MeetingService registrant write payloads', () => {
       last_name: 'B',
     });
 
-    expect(result).toMatchObject({ email: 'a@example.com' });
+    expect(result).toMatchObject({ meeting_id: 'meeting-1', first_name: 'A', last_name: 'B' });
     expect(logger.success).toHaveBeenCalledWith(
       req,
       'add_meeting_registrant_self',
       expect.anything(),
       expect.objectContaining({ registrant_uid: null, has_upstream_body: false })
     );
+  });
+
+  // The fallback answers a registrant, not an admin: `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS` carries
+  // `host`, `created_at` and `updated_at` back out, and a write upstream acknowledged with no body
+  // says nothing about any of them. Omitting is what keeps "the write response didn't say" distinct
+  // from "upstream stored nothing" — a fabricated `host: false` with empty timestamps reads as the row.
+  // `email` and `username` are absent for a second reason: this route never sends them, so the body's
+  // copy would be a reading of the request rather than of the registrant upstream identified.
+  it.each(['uid', 'host', 'created_at', 'updated_at', 'email', 'username', 'org_is_member', 'invite_accepted', 'attended'])(
+    'omits %s from the self-registration fallback rather than inventing one',
+    async (field) => {
+      proxyRequest.mockResolvedValue(null);
+
+      const result = await service.addMeetingRegistrantSelf(req, 'meeting-1', {
+        meeting_id: 'meeting-1',
+        email: 'a@example.com',
+        first_name: 'A',
+        last_name: 'B',
+      });
+
+      expect(result).not.toHaveProperty(field);
+    }
+  );
+
+  // The renames are the whole reason this is a separate fallback from the M2M one: what comes back
+  // has to be spelled the way the response allowlist reads it, and only the fields the request
+  // actually carried may appear.
+  it('carries the submitted optional fields through the self-registration fallback under their app spelling', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.addMeetingRegistrantSelf(req, 'meeting-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: 'Acme',
+      job_title: 'Engineer',
+      occurrence_id: 'occ-42',
+    });
+
+    expect(result).toMatchObject({ org_name: 'Acme', job_title: 'Engineer', occurrence_id: 'occ-42' });
   });
 
   it('reports the upstream branch on the self-registration create when upstream does answer', async () => {
@@ -1377,5 +1418,35 @@ describe('MeetingService registrant paths reject hostile identifiers', () => {
     await expect(service.deleteMeetingRegistrant(req, 'mtg-1', hostile)).rejects.toThrow();
 
     expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  // The past-meeting participant writes interpolate the same way and were the three call sites still
+  // reaching for bare `encodeURIComponent`. Encoding is the half those already had; refusing a
+  // dot-only segment is the half only `encodePathSegment` adds, and it is the half that matters —
+  // `%2E%2E` percent-decodes before the URL is normalized, so an encoded `..` traverses exactly as a
+  // raw one does.
+  it.each([
+    ['create', (s: MeetingService, hostile: string) => s.createPastMeetingParticipant(req, hostile, {} as never)],
+    ['update', (s: MeetingService, hostile: string) => s.updatePastMeetingParticipant(req, hostile, 'p-1', {} as never)],
+    ['delete', (s: MeetingService, hostile: string) => s.deletePastMeetingParticipant(req, hostile, 'p-1')],
+  ])('refuses a dot-only past meeting id on the participant %s path', async (_label, call) => {
+    await expect(call(service, '..')).rejects.toThrow();
+
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['update', (s: MeetingService, hostile: string) => s.updatePastMeetingParticipant(req, 'pm-1', hostile, {} as never)],
+    ['delete', (s: MeetingService, hostile: string) => s.deletePastMeetingParticipant(req, 'pm-1', hostile)],
+  ])('refuses a dot-only participant id on the participant %s path', async (_label, call) => {
+    await expect(call(service, '..')).rejects.toThrow();
+
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  it('still encodes a slash in the participant path', async () => {
+    await service.updatePastMeetingParticipant(req, 'pm/1', 'p 1', {} as never);
+
+    expect(pathOf()).toBe('/itx/past_meetings/pm%2F1/participants/p%201');
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -735,13 +735,16 @@ describe('MeetingService.getAuthorizedCompleteRegistrants', () => {
     expect(proxyRequest).not.toHaveBeenCalled();
   });
 
-  it('checks organizer access on the meeting itself, not writer access on some other resource', async () => {
+  // The resource *type* is load-bearing, not incidental: organizer tuples live on `v1_meeting`, so
+  // probing the bare `meeting` type finds nothing and fails closed on the very organizers this path
+  // exists to serve. The stub answers `true` either way, so only this assertion catches the drift.
+  it('probes organizer access on the v1_meeting type, not writer access on some other resource', async () => {
     accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
     proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
 
     await service.getAuthorizedCompleteRegistrants(req, MEETING_UID);
 
-    expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(req, { resource: 'meeting', id: MEETING_UID, access: 'organizer' });
+    expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(req, { resource: 'v1_meeting', id: MEETING_UID, access: 'organizer' });
   });
 
   it('returns the roster for an organizer', async () => {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1283,6 +1283,27 @@ describe('MeetingService registrant write payloads', () => {
     }
   });
 
+  // Same allowlist, other verb. `toUpstreamRegistrantBody` is shared between the two writes, so a
+  // regression that scoped the allowlist loop to the create path would keep every test above green
+  // while the `PUT` went back to forwarding a client-named `uid` — the one key ITX derives from the
+  // path, on the branch whose controller spreads `req.body` wholesale.
+  it('forwards no undeclared key on the update path either', async () => {
+    await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'other-meeting',
+      uid: 'client-chosen',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      totally_made_up: 'x',
+    } as UpdateMeetingRegistrantRequest & { uid: string; totally_made_up: string });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
+    expect(bodyOf()).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
+    for (const key of ['uid', 'totally_made_up', 'meeting_id']) {
+      expect(bodyOf()).not.toHaveProperty(key);
+    }
+  });
+
   // Self-registration is the path a registrant drives from the public meeting page, so the same
   // unusable body used to surface to them as a `{}` "created" record. Its success line has to say
   // which branch produced the result — without `has_upstream_body` and an explicit `null` uid, the
@@ -1428,7 +1449,7 @@ describe('MeetingService registrant paths reject hostile identifiers', () => {
 
   const pathOf = (): string => proxyRequest.mock.calls[0][2] as string;
 
-  it('encodes a slash and a space in the create path', async () => {
+  it('encodes a slash in the create path', async () => {
     await service.addMeetingRegistrant(req, { meeting_id: 'mtg/1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
 
     expect(pathOf()).toBe('/itx/meetings/mtg%2F1/registrants');

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -714,6 +714,56 @@ describe('MeetingService.getAuthorizedRegistrantsForImport', () => {
   });
 });
 
+describe('MeetingService.getAuthorizedCompleteRegistrants', () => {
+  let service: MeetingService;
+
+  const MEETING_UID = 'meeting-1';
+  const registrantRecord = (id: string) => ({ id: `v1_meeting_registrant:${id}`, data: { uid: id, email: `${id}@example.com` } as MeetingRegistrant });
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    accessCheckSvc.checkSingleAccess.mockReset();
+    service = new MeetingService();
+  });
+
+  // The guard, not the listing, is the security property: upstream applies no per-user filtering
+  // to v1_meeting_registrant, so an unauthorized caller reaching the walk at all is the leak.
+  it('refuses a non-organizer with a 403 before any registrant is fetched', async () => {
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(false);
+
+    await expect(service.getAuthorizedCompleteRegistrants(req, MEETING_UID)).rejects.toMatchObject({ statusCode: 403 });
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  it('checks organizer access on the meeting itself, not writer access on some other resource', async () => {
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    await service.getAuthorizedCompleteRegistrants(req, MEETING_UID);
+
+    expect(accessCheckSvc.checkSingleAccess).toHaveBeenCalledWith(req, { resource: 'meeting', id: MEETING_UID, access: 'organizer' });
+  });
+
+  it('returns the roster for an organizer', async () => {
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    const result = await service.getAuthorizedCompleteRegistrants(req, MEETING_UID);
+
+    expect(result).toEqual([{ uid: 'a', email: 'a@example.com' }]);
+  });
+
+  // Strictness is the whole reason this path exists — a short list reads to the composer as
+  // "these people are not registered yet", and the organizer re-invites guests who already have
+  // an invite. It must surface as an error, so failOnPartial cannot be left to the caller.
+  it('fetches strictly, so a mid-walk page failure throws instead of returning a short roster', async () => {
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')], page_token: 'next' }).mockRejectedValueOnce(new Error('query service down'));
+
+    await expect(service.getAuthorizedCompleteRegistrants(req, MEETING_UID)).rejects.toThrow();
+  });
+});
+
 describe('MeetingService.getPastMeetingParticipants', () => {
   let service: MeetingService;
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1140,8 +1140,7 @@ describe('MeetingService registrant write payloads', () => {
   // empty response body to `null`, and a 201 carrying a literal `{}` is truthy — so both were mapped
   // straight through and reported a created registrant with every field missing. The submitted payload
   // is the closest description of what upstream now holds; `uid` is the one thing it can't supply, so
-  // it is stated as `''` — falsy, so a caller's `if (uid)` still routes to a read-back, and present,
-  // so the `MeetingRegistrant` cast isn't claiming a required field the object lacks.
+  // it is stated as `''` — falsy, so a caller's `if (uid)` still routes to a read-back.
   it.each([
     ['null', null],
     ['an empty object', {}],
@@ -1157,6 +1156,42 @@ describe('MeetingService registrant write payloads', () => {
 
     expect(result).toMatchObject({ email: 'a@example.com', first_name: 'A', last_name: 'B' });
     expect(result.uid).toBe('');
+  });
+
+  // The fallback used to spread the request shape and cast the result, which asserted a dozen required
+  // fields the request does not carry — a consumer typing them as present read `undefined`. This pins
+  // the whole surface rather than the handful the other tests happen to touch, because the failure it
+  // guards against is a field going missing, not one holding the wrong value.
+  it('states every field MeetingRegistrant declares, not just the ones the request carries', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.addMeetingRegistrant(req, { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    for (const key of ['uid', 'meeting_id', 'email', 'first_name', 'last_name', 'host', 'job_title', 'org_name', 'occurrence_id'] as const) {
+      expect(result[key]).toBeDefined();
+    }
+    for (const key of ['avatar_url', 'username', 'linkedin_profile', 'org_is_member', 'org_is_project_member', 'created_at', 'updated_at', 'type'] as const) {
+      expect(result[key]).toBeDefined();
+    }
+    expect(result.type).toBe('direct');
+    expect(result).not.toHaveProperty('committee_uid');
+  });
+
+  // Upstream derives `type` from the committee it stores, so a committee-sourced create whose body
+  // never came back must not describe itself as a direct guest.
+  it('describes a committee-sourced create as a committee registrant', async () => {
+    proxyRequest.mockResolvedValue(null);
+
+    const result = await service.addMeetingRegistrant(req, {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      committee_uid: 'cmt-1',
+    });
+
+    expect(result.type).toBe('committee');
+    expect(result.committee_uid).toBe('cmt-1');
   });
 
   // `registrantData` comes from `req.body` and the create route carries no express-validator, so a

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -826,7 +826,11 @@ export class MeetingService {
     includeRsvp: boolean = false,
     occurrenceId?: string
   ): Promise<MeetingRegistrant[]> {
-    const isOrganizer = await this.accessCheckService.checkSingleAccess(req, { resource: 'meeting', id: meetingUid, access: 'organizer' });
+    // `v1_meeting`, not `meeting`: the organizer tuples the platform writes hang off the v1 type,
+    // which is what every other organizer probe in this codebase asks about (see
+    // `resolveOrganizerAndHostKey` in meeting.helper.ts, and `getMeetingById`'s default
+    // `meetingType`). Asking about `meeting` finds no tuple and fails closed on real organizers.
+    const isOrganizer = await this.accessCheckService.checkSingleAccess(req, { resource: 'v1_meeting', id: meetingUid, access: 'organizer' });
     if (!isOrganizer) {
       throw new AuthorizationError('Not authorized to read the complete registrant roster for this meeting', {
         operation: 'get_authorized_complete_registrants',

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -804,6 +804,40 @@ export class MeetingService {
   }
 
   /**
+   * Fetches a meeting's complete registrant roster for a caller who is authorized to edit that
+   * meeting — the composer's Guests section, which needs the saved list to be whole before it
+   * reconciles the organizer's edits against it.
+   *
+   * Completeness is the thing that needs authorizing, not the listing. The upstream query-service
+   * applies no per-user grant filtering to v1_meeting_registrant, so a strict, unpaginated roster
+   * is every registrant's PII for any meeting whose uid the caller can name — authentication alone
+   * does not earn it. `organizer` is the right relation to require rather than mere registrant
+   * membership: it is the same access the composer's edit mode is gated on client-side, so the
+   * check refuses exactly the callers who could not have opened the section in the first place.
+   *
+   * The committee "import registrants" flow has its own, wider rules — see
+   * `getAuthorizedRegistrantsForImport`.
+   *
+   * @throws AuthorizationError if the caller is not an organizer of the meeting.
+   */
+  public async getAuthorizedCompleteRegistrants(
+    req: Request,
+    meetingUid: string,
+    includeRsvp: boolean = false,
+    occurrenceId?: string
+  ): Promise<MeetingRegistrant[]> {
+    const isOrganizer = await this.accessCheckService.checkSingleAccess(req, { resource: 'meeting', id: meetingUid, access: 'organizer' });
+    if (!isOrganizer) {
+      throw new AuthorizationError('Not authorized to read the complete registrant roster for this meeting', {
+        operation: 'get_authorized_complete_registrants',
+        service: 'meeting_service',
+      });
+    }
+
+    return this.getMeetingRegistrants(req, meetingUid, includeRsvp, occurrenceId, true);
+  }
+
+  /**
    * Fetches all registrants for a meeting by email
    */
   public async getMeetingRegistrantsByEmail(req: Request, meetingUid: string, email: string, m2mToken?: string): Promise<MeetingRegistrant[]> {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1948,7 +1948,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<ITXPastMeetingParticipantResult>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/participants`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/participants`,
       'POST',
       undefined,
       participantData
@@ -1972,7 +1972,7 @@ export class MeetingService {
     return this.microserviceProxy.proxyRequest<ITXPastMeetingParticipantResult>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/participants/${encodeURIComponent(participantId)}`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/participants/${encodePathSegment(participantId)}`,
       'PUT',
       undefined,
       participantData
@@ -1991,7 +1991,7 @@ export class MeetingService {
     await this.microserviceProxy.proxyRequest<void>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/past_meetings/${encodeURIComponent(pastMeetingUid)}/participants/${encodeURIComponent(participantId)}`,
+      `/itx/past_meetings/${encodePathSegment(pastMeetingUid)}/participants/${encodePathSegment(participantId)}`,
       'DELETE'
     );
   }
@@ -2002,7 +2002,7 @@ export class MeetingService {
    * not be included in the payload. Only public meetings are supported; private meetings
    * return 403.
    */
-  public async addMeetingRegistrantSelf(req: Request, meetingId: string, registrantData: CreateMeetingRegistrantRequest): Promise<MeetingRegistrant> {
+  public async addMeetingRegistrantSelf(req: Request, meetingId: string, registrantData: CreateMeetingRegistrantRequest): Promise<Partial<MeetingRegistrant>> {
     const startTime = logger.startOperation(req, 'add_meeting_registrant_self', { meeting_id: meetingId });
 
     logger.debug(req, 'add_meeting_registrant_self', 'Self-registering authenticated user for meeting', { meeting_id: meetingId });
@@ -2030,15 +2030,17 @@ export class MeetingService {
     // Keys, not truthiness — see `addMeetingRegistrant`. This is the path a registrant drives from the
     // public meeting page, so an unusable body used to surface to them as a `{}` "created" record.
     const hasUpstreamBody = !!upstreamRegistrant && Object.keys(upstreamRegistrant).length > 0;
-    const newRegistrant = hasUpstreamBody ? this.fromUpstreamRegistrant(upstreamRegistrant) : MeetingService.registrantFromSubmittedPayload(registrantData);
+    const newRegistrant: Partial<MeetingRegistrant> = hasUpstreamBody
+      ? this.fromUpstreamRegistrant(upstreamRegistrant)
+      : MeetingService.selfRegistrationFromSubmittedPayload(meetingId, registrantData);
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {
       meeting_id: meetingId,
       // `|| null` rather than leaving it as it comes: Pino drops undefined values, so a create whose
       // upstream body carried no UID logged as a success line with no `registrant_uid` field at all,
-      // indistinguishable from a log-shape change — and the fallback's own placeholder `''` would read
-      // as a UID that is empty rather than one upstream never minted. `has_upstream_body` says which
-      // branch produced it.
+      // indistinguishable from a log-shape change. It catches both shapes the two branches can produce
+      // — an upstream row whose UID came back empty, and the fallback, which omits `uid` entirely.
+      // `has_upstream_body` says which branch produced it.
       registrant_uid: newRegistrant.uid || null,
       has_upstream_body: hasUpstreamBody,
     });
@@ -2402,7 +2404,40 @@ export class MeetingService {
   }
 
   /**
-   * Fallback registrant for a create that upstream acknowledged with no usable body.
+   * Fallback self-registration result for a create that upstream acknowledged with no usable body.
+   *
+   * A `Partial`, and deliberately not `registrantFromSubmittedPayload`. That one fills in every
+   * required field of `MeetingRegistrant` so the M2M caller gets the whole type it is promised, and
+   * on that path the placeholders never leave the server unfiltered. Here they would: the reply this
+   * feeds is `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`, which carries `host`, `created_at` and
+   * `updated_at` straight back to the registrant, so `host: false` and two empty timestamps would be
+   * presented as the row upstream stored. `PublicMeetingRegistrationResponse` reserves omission for
+   * exactly this — "the write response didn't say" has to stay distinct from "upstream stored
+   * nothing" — and only leaving the keys off preserves it.
+   *
+   * The fields are the ones this route actually put on the wire, under their app spelling, plus the
+   * routed `meeting_id`. `email` and `username` are absent for the same reason the payload omits
+   * them: the meeting service reads identity from the caller's JWT, so echoing the body's copy back
+   * would describe the request rather than the row. `uid` is upstream's to mint, so it is simply
+   * missing — `toSelfRegistrationResponse` drops it rather than sending `''` as an identity.
+   */
+  private static selfRegistrationFromSubmittedPayload(meetingId: string, registrantData: CreateMeetingRegistrantRequest): Partial<MeetingRegistrant> {
+    return {
+      meeting_id: meetingId,
+      first_name: registrantData.first_name,
+      last_name: registrantData.last_name,
+      ...(registrantData.org_name ? { org_name: registrantData.org_name } : {}),
+      ...(registrantData.job_title ? { job_title: registrantData.job_title } : {}),
+      ...(registrantData.occurrence_id ? { occurrence_id: registrantData.occurrence_id } : {}),
+    };
+  }
+
+  /**
+   * Fallback registrant for an M2M create that upstream acknowledged with no usable body.
+   *
+   * Self-registration has its own (`selfRegistrationFromSubmittedPayload`) because it sends a different
+   * body and answers a different caller: this one returns a whole `MeetingRegistrant` because
+   * `addMeetingRegistrant`'s contract is one, and its result is not narrowed on the way out.
    *
    * The submitted payload is the closest available description of what upstream now stores, on the
    * same reasoning `updateMeetingRegistrant` uses for its fallback. The one thing it cannot supply is

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -2411,18 +2411,53 @@ export class MeetingService {
    * Deliberately not thrown: the write already succeeded, and throwing here would report a created
    * registrant as a failure. Callers that need the UID have to read the registrant back.
    *
-   * `uid` is stated as `''` rather than left off. `MeetingRegistrant` declares it required, so the cast
-   * would otherwise claim a field the object doesn't carry; an empty string is falsy, so a caller's
+   * `uid` is stated as `''` rather than left off: an empty string is falsy, so a caller's
    * `if (registrant.uid)` still routes to the read-back, whereas an absent one would reach a template
    * or a URL segment as the literal `"undefined"`.
    *
-   * It is written *after* the spread, not before it. `registrantData` comes from `req.body`, so a
-   * client that names a `uid` of its own would otherwise have it win over the empty one and be
-   * echoed back as the created registrant's identity — a UID upstream never minted, presented as
-   * though it had. Same ordering rule as `updateMeetingRegistrant`'s fallback, where the routed
-   * `uid` and `meeting_id` are written last for the same reason.
+   * Every field is named rather than spread from the payload, and nothing is cast. Spreading a
+   * `CreateMeetingRegistrantRequest` into a `MeetingRegistrant` needs an `as` to compile, and that cast
+   * asserted a dozen required fields — `host`, `type`, the two org-membership flags, both timestamps —
+   * that the request shape does not carry and the object therefore did not have. Consumers typing them
+   * as present read `undefined`. Writing them out puts honest placeholders on the wire instead, and
+   * makes the compiler, not a reviewer, the thing that notices when `MeetingRegistrant` grows a field.
+   *
+   * The placeholders are what the submission can honestly say and no more. `host` and the renamed
+   * optional fields come from the payload because upstream was asked to store exactly those; `type`
+   * follows `committee_uid`, which is how upstream derives it too; the read-only membership flags and
+   * the timestamps are upstream's alone to compute, so they take the type's own empty value.
+   * `invite_accepted` and `attended` are `null` for the same reason and because `null` is what they
+   * genuinely mean here — nobody has answered the invitation this request is creating, and the
+   * meeting it is for has not happened. None of them is a reading of what upstream stored — `uid: ''` is the signal that this whole object is a
+   * description of the request, not of the row.
+   *
+   * `uid` is not taken from the payload at all. `registrantData` comes from `req.body`, so a client
+   * that names a `uid` of its own would otherwise have it echoed back as the created registrant's
+   * identity — a UID upstream never minted, presented as though it had. Same rule as
+   * `updateMeetingRegistrant`'s fallback, where the routed `uid` and `meeting_id` win over the body.
    */
   private static registrantFromSubmittedPayload(registrantData: CreateMeetingRegistrantRequest): MeetingRegistrant {
-    return { ...registrantData, uid: '' } as MeetingRegistrant;
+    return {
+      uid: '',
+      meeting_id: registrantData.meeting_id,
+      email: registrantData.email,
+      first_name: registrantData.first_name,
+      last_name: registrantData.last_name,
+      host: registrantData.host ?? false,
+      job_title: registrantData.job_title ?? null,
+      org_name: registrantData.org_name ?? null,
+      occurrence_id: registrantData.occurrence_id ?? null,
+      avatar_url: registrantData.avatar_url ?? null,
+      username: registrantData.username ?? null,
+      linkedin_profile: null,
+      org_is_member: false,
+      org_is_project_member: false,
+      invite_accepted: null,
+      attended: null,
+      created_at: '',
+      updated_at: '',
+      type: registrantData.committee_uid ? 'committee' : 'direct',
+      ...(registrantData.committee_uid === undefined ? {} : { committee_uid: registrantData.committee_uid }),
+    };
   }
 }

--- a/docs/architecture/backend/ai-service.md
+++ b/docs/architecture/backend/ai-service.md
@@ -61,13 +61,36 @@ Defaults are empty strings, not placeholder URLs/keys — so missing env never s
 
 ```typescript
 export interface GenerateAgendaRequest {
-  meetingType: MeetingType; // Meeting type enum (BOARD, TECHNICAL, etc.)
-  title: string; // Meeting title/topic
-  projectName: string; // Project name for context
-  context?: string; // Additional context from user
-  maxCharacters?: number; // Max agenda length (default: 2000)
+  meetingType?: MeetingType; // Meeting type enum (BOARD, TECHNICAL, etc.)
+  title?: string; // Meeting title/topic
+  projectName?: string; // Project name for context
+  context?: string; // Additional context from user — required when `title` is absent
+  maxCharacters?: number; // Max agenda length (default: MEETING_AGENDA_MAX_LENGTH)
 }
 ```
+
+Every descriptor is optional, and that is deliberate rather than lax: the composer's Agenda &
+Resources section is reachable before a type is chosen, edit mode drops the rail's section locking so
+the organizer can ask for an agenda having just cleared the title, and the client's project context
+resolves asynchronously. What the endpoint does require is **enough signal to write a useful agenda —
+a title or a free-text goal**. `MeetingController.generateAgenda` rejects a body carrying neither with
+a `400` naming both fields; the prompt builder omits whatever else is missing.
+
+Server-side normalization runs before the prompt is built, so a caller cannot rely on sending the
+values through untouched:
+
+| Input                             | Handling                                                                                                                                                                                                                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `meetingType`                     | Narrowed to the `MeetingType` enum, or **dropped**. It has a closed value set, so an unrecognized value carries no signal — `AiService.getMeetingTypeDescription` already falls back to a generic descriptor.                                                                         |
+| `title`, `context`, `projectName` | Trimmed; dropped when empty; **truncated** to `MEETING_AGENDA_PROMPT_MAX_LENGTH` (1000). Truncated rather than dropped so an over-budget title with no goal can still satisfy the title-or-context rule. Truncation is logged (field and lengths only — the values are user content). |
+| `maxCharacters`                   | Floored; anything non-finite or outside `1..MEETING_AGENDA_MAX_LENGTH` (2000) **falls back to the default** rather than being pinned to the nearest bound. The value reaches the model twice — as `maxLength` in the response schema and interpolated into the prompt.                |
+
+The route also carries a **per-user AI limiter** (`aiRateLimiter`, `middleware/rate-limit.middleware.ts`)
+on top of the global `/api` one: 10 generations per minute, keyed on the OIDC `sub` and falling back
+to a masked IP for anonymous callers, because every call costs a LiteLLM completion. The counter lives
+in the default in-process store, so the effective ceiling is `limit × replicas`. The limiter is not
+applied to the other LiteLLM callers (newsletter generation, weekly-brief extraction) — those are
+reached from different modules and are bounded only by the global limiter.
 
 #### Generate Agenda Response
 
@@ -124,7 +147,9 @@ response_format: {
 
 **Authentication**: Required (Bearer token)
 
-**Request Body**:
+**Rate limit**: `aiRateLimiter` — 10 requests per minute per user
+
+**Request Body** — every field is optional, but at least one of `title` / `context` must be present:
 
 ```json
 {
@@ -133,6 +158,12 @@ response_format: {
   "projectName": "LFX Platform",
   "context": "Review microservices architecture and discuss scaling plans"
 }
+```
+
+A body carrying only a goal is equally valid:
+
+```json
+{ "context": "Agree on the release date and unblock the remaining Q3 roadmap items" }
 ```
 
 **Response**:
@@ -146,9 +177,10 @@ response_format: {
 
 **Error Responses**:
 
-- `400 Bad Request`: Missing required fields
+- `400 Bad Request`: Neither `title` nor `context` was supplied (both fields are named in the error)
 - `401 Unauthorized`: Invalid or missing authentication
-- `500 Internal Server Error`: AI service failure
+- `429 Too Many Requests`: Per-user AI limiter exhausted
+- `500 Internal Server Error`: AI service failure (including an unconfigured `AI_PROXY_URL` / `AI_API_KEY`, which is surfaced generically and logged server-side)
 
 ## 🔐 Security & Authentication
 
@@ -225,11 +257,15 @@ Focus on transparency, collaboration, and effective time management.`;
 ### Frontend Integration
 
 ```typescript
-// Meeting Form Component
+// Composer agenda field
 public async generateAiAgenda(): Promise<void> {
+  // Every descriptor is sent as-is, including the ones that are still empty — the server treats an
+  // absent title or type as "not chosen yet" rather than as a bad request. The client mirrors the
+  // server's one hard rule (a title or a goal) so the button is disabled rather than the request
+  // failing.
   const request: GenerateAgendaRequest = {
     meetingType: this.form().get('meeting_type')?.value,
-    title: this.form().get('topic')?.value,
+    title: this.form().get('title')?.value,
     projectName: this.projectService.project()?.name,
     context: this.form().get('aiPrompt')?.value
   };

--- a/docs/architecture/backend/public-meetings.md
+++ b/docs/architecture/backend/public-meetings.md
@@ -11,6 +11,7 @@ The public meetings feature allows unauthenticated users to access specific meet
 The system exposes public endpoints that bypass user authentication:
 
 - **Public API Endpoint**: `/public/api/meetings/:id` - Returns meeting and project data
+- **Self-Registration Endpoint**: `POST /public/api/meetings/register` - Registers the caller for a public, non-restricted meeting. Mounted on the same optional-auth router, but the handler requires a session of its own — see [Self-Registration Contract](#self-registration-contract-post-publicapimeetingsregister)
 - **Frontend Route**: `/meetings/:id` - Displays the meeting page without authentication
 - **Access Control**: Meeting visibility levels and optional passcode protection
 
@@ -54,6 +55,48 @@ For private meetings:
 - **Passcode Validation**: Compares provided passcode with stored Zoom configuration
 - **Limited Data Exposure**: Returns only essential project information when passcode-protected
 - **Error Handling**: Returns authentication errors for invalid passcodes
+
+### Self-Registration Contract (`POST /public/api/meetings/register`)
+
+The one registrant **write** served from the `/public/api` surface. Being mounted there is not what
+decides its auth: the router is `auth: 'optional'`, but the handler rejects an anonymous caller before
+any shape check, so the reader of the response is always an authenticated self-registrant.
+
+**Authentication.** `registerForPublicMeeting` requires both `req.oidc.isAuthenticated()` and
+`req.bearerToken` — a refresh failure can leave the session flag true with no user token captured, and
+this route has to post _as the caller_. It answers `AuthenticationError` first so a prober is told to
+sign in rather than walked through the route's field rules. The M2M token this controller mints covers
+only the meeting lookup that decides whether the meeting is public and unrestricted; it is swapped back
+before the write, which travels under the registrant's own bearer token.
+
+**Inbound allowlist.** `toSelfRegistration` rebuilds the payload key by key from `unknown` rather than
+spreading `req.body` — the route mounts the handler bare, with no express-validator. Non-string values
+are dropped, free text is trimmed and truncated to `PUBLIC_REGISTRATION_FIELD_MAX_LENGTH`, and the three
+identifiers (`meeting_id`, `email`, `occurrence_id`) are trimmed but _rejected_ rather than truncated
+when over-length, so an unusable value can never become a different valid-looking one. `host` is forced
+to `false` and `committee_uid` is dropped: neither is the caller's to assert.
+
+**Upstream write allowlist.** `MeetingService.addMeetingRegistrantSelf` posts to
+`/itx/meetings/:id/registrants/self` with only `first_name`, `last_name`, and the optional `org`,
+`job_title` and `occurrence`. It deliberately sends neither `email` nor `username` — the meeting service
+reads the registrant's identity off their JWT, which is the whole point of the `self` endpoint. An empty
+or missing upstream body falls back to the submitted payload rather than reporting a registrant with
+every field blank.
+
+**Response allowlist.** The reply is narrowed to `PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`
+(`packages/shared/src/constants/meeting-registrant.constants.ts`): `uid`, `meeting_id`, `email`,
+`first_name`, `last_name`, `host`, `job_title`, `org_name`, `occurrence_id`, `avatar_url`, `created_at`,
+`updated_at`. Everything else the upstream row carries — committee attribution, attendance, and the
+`created_by` / `updated_by` audit objects, which are nested users rather than identifier strings — is
+withheld. The narrowing is about what a person may learn from registering themselves, not about who
+reached the endpoint.
+
+The client types the same response off that constant via `PublicMeetingRegistrationResponse`
+(`packages/shared/src/interfaces/meeting.interface.ts`), so a server-side narrowing cannot drift from a
+client that still believes it holds a full `MeetingRegistrant`. Every key is optional because the
+response omits what upstream did not return rather than stating it as `undefined`. Adding a key to the
+allowlist is therefore a deliberate two-sided contract change, and it is asserted in
+`public-meeting.controller.spec.ts`.
 
 ## 📁 Frontend Implementation
 

--- a/packages/shared/src/constants/meeting-registrant.constants.ts
+++ b/packages/shared/src/constants/meeting-registrant.constants.ts
@@ -5,14 +5,14 @@ import type { MeetingRegistrant } from '../interfaces/meeting.interface';
 
 /**
  * The only registrant fields a public self-registration response carries back to the caller.
- * @description An allowlist, so a column added to the upstream registrant row later has to be named
- * here before a self-registrant can see it. The route sits under `/public/api`, but the handler behind
- * it requires a session of its own, so the reader is an authenticated self-registrant rather than an
- * anonymous caller — the narrowing is about what a person may learn from registering themselves, not
- * about who reached the endpoint. Shared rather than local to the controller
- * because the client types the same response off it — a server-side narrowing the client still typed
- * as a full `MeetingRegistrant` is how a caller ends up reading a field the wire never carried. The
- * derived response type is `PublicMeetingRegistrationResponse` (`meeting.interface.ts`).
+ * @description An allowlist, so a column added to the upstream registrant row later has to be named here before
+ * a self-registrant can see it. The route sits under `/public/api`, but the handler behind it requires a
+ * session of its own, so the reader is an authenticated self-registrant rather than an anonymous caller — the
+ * narrowing is about what a person may learn from registering themselves, not about who reached the endpoint.
+ * Shared rather than local to the controller because the client types the same response off it — a server-side
+ * narrowing the client still typed as a full `MeetingRegistrant` is how a caller ends up reading a field the
+ * wire never carried. The derived response type is `PublicMeetingRegistrationResponse`
+ * (`meeting.interface.ts`).
  *
  * Its own file rather than `meeting.constants.ts` so it stays a runtime leaf — the only import here
  * is type-only, which lets a spec that mocks the constants barrel pull the real list in by relative

--- a/packages/shared/src/constants/meeting-registrant.constants.ts
+++ b/packages/shared/src/constants/meeting-registrant.constants.ts
@@ -6,7 +6,10 @@ import type { MeetingRegistrant } from '../interfaces/meeting.interface';
 /**
  * The only registrant fields a public self-registration response carries back to the caller.
  * @description An allowlist, so a column added to the upstream registrant row later has to be named
- * here before an unauthenticated caller can see it. Shared rather than local to the controller
+ * here before a self-registrant can see it. The route sits under `/public/api`, but the handler behind
+ * it requires a session of its own, so the reader is an authenticated self-registrant rather than an
+ * anonymous caller — the narrowing is about what a person may learn from registering themselves, not
+ * about who reached the endpoint. Shared rather than local to the controller
  * because the client types the same response off it — a server-side narrowing the client still typed
  * as a full `MeetingRegistrant` is how a caller ends up reading a field the wire never carried. The
  * derived response type is `PublicMeetingRegistrationResponse` (`meeting.interface.ts`).

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -101,6 +101,14 @@ export const MEETING_FEATURE_BY_KEY = {
     recommended: false,
     color: lfxColors.red[500],
   },
+  auto_email_reminder_enabled: {
+    key: 'auto_email_reminder_enabled',
+    icon: 'fa-light fa-bell',
+    title: 'Send reminder email to participants',
+    description: 'Automatically send a reminder email to all participants before the meeting starts',
+    recommended: false,
+    color: lfxColors.amber[500],
+  },
 };
 
 /**
@@ -365,6 +373,7 @@ export const MEETING_COMPOSER_PREVIEW_FEATURES: MeetingComposerPreviewFeature[] 
     { control: 'zoom_ai_enabled', label: 'AI meeting summary' },
     { control: 'transcript_enabled', label: 'Transcript' },
     { control: 'youtube_upload_enabled', label: 'Auto-upload to YouTube' },
+    { control: 'auto_email_reminder_enabled', label: 'Reminder email' },
   ] as const
 ).map(({ control, label }) => ({ control, label, icon: MEETING_FEATURE_BY_KEY[control].icon }));
 
@@ -682,16 +691,12 @@ export const RECURRING_MEETING_FEATURE = {
 
 /**
  * Send reminder email feature configuration
- * @description Feature toggle config for the automatic participant reminder email
+ * @description Feature toggle config for the automatic participant reminder email. An alias into
+ * {@link MEETING_FEATURE_BY_KEY} rather than a second definition: the composer preview lists a row
+ * per enabled feature off that map, so a reminder config living outside it is a toggle the preview
+ * cannot see.
  */
-export const EMAIL_REMINDER_FEATURE = {
-  key: 'auto_email_reminder_enabled',
-  icon: 'fa-light fa-bell',
-  title: 'Send reminder email to participants',
-  description: 'Automatically send a reminder email to all participants before the meeting starts',
-  recommended: false,
-  color: lfxColors.amber[500],
-};
+export const EMAIL_REMINDER_FEATURE = MEETING_FEATURE_BY_KEY.auto_email_reminder_enabled;
 
 /**
  * Restricted meeting feature configuration

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -290,8 +290,15 @@ export interface ButtonProps {
 
 /** PrimeNG `pt` (passthrough) shape accepted for a Button's root slot. */
 export interface ButtonRootPassThrough {
-  root: { 'aria-pressed'?: boolean; 'aria-expanded'?: boolean };
+  root: { 'aria-pressed'?: boolean; 'aria-expanded'?: boolean; 'aria-haspopup'?: ButtonAriaHasPopup };
 }
+
+/**
+ * The popup kinds a button may declare through `aria-haspopup`.
+ * @description Names the kind rather than allowing the bare `true`, which is only a legacy synonym
+ * for `'menu'` and tells a screen-reader user less than the word does.
+ */
+export type ButtonAriaHasPopup = 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
 
 /**
  * Avatar size options

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -642,9 +642,12 @@ export interface MeetingRegistrant {
 
 /**
  * What a public self-registration (`POST /public/api/meetings/register`) actually returns.
- * @description Narrower than `MeetingRegistrant`: the endpoint answers unauthenticated callers, so it
- * replies with an allowlist of the registrant's own record rather than the whole upstream row
- * (`PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`). Every key is optional because the response omits a key
+ * @description Narrower than `MeetingRegistrant`. The route is mounted on the optional-auth
+ * `/public/api` surface, but the handler itself requires a session and a bearer token, so the caller is
+ * an authenticated self-registrant — anonymous registration is not supported here. What the narrowing
+ * withholds is therefore roster context rather than access: the reply is an allowlist of the
+ * registrant's own record (`PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`) rather than the whole upstream
+ * row, which also carries committee attribution, attendance and the admins who last touched it. Every key is optional because the response omits a key
  * upstream did not return rather than stating it as `undefined` — "the write response didn't say" and
  * "upstream stored nothing" are different answers, and only omission preserves the distinction.
  */
@@ -794,7 +797,10 @@ export interface ComposerGuestRow {
   displayName: string;
   /** `email · org`, collapsing to just the email when the org is unknown. */
   secondaryLine: string;
-  /** The remove button's accessible name: the display name, or the email when there is no name. */
+  /**
+   * The remove button's accessible name: the display name, the email when there is no name, and
+   * the literal `guest` when a registrant arrives carrying neither.
+   */
   removeLabel: string;
 }
 
@@ -2008,10 +2014,12 @@ export type MeetingComposerVariant = 'drawer' | 'quick';
 
 /**
  * Why an edit-mode hydration failed, and therefore whether retrying can help.
- * @description `denied` is a 404 or a 403: the meeting is gone or access was lost, and the same
- * request will keep failing, so the drawer must not offer a retry. `retryable` is everything else
- * — a 5xx or a network blip — where the fetch is worth running again and calling it "not found"
- * would be a lie. Restores the split the full-page editor carried for #2037.
+ * @description `denied` is a 403: access was lost, and the same request will keep failing, so the
+ * drawer must not offer a retry — but the meeting is still there, so it must not be announced as
+ * missing either. `retryable` is everything else — a 5xx or a network blip — where the fetch is
+ * worth running again and calling it "not found" would be a lie. Restores the split the full-page
+ * editor carried for #2037. A 404 is neither: the meeting genuinely isn't there, so the composer
+ * closes rather than describing a failure, which is that issue's other criterion.
  */
 export type MeetingComposerLoadFailure = 'retryable' | 'denied';
 
@@ -2035,14 +2043,6 @@ export interface MeetingComposerToastData {
    * Absent when the meeting has no password.
    */
   meetingLinkState?: Record<string, string>;
-  /**
-   * Project the meeting was created under, or `null` when the response carried none.
-   * @description The composer can save into a project other than the active one — a group-scoped
-   * create passes its own `projectUid` — and the toast outlives that open. Without it the Edit
-   * action can only ask whether the organizer may write meetings *here*, which is the wrong
-   * question for a meeting created somewhere else.
-   */
-  projectUid: string | null;
 }
 
 /** Dialog data for the composer's manual guest entry dialog. */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -642,13 +642,13 @@ export interface MeetingRegistrant {
 
 /**
  * What a public self-registration (`POST /public/api/meetings/register`) actually returns.
- * @description Narrower than `MeetingRegistrant`. The route is mounted on the optional-auth
- * `/public/api` surface, but the handler itself requires a session and a bearer token, so the caller is
- * an authenticated self-registrant — anonymous registration is not supported here. What the narrowing
- * withholds is therefore roster context rather than access: the reply is an allowlist of the
- * registrant's own record (`PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`) rather than the whole upstream
- * row, which also carries committee attribution, attendance and the admins who last touched it. Every key is optional because the response omits a key
- * upstream did not return rather than stating it as `undefined` — "the write response didn't say" and
+ * @description Narrower than `MeetingRegistrant`. The route is mounted on the optional-auth `/public/api`
+ * surface, but the handler itself requires a session and a bearer token, so the caller is an authenticated
+ * self-registrant — anonymous registration is not supported here. What the narrowing withholds is therefore
+ * roster context rather than access: the reply is an allowlist of the registrant's own record
+ * (`PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS`) rather than the whole upstream row, which also carries committee
+ * attribution, attendance and the admins who last touched it. Every key is optional because the response omits
+ * a key upstream did not return rather than stating it as `undefined` — "the write response didn't say" and
  * "upstream stored nothing" are different answers, and only omission preserves the distinction.
  */
 export type PublicMeetingRegistrationResponse = Partial<Pick<MeetingRegistrant, (typeof PUBLIC_SELF_REGISTRATION_RESPONSE_KEYS)[number]>>;

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -105,6 +105,20 @@ export interface ProjectContext {
   logoUrl?: string;
 }
 
+/**
+ * Meeting-authoring permission paired with the context it was resolved against.
+ *
+ * The two travel together because a consumer watching for *lost* access has to tell a genuine
+ * revocation apart from the active context simply moving to another project. Read separately, the
+ * uid updates a tick before its answer does, so the previous project's answer briefly reads as the
+ * new project's — and a cross-project move is indistinguishable from a revocation.
+ */
+export interface MeetingWriteAccess {
+  /** `''` while no context is active. */
+  contextUid: string;
+  canWrite: boolean;
+}
+
 export type ProjectDocumentType = 'file' | 'link' | 'folder';
 
 /**

--- a/packages/shared/src/utils/button.utils.spec.ts
+++ b/packages/shared/src/utils/button.utils.spec.ts
@@ -23,4 +23,18 @@ describe('resolveButtonAriaPt', () => {
   it('merges both attributes into one root object when both are set', () => {
     expect(resolveButtonAriaPt(true, false)).toEqual({ root: { 'aria-pressed': true, 'aria-expanded': false } });
   });
+
+  // A menu trigger sets `aria-haspopup` on its own, without a toggle or a disclosure state, so the
+  // popup kind has to be enough on its own to produce a `pt` object.
+  it('returns a pt object with aria-haspopup only when it is the only one set', () => {
+    expect(resolveButtonAriaPt(undefined, undefined, 'menu')).toEqual({ root: { 'aria-haspopup': 'menu' } });
+  });
+
+  it('merges the popup kind alongside the disclosure state a menu trigger also carries', () => {
+    expect(resolveButtonAriaPt(undefined, true, 'menu')).toEqual({ root: { 'aria-expanded': true, 'aria-haspopup': 'menu' } });
+  });
+
+  it('still returns undefined when only the popup kind is left off', () => {
+    expect(resolveButtonAriaPt(undefined, undefined, undefined)).toBeUndefined();
+  });
 });

--- a/packages/shared/src/utils/button.utils.ts
+++ b/packages/shared/src/utils/button.utils.ts
@@ -1,21 +1,26 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ButtonRootPassThrough } from '../interfaces/components.interface';
+import { ButtonAriaHasPopup, ButtonRootPassThrough } from '../interfaces/components.interface';
 
 /**
- * Resolves the `pt` passthrough forwarding `aria-pressed` / `aria-expanded` to the native `<button>`
- * PrimeNG's `<p-button>` renders internally.
+ * Resolves the `pt` passthrough forwarding `aria-pressed` / `aria-expanded` / `aria-haspopup` to the
+ * native `<button>` PrimeNG's `<p-button>` renders internally.
  *
- * Returns `undefined` — not an object with undefined values inside it — when both are unset, so an
+ * Returns `undefined` — not an object with undefined values inside it — when all are unset, so an
  * ordinary button (the vast majority of `<lfx-button>` usages) doesn't get handed a `pt` object at all.
  * `undefined` is the "no pt config" value PrimeNG expects; some PrimeNG versions stringify an
  * `undefined` attribute value, and a component-level `pt.root` shallowly shadows individual global
  * `pt` root attributes even though it doesn't replace the config outright.
  */
-export function resolveButtonAriaPt(pressed: boolean | undefined, expanded: boolean | undefined): ButtonRootPassThrough | undefined {
+export function resolveButtonAriaPt(
+  pressed: boolean | undefined,
+  expanded: boolean | undefined,
+  hasPopup?: ButtonAriaHasPopup
+): ButtonRootPassThrough | undefined {
   const root: ButtonRootPassThrough['root'] = {};
   if (pressed !== undefined) root['aria-pressed'] = pressed;
   if (expanded !== undefined) root['aria-expanded'] = expanded;
+  if (hasPopup !== undefined) root['aria-haspopup'] = hasPopup;
   return Object.keys(root).length === 0 ? undefined : { root };
 }


### PR DESCRIPTION
## What

Front-end half of the automated-review sweep. Every finding was re-verified against the current head before anything changed, and every fix carries a regression test that was mutation-checked — revert the fix and exactly the intended test fails.

**Guests**
- `loadGuests` passes `failOnPartial: true`. A truncated registrant page was loading as if it were the complete guest list, so a save could drop guests nobody saw.
- `onRemoveGuest` matches on `uid || tempId` instead of object identity, so removing a keyless row removes that row rather than the first equal one.
- The acceptance summary is hidden when invite responses are disabled, and carries a `pTooltip` plus an `aria-label`.

**Details & Access**
- The YouTube title-limit counter is announced through an always-mounted `aria-live` region. An interpolation that recomputes to the same string never touches the DOM text node, and a region mounted at the same moment its content changes is not announced — so the previous markup was silent for screen readers.

**Platform & Features**
- `syncReminderTimingControls` / `syncReminderMinutesControl` let `disable()` and `enable()` emit while value writes stay silent, so signals derived from `control.events` stop going stale.

**Date & Schedule**
- `duration` and `recurrenceType` drop `[unselectable]="false"`. PrimeNG reads that input backwards from its name — the setter assigns `allowEmpty = !value` — so passing `false` left two required controls clearable with no chip to get back to, and nothing validates until submit. Early join deliberately keeps `false`, because `EARLY_JOIN_CHIP_OPTIONS` has no "no early join" entry; that exception is asserted too, so removing it also breaks the build.

**Host**
- Write-access eviction pairs the answer with the context uid and exempts EDs, so switching projects no longer closes an open drawer out from under an organizer.
- The created-meeting toast keeps the project the meeting was created under, guarded against a stale async probe.

**Elsewhere**
- Meeting card edit re-checks `organizer` against a fresh detail fetch before opening the composer.
- Occurrence links on the join page keep the password from the query string.
- The agenda character-limit state uses the wrapper's `invalid` input rather than a raw `aria-invalid`.
- Retryable load-failure copy no longer implies the meeting was deleted.

## Verification

`./check-headers.sh`, `yarn format:check`, `yarn lint:check`, `yarn check-types`, `yarn build`, `yarn workspace lfx-one run test:app` (155 files / 2816 tests), `yarn workspace lfx-one run test:server` (118 files / 3279 tests) — all green.

## Related

Slice 24 of the `#1451` composer stack, based on #2314.

Refs #1451
