### PR TITLE
feat(org-lens): port the insights health score v2 popup to org lens

### DIFF
--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -486,8 +486,8 @@ test.describe('Org Project Detail — hero health popup', () => {
           organizations: [
             {
               accountId: TEST_ACCOUNT_ID,
-              accountName: 'Red Hat LLC',
-              accountSlug: 'red-hat-llc',
+              accountName: 'Acme Motors',
+              accountSlug: 'acme-motors',
               membershipTier: '',
               uid: TEST_ACCOUNT_ID,
             },
@@ -508,7 +508,9 @@ test.describe('Org Project Detail — hero health popup', () => {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          items: [{ uid: TEST_ACCOUNT_ID, accountId: TEST_ACCOUNT_ID, name: 'Red Hat LLC', logoUrl: null, primaryDomain: 'redhat.com', isMember: true }],
+          items: [
+            { uid: TEST_ACCOUNT_ID, accountId: TEST_ACCOUNT_ID, name: 'Acme Motors', logoUrl: null, primaryDomain: 'acme-motors.example', isMember: true },
+          ],
           next_page_token: null,
           upstream_failed: false,
           total: 1,
@@ -521,10 +523,17 @@ test.describe('Org Project Detail — hero health popup', () => {
     });
   }
 
-  test('opens the hero health popup on hover with the table-matching breakdown', async ({ page }) => {
-    await stubHeroContext(page, heroBlock());
+  async function gotoHero(page: Page): Promise<void> {
     await page.goto('/org/projects/kubernetes', { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
+    if (!page.url().includes('/org/projects')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/projects redirected away');
+    }
+  }
+
+  test('opens the hero health popup on hover with the table-matching breakdown', async ({ page }) => {
+    await stubHeroContext(page, heroBlock());
+    await gotoHero(page);
     await expect(page.getByTestId('project-detail-health-badge')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await page.getByTestId('project-detail-health-badge').hover();
@@ -537,8 +546,7 @@ test.describe('Org Project Detail — hero health popup', () => {
 
   test('opens the hero health popup on keyboard focus with a matching accessible name', async ({ page }) => {
     await stubHeroContext(page, heroBlock());
-    await page.goto('/org/projects/kubernetes', { waitUntil: 'domcontentloaded' });
-    await expect(page).not.toHaveURL(/auth0\.com/);
+    await gotoHero(page);
     await expect(page.getByTestId('project-detail-health-badge')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await page.getByTestId('project-detail-health-badge').focus();
@@ -562,8 +570,7 @@ test.describe('Org Project Detail — hero health popup', () => {
         healthDevelopment: null,
       })
     );
-    await page.goto('/org/projects/kubernetes', { waitUntil: 'domcontentloaded' });
-    await expect(page).not.toHaveURL(/auth0\.com/);
+    await gotoHero(page);
     const badge = page.getByTestId('project-detail-health-badge');
     await expect(badge).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(badge).toHaveText('Unavailable');

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -10,14 +10,16 @@
  * - leaderboard ranking, score/metric toggles with ?metric= persistence,
  *   Activity Count hiding the band tags, and server-side pagination + search over the full ranked set
  * - not-found (404) panel for an unknown slug
+ * - hero health badge popup (hover / keyboard / unavailable) against a stubbed `/hero` response
  *
  * Prerequisites:
  * - Dev server running on the Playwright baseURL
  * - User authenticated with the `org-lens-enabled` flag on and an organization selected
  *
- * Data semantics (v1): the page is served from live Snowflake platinum via the BFF. `k8s` is the real
- * catalog slug for the Kubernetes project (the earlier `kubernetes` was only the removed demo-fixture
- * key); a slug with no catalog row for the selected org returns null → the not-found panel.
+ * Data semantics: the live suites are served from Snowflake platinum via the BFF. `k8s` is the real
+ * catalog slug for the Kubernetes project; a slug with no catalog row for the selected org returns null →
+ * the not-found panel. The hero-popup suite stubs the BFF instead (synthetic org + fixed v2 scores) so
+ * headline/rows/aria can be asserted exactly.
  */
 
 import { expect, Page, test } from '@playwright/test';

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -515,7 +515,7 @@ test.describe('Org Project Detail — hero health popup', () => {
         }),
       })
     );
-    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/[^/]+\/hero$/, (route) => {
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/[^/]+\/hero(?:\?.*)?$/, (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(block) });
     });

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -20,7 +20,7 @@
  * key); a slug with no catalog row for the selected org returns null → the not-found panel.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { skipWhenAuthMissing } from './helpers/auth.helper';
 
 test.beforeEach(() => skipWhenAuthMissing());
@@ -443,5 +443,132 @@ test.describe('Org Project Detail — not found', () => {
     await page.goto(DETAIL_URL_BOGUS, { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
     await expect(page.getByTestId('project-detail-not-found')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+});
+
+test.describe('Org Project Detail — hero health popup', () => {
+  const TEST_ACCOUNT_ID = '0014100000Te2QjAAJ';
+
+  // Partial v2 score with a consistent same-row shape: maintainer 30/40 + development 22/25 = 52,
+  // security uncovered, so the max is 65 (40 + 25).
+  function heroBlock(heroOverrides: Record<string, unknown> = {}) {
+    return {
+      hero: {
+        projectName: 'Kubernetes',
+        description: 'Kubernetes project description.',
+        logoUrl: '',
+        lfxInsightsUrl: 'https://insights.linuxfoundation.org/project/kubernetes',
+        firstCommit: '2014-06-07',
+        softwareValueUsd: null,
+        health: 'healthy',
+        healthOverallScore: 52,
+        healthMaxScore: 65,
+        healthCoveredCategoryCount: 2,
+        healthMaintainer: 30,
+        healthSecurity: null,
+        healthDevelopment: 22,
+        foundationLabel: 'CNCF',
+        ...heroOverrides,
+      },
+      isNonLfProject: false,
+    };
+  }
+
+  async function stubHeroContext(page: Page, block: unknown): Promise<void> {
+    await page.route('**/api/user/personas*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          personas: ['contributor'],
+          personaProjects: {},
+          projects: [],
+          organizations: [
+            {
+              accountId: TEST_ACCOUNT_ID,
+              accountName: 'Red Hat LLC',
+              accountSlug: 'red-hat-llc',
+              membershipTier: '',
+              uid: TEST_ACCOUNT_ID,
+            },
+          ],
+          isRootWriter: false,
+        }),
+      })
+    );
+    await page.route('**/api/orgs/me/role-grants', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ writers: [TEST_ACCOUNT_ID], auditors: [], cascadingWriters: [], cascadingAuditors: [] }),
+      })
+    );
+    await page.route('**/api/nav/org-items*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [{ uid: TEST_ACCOUNT_ID, accountId: TEST_ACCOUNT_ID, name: 'Red Hat LLC', logoUrl: null, primaryDomain: 'redhat.com', isMember: true }],
+          next_page_token: null,
+          upstream_failed: false,
+          total: 1,
+        }),
+      })
+    );
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/[^/]+\/hero$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(block) });
+    });
+  }
+
+  test('opens the hero health popup on hover with the table-matching breakdown', async ({ page }) => {
+    await stubHeroContext(page, heroBlock());
+    await page.goto('/org/projects/kubernetes', { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page.getByTestId('project-detail-health-badge')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('project-detail-health-badge').hover();
+    await expect(page.getByTestId('org-health-popup-headline')).toHaveText('Healthy - Partial (52/65)');
+    await expect(page.getByTestId('org-health-popup-row-maintainer')).toContainText('30/40');
+    await expect(page.getByTestId('org-health-popup-row-security')).toContainText('-/35');
+    await expect(page.getByTestId('org-health-popup-row-development')).toContainText('22/25');
+    await expect(page.getByTestId('org-health-popup-link')).toHaveAttribute('href', /\/project\/kubernetes/);
+  });
+
+  test('opens the hero health popup on keyboard focus with a matching accessible name', async ({ page }) => {
+    await stubHeroContext(page, heroBlock());
+    await page.goto('/org/projects/kubernetes', { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page.getByTestId('project-detail-health-badge')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('project-detail-health-badge').focus();
+    await expect(page.getByTestId('org-health-popup-headline')).toHaveText('Healthy - Partial (52/65)');
+    await expect(page.getByTestId('project-detail-health-badge')).toHaveAttribute(
+      'aria-label',
+      'Health: Healthy - Partial (52/65). Maintainer Health 30/40, Security & Supply Chain -/35, Development Activity 22/25.'
+    );
+  });
+
+  test('renders the unavailable badge and popup block when the hero has no v2 score', async ({ page }) => {
+    await stubHeroContext(
+      page,
+      heroBlock({
+        health: null,
+        healthOverallScore: null,
+        healthMaxScore: null,
+        healthCoveredCategoryCount: null,
+        healthMaintainer: null,
+        healthSecurity: null,
+        healthDevelopment: null,
+      })
+    );
+    await page.goto('/org/projects/kubernetes', { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    const badge = page.getByTestId('project-detail-health-badge');
+    await expect(badge).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(badge).toHaveText('Unavailable');
+
+    await badge.hover();
+    await expect(page.getByTestId('org-health-popup-unavailable')).toHaveText('Health score is unavailable for this project.');
   });
 });

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -84,6 +84,21 @@ function healthOnlyProject(slug: string, name: string) {
   };
 }
 
+// Partial v2 score with a consistent same-row shape: maintainer 30/40 + development 22/25 = 52,
+// security uncovered, so the max is 65 (40 + 25).
+function partialProject(slug: string, name: string) {
+  return {
+    ...project(slug, name),
+    health: 'healthy',
+    healthOverallScore: 52,
+    healthMaxScore: 65,
+    healthCoveredCategoryCount: 2,
+    healthMaintainer: 30,
+    healthSecurity: null,
+    healthDevelopment: 22,
+  };
+}
+
 // Ecosystem-only participation: a project the org participates in through non-code channels (no trailing-24-month
 // code activity) but which the org dashboard still lists with real bands/health/trend. metricsState stays `full`
 // (org-dashboard parity), so the row renders as a real, linkable project — NOT an Unavailable fallback.
@@ -474,6 +489,71 @@ test.describe('Org Projects', () => {
     await expect(page.getByTestId('org-projects-health-kubernetes')).toHaveAttribute('aria-label', /Health: Excellent/);
     await expect(page.getByTestId('org-projects-trend-kubernetes')).toHaveText('Unavailable');
     await expect(row.getByText('Unavailable').first()).toBeVisible();
+  });
+
+  test('opens the health popup on hover with headline, description, and rows', async ({ page }) => {
+    await gotoOrgProjectsPage(page);
+    await expect(page.getByTestId('org-projects-row-kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('org-projects-health-kubernetes').hover();
+    await expect(page.getByTestId('org-health-popup-headline')).toHaveText('Excellent (88/100)');
+    await expect(page.getByTestId('org-health-popup-description')).toContainText('Strong development cadence');
+    await expect(page.getByTestId('org-health-popup-row-maintainer')).toContainText('35/40');
+    await expect(page.getByTestId('org-health-popup-row-security')).toContainText('30/35');
+    await expect(page.getByTestId('org-health-popup-row-development')).toContainText('23/25');
+    await expect(page.getByTestId('org-health-popup-link')).toHaveAttribute('href', /\/project\/kubernetes/);
+  });
+
+  test('opens the health popup on focus with badge, popup, and aria in agreement', async ({ page }) => {
+    await stubOrgContext(page);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects(?:\?.*)?$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return fulfillJson(route, projectsResponse([partialProject('seapath', 'SEAPATH')]));
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto(ORG_PROJECTS_URL, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    if (!page.url().includes('/org/projects')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/projects redirected away');
+    }
+
+    const badge = page.getByTestId('org-projects-health-seapath');
+    await expect(badge).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(badge).toHaveText('Healthy - Partial');
+    await badge.focus();
+    await expect(page.getByTestId('org-health-popup-headline')).toHaveText('Healthy - Partial (52/65)');
+    await expect(page.getByTestId('org-health-popup-row-security')).toContainText('-/35');
+    await expect(badge).toHaveAttribute(
+      'aria-label',
+      'Health: Healthy - Partial (52/65). Maintainer Health 30/40, Security & Supply Chain -/35, Development Activity 22/25.'
+    );
+    await expect(page.getByTestId('org-health-popup-link')).toHaveAttribute('href', /\/project\/seapath/);
+  });
+
+  test('renders the unavailable popup block for projects without a v2 score', async ({ page }) => {
+    await stubOrgContext(page);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects(?:\?.*)?$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return fulfillJson(route, projectsResponse([unavailableProject('cnab', 'CNAB')]));
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto(ORG_PROJECTS_URL, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    if (!page.url().includes('/org/projects')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/projects redirected away');
+    }
+
+    const badge = page.getByTestId('org-projects-health-cnab');
+    await expect(badge).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(badge).toHaveAttribute('aria-label', 'Health: Unavailable.');
+    await badge.hover();
+    await expect(page.getByTestId('org-health-popup-unavailable')).toHaveText('Health score is unavailable for this project.');
   });
 
   test('shows the already-in-workspace empty state when a search matches only existing projects', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -30,6 +30,12 @@ function project(slug: string, name: string) {
     logoUrl: '',
     foundation: { slug: 'cncf', name: 'CNCF', logoUrl: '' },
     health: 'excellent',
+    healthOverallScore: 88,
+    healthMaxScore: 100,
+    healthCoveredCategoryCount: 3,
+    healthMaintainer: 35,
+    healthSecurity: 30,
+    healthDevelopment: 23,
     technicalInfluence: 'leading',
     ecosystemInfluence: 'leading',
     influenceScore: 90,
@@ -41,12 +47,6 @@ function project(slug: string, name: string) {
     commits1y: 42,
     changeDriver: { label: 'Not calculated yet', direction: 'flat' },
     description: `${name} project description.`,
-    healthMetrics: [
-      { label: 'Contributors', value: 90 },
-      { label: 'Popularity', value: 80 },
-      { label: 'Development', value: 85 },
-      { label: 'Security', value: 75 },
-    ],
     metricsState: 'full',
   };
 }
@@ -56,10 +56,15 @@ function unavailableProject(slug: string, name: string) {
   return {
     ...project(slug, name),
     health: 'unavailable',
+    healthOverallScore: null,
+    healthMaxScore: null,
+    healthCoveredCategoryCount: null,
+    healthMaintainer: null,
+    healthSecurity: null,
+    healthDevelopment: null,
     trend: { deltaPct: 0, technicalDeltaPct: 0, ecosystemDeltaPct: 0, direction: 'flat', series: [0, 0, 0, 0] },
     contributors: [],
     participants: [],
-    healthMetrics: [],
     metricsState: 'unavailable',
     noActivityYet: true,
   };
@@ -74,12 +79,6 @@ function healthOnlyProject(slug: string, name: string) {
     trend: { deltaPct: 0, technicalDeltaPct: 0, ecosystemDeltaPct: 0, direction: 'flat', series: [0, 0, 0, 0] },
     contributors: [],
     participants: [],
-    healthMetrics: [
-      { label: 'Contributors', value: 90 },
-      { label: 'Popularity', value: 80 },
-      { label: 'Development', value: 85 },
-      { label: 'Security', value: 75 },
-    ],
     metricsState: 'health-only',
     noActivityYet: true,
   };

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
@@ -7,6 +7,7 @@
   appendTo="body"
   ariaLabel="Health score details"
   hideTransitionOptions="0ms"
+  [focusOnShow]="false"
   (onShow)="onShow()"
   (onHide)="onHide()"
   data-testid="org-health-popup">

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
@@ -1,8 +1,16 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<p-popover #popover [dismissable]="true" appendTo="body" ariaLabel="Health score details" data-testid="org-health-popup">
-  <div class="flex w-64 flex-col gap-3 text-xs" (mouseenter)="cancelHide()" (mouseleave)="scheduleHide()">
+<p-popover #popover [dismissable]="true" appendTo="body" ariaLabel="Health score details" hideTransitionOptions="0ms" data-testid="org-health-popup">
+  <div
+    class="flex w-64 flex-col gap-3 rounded text-xs focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+    tabindex="0"
+    role="group"
+    aria-label="Health score details"
+    (mouseenter)="cancelHide()"
+    (mouseleave)="scheduleHide()"
+    (focusin)="cancelHide()"
+    (focusout)="scheduleHide()">
     <div class="flex items-center justify-between gap-2">
       <span class="text-sm font-semibold text-gray-900">Health score</span>
       <a [href]="insightsUrl()" target="_blank" rel="noopener noreferrer" class="font-medium text-blue-600 hover:underline" data-testid="org-health-popup-link">

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<p-popover #popover [dismissable]="true" appendTo="body" data-testid="org-health-popup">
+<p-popover #popover [dismissable]="true" appendTo="body" ariaLabel="Health score details" data-testid="org-health-popup">
   <div class="flex w-64 flex-col gap-3 text-xs" (mouseenter)="cancelHide()" (mouseleave)="scheduleHide()">
     <div class="flex items-center justify-between gap-2">
       <span class="text-sm font-semibold text-gray-900">Health score</span>

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
@@ -1,0 +1,35 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-popover #popover [dismissable]="true" appendTo="body" data-testid="org-health-popup">
+  <div class="flex w-64 flex-col gap-3 text-xs" (mouseenter)="cancelHide()" (mouseleave)="scheduleHide()">
+    <div class="flex items-center justify-between gap-2">
+      <span class="text-sm font-semibold text-gray-900">Health score</span>
+      <a [href]="insightsUrl()" target="_blank" rel="noopener noreferrer" class="font-medium text-blue-600 hover:underline" data-testid="org-health-popup-link">
+        LFX Insights <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+      </a>
+    </div>
+    @if (available()) {
+      <div class="flex items-center gap-1.5" data-testid="org-health-popup-headline">
+        <span class="font-semibold text-gray-900">{{ headline() }}</span>
+      </div>
+      <div class="h-1.5 w-full overflow-hidden rounded-full bg-gray-200" aria-hidden="true">
+        <div class="h-full rounded-full" [style.width.%]="barFill()" [style.backgroundColor]="barFillColor()"></div>
+      </div>
+      @if (description(); as text) {
+        <p class="text-gray-500" data-testid="org-health-popup-description">{{ text }}</p>
+      }
+      <div class="flex flex-col gap-1.5 border-t border-gray-100 pt-2">
+        @for (row of rows(); track row.key) {
+          <div class="flex items-center gap-1.5" [attr.data-testid]="'org-health-popup-row-' + row.key">
+            <i [class]="'fa-light fa-' + row.icon + ' w-3 text-center text-gray-400'" aria-hidden="true"></i>
+            <span class="text-gray-500">{{ row.name }}</span>
+            <span class="ml-auto font-medium text-gray-900">{{ row.display }}</span>
+          </div>
+        }
+      </div>
+    } @else {
+      <p class="text-gray-500" data-testid="org-health-popup-unavailable">{{ unavailableText }}</p>
+    }
+  </div>
+</p-popover>

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.html
@@ -1,8 +1,17 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<p-popover #popover [dismissable]="true" appendTo="body" ariaLabel="Health score details" hideTransitionOptions="0ms" data-testid="org-health-popup">
+<p-popover
+  #popover
+  [dismissable]="true"
+  appendTo="body"
+  ariaLabel="Health score details"
+  hideTransitionOptions="0ms"
+  (onShow)="onShow()"
+  (onHide)="onHide()"
+  data-testid="org-health-popup">
   <div
+    #content
     class="flex w-64 flex-col gap-3 rounded text-xs focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
     tabindex="0"
     role="group"
@@ -13,9 +22,11 @@
     (focusout)="scheduleHide()">
     <div class="flex items-center justify-between gap-2">
       <span class="text-sm font-semibold text-gray-900">Health score</span>
-      <a [href]="insightsUrl()" target="_blank" rel="noopener noreferrer" class="font-medium text-blue-600 hover:underline" data-testid="org-health-popup-link">
-        LFX Insights <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
-      </a>
+      @if (insightsUrl(); as url) {
+        <a [href]="url" target="_blank" rel="noopener noreferrer" class="font-medium text-blue-600 hover:underline" data-testid="org-health-popup-link">
+          LFX Insights <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+        </a>
+      }
     </div>
     @if (available()) {
       <div class="flex items-center gap-1.5" data-testid="org-health-popup-headline">

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
@@ -77,9 +77,11 @@ export class OrgHealthPopupComponent {
   // itself cancel it first (same pattern as org-spend-bar's "others" popover).
   private hidePopoverTimeoutId: ReturnType<typeof setTimeout> | undefined;
   // Keyboard activation moves focus into the popup so the Insights link is reachable; the badge
-  // that opened it gets focus back on hide. Hover/focus opens never steal focus.
+  // that opened it gets focus back on hide. Hover/focus opens never steal focus. Restoring focus
+  // fires the badge's own `(focus)` → `show()`, which must not reopen what the user just closed.
   private focusOnShow = false;
   private returnFocusTo: HTMLElement | null = null;
+  private suppressNextFocusShow = false;
 
   public constructor() {
     // Navigating away mid-hover would otherwise leave the pending hide holding a destroyed component.
@@ -87,6 +89,10 @@ export class OrgHealthPopupComponent {
   }
 
   public show(event: Event): void {
+    if (event.type === 'focus' && this.suppressNextFocusShow) {
+      this.suppressNextFocusShow = false;
+      return;
+    }
     this.cancelHide();
     this.popover()?.show(event);
   }
@@ -120,8 +126,17 @@ export class OrgHealthPopupComponent {
   protected onHide(): void {
     this.isOpen.set(false);
     this.focusOnShow = false;
-    this.returnFocusTo?.focus();
+    const badge = this.returnFocusTo;
     this.returnFocusTo = null;
+    // Restore focus only when the close left it nowhere useful (Escape / click-outside → body, or still inside the
+    // popup). A Tab-away already moved focus on purpose; yanking it back would trap the user.
+    const active = document.activeElement;
+    const focusStranded = active === null || active === document.body || (this.content()?.nativeElement.contains(active) ?? false);
+    if (badge && focusStranded) {
+      this.suppressNextFocusShow = true;
+      badge.focus();
+      this.suppressNextFocusShow = false;
+    }
   }
 
   private focusContent(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
@@ -2,14 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, DestroyRef, inject, input, viewChild } from '@angular/core';
-import { HEALTH_SCORE_BAR_FILL, HEALTH_SCORE_LABELS, HEALTH_SCORE_PARTIAL_SUFFIX, ORG_HEALTH_POPUP_UNAVAILABLE_TEXT } from '@lfx-one/shared/constants';
-import { buildInsightsUrl, getHealthScoreDescription, isPartialHealthScore } from '@lfx-one/shared/utils';
-import { Popover, PopoverModule } from 'primeng/popover';
+import {
+  HEALTH_SCORE_BAR_FILL,
+  HEALTH_SCORE_CATEGORIES,
+  HEALTH_SCORE_LABELS,
+  HEALTH_SCORE_PARTIAL_SUFFIX,
+  ORG_HEALTH_POPUP_UNAVAILABLE_TEXT,
+} from '@lfx-one/shared/constants';
+import { getHealthScoreDescription, isPartialHealthScore } from '@lfx-one/shared/utils';
+import { PopoverModule } from 'primeng/popover';
+import type { Popover } from 'primeng/popover';
 
 import type { HealthScore, OrgLensHealthPopupRow } from '@lfx-one/shared/interfaces';
 
 /**
- * Shared Org Lens health popup (#2096) — a PrimeNG popover bound to a health badge on the Projects
+ * Shared Org Lens health popup — a PrimeNG popover bound to a health badge on the Projects
  * table and the project-detail hero. Content ports the Insights health-score pill 1:1 (headline,
  * rescaled bar, generated description, three `/40 /35 /25` rows); the header shell (title + outbound
  * `LFX Insights` link) is Org Lens. Hosts open it on badge hover/focus and schedule-hide on
@@ -28,7 +35,8 @@ export class OrgHealthPopupComponent {
   public readonly maintainer = input<number | null>(null);
   public readonly security = input<number | null>(null);
   public readonly development = input<number | null>(null);
-  public readonly projectSlug = input.required<string>();
+  /** Project's LFX Insights page URL — computed once by the host (BFF `lfxInsightsUrl` / table `insightsUrl`). */
+  public readonly insightsUrl = input.required<string>();
 
   protected readonly unavailableText = ORG_HEALTH_POPUP_UNAVAILABLE_TEXT;
   protected readonly available = computed(() => this.label() != null && this.score() != null);
@@ -53,12 +61,9 @@ export class OrgHealthPopupComponent {
     return band == null ? HEALTH_SCORE_BAR_FILL.healthy : HEALTH_SCORE_BAR_FILL[band];
   });
   protected readonly description = computed(() => getHealthScoreDescription(this.label(), this.maintainer(), this.security(), this.development()));
-  protected readonly rows = computed<OrgLensHealthPopupRow[]>(() => [
-    { key: 'maintainer', name: 'Maintainer Health', icon: 'heart-pulse', display: `${this.maintainer() ?? '-'}/40` },
-    { key: 'security', name: 'Security & Supply Chain', icon: 'shield-check', display: `${this.security() ?? '-'}/35` },
-    { key: 'development', name: 'Development Activity', icon: 'laptop-code', display: `${this.development() ?? '-'}/25` },
-  ]);
-  protected readonly insightsUrl = computed(() => buildInsightsUrl(`/project/${this.projectSlug()}`));
+  protected readonly rows = computed<OrgLensHealthPopupRow[]>(() =>
+    HEALTH_SCORE_CATEGORIES.map((c) => ({ key: c.key, name: c.name, icon: c.icon, display: `${this[c.key]() ?? '-'}/${c.max}` }))
+  );
 
   private readonly popover = viewChild<Popover>('popover');
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
@@ -86,4 +86,8 @@ export class OrgHealthPopupComponent {
   public cancelHide(): void {
     clearTimeout(this.hidePopoverTimeoutId);
   }
+
+  public get isOpen(): boolean {
+    return this.popover()?.overlayVisible ?? false;
+  }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
@@ -1,0 +1,89 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, input, viewChild } from '@angular/core';
+import { HEALTH_SCORE_BAR_FILL, HEALTH_SCORE_LABELS, HEALTH_SCORE_PARTIAL_SUFFIX, ORG_HEALTH_POPUP_UNAVAILABLE_TEXT } from '@lfx-one/shared/constants';
+import { buildInsightsUrl, getHealthScoreDescription, isPartialHealthScore } from '@lfx-one/shared/utils';
+import { Popover, PopoverModule } from 'primeng/popover';
+
+import type { HealthScore, OrgLensHealthPopupRow } from '@lfx-one/shared/interfaces';
+
+/**
+ * Shared Org Lens health popup (#2096) — a PrimeNG popover bound to a health badge on the Projects
+ * table and the project-detail hero. Content ports the Insights health-score pill 1:1 (headline,
+ * rescaled bar, generated description, three `/40 /35 /25` rows); the header shell (title + outbound
+ * `LFX Insights` link) is Org Lens. Hosts open it on badge hover/focus and schedule-hide on
+ * leave/blur (see `scheduleHide`).
+ */
+@Component({
+  selector: 'lfx-org-health-popup',
+  imports: [PopoverModule],
+  templateUrl: './org-health-popup.component.html',
+})
+export class OrgHealthPopupComponent {
+  public readonly score = input<number | null>(null);
+  public readonly label = input<Exclude<HealthScore, 'unavailable'> | null>(null);
+  public readonly maxScore = input<number | null>(null);
+  public readonly coveredCount = input<number | null>(null);
+  public readonly maintainer = input<number | null>(null);
+  public readonly security = input<number | null>(null);
+  public readonly development = input<number | null>(null);
+  public readonly projectSlug = input.required<string>();
+
+  protected readonly unavailableText = ORG_HEALTH_POPUP_UNAVAILABLE_TEXT;
+  protected readonly available = computed(() => this.label() != null && this.score() != null);
+  protected readonly partial = computed(() => this.available() && isPartialHealthScore(this.coveredCount()));
+  protected readonly headline = computed(() => {
+    const band = this.label();
+    const points = this.score();
+    if (band == null || points == null) {
+      return '';
+    }
+    return `${HEALTH_SCORE_LABELS[band]}${this.partial() ? HEALTH_SCORE_PARTIAL_SUFFIX : ''} (${points}/${this.maxScore() ?? 100})`;
+  });
+  protected readonly barFill = computed(() => {
+    const points = this.score();
+    if (points == null) {
+      return 0;
+    }
+    return (points / (this.maxScore() ?? 100)) * 100;
+  });
+  protected readonly barFillColor = computed(() => {
+    const band = this.label();
+    return band == null ? HEALTH_SCORE_BAR_FILL.healthy : HEALTH_SCORE_BAR_FILL[band];
+  });
+  protected readonly description = computed(() => getHealthScoreDescription(this.label(), this.maintainer(), this.security(), this.development()));
+  protected readonly rows = computed<OrgLensHealthPopupRow[]>(() => [
+    { key: 'maintainer', name: 'Maintainer Health', icon: 'heart-pulse', display: `${this.maintainer() ?? '-'}/40` },
+    { key: 'security', name: 'Security & Supply Chain', icon: 'shield-check', display: `${this.security() ?? '-'}/35` },
+    { key: 'development', name: 'Development Activity', icon: 'laptop-code', display: `${this.development() ?? '-'}/25` },
+  ]);
+  protected readonly insightsUrl = computed(() => buildInsightsUrl(`/project/${this.projectSlug()}`));
+
+  private readonly popover = viewChild<Popover>('popover');
+
+  // `appendTo="body"` detaches the popover from the triggering badge, so the pointer briefly leaves
+  // the badge while crossing to the popover — a same-tick `hide()` on the badge's `mouseleave` would
+  // close it before the pointer arrives. Deferring the hide lets a `mouseenter` on the popover
+  // itself cancel it first (same pattern as org-spend-bar's "others" popover).
+  private hidePopoverTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  public constructor() {
+    // Navigating away mid-hover would otherwise leave the pending hide holding a destroyed component.
+    inject(DestroyRef).onDestroy(() => clearTimeout(this.hidePopoverTimeoutId));
+  }
+
+  public show(event: Event): void {
+    this.cancelHide();
+    this.popover()?.show(event);
+  }
+
+  public scheduleHide(): void {
+    this.cancelHide();
+    this.hidePopoverTimeoutId = setTimeout(() => this.popover()?.hide(), 100);
+  }
+
+  public cancelHide(): void {
+    clearTimeout(this.hidePopoverTimeoutId);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, ElementRef, inject, input, signal, viewChild } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, DestroyRef, ElementRef, inject, input, PLATFORM_ID, signal, viewChild } from '@angular/core';
 import {
   HEALTH_SCORE_BAR_FILL,
   HEALTH_SCORE_CATEGORIES,
@@ -65,6 +66,7 @@ export class OrgHealthPopupComponent {
     HEALTH_SCORE_CATEGORIES.map((c) => ({ key: c.key, name: c.name, icon: c.icon, display: `${this[c.key]() ?? '-'}/${c.max}` }))
   );
 
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly popover = viewChild<Popover>('popover');
   private readonly content = viewChild<ElementRef<HTMLElement>>('content');
 
@@ -100,7 +102,7 @@ export class OrgHealthPopupComponent {
   /** Keyboard-activated open (Enter/Space on the badge): opens and moves focus into the popup. */
   public showAndFocus(event: Event): void {
     this.focusOnShow = true;
-    this.returnFocusTo = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    this.returnFocusTo = this.isBrowser && event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
     this.show(event);
     if (this.isOpen()) {
       this.focusContent();
@@ -128,6 +130,9 @@ export class OrgHealthPopupComponent {
     this.focusOnShow = false;
     const badge = this.returnFocusTo;
     this.returnFocusTo = null;
+    if (!this.isBrowser) {
+      return;
+    }
     // Restore focus only when the close left it nowhere useful (Escape / click-outside → body, or still inside the
     // popup). A Tab-away already moved focus on purpose; yanking it back would trap the user.
     const active = document.activeElement;

--- a/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/components/org-health-popup/org-health-popup.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, inject, input, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, ElementRef, inject, input, signal, viewChild } from '@angular/core';
 import {
   HEALTH_SCORE_BAR_FILL,
   HEALTH_SCORE_CATEGORIES,
@@ -66,12 +66,20 @@ export class OrgHealthPopupComponent {
   );
 
   private readonly popover = viewChild<Popover>('popover');
+  private readonly content = viewChild<ElementRef<HTMLElement>>('content');
+
+  /** Open state for the badge's `aria-expanded`; driven by the popover's own show/hide events. */
+  public readonly isOpen = signal(false);
 
   // `appendTo="body"` detaches the popover from the triggering badge, so the pointer briefly leaves
   // the badge while crossing to the popover — a same-tick `hide()` on the badge's `mouseleave` would
   // close it before the pointer arrives. Deferring the hide lets a `mouseenter` on the popover
   // itself cancel it first (same pattern as org-spend-bar's "others" popover).
   private hidePopoverTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  // Keyboard activation moves focus into the popup so the Insights link is reachable; the badge
+  // that opened it gets focus back on hide. Hover/focus opens never steal focus.
+  private focusOnShow = false;
+  private returnFocusTo: HTMLElement | null = null;
 
   public constructor() {
     // Navigating away mid-hover would otherwise leave the pending hide holding a destroyed component.
@@ -83,6 +91,16 @@ export class OrgHealthPopupComponent {
     this.popover()?.show(event);
   }
 
+  /** Keyboard-activated open (Enter/Space on the badge): opens and moves focus into the popup. */
+  public showAndFocus(event: Event): void {
+    this.focusOnShow = true;
+    this.returnFocusTo = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    this.show(event);
+    if (this.isOpen()) {
+      this.focusContent();
+    }
+  }
+
   public scheduleHide(): void {
     this.cancelHide();
     this.hidePopoverTimeoutId = setTimeout(() => this.popover()?.hide(), 100);
@@ -92,7 +110,22 @@ export class OrgHealthPopupComponent {
     clearTimeout(this.hidePopoverTimeoutId);
   }
 
-  public get isOpen(): boolean {
-    return this.popover()?.overlayVisible ?? false;
+  protected onShow(): void {
+    this.isOpen.set(true);
+    if (this.focusOnShow) {
+      this.focusContent();
+    }
+  }
+
+  protected onHide(): void {
+    this.isOpen.set(false);
+    this.focusOnShow = false;
+    this.returnFocusTo?.focus();
+    this.returnFocusTo = null;
+  }
+
+  private focusContent(): void {
+    this.focusOnShow = false;
+    this.content()?.nativeElement.focus();
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -119,7 +119,7 @@
                   [maintainer]="h.healthMaintainer"
                   [security]="h.healthSecurity"
                   [development]="h.healthDevelopment"
-                  [projectSlug]="projectSlug() ?? ''" />
+                  [insightsUrl]="h.lfxInsightsUrl ?? ''" />
               </span>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -93,10 +93,31 @@
           <div class="flex flex-col gap-1">
             <span class="text-xs font-medium uppercase tracking-wide text-gray-500">Health score</span>
             @if (healthMeta(); as hm) {
-              <span class="md:ml-auto" data-testid="project-detail-health-badge">
-                <span class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold" [style.backgroundColor]="hm.bg" [style.color]="hm.text">{{
-                  hm.label
-                }}</span>
+              <span class="md:ml-auto">
+                <button
+                  type="button"
+                  data-testid="project-detail-health-badge"
+                  class="rounded bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  [attr.aria-label]="heroHealthAriaLabel()"
+                  (mouseenter)="heroHealthPopup.show($event)"
+                  (mouseleave)="heroHealthPopup.scheduleHide()"
+                  (focus)="heroHealthPopup.show($event)"
+                  (blur)="heroHealthPopup.scheduleHide()"
+                  (click)="heroHealthPopup.show($event)">
+                  <span class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold" [style.backgroundColor]="hm.bg" [style.color]="hm.text">{{
+                    hm.label
+                  }}</span>
+                </button>
+                <lfx-org-health-popup
+                  #heroHealthPopup
+                  [score]="h.healthOverallScore"
+                  [label]="h.health"
+                  [maxScore]="h.healthMaxScore"
+                  [coveredCount]="h.healthCoveredCategoryCount"
+                  [maintainer]="h.healthMaintainer"
+                  [security]="h.healthSecurity"
+                  [development]="h.healthDevelopment"
+                  [projectSlug]="projectSlug() ?? ''" />
               </span>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -99,6 +99,8 @@
                   data-testid="project-detail-health-badge"
                   class="rounded bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   [attr.aria-label]="heroHealthAriaLabel()"
+                  aria-haspopup="dialog"
+                  [attr.aria-expanded]="heroHealthPopup.isOpen"
                   (mouseenter)="heroHealthPopup.show($event)"
                   (mouseleave)="heroHealthPopup.scheduleHide()"
                   (focus)="heroHealthPopup.show($event)"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.html
@@ -100,12 +100,14 @@
                   class="rounded bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   [attr.aria-label]="heroHealthAriaLabel()"
                   aria-haspopup="dialog"
-                  [attr.aria-expanded]="heroHealthPopup.isOpen"
+                  [attr.aria-expanded]="heroHealthPopup.isOpen()"
                   (mouseenter)="heroHealthPopup.show($event)"
                   (mouseleave)="heroHealthPopup.scheduleHide()"
                   (focus)="heroHealthPopup.show($event)"
                   (blur)="heroHealthPopup.scheduleHide()"
-                  (click)="heroHealthPopup.show($event)">
+                  (click)="heroHealthPopup.show($event)"
+                  (keydown.enter)="heroHealthPopup.showAndFocus($event)"
+                  (keydown.space)="$event.preventDefault(); heroHealthPopup.showAndFocus($event)">
                   <span class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold" [style.backgroundColor]="hm.bg" [style.color]="hm.text">{{
                     hm.label
                   }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.spec.ts
@@ -162,8 +162,12 @@ describe('OrgProjectDetailComponent — healthMeta', () => {
     firstCommit: null,
     softwareValueUsd: null,
     health: null,
+    healthOverallScore: null,
     healthMaxScore: null,
     healthCoveredCategoryCount: null,
+    healthMaintainer: null,
+    healthSecurity: null,
+    healthDevelopment: null,
     foundationLabel: '',
   };
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -17,6 +17,7 @@ import { PersonDetailDrawerComponent } from '@components/person-detail-drawer/pe
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { OrgLeaderboardDetailDrawerComponent } from '../../components/org-leaderboard-detail-drawer/org-leaderboard-detail-drawer.component';
+import { OrgHealthPopupComponent } from '../components/org-health-popup/org-health-popup.component';
 import { OrgProjectDetailTabBarComponent } from './org-project-detail-tab-bar.component';
 import {
   BAND_CHIP_CLASS,
@@ -61,7 +62,7 @@ import type {
   OrgLensProjectLeaderboardRow,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
-import { isPartialHealthScore, parseLocalDateString } from '@lfx-one/shared/utils';
+import { buildHealthAriaLabel, isPartialHealthScore, parseLocalDateString } from '@lfx-one/shared/utils';
 import type { MenuItem } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { InputTextModule } from 'primeng/inputtext';
@@ -93,6 +94,7 @@ import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, 
     PersonDetailDrawerComponent,
     TableComponent,
     TagComponent,
+    OrgHealthPopupComponent,
     DrawerModule,
     InputTextModule,
     SkeletonModule,
@@ -225,6 +227,17 @@ export class OrgProjectDetailComponent {
     // sourced straight from the BFF's healthCoveredCategoryCount — never recomputed locally.
     return isPartialHealthScore(hero?.healthCoveredCategoryCount ?? null) ? { ...tag, label: `${tag.label}${HEALTH_SCORE_PARTIAL_SUFFIX}` } : tag;
   });
+  protected readonly heroHealthAriaLabel = computed(() =>
+    buildHealthAriaLabel({
+      label: this.hero()?.health ?? null,
+      score: this.hero()?.healthOverallScore ?? null,
+      maxScore: this.hero()?.healthMaxScore ?? null,
+      coveredCount: this.hero()?.healthCoveredCategoryCount ?? null,
+      maintainer: this.hero()?.healthMaintainer ?? null,
+      security: this.hero()?.healthSecurity ?? null,
+      development: this.hero()?.healthDevelopment ?? null,
+    })
+  );
   protected readonly firstCommitLabel = computed(() => this.formatMonthYear(this.hero()?.firstCommit ?? null));
   protected readonly softwareValueLabel = computed(() => this.formatCompactUsd(this.hero()?.softwareValueUsd ?? null));
   protected readonly logoInitials = computed(() => this.initialsFor(this.hero()?.projectName ?? ''));

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -284,18 +284,33 @@
                   </div>
                 </td>
                 <td>
-                  <span
-                    class="inline-flex rounded"
-                    role="img"
+                  <button
+                    type="button"
+                    class="rounded bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     [attr.aria-label]="project.healthAriaLabel"
-                    [attr.data-testid]="'org-projects-health-' + project.slug">
+                    [attr.data-testid]="'org-projects-health-' + project.slug"
+                    (mouseenter)="healthPopup.show($event)"
+                    (mouseleave)="healthPopup.scheduleHide()"
+                    (focus)="healthPopup.show($event)"
+                    (blur)="healthPopup.scheduleHide()"
+                    (click)="healthPopup.show($event)">
                     <span
                       class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
                       [style.backgroundColor]="project.healthBadge.bg"
                       [style.color]="project.healthBadge.text"
                       >{{ project.healthLabel }}</span
                     >
-                  </span>
+                  </button>
+                  <lfx-org-health-popup
+                    #healthPopup
+                    [score]="project.healthOverallScore"
+                    [label]="project.health === 'unavailable' ? null : project.health"
+                    [maxScore]="project.healthMaxScore"
+                    [coveredCount]="project.healthCoveredCategoryCount"
+                    [maintainer]="project.healthMaintainer"
+                    [security]="project.healthSecurity"
+                    [development]="project.healthDevelopment"
+                    [projectSlug]="project.slug" />
                 </td>
                 <td>
                   <span class="inline-flex items-center gap-2">
@@ -420,7 +435,6 @@
 <!-- Shared popup action menu — items rebuilt per row on open -->
 <lfx-menu #rowActionMenu [model]="rowMenuItems" [popup]="true" appendTo="body" data-testid="org-projects-row-action-menu" />
 
-<!-- Shared health-detail popover — content bound to the hovered row (LFX Insights style) -->
 <!-- Workspace dropdown — shared workspaces, per-item settings, add-workspace footer -->
 <p-popover #workspacePopover [dismissable]="true" data-testid="org-projects-workspace-popover">
   <div class="flex w-72 flex-col py-1">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -288,6 +288,8 @@
                     type="button"
                     class="rounded bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     [attr.aria-label]="project.healthAriaLabel"
+                    aria-haspopup="dialog"
+                    [attr.aria-expanded]="healthPopup.isOpen"
                     [attr.data-testid]="'org-projects-health-' + project.slug"
                     (mouseenter)="healthPopup.show($event)"
                     (mouseleave)="healthPopup.scheduleHide()"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -289,13 +289,15 @@
                     class="rounded bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     [attr.aria-label]="project.healthAriaLabel"
                     aria-haspopup="dialog"
-                    [attr.aria-expanded]="healthPopup.isOpen"
+                    [attr.aria-expanded]="healthPopup.isOpen()"
                     [attr.data-testid]="'org-projects-health-' + project.slug"
                     (mouseenter)="healthPopup.show($event)"
                     (mouseleave)="healthPopup.scheduleHide()"
                     (focus)="healthPopup.show($event)"
                     (blur)="healthPopup.scheduleHide()"
-                    (click)="healthPopup.show($event)">
+                    (click)="healthPopup.show($event)"
+                    (keydown.enter)="healthPopup.showAndFocus($event)"
+                    (keydown.space)="$event.preventDefault(); healthPopup.showAndFocus($event)">
                     <span
                       class="inline-flex px-2.5 py-1 rounded-full text-xs font-semibold"
                       [style.backgroundColor]="project.healthBadge.bg"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -312,7 +312,7 @@
                     [maintainer]="project.healthMaintainer"
                     [security]="project.healthSecurity"
                     [development]="project.healthDevelopment"
-                    [projectSlug]="project.slug" />
+                    [insightsUrl]="project.insightsUrl" />
                 </td>
                 <td>
                   <span class="inline-flex items-center gap-2">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -541,7 +541,7 @@ export class OrgProjectsComponent {
       const orgMetricsUnavailable = this.isOrgMetricsUnavailable(p);
       return [
         p.name,
-        HEALTH_SCORE_LABELS[this.normalizeHealth(p.health)],
+        this.healthLabelFor(p),
         orgMetricsUnavailable ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[p.technicalInfluence],
         orgMetricsUnavailable ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[p.ecosystemInfluence],
         orgMetricsUnavailable ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : p.trend.deltaPct,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -48,7 +48,7 @@ import type {
   OrgProjectsWorkspaceId,
   SortDirection,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl, downloadCsv, isPartialHealthScore, localDateStamp } from '@lfx-one/shared/utils';
+import { buildHealthAriaLabel, buildInsightsUrl, downloadCsv, isPartialHealthScore, localDateStamp } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogModule } from 'primeng/dialog';
 import { PopoverModule } from 'primeng/popover';
@@ -67,6 +67,7 @@ import { MultiSelectComponent } from '@components/multi-select/multi-select.comp
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
+import { OrgHealthPopupComponent } from '../components/org-health-popup/org-health-popup.component';
 import { AccountContextService } from '@shared/services/account-context.service';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 import { OrgLensProjectsService } from '@shared/services/org-lens-projects.service';
@@ -92,6 +93,7 @@ import { PersonaService } from '@shared/services/persona.service';
     SkeletonModule,
     TableComponent,
     TooltipModule,
+    OrgHealthPopupComponent,
   ],
   templateUrl: './org-projects.component.html',
   styleUrl: './org-projects.component.scss',
@@ -593,10 +595,18 @@ export class OrgProjectsComponent {
     const fmt = (v: number): string => `${v > 0 ? '+' : ''}${v}%`;
     return `Influence trend over the past year — combined ${fmt(t.deltaPct)}, technical ${fmt(t.technicalDeltaPct)}, ecosystem ${fmt(t.ecosystemDeltaPct)}.`;
   }
-  // Full health summary (rating + sub-scores) so keyboard/screen-reader users get the popover's content without a mouse.
+  // Full health summary so keyboard/screen-reader users get the popup's content without a mouse —
+  // one shared rule (contract §4), same text the hero badge uses.
   protected healthAriaLabel(project: OrgLensProject): string {
-    const metrics = project.healthMetrics.map((m) => `${m.label} ${m.value}`).join(', ');
-    return `Health: ${this.healthLabelFor(project)}. ${metrics}.`;
+    return buildHealthAriaLabel({
+      label: project.health === 'unavailable' ? null : project.health,
+      score: project.healthOverallScore,
+      maxScore: project.healthMaxScore,
+      coveredCount: project.healthCoveredCategoryCount,
+      maintainer: project.healthMaintainer,
+      security: project.healthSecurity,
+      development: project.healthDevelopment,
+    });
   }
   /** The "Add project(s)" multi-select filter box drives the debounced server-side project search. */
   protected onAddProjectsFilter(query: string): void {
@@ -1038,9 +1048,13 @@ export class OrgProjectsComponent {
   }
 
   // Bare band label, plus " - Partial" when the BFF-sourced coveredCategoryCount marks a 2-of-3 score
-  // (never recomputed locally — see OrgLensProject.healthCoveredCategoryCount).
+  // (never recomputed locally — see OrgLensProject.healthCoveredCategoryCount). Gated on available:
+  // an unavailable badge never carries the suffix.
   private healthLabelFor(project: OrgLensProject): string {
     const label = HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)];
+    if (project.health === 'unavailable') {
+      return label;
+    }
     return isPartialHealthScore(project.healthCoveredCategoryCount) ? `${label}${HEALTH_SCORE_PARTIAL_SUFFIX}` : label;
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -596,7 +596,7 @@ export class OrgProjectsComponent {
     return `Influence trend over the past year — combined ${fmt(t.deltaPct)}, technical ${fmt(t.technicalDeltaPct)}, ecosystem ${fmt(t.ecosystemDeltaPct)}.`;
   }
   // Full health summary so keyboard/screen-reader users get the popup's content without a mouse —
-  // one shared rule (contract §4), same text the hero badge uses.
+  // one shared rule, same text the hero badge uses.
   protected healthAriaLabel(project: OrgLensProject): string {
     return buildHealthAriaLabel({
       label: project.health === 'unavailable' ? null : project.health,

--- a/apps/lfx-one/src/app/shared/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-project-detail.service.ts
@@ -40,10 +40,10 @@ export class OrgLensProjectDetailService {
     }
     return this.blockGet<OrgLensHeroBlock>(`${this.baseUrl(orgUid, projectSlug)}/hero`, { orgName }).pipe(
       map((block) => {
-        // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never sees them.
-        const normalized = block
-          ? { ...block, hero: { ...block.hero, health: block.hero.health ? (mapV1BandToV2(block.hero.health) as OrgLensProjectHealth) : null } }
-          : block;
+        // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never
+        // sees them; a band without `healthOverallScore` (pre-v2-breakdown BFF) is unavailable so badge and popup agree.
+        const health = block?.hero.health && block.hero.healthOverallScore != null ? (mapV1BandToV2(block.hero.health) as OrgLensProjectHealth) : null;
+        const normalized = block ? { ...block, hero: { ...block.hero, health } } : block;
         if (this.heroCache.size >= OrgLensProjectDetailService.maxHeroEntries) {
           this.heroCache.clear();
         }

--- a/apps/lfx-one/src/app/shared/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-projects.service.ts
@@ -25,10 +25,15 @@ export class OrgLensProjectsService {
       params = params.set('slugs', slugs.join(','));
     }
     return this.http.get<OrgLensProjectsResponse>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/projects`, { params }).pipe(
-      // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never sees them.
+      // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never
+      // sees them; a pre-v2-breakdown BFF also emits a band without `healthOverallScore`, which the badge must treat as
+      // unavailable so it agrees with the popup and accessible name.
       map((response) => ({
         ...response,
-        projects: response.projects.map((project) => ({ ...project, health: mapV1BandToV2(project.health) as HealthScore })),
+        projects: response.projects.map((project) => ({
+          ...project,
+          health: project.healthOverallScore == null ? ('unavailable' as HealthScore) : (mapV1BandToV2(project.health) as HealthScore),
+        })),
       }))
     );
   }

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -254,13 +254,25 @@ describe('OrgLensProjectDetailService.getHeroBlock health mapping', () => {
     expect(block?.hero.health).toBeNull();
   });
 
-  it('passes healthMaxScore and healthCoveredCategoryCount straight through from the warehouse', async () => {
-    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 70, HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 });
+  it('passes the v2 score, max, covered count and category scores straight through from the warehouse', async () => {
+    mockHeroRow({
+      HEALTH_OVERALL_SCORE_V2: 70,
+      HEALTH_SCORE_CATEGORY_V2: 'Healthy',
+      COVERED_CATEGORY_COUNT_V2: 2,
+      HEALTH_MAX_SCORE_V2: 75,
+      HEALTH_MAINTAINER_V2: 38,
+      HEALTH_SECURITY_V2: 32,
+      HEALTH_DEVELOPMENT_V2: null,
+    });
 
     const block = await service.getHeroBlock(ORG, SLUG);
 
     expect(block?.hero.healthCoveredCategoryCount).toBe(2);
     expect(block?.hero.healthMaxScore).toBe(75);
+    expect(block?.hero.healthOverallScore).toBe(70);
+    expect(block?.hero.healthMaintainer).toBe(38);
+    expect(block?.hero.healthSecurity).toBe(32);
+    expect(block?.hero.healthDevelopment).toBeNull();
   });
 });
 

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -31,7 +31,6 @@ vi.mock('@lfx-one/shared/utils', async () => {
   const actual = await import('../../../../../packages/shared/src/utils/insights.utils');
   return {
     buildInsightsUrl: () => '',
-    classifyHealthScore: actual.classifyHealthScore,
     normalizeHealthScoreCategoryV2: actual.normalizeHealthScoreCategoryV2,
   };
 });

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1905,8 +1905,8 @@ export class OrgLensProjectDetailService {
 
   private mapHealth(row: Pick<HeroRow, 'HEALTH_SCORE_CATEGORY_V2' | 'HEALTH_OVERALL_SCORE_V2' | 'PROJECT_SLUG'>): OrgLensProjectHealth | null {
     // The warehouse v2 category is the sole source of truth for the health label — never fall back to
-    // classifying the legacy v1 score when the v2 category is null (LFXV2-3379). Available ⇔ normalized
-    // label non-null AND score non-null (#2096); `covered` drives only the ` - Partial` suffix.
+    // classifying the legacy v1 score when the v2 category is null (LFXV2-3379). Availability rule:
+    // see OrgLensProjectHero.health.
     const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
     if (row.HEALTH_SCORE_CATEGORY_V2 != null && !category) {
       logger.warning(undefined, 'map_org_project_health', 'Unrecognized warehouse health_score_category_v2; treating as unavailable', {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -45,9 +45,13 @@ interface HeroRow {
   FOUNDATION_NAME: string | null;
   IS_LF_PROJECT: boolean | null;
   DESCRIPTION: string | null;
+  HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
   COVERED_CATEGORY_COUNT_V2: number | null;
   HEALTH_MAX_SCORE_V2: number | null;
+  HEALTH_MAINTAINER_V2: number | null;
+  HEALTH_SECURITY_V2: number | null;
+  HEALTH_DEVELOPMENT_V2: number | null;
   SOFTWARE_VALUE: number | null;
   FIRST_COMMIT_TS: Date | string | null;
 }
@@ -552,9 +556,9 @@ export class OrgLensProjectDetailService {
 
   public async getHeroBlock(orgUid: string, projectSlug: string): Promise<OrgLensHeroBlock | null> {
     const slug = projectSlug.trim().toLowerCase();
-    // `v2` bump: mapHealth no longer falls back to the legacy v1 score when the v2 category is null
-    // (LFXV2-3379) — bumping drops cached hero blocks computed under the old fallback logic (e.g. "Fair").
-    const key = buildOrgCacheKey(orgUid, `project-detail-hero:v2:${this.paramSignature([slug])}`);
+    // `v3` bump: hero now carries the v2 breakdown (`healthOverallScore` + Maintainer/Security/Development, #2096)
+    // mapped from the same snapshot row — bumping drops cached hero blocks computed under the old shape.
+    const key = buildOrgCacheKey(orgUid, `project-detail-hero:v3:${this.paramSignature([slug])}`);
     if (key !== null) {
       const cached = await valkeyService.getJson<OrgLensHeroBlock>(key, OrgLensProjectDetailService.isHeroBlock);
       if (cached !== null) return cached;
@@ -1102,8 +1106,9 @@ export class OrgLensProjectDetailService {
     const result = await this.snowflakeService.execute<HeroRow>(
       `
         SELECT PROJECT_NAME, PROJECT_SLUG, PROJECT_LOGO_URL, FOUNDATION_NAME, IS_LF_PROJECT,
-               DESCRIPTION, HEALTH_SCORE_CATEGORY_V2,
+               DESCRIPTION, HEALTH_OVERALL_SCORE_V2, HEALTH_SCORE_CATEGORY_V2,
                COVERED_CATEGORY_COUNT_V2, HEALTH_MAX_SCORE_V2,
+               HEALTH_MAINTAINER_V2, HEALTH_SECURITY_V2, HEALTH_DEVELOPMENT_V2,
                SOFTWARE_VALUE, FIRST_COMMIT_TS
         FROM ${this.projectsTable()}
         WHERE ACCOUNT_ID = ? AND PROJECT_SLUG = ?
@@ -1887,16 +1892,21 @@ export class OrgLensProjectDetailService {
       firstCommit: toIsoDate(row.FIRST_COMMIT_TS),
       softwareValueUsd: row.SOFTWARE_VALUE ?? null,
       health: this.mapHealth(row),
-      // Sourced straight from the warehouse — never recomputed, independent of mapHealth's category normalization.
+      // Sourced straight from the same warehouse snapshot row as the label — never recomputed.
+      healthOverallScore: row.HEALTH_OVERALL_SCORE_V2 ?? null,
       healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
       healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
+      healthMaintainer: row.HEALTH_MAINTAINER_V2 ?? null,
+      healthSecurity: row.HEALTH_SECURITY_V2 ?? null,
+      healthDevelopment: row.HEALTH_DEVELOPMENT_V2 ?? null,
       foundationLabel,
     };
   }
 
-  private mapHealth(row: Pick<HeroRow, 'HEALTH_SCORE_CATEGORY_V2' | 'PROJECT_SLUG'>): OrgLensProjectHealth | null {
+  private mapHealth(row: Pick<HeroRow, 'HEALTH_SCORE_CATEGORY_V2' | 'HEALTH_OVERALL_SCORE_V2' | 'PROJECT_SLUG'>): OrgLensProjectHealth | null {
     // The warehouse v2 category is the sole source of truth for the health label — never fall back to
-    // classifying the legacy v1 score when the v2 category is null (LFXV2-3379).
+    // classifying the legacy v1 score when the v2 category is null (LFXV2-3379). Available ⇔ normalized
+    // label non-null AND score non-null (#2096); `covered` drives only the ` - Partial` suffix.
     const category = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
     if (row.HEALTH_SCORE_CATEGORY_V2 != null && !category) {
       logger.warning(undefined, 'map_org_project_health', 'Unrecognized warehouse health_score_category_v2; treating as unavailable', {
@@ -1904,7 +1914,7 @@ export class OrgLensProjectDetailService {
         category: row.HEALTH_SCORE_CATEGORY_V2,
       });
     }
-    return category;
+    return category != null && row.HEALTH_OVERALL_SCORE_V2 != null ? category : null;
   }
 
   private buildTechnicalCards(cards: CardsRow | null, index: SparklineIndex, axis: string[]): OrgLensProjectInfluenceCard[] {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1884,6 +1884,9 @@ export class OrgLensProjectDetailService {
   }
 
   private mapHero(row: HeroRow, slug: string, foundationLabel: string): OrgLensProjectHero {
+    const health = this.mapHealth(row);
+    // When unavailable every health field is null so badge, popup and accessible name can never disagree.
+    const available = health !== null;
     return {
       projectName: row.PROJECT_NAME,
       description: row.DESCRIPTION ?? `${row.PROJECT_NAME} is an open source project in the ${foundationLabel} ecosystem.`,
@@ -1891,14 +1894,14 @@ export class OrgLensProjectDetailService {
       lfxInsightsUrl: buildInsightsUrl(`/project/${slug}`),
       firstCommit: toIsoDate(row.FIRST_COMMIT_TS),
       softwareValueUsd: row.SOFTWARE_VALUE ?? null,
-      health: this.mapHealth(row),
+      health,
       // Sourced straight from the same warehouse snapshot row as the label — never recomputed.
-      healthOverallScore: row.HEALTH_OVERALL_SCORE_V2 ?? null,
-      healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
-      healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
-      healthMaintainer: row.HEALTH_MAINTAINER_V2 ?? null,
-      healthSecurity: row.HEALTH_SECURITY_V2 ?? null,
-      healthDevelopment: row.HEALTH_DEVELOPMENT_V2 ?? null,
+      healthOverallScore: available ? (row.HEALTH_OVERALL_SCORE_V2 ?? null) : null,
+      healthMaxScore: available ? (row.HEALTH_MAX_SCORE_V2 ?? null) : null,
+      healthCoveredCategoryCount: available ? (row.COVERED_CATEGORY_COUNT_V2 ?? null) : null,
+      healthMaintainer: available ? (row.HEALTH_MAINTAINER_V2 ?? null) : null,
+      healthSecurity: available ? (row.HEALTH_SECURITY_V2 ?? null) : null,
+      healthDevelopment: available ? (row.HEALTH_DEVELOPMENT_V2 ?? null) : null,
       foundationLabel,
     };
   }
@@ -2286,7 +2289,10 @@ export class OrgLensProjectDetailService {
     if (value === null || typeof value !== 'object') return false;
     const candidate = value as OrgLensHeroBlock;
     if (!candidate.hero || typeof candidate.hero !== 'object' || typeof candidate.isNonLfProject !== 'boolean') return false;
-    const { health } = candidate.hero as OrgLensProjectHero;
+    const { health, healthOverallScore } = candidate.hero as OrgLensProjectHero;
+    // Reject pre-v2-breakdown entries (no `healthOverallScore` key) so a cached band never renders with an
+    // unavailable popup.
+    if (healthOverallScore !== null && typeof healthOverallScore !== 'number') return false;
     return health === null || Object.prototype.hasOwnProperty.call(PD_HEALTH_TAG, health);
   }
 

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -23,7 +23,6 @@ vi.mock('./valkey.service', () => ({
 vi.mock('@lfx-one/shared/utils', async () => {
   const actual = await import('../../../../../packages/shared/src/utils/insights.utils');
   return {
-    classifyHealthScore: actual.classifyHealthScore,
     normalizeHealthScoreCategoryV2: actual.normalizeHealthScoreCategoryV2,
   };
 });
@@ -54,13 +53,13 @@ function projectsRow(overrides: Record<string, unknown> = {}) {
     TREND_DIRECTION: null,
     COMBINED_SCORE_SERIES: null,
     DBT_RUN_AT: null,
+    HEALTH_OVERALL_SCORE_V2: null,
     HEALTH_SCORE_CATEGORY_V2: null,
     COVERED_CATEGORY_COUNT_V2: null,
     HEALTH_MAX_SCORE_V2: null,
-    HEALTH_CONTRIBUTOR_PERCENTAGE: null,
-    HEALTH_POPULARITY_PERCENTAGE: null,
-    HEALTH_DEVELOPMENT_PERCENTAGE: null,
-    HEALTH_SECURITY_PERCENTAGE: null,
+    HEALTH_MAINTAINER_V2: null,
+    HEALTH_SECURITY_V2: null,
+    HEALTH_DEVELOPMENT_V2: null,
     DESCRIPTION: null,
     ...overrides,
   };
@@ -83,7 +82,7 @@ describe('OrgLensProjectsService health score mapping', () => {
   });
 
   it('uses the warehouse v2 category when present', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 65, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
@@ -107,7 +106,7 @@ describe('OrgLensProjectsService health score mapping', () => {
   });
 
   it('passes healthMaxScore and healthCoveredCategoryCount straight through from the warehouse', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 }));
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 52, HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
@@ -122,50 +121,5 @@ describe('OrgLensProjectsService health score mapping', () => {
 
     expect(response.projects[0]?.healthCoveredCategoryCount).toBe(3);
     expect(response.projects[0]?.healthMaxScore).toBe(100);
-  });
-
-  it('renders health metrics from the warehouse percentage columns even when the v2 category is null (LFXV2-3379)', async () => {
-    mockProjectsRow(
-      projectsRow({
-        HEALTH_SCORE_CATEGORY_V2: null,
-        HEALTH_CONTRIBUTOR_PERCENTAGE: 42,
-        HEALTH_POPULARITY_PERCENTAGE: 10,
-        HEALTH_DEVELOPMENT_PERCENTAGE: 75,
-        HEALTH_SECURITY_PERCENTAGE: 30,
-      })
-    );
-
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
-
-    expect(response.projects[0]?.health).toBe('unavailable');
-    expect(response.projects[0]?.healthMetrics).toEqual([
-      { label: 'Contributors', value: 42 },
-      { label: 'Popularity', value: 10 },
-      { label: 'Development', value: 75 },
-      { label: 'Security', value: 30 },
-    ]);
-  });
-
-  it('omits health metrics when no warehouse percentage columns are present', async () => {
-    mockProjectsRow(projectsRow());
-
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
-
-    expect(response.projects[0]?.healthMetrics).toEqual([]);
-  });
-
-  it('omits health metrics when only some warehouse percentage columns are present, never fabricating 0% for the rest (LFXV2-3379)', async () => {
-    mockProjectsRow(
-      projectsRow({
-        HEALTH_CONTRIBUTOR_PERCENTAGE: 42,
-        HEALTH_POPULARITY_PERCENTAGE: null,
-        HEALTH_DEVELOPMENT_PERCENTAGE: 75,
-        HEALTH_SECURITY_PERCENTAGE: null,
-      })
-    );
-
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
-
-    expect(response.projects[0]?.healthMetrics).toEqual([]);
   });
 });

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -115,7 +115,9 @@ describe('OrgLensProjectsService health score mapping', () => {
   });
 
   it('passes through a full (3-category) score unchanged, not marked partial', async () => {
-    mockProjectsRow(projectsRow({ COVERED_CATEGORY_COUNT_V2: 3, HEALTH_MAX_SCORE_V2: 100 }));
+    mockProjectsRow(
+      projectsRow({ HEALTH_OVERALL_SCORE_V2: 88, HEALTH_SCORE_CATEGORY_V2: 'Excellent', COVERED_CATEGORY_COUNT_V2: 3, HEALTH_MAX_SCORE_V2: 100 })
+    );
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -97,14 +97,17 @@ describe('OrgLensProjectsService health score mapping', () => {
     expect(response.projects[0]?.health).toBe('unavailable');
   });
 
-  it('marks health unavailable when no v2 category is present, or when the category has no score', async () => {
+  it('marks health unavailable when no v2 category is present', async () => {
     mockProjectsRow(projectsRow());
 
-    let response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('unavailable');
+  });
 
-    // Split row: label without a same-row score is unavailable and every health field is nulled.
+  // Split rows: label and score must come from the same snapshot; either one missing is unavailable and every
+  // health field is nulled so badge, popup, accessible name and CSV cannot disagree.
+  it('marks health unavailable and nulls every health field when the label has no same-row score', async () => {
     mockProjectsRow(
       projectsRow({
         HEALTH_SCORE_CATEGORY_V2: 'Healthy',
@@ -115,13 +118,37 @@ describe('OrgLensProjectsService health score mapping', () => {
       })
     );
 
-    response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('unavailable');
     expect(response.projects[0]?.healthOverallScore).toBeNull();
     expect(response.projects[0]?.healthMaxScore).toBeNull();
     expect(response.projects[0]?.healthCoveredCategoryCount).toBeNull();
     expect(response.projects[0]?.healthMaintainer).toBeNull();
+  });
+
+  it('marks health unavailable and nulls every health field when the score has no same-row label', async () => {
+    mockProjectsRow(
+      projectsRow({
+        HEALTH_SCORE_CATEGORY_V2: null,
+        HEALTH_OVERALL_SCORE_V2: 52,
+        COVERED_CATEGORY_COUNT_V2: 2,
+        HEALTH_MAX_SCORE_V2: 65,
+        HEALTH_MAINTAINER_V2: 30,
+        HEALTH_SECURITY_V2: null,
+        HEALTH_DEVELOPMENT_V2: 22,
+      })
+    );
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('unavailable');
+    expect(response.projects[0]?.healthOverallScore).toBeNull();
+    expect(response.projects[0]?.healthMaxScore).toBeNull();
+    expect(response.projects[0]?.healthCoveredCategoryCount).toBeNull();
+    expect(response.projects[0]?.healthMaintainer).toBeNull();
+    expect(response.projects[0]?.healthSecurity).toBeNull();
+    expect(response.projects[0]?.healthDevelopment).toBeNull();
   });
 
   it('passes the v2 score, max, covered count and category scores straight through from the warehouse', async () => {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -97,21 +97,55 @@ describe('OrgLensProjectsService health score mapping', () => {
     expect(response.projects[0]?.health).toBe('unavailable');
   });
 
-  it('marks health unavailable when no v2 category is present', async () => {
+  it('marks health unavailable when no v2 category is present, or when the category has no score', async () => {
     mockProjectsRow(projectsRow());
 
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+    let response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('unavailable');
+
+    // Split row: label without a same-row score is unavailable and every health field is nulled.
+    mockProjectsRow(
+      projectsRow({
+        HEALTH_SCORE_CATEGORY_V2: 'Healthy',
+        HEALTH_OVERALL_SCORE_V2: null,
+        COVERED_CATEGORY_COUNT_V2: 2,
+        HEALTH_MAX_SCORE_V2: 65,
+        HEALTH_MAINTAINER_V2: 30,
+      })
+    );
+
+    response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('unavailable');
+    expect(response.projects[0]?.healthOverallScore).toBeNull();
+    expect(response.projects[0]?.healthMaxScore).toBeNull();
+    expect(response.projects[0]?.healthCoveredCategoryCount).toBeNull();
+    expect(response.projects[0]?.healthMaintainer).toBeNull();
   });
 
-  it('passes healthMaxScore and healthCoveredCategoryCount straight through from the warehouse', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 52, HEALTH_SCORE_CATEGORY_V2: 'Healthy', COVERED_CATEGORY_COUNT_V2: 2, HEALTH_MAX_SCORE_V2: 75 }));
+  it('passes the v2 score, max, covered count and category scores straight through from the warehouse', async () => {
+    mockProjectsRow(
+      projectsRow({
+        HEALTH_OVERALL_SCORE_V2: 52,
+        HEALTH_SCORE_CATEGORY_V2: 'Healthy',
+        COVERED_CATEGORY_COUNT_V2: 2,
+        HEALTH_MAX_SCORE_V2: 65,
+        HEALTH_MAINTAINER_V2: 30,
+        HEALTH_SECURITY_V2: null,
+        HEALTH_DEVELOPMENT_V2: 22,
+      })
+    );
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
+    expect(response.projects[0]?.health).toBe('healthy');
     expect(response.projects[0]?.healthCoveredCategoryCount).toBe(2);
-    expect(response.projects[0]?.healthMaxScore).toBe(75);
+    expect(response.projects[0]?.healthMaxScore).toBe(65);
+    expect(response.projects[0]?.healthOverallScore).toBe(52);
+    expect(response.projects[0]?.healthMaintainer).toBe(30);
+    expect(response.projects[0]?.healthSecurity).toBeNull();
+    expect(response.projects[0]?.healthDevelopment).toBe(22);
   });
 
   it('passes through a full (3-category) score unchanged, not marked partial', async () => {
@@ -121,6 +155,7 @@ describe('OrgLensProjectsService health score mapping', () => {
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
+    expect(response.projects[0]?.health).toBe('excellent');
     expect(response.projects[0]?.healthCoveredCategoryCount).toBe(3);
     expect(response.projects[0]?.healthMaxScore).toBe(100);
   });

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -500,22 +500,23 @@ export class OrgLensProjectsService {
         category: row.HEALTH_SCORE_CATEGORY_V2,
       });
     }
-    // Availability rule: see OrgLensProject.health.
-    const health = category != null && row.HEALTH_OVERALL_SCORE_V2 != null ? category : 'unavailable';
+    // Availability rule: see OrgLensProject.health. When unavailable every health field is null so the badge,
+    // popup, accessible name and CSV can never disagree.
+    const available = category != null && row.HEALTH_OVERALL_SCORE_V2 != null;
     return {
       slug: row.PROJECT_SLUG,
       name: row.PROJECT_NAME,
       logoUrl: row.PROJECT_LOGO_URL ?? '',
       foundation: this.mapFoundation(row),
-      health,
-      // Sourced straight from the same warehouse snapshot row as the label — never recomputed. Breakdowns render
-      // off their own null-ness (missing → `-/N`), matching the Insights breakdown port.
-      healthOverallScore: row.HEALTH_OVERALL_SCORE_V2 ?? null,
-      healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
-      healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
-      healthMaintainer: row.HEALTH_MAINTAINER_V2 ?? null,
-      healthSecurity: row.HEALTH_SECURITY_V2 ?? null,
-      healthDevelopment: row.HEALTH_DEVELOPMENT_V2 ?? null,
+      health: available ? category : 'unavailable',
+      // Sourced straight from the same warehouse snapshot row as the label — never recomputed. Covered
+      // breakdowns render off their own null-ness (missing → `-/N`), matching the Insights breakdown port.
+      healthOverallScore: available ? row.HEALTH_OVERALL_SCORE_V2 : null,
+      healthMaxScore: available ? (row.HEALTH_MAX_SCORE_V2 ?? null) : null,
+      healthCoveredCategoryCount: available ? (row.COVERED_CATEGORY_COUNT_V2 ?? null) : null,
+      healthMaintainer: available ? (row.HEALTH_MAINTAINER_V2 ?? null) : null,
+      healthSecurity: available ? (row.HEALTH_SECURITY_V2 ?? null) : null,
+      healthDevelopment: available ? (row.HEALTH_DEVELOPMENT_V2 ?? null) : null,
       // These 'silent'/'non-lf' fallbacks are only user-visible for real (activity) rows. For no-activity rows the
       // UI shows "Unavailable" and compareInfluenceAvailability sinks them past measured rows, so the fallback band
       // is never compared against a measured one — it only affects the (tied) ordering of two no-activity rows.
@@ -977,6 +978,9 @@ export class OrgLensProjectsService {
         // current-shape payloads instead of serving a mixed schema from Valkey.
         (project.metricsState === 'full' || project.metricsState === 'health-only' || project.metricsState === 'unavailable') &&
         Object.prototype.hasOwnProperty.call(HEALTH_SCORE_LABELS, project.health) &&
+        // Reject pre-v2-breakdown entries (no `healthOverallScore` key) so a cached band never renders with an
+        // unavailable popup.
+        (project.healthOverallScore === null || typeof project.healthOverallScore === 'number') &&
         Array.isArray(project.maintainers) &&
         Array.isArray(project.contributors)
     );

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -50,8 +50,8 @@ export class OrgLensProjectsService {
 
   public async getProjects(accountId: string, orgName: string, slugs: string[] | null): Promise<OrgLensProjectsResponse> {
     // `v6` bump: health now carries the v2 breakdown (`healthOverallScore` + Maintainer/Security/Development) mapped
-    // from the same snapshot row, replacing the v1 `healthMetrics` percentages (#2096) — bump drops cache entries
-    // computed under the old percentage shape.
+    // from the same snapshot row, replacing the v1 percentage columns (#2096) — bump drops cache entries computed
+    // under the old percentage shape.
     const cacheKey = `projects:v6:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
     const key = buildOrgCacheKey(accountId, cacheKey);
     if (key !== null) {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -49,10 +49,10 @@ export class OrgLensProjectsService {
   private readonly microserviceProxy = new MicroserviceProxyService();
 
   public async getProjects(accountId: string, orgName: string, slugs: string[] | null): Promise<OrgLensProjectsResponse> {
-    // `v5` bump: hasHealthMetrics now requires all four warehouse percentage columns to be present, instead of
-    // fabricating 0% for a column that's actually unmeasured (LFXV2-3379) — bump drops cache entries computed
-    // under the old fallback/partial-metrics logic.
-    const cacheKey = `projects:v5:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
+    // `v6` bump: health now carries the v2 breakdown (`healthOverallScore` + Maintainer/Security/Development) mapped
+    // from the same snapshot row, replacing the v1 `healthMetrics` percentages (#2096) — bump drops cache entries
+    // computed under the old percentage shape.
+    const cacheKey = `projects:v6:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
     const key = buildOrgCacheKey(accountId, cacheKey);
     if (key !== null) {
       const cached = await valkeyService.getJson<OrgLensProjectsResponse>(key, OrgLensProjectsService.isProjectsResponse);
@@ -408,22 +408,19 @@ export class OrgLensProjectsService {
         HEALTH_SCORE_CATEGORY_V2,
         COVERED_CATEGORY_COUNT_V2,
         HEALTH_MAX_SCORE_V2,
-        HEALTH_CONTRIBUTOR_PERCENTAGE,
-        HEALTH_POPULARITY_PERCENTAGE,
-        HEALTH_DEVELOPMENT_PERCENTAGE,
-        HEALTH_SECURITY_PERCENTAGE
+        HEALTH_OVERALL_SCORE_V2,
+        HEALTH_MAINTAINER_V2,
+        HEALTH_SECURITY_V2,
+        HEALTH_DEVELOPMENT_V2
       FROM ${this.onboardedProjectsTable()}
       WHERE LOWER(PROJECT_SLUG) IN (${missing.map(() => '?').join(', ')})
     `;
     const result = await this.snowflakeService.execute<OrgLensProjectRow>(sql, missing);
-    // mapProject fills unselected org-relative metrics with placeholders and maps health/healthMetrics from the
-    // columns above. metricsState here reflects only the health label (category present → 'health-only'; null →
-    // 'unavailable') — healthMetrics is gated independently inside mapProject and may still be populated on an
-    // 'unavailable' row if the warehouse percentage columns are present without a category.
+    // mapProject fills unselected org-relative metrics with placeholders and maps health from the columns above.
+    // metricsState here reflects only health availability (label + score present → 'health-only'; else 'unavailable').
     return result.rows.map((row) => {
-      const hasHealthScore = this.hasHealthScore(row);
-      // Emit both discriminators: metricsState for the new frontend, noActivityYet so a still-running pre-close-out
-      // frontend keeps treating these as unavailable during a rolling deploy.
+      // Available ⇔ normalized label non-null AND score non-null (#2096); `covered` drives only the ` - Partial` suffix.
+      const hasHealthScore = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) != null && row.HEALTH_OVERALL_SCORE_V2 != null;
       return {
         ...this.mapProject(row, []),
         metricsState: hasHealthScore ? ('health-only' as const) : ('unavailable' as const),
@@ -459,10 +456,10 @@ export class OrgLensProjectsService {
         HEALTH_SCORE_CATEGORY_V2,
         COVERED_CATEGORY_COUNT_V2,
         HEALTH_MAX_SCORE_V2,
-        HEALTH_CONTRIBUTOR_PERCENTAGE,
-        HEALTH_POPULARITY_PERCENTAGE,
-        HEALTH_DEVELOPMENT_PERCENTAGE,
-        HEALTH_SECURITY_PERCENTAGE,
+        HEALTH_OVERALL_SCORE_V2,
+        HEALTH_MAINTAINER_V2,
+        HEALTH_SECURITY_V2,
+        HEALTH_DEVELOPMENT_V2,
         DESCRIPTION
       FROM ${this.projectsTable()}
       WHERE ACCOUNT_ID = ?
@@ -502,16 +499,23 @@ export class OrgLensProjectsService {
         category: row.HEALTH_SCORE_CATEGORY_V2,
       });
     }
+    // Available ⇔ normalized label non-null AND score non-null (#2096). `covered` drives only the UI's
+    // ` - Partial` suffix, never availability — a null label is 'unavailable' regardless of covered count.
+    const health = category != null && row.HEALTH_OVERALL_SCORE_V2 != null ? category : 'unavailable';
     return {
       slug: row.PROJECT_SLUG,
       name: row.PROJECT_NAME,
       logoUrl: row.PROJECT_LOGO_URL ?? '',
       foundation: this.mapFoundation(row),
-      health: category ?? 'unavailable',
-      // Sourced straight from the warehouse — never recomputed; independent of the category fallback removed
-      // by LFXV2-3379.
+      health,
+      // Sourced straight from the same warehouse snapshot row as the label — never recomputed. Breakdowns render
+      // off their own null-ness (missing → `-/N`), matching the Insights breakdown port.
+      healthOverallScore: row.HEALTH_OVERALL_SCORE_V2 ?? null,
       healthMaxScore: row.HEALTH_MAX_SCORE_V2 ?? null,
       healthCoveredCategoryCount: row.COVERED_CATEGORY_COUNT_V2 ?? null,
+      healthMaintainer: row.HEALTH_MAINTAINER_V2 ?? null,
+      healthSecurity: row.HEALTH_SECURITY_V2 ?? null,
+      healthDevelopment: row.HEALTH_DEVELOPMENT_V2 ?? null,
       // These 'silent'/'non-lf' fallbacks are only user-visible for real (activity) rows. For no-activity rows the
       // UI shows "Unavailable" and compareInfluenceAvailability sinks them past measured rows, so the fallback band
       // is never compared against a measured one — it only affects the (tied) ordering of two no-activity rows.
@@ -533,11 +537,6 @@ export class OrgLensProjectsService {
       commits1y: 0,
       changeDriver: { label: 'Not calculated yet', direction: 'flat' },
       description: row.DESCRIPTION ?? `${row.PROJECT_NAME} is an open source project in the ${this.mapFoundation(row).name} ecosystem.`,
-      // Independent of `category`/`health`: the warehouse can populate these percentage columns without a
-      // resolvable category, and per-metric "Unavailable" (see hasHealthMetrics) is the correct render for
-      // that case, not suppressing metrics that genuinely have data — same pattern as insights' health
-      // breakdown, where each sub-score renders off its own null-ness, not off the top-level label.
-      healthMetrics: this.hasHealthMetrics(row) ? this.mapHealthMetrics(row) : [],
       // Real org-scoped row (org-dashboard parity): every metric is genuine, including participating
       // projects with activity_count = 0. fetchNoActivityProjects overrides this for its fallback rows.
       metricsState: 'full',
@@ -581,36 +580,6 @@ export class OrgLensProjectsService {
 
   private mapTrendDirection(value: string | null): InfluenceTrendDirection {
     return value === 'up' || value === 'down' || value === 'flat' ? value : 'flat';
-  }
-
-  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_SCORE_CATEGORY_V2'>): boolean {
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) != null;
-  }
-
-  private hasHealthMetrics(
-    row: Pick<
-      OrgLensProjectRow,
-      'HEALTH_CONTRIBUTOR_PERCENTAGE' | 'HEALTH_POPULARITY_PERCENTAGE' | 'HEALTH_DEVELOPMENT_PERCENTAGE' | 'HEALTH_SECURITY_PERCENTAGE'
-    >
-  ): boolean {
-    // All four required (not "any"): mapHealthMetrics emits all four dimensions unconditionally and
-    // roundMetric() defaults a missing value to 0 — an OR gate would render an unmeasured dimension as a
-    // fabricated 0% for a row where only some of the four columns are populated (LFXV2-3379).
-    return (
-      row.HEALTH_CONTRIBUTOR_PERCENTAGE != null &&
-      row.HEALTH_POPULARITY_PERCENTAGE != null &&
-      row.HEALTH_DEVELOPMENT_PERCENTAGE != null &&
-      row.HEALTH_SECURITY_PERCENTAGE != null
-    );
-  }
-
-  private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {
-    return [
-      { label: 'Contributors', value: this.roundMetric(row.HEALTH_CONTRIBUTOR_PERCENTAGE) },
-      { label: 'Popularity', value: this.roundMetric(row.HEALTH_POPULARITY_PERCENTAGE) },
-      { label: 'Development', value: this.roundMetric(row.HEALTH_DEVELOPMENT_PERCENTAGE) },
-      { label: 'Security', value: this.roundMetric(row.HEALTH_SECURITY_PERCENTAGE) },
-    ];
   }
 
   private async fetchWorkspaceMetadata(req: Request, accountId: string): Promise<OrgProjectsWorkspace[]> {
@@ -936,10 +905,6 @@ export class OrgLensProjectsService {
     return Math.round(value * 10) / 10;
   }
 
-  private roundMetric(value: number | null | undefined): number {
-    return Math.max(0, Math.min(100, Math.round(value ?? 0)));
-  }
-
   private parseNumberArray(value: unknown): number[] {
     if (Array.isArray(value)) {
       return value
@@ -1012,7 +977,6 @@ export class OrgLensProjectsService {
         // current-shape payloads instead of serving a mixed schema from Valkey.
         (project.metricsState === 'full' || project.metricsState === 'health-only' || project.metricsState === 'unavailable') &&
         Object.prototype.hasOwnProperty.call(HEALTH_SCORE_LABELS, project.health) &&
-        Array.isArray(project.healthMetrics) &&
         Array.isArray(project.maintainers) &&
         Array.isArray(project.contributors)
     );

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -417,13 +417,14 @@ export class OrgLensProjectsService {
     `;
     const result = await this.snowflakeService.execute<OrgLensProjectRow>(sql, missing);
     // mapProject fills unselected org-relative metrics with placeholders and maps health from the columns above.
-    // metricsState here reflects only health availability (label + score present → 'health-only'; else 'unavailable').
+    // metricsState reflects only health availability — derived from mapProject's `health` so the two can't drift.
+    // Emit both discriminators: metricsState for the new frontend, noActivityYet for a still-running pre-close-out
+    // frontend during a rolling deploy.
     return result.rows.map((row) => {
-      // Available ⇔ normalized label non-null AND score non-null (#2096); `covered` drives only the ` - Partial` suffix.
-      const hasHealthScore = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) != null && row.HEALTH_OVERALL_SCORE_V2 != null;
+      const project = this.mapProject(row, []);
       return {
-        ...this.mapProject(row, []),
-        metricsState: hasHealthScore ? ('health-only' as const) : ('unavailable' as const),
+        ...project,
+        metricsState: project.health === 'unavailable' ? ('unavailable' as const) : ('health-only' as const),
         noActivityYet: true,
       };
     });
@@ -499,8 +500,7 @@ export class OrgLensProjectsService {
         category: row.HEALTH_SCORE_CATEGORY_V2,
       });
     }
-    // Available ⇔ normalized label non-null AND score non-null (#2096). `covered` drives only the UI's
-    // ` - Partial` suffix, never availability — a null label is 'unavailable' regardless of covered count.
+    // Availability rule: see OrgLensProject.health.
     const health = category != null && row.HEALTH_OVERALL_SCORE_V2 != null ? category : 'unavailable';
     return {
       slug: row.PROJECT_SLUG,

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -3,6 +3,7 @@
 
 import type {
   HealthScore,
+  HealthScoreCategoryDescriptor,
   InfluenceBand,
   InfluenceTrendDirection,
   OrgProjectsSortField,
@@ -127,6 +128,17 @@ export const HEALTH_SCORE_BAR_FILL: Record<Exclude<HealthScore, 'unavailable'>, 
 
 /** Health popup unavailable-state copy (project noun — the Insights "collection" original does not apply). */
 export const ORG_HEALTH_POPUP_UNAVAILABLE_TEXT = 'Health score is unavailable for this project.';
+
+/**
+ * Health Score v2 categories in popup order, with the Insights display names, icons and fixed
+ * denominators (sum to 100). Single source for the popup rows, the badge accessible name and the
+ * redistribution clause.
+ */
+export const HEALTH_SCORE_CATEGORIES: readonly HealthScoreCategoryDescriptor[] = [
+  { key: 'maintainer', name: 'Maintainer Health', icon: 'heart-pulse', max: 40 },
+  { key: 'security', name: 'Security & Supply Chain', icon: 'shield-check', max: 35 },
+  { key: 'development', name: 'Development Activity', icon: 'laptop-code', max: 25 },
+];
 
 /** Projects-table page sizes; 25 is the default. */
 export const ORG_PROJECTS_PAGE_SIZE_OPTIONS: readonly number[] = [10, 25, 50];

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -131,8 +131,7 @@ export const ORG_HEALTH_POPUP_UNAVAILABLE_TEXT = 'Health score is unavailable fo
 
 /**
  * Health Score v2 categories in popup order, with the Insights display names, icons and fixed
- * denominators (sum to 100). Single source for the popup rows, the badge accessible name and the
- * redistribution clause.
+ * denominators (sum to 100). Single source for the popup rows and the badge accessible name.
  */
 export const HEALTH_SCORE_CATEGORIES: readonly HealthScoreCategoryDescriptor[] = [
   { key: 'maintainer', name: 'Maintainer Health', icon: 'heart-pulse', max: 40 },

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -113,6 +113,21 @@ export const HEALTH_SCORE_BADGE: Record<HealthScore, { bg: string; text: string 
   unavailable: { bg: lfxColors.gray[100], text: lfxColors.gray[600] },
 };
 
+/**
+ * Health popup progress-bar fill per band — mirrors the Insights pill's `progressBarColor`
+ * (top two bands positive, then accent, warning, negative).
+ */
+export const HEALTH_SCORE_BAR_FILL: Record<Exclude<HealthScore, 'unavailable'>, string> = {
+  excellent: lfxColors.emerald[500],
+  healthy: lfxColors.emerald[500],
+  fair: lfxColors.violet[500],
+  concerning: lfxColors.amber[500],
+  critical: lfxColors.red[500],
+};
+
+/** Health popup unavailable-state copy (project noun — the Insights "collection" original does not apply). */
+export const ORG_HEALTH_POPUP_UNAVAILABLE_TEXT = 'Health score is unavailable for this project.';
+
 /** Projects-table page sizes; 25 is the default. */
 export const ORG_PROJECTS_PAGE_SIZE_OPTIONS: readonly number[] = [10, 25, 50];
 

--- a/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-project-detail.interface.ts
@@ -64,19 +64,31 @@ export interface OrgLensProjectHero {
   firstCommit: string | null;
   /** Project-level CHAOSS / Insights software-value estimate in USD (not the org's individual return). */
   softwareValueUsd: number | null;
-  /** Overall health tier; null when the warehouse has no health score for the project (hero renders an "Unavailable" tag). */
-  health: OrgLensProjectHealth | null;
   /**
-   * Warehouse-computed max score for `health` (100 when all 3 CHAOSS categories are covered; 60/65/75 when
-   * exactly one is missing; `null` when fewer than 2 are covered, matching `health: null`). Sourced straight
-   * from `health_max_score_v2` — never recompute this locally.
+   * Overall health tier; `null` when the warehouse has no health score for the project (null label/unrecognized
+   * label or null score — never derived from the score client-side).
+   */
+  health: OrgLensProjectHealth | null;
+  /** Raw Health Score v2 points (e.g. 88 full, 52 partial) from the same snapshot row as the label; `null` when unavailable. */
+  healthOverallScore: number | null;
+  /**
+   * Warehouse-computed max score for `health` (100 when all 3 categories are covered; 60/65/75 when exactly one is
+   * missing; `null` for legacy rows or when unavailable). Popup denominators use `healthMaxScore ?? 100` (Insights
+   * fallback). Sourced straight from `health_max_score_v2` — never recompute this locally.
    */
   healthMaxScore: number | null;
   /**
-   * Warehouse-computed count (0–3) of CHAOSS categories covered for `health`. `healthMaxScore < 100` (i.e. `2`)
-   * marks a partial score — sourced straight from `covered_category_count_v2`, never recomputed locally.
+   * Warehouse-computed count (0–3) of categories covered for `health`. `2` marks a partial score and drives only the
+   * ` - Partial` suffix — never availability: a null label is unavailable regardless of this count. Sourced straight
+   * from `covered_category_count_v2`, never recomputed locally.
    */
   healthCoveredCategoryCount: number | null;
+  /** Maintainer Health category score (0–40) from the same snapshot row; `null` when the category is uncovered/unavailable. */
+  healthMaintainer: number | null;
+  /** Security & Supply Chain category score (0–35) from the same snapshot row; `null` when uncovered/unavailable. */
+  healthSecurity: number | null;
+  /** Development Activity category score (0–25) from the same snapshot row; `null` when uncovered/unavailable. */
+  healthDevelopment: number | null;
   foundationLabel: string;
 }
 

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -68,19 +68,31 @@ export interface OrgLensProject {
   logoUrl: string;
   /** Owning foundation. */
   foundation: OrgLensProjectFoundation;
-  /** CHAOSS health classification. */
-  health: HealthScore;
   /**
-   * Warehouse-computed max score for `health` (100 when all 3 CHAOSS categories are covered; 60/65/75 when
-   * exactly one is missing; `null` when fewer than 2 are covered, matching `health: 'unavailable'`). Sourced
-   * straight from `health_max_score_v2` — never recompute this locally.
+   * Health Score v2 band, normalized from the warehouse label (`health_score_category_v2`). `'unavailable'` when the
+   * label is null/unrecognized or `healthOverallScore` is null — never derived from the score client-side.
+   */
+  health: HealthScore;
+  /** Raw Health Score v2 points (e.g. 88 full, 52 partial) from the same snapshot row as the label; `null` when unavailable. */
+  healthOverallScore: number | null;
+  /**
+   * Warehouse-computed max score for `health` (100 when all 3 categories are covered; 60/65/75 when exactly one is
+   * missing; `null` for legacy rows or when unavailable). Popup denominators use `healthMaxScore ?? 100` (Insights
+   * fallback). Sourced straight from `health_max_score_v2` — never recompute this locally.
    */
   healthMaxScore: number | null;
   /**
-   * Warehouse-computed count (0–3) of CHAOSS categories covered for `health`. `healthMaxScore < 100` (i.e. `2`)
-   * marks a partial score — sourced straight from `covered_category_count_v2`, never recomputed locally.
+   * Warehouse-computed count (0–3) of categories covered for `health`. `2` marks a partial score and drives only the
+   * ` - Partial` suffix — never availability: a null label is `'unavailable'` regardless of this count. Sourced
+   * straight from `covered_category_count_v2`, never recomputed locally.
    */
   healthCoveredCategoryCount: number | null;
+  /** Maintainer Health category score (0–40) from the same snapshot row; `null` when the category is uncovered/unavailable. */
+  healthMaintainer: number | null;
+  /** Security & Supply Chain category score (0–35) from the same snapshot row; `null` when uncovered/unavailable. */
+  healthSecurity: number | null;
+  /** Development Activity category score (0–25) from the same snapshot row; `null` when uncovered/unavailable. */
+  healthDevelopment: number | null;
   /** Technical influence band. */
   technicalInfluence: InfluenceBand;
   /** Ecosystem influence band. */
@@ -101,10 +113,8 @@ export interface OrgLensProject {
   commits1y: number;
   /** Largest single driver of the influence delta (used by Influence Summary cards). */
   changeDriver: ChangeDriver;
-  /** Short project description shown in the health-detail popover. */
+  /** Short project description. */
   description: string;
-  /** CHAOSS-style health sub-scores (0–100) shown in the health-detail popover. */
-  healthMetrics: ProjectHealthMetric[];
   /**
    * Which metrics the org has for this project: `full` rows render every metric for real; `health-only`/`unavailable`
    * fallback rows (no org metrics row) drive the "Unavailable" renders and "No activity yet" treatment.
@@ -118,12 +128,16 @@ export interface OrgLensProject {
   noActivityYet?: boolean;
 }
 
-/** A single CHAOSS health sub-score (0–100) shown in the health-detail popover. */
-export interface ProjectHealthMetric {
-  /** Metric name, e.g. `Contributors`, `Popularity`, `Development`, `Security`. */
-  label: string;
-  /** Score on a 0–100 scale, rendered as a progress bar. */
-  value: number;
+/** One fixed-denominator category row in the shared Org Lens health popup. */
+export interface OrgLensHealthPopupRow {
+  /** Stable key for testids (`maintainer` | `security` | `development`). */
+  key: 'maintainer' | 'security' | 'development';
+  /** Display name (e.g. `Maintainer Health`). */
+  name: string;
+  /** FontAwesome icon name (e.g. `heart-pulse`). */
+  icon: string;
+  /** Score display (e.g. `32/40`) or `-` with denominator when uncovered (e.g. `-/35`). */
+  display: string;
 }
 
 /** Top-level response for the Org Lens Projects page. */
@@ -239,7 +253,7 @@ export interface OrgProjectsTableRow extends OrgLensProject {
   trendArrowIcon: string;
   trendDeltaTextClass: string;
   trendArrowBadgeClass: string;
-  /** Plain-text health summary (rating + sub-scores) for screen readers / keyboard focus. */
+  /** Plain-text health summary (headline + three category rows) for screen readers / keyboard focus. */
   healthAriaLabel: string;
   /** Plain-text, count-correlated label for the Contributors count link (screen readers / keyboard focus). */
   contributorsAriaLabel: string;
@@ -267,13 +281,13 @@ export interface OrgLensProjectRow {
   TREND_DIRECTION: string | null;
   COMBINED_SCORE_SERIES: unknown;
   DBT_RUN_AT: string | Date | null;
+  HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
   COVERED_CATEGORY_COUNT_V2: number | null;
   HEALTH_MAX_SCORE_V2: number | null;
-  HEALTH_CONTRIBUTOR_PERCENTAGE: number | null;
-  HEALTH_POPULARITY_PERCENTAGE: number | null;
-  HEALTH_DEVELOPMENT_PERCENTAGE: number | null;
-  HEALTH_SECURITY_PERCENTAGE: number | null;
+  HEALTH_MAINTAINER_V2: number | null;
+  HEALTH_SECURITY_V2: number | null;
+  HEALTH_DEVELOPMENT_V2: number | null;
   DESCRIPTION: string | null;
 }
 

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -128,10 +128,24 @@ export interface OrgLensProject {
   noActivityYet?: boolean;
 }
 
+/** The three fixed Health Score v2 categories, in display order. */
+export type HealthScoreCategoryKey = 'maintainer' | 'security' | 'development';
+
+/** Static descriptor for one Health Score v2 category (name, icon, fixed denominator). */
+export interface HealthScoreCategoryDescriptor {
+  key: HealthScoreCategoryKey;
+  /** Display name (e.g. `Maintainer Health`). */
+  name: string;
+  /** FontAwesome icon name (e.g. `heart-pulse`). */
+  icon: string;
+  /** Fixed denominator (40 / 35 / 25). */
+  max: number;
+}
+
 /** One fixed-denominator category row in the shared Org Lens health popup. */
 export interface OrgLensHealthPopupRow {
-  /** Stable key for testids (`maintainer` | `security` | `development`). */
-  key: 'maintainer' | 'security' | 'development';
+  /** Stable key for testids. */
+  key: HealthScoreCategoryKey;
   /** Display name (e.g. `Maintainer Health`). */
   name: string;
   /** FontAwesome icon name (e.g. `heart-pulse`). */

--- a/packages/shared/src/utils/health-breakdown.utils.ts
+++ b/packages/shared/src/utils/health-breakdown.utils.ts
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Health Score v2 summary-description port (#2096).
- *
- * Verbatim port of `getHealthScoreDescription` (+ its private helpers) from Insights
- * `apps/insights/frontend/config/health-breakdown-templates.ts` (Section 3: Health Score summary):
- * same thresholds, templates, `CATEGORY_LABEL`/`CATEGORY_NAME` maps, and redistribution clause.
- * The single nested ternary in the original is an equivalent if-chain here per repo style
- * (never nest ternaries); all logic and copy are otherwise byte-identical.
- * Fidelity is verified by Playwright (T021) + manual same-snapshot parity (T023), not unit tests.
+ * Health Score v2 summary description, ported verbatim from LFX Insights
+ * (`frontend/config/health-breakdown-templates.ts`, `getHealthScoreDescription` + private helpers):
+ * same thresholds, templates, category label maps, and redistribution clause. The single nested
+ * ternary in the original is an equivalent if-chain here (repo style: never nest ternaries).
  */
 
 type HealthCategoryKey = 'maintainer' | 'security' | 'development';
@@ -28,8 +24,7 @@ const CATEGORY_NAME: Record<HealthCategoryKey, string> = {
   development: 'Development Activity',
 };
 
-const capitalize = (value: string): string =>
-  value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+const capitalize = (value: string): string => (value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value);
 
 const joinWithAnd = (items: string[]): string => {
   if (items.length === 0) return '';
@@ -51,7 +46,7 @@ export const getHealthScoreDescription = (
   healthLabel: string | null,
   maintainerScore: number | null,
   securityScore: number | null,
-  developmentScore: number | null,
+  developmentScore: number | null
 ): string | null => {
   if (healthLabel === null) {
     return 'No scoring data is available. This project has no indexed repositories or the connected platform has no supported data pipeline.';

--- a/packages/shared/src/utils/health-breakdown.utils.ts
+++ b/packages/shared/src/utils/health-breakdown.utils.ts
@@ -1,16 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/**
- * Health Score v2 summary description, ported verbatim from LFX Insights
- * (`frontend/config/health-breakdown-templates.ts`, `getHealthScoreDescription` + private helpers):
- * same thresholds, templates, category label maps, and redistribution clause. The single nested
- * ternary in the original is an equivalent if-chain here (repo style: never nest ternaries).
- */
+import type { HealthScoreCategoryKey } from '../interfaces';
 
-type HealthCategoryKey = 'maintainer' | 'security' | 'development';
-
-const CATEGORY_LABEL: Record<HealthCategoryKey, string> = {
+const CATEGORY_LABEL: Record<HealthScoreCategoryKey, string> = {
   maintainer: 'maintainer coverage',
   security: 'security posture',
   development: 'development cadence',
@@ -18,7 +11,7 @@ const CATEGORY_LABEL: Record<HealthCategoryKey, string> = {
 
 // Plain-name form for the redistribution clause, distinct from the lowercase CATEGORY_LABEL
 // used inline in strength/gap sentences.
-const CATEGORY_NAME: Record<HealthCategoryKey, string> = {
+const CATEGORY_NAME: Record<HealthScoreCategoryKey, string> = {
   maintainer: 'Maintainer Health',
   security: 'Security & Supply Chain',
   development: 'Development Activity',
@@ -33,8 +26,8 @@ const joinWithAnd = (items: string[]): string => {
   return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
 };
 
-const buildRedistributionClause = (availableKeys: HealthCategoryKey[]): string => {
-  const allKeys: HealthCategoryKey[] = ['maintainer', 'security', 'development'];
+const buildRedistributionClause = (availableKeys: HealthScoreCategoryKey[]): string => {
+  const allKeys: HealthScoreCategoryKey[] = ['maintainer', 'security', 'development'];
   const unavailable = allKeys.filter((key) => !availableKeys.includes(key));
   if (unavailable.length === 0) return '';
   const names = joinWithAnd(unavailable.map((key) => CATEGORY_NAME[key]));
@@ -42,6 +35,13 @@ const buildRedistributionClause = (availableKeys: HealthCategoryKey[]): string =
   return ` ${names} ${verb} unavailable, so weights were redistributed.`;
 };
 
+/**
+ * Health Score v2 summary description, ported verbatim from LFX Insights
+ * (`frontend/config/health-breakdown-templates.ts`, `getHealthScoreDescription` + private helpers):
+ * same thresholds, templates, category phrasing, and redistribution clause. The single nested
+ * ternary in the original is an equivalent if-chain here (repo style: never nest ternaries).
+ * A null label yields the Insights "no scoring data" sentence; callers gate on availability first.
+ */
 export const getHealthScoreDescription = (
   healthLabel: string | null,
   maintainerScore: number | null,
@@ -56,7 +56,7 @@ export const getHealthScoreDescription = (
       { key: 'maintainer', percent: maintainerScore !== null ? maintainerScore / 40 : -1 },
       { key: 'security', percent: securityScore !== null ? securityScore / 35 : -1 },
       { key: 'development', percent: developmentScore !== null ? developmentScore / 25 : -1 },
-    ] as { key: HealthCategoryKey; percent: number }[]
+    ] as { key: HealthScoreCategoryKey; percent: number }[]
   ).filter((c) => c.percent >= 0);
 
   if (categoryPercents.length === 0) {
@@ -67,7 +67,7 @@ export const getHealthScoreDescription = (
   const redistributionClause = buildRedistributionClause(availableKeys);
 
   if (categoryPercents.length === 1) {
-    const only = categoryPercents[0] as { key: HealthCategoryKey; percent: number };
+    const only = categoryPercents[0] as { key: HealthScoreCategoryKey; percent: number };
     const label = CATEGORY_LABEL[only.key];
     let strengthWord = 'Weak';
     if (only.percent >= 0.7) {
@@ -79,8 +79,8 @@ export const getHealthScoreDescription = (
   }
 
   const sorted = [...categoryPercents].sort((a, b) => b.percent - a.percent);
-  const strongest = sorted[0] as { key: HealthCategoryKey; percent: number };
-  const weakest = sorted[sorted.length - 1] as { key: HealthCategoryKey; percent: number };
+  const strongest = sorted[0] as { key: HealthScoreCategoryKey; percent: number };
+  const weakest = sorted[sorted.length - 1] as { key: HealthScoreCategoryKey; percent: number };
   const strengthLabels = sorted.slice(0, -1).map((c) => CATEGORY_LABEL[c.key]);
   const strengthsText = joinWithAnd(strengthLabels);
   const gapLabel = CATEGORY_LABEL[weakest.key];

--- a/packages/shared/src/utils/health-breakdown.utils.ts
+++ b/packages/shared/src/utils/health-breakdown.utils.ts
@@ -1,0 +1,138 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Health Score v2 summary-description port (#2096).
+ *
+ * Verbatim port of `getHealthScoreDescription` (+ its private helpers) from Insights
+ * `apps/insights/frontend/config/health-breakdown-templates.ts` (Section 3: Health Score summary):
+ * same thresholds, templates, `CATEGORY_LABEL`/`CATEGORY_NAME` maps, and redistribution clause.
+ * The single nested ternary in the original is an equivalent if-chain here per repo style
+ * (never nest ternaries); all logic and copy are otherwise byte-identical.
+ * Fidelity is verified by Playwright (T021) + manual same-snapshot parity (T023), not unit tests.
+ */
+
+type HealthCategoryKey = 'maintainer' | 'security' | 'development';
+
+const CATEGORY_LABEL: Record<HealthCategoryKey, string> = {
+  maintainer: 'maintainer coverage',
+  security: 'security posture',
+  development: 'development cadence',
+};
+
+// Plain-name form for the redistribution clause, distinct from the lowercase CATEGORY_LABEL
+// used inline in strength/gap sentences.
+const CATEGORY_NAME: Record<HealthCategoryKey, string> = {
+  maintainer: 'Maintainer Health',
+  security: 'Security & Supply Chain',
+  development: 'Development Activity',
+};
+
+const capitalize = (value: string): string =>
+  value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+
+const joinWithAnd = (items: string[]): string => {
+  if (items.length === 0) return '';
+  if (items.length === 1) return items[0] as string;
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+};
+
+const buildRedistributionClause = (availableKeys: HealthCategoryKey[]): string => {
+  const allKeys: HealthCategoryKey[] = ['maintainer', 'security', 'development'];
+  const unavailable = allKeys.filter((key) => !availableKeys.includes(key));
+  if (unavailable.length === 0) return '';
+  const names = joinWithAnd(unavailable.map((key) => CATEGORY_NAME[key]));
+  const verb = unavailable.length === 1 ? 'is' : 'are';
+  return ` ${names} ${verb} unavailable, so weights were redistributed.`;
+};
+
+export const getHealthScoreDescription = (
+  healthLabel: string | null,
+  maintainerScore: number | null,
+  securityScore: number | null,
+  developmentScore: number | null,
+): string | null => {
+  if (healthLabel === null) {
+    return 'No scoring data is available. This project has no indexed repositories or the connected platform has no supported data pipeline.';
+  }
+  const categoryPercents = (
+    [
+      { key: 'maintainer', percent: maintainerScore !== null ? maintainerScore / 40 : -1 },
+      { key: 'security', percent: securityScore !== null ? securityScore / 35 : -1 },
+      { key: 'development', percent: developmentScore !== null ? developmentScore / 25 : -1 },
+    ] as { key: HealthCategoryKey; percent: number }[]
+  ).filter((c) => c.percent >= 0);
+
+  if (categoryPercents.length === 0) {
+    return `Overall project health is ${healthLabel}, based on maintainer activity, security posture, and development cadence.`;
+  }
+
+  const availableKeys = categoryPercents.map((c) => c.key);
+  const redistributionClause = buildRedistributionClause(availableKeys);
+
+  if (categoryPercents.length === 1) {
+    const only = categoryPercents[0] as { key: HealthCategoryKey; percent: number };
+    const label = CATEGORY_LABEL[only.key];
+    let strengthWord = 'Weak';
+    if (only.percent >= 0.7) {
+      strengthWord = 'Strong';
+    } else if (only.percent >= 0.4) {
+      strengthWord = 'Middling';
+    }
+    return `${strengthWord} ${label} is the only scored signal for this project.${redistributionClause}`;
+  }
+
+  const sorted = [...categoryPercents].sort((a, b) => b.percent - a.percent);
+  const strongest = sorted[0] as { key: HealthCategoryKey; percent: number };
+  const weakest = sorted[sorted.length - 1] as { key: HealthCategoryKey; percent: number };
+  const strengthLabels = sorted.slice(0, -1).map((c) => CATEGORY_LABEL[c.key]);
+  const strengthsText = joinWithAnd(strengthLabels);
+  const gapLabel = CATEGORY_LABEL[weakest.key];
+
+  if (strongest.percent === weakest.percent) {
+    const allLabels = joinWithAnd(sorted.map((c) => CATEGORY_LABEL[c.key]));
+    if (healthLabel === 'excellent' || healthLabel === 'healthy') {
+      return `Consistent ${allLabels} across the board.${redistributionClause || ' No single category stands out as a gap.'}`;
+    }
+    if (healthLabel === 'fair') {
+      return `${capitalize(allLabels)} are all middling, with no clear strength to lean on.${redistributionClause}`;
+    }
+    return `${capitalize(allLabels)} are all weak, with no clear strength to offset the risk.${redistributionClause}`;
+  }
+
+  const strengthVerbHelp = strengthLabels.length === 1 ? 'helps' : 'help';
+  const strengthVerbBe = strengthLabels.length === 1 ? 'is' : 'are';
+  const strengthVerbShow = strengthLabels.length === 1 ? 'shows' : 'show';
+
+  let sentence1: string;
+  let sentence2: string;
+
+  switch (healthLabel) {
+    case 'excellent':
+      sentence1 = `Strong ${strengthsText}.`;
+      sentence2 = `${capitalize(gapLabel)} is the only remaining gap.`;
+      break;
+    case 'healthy':
+      sentence1 = `Solid ${strengthsText}.`;
+      sentence2 = `${capitalize(gapLabel)} keeps the score from reaching Excellent.`;
+      break;
+    case 'fair':
+      sentence1 = `${capitalize(gapLabel)} drags the score down.`;
+      sentence2 = `${capitalize(strengthsText)} ${strengthVerbHelp} keep it from falling further.`;
+      break;
+    case 'concerning':
+      sentence1 = `${capitalize(gapLabel)} is the lead risk.`;
+      sentence2 = `${capitalize(strengthsText)} ${strengthVerbBe} present but not enough to offset the structural risk.`;
+      break;
+    case 'critical':
+      sentence1 = `${capitalize(gapLabel)} is the primary crisis signal.`;
+      sentence2 = `${capitalize(strengthsText)} ${strengthVerbShow} little to offset it. Every health signal is at or near zero.`;
+      break;
+    default:
+      sentence1 = `Overall project health is ${healthLabel}.`;
+      sentence2 = `${capitalize(gapLabel)} is the weakest area.`;
+  }
+
+  return `${sentence1} ${sentence2}${redistributionClause}`;
+};

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -39,6 +39,7 @@ export * from './marketing-impact.utils';
 export * from './flywheel.utils';
 export * from './rewards.utils';
 export * from './insights.utils';
+export * from './health-breakdown.utils';
 export * from './pagination.utils';
 export * from './project-counts.utils';
 export * from './identity.utils';

--- a/packages/shared/src/utils/insights.utils.spec.ts
+++ b/packages/shared/src/utils/insights.utils.spec.ts
@@ -3,29 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { classifyHealthScore, isPartialHealthScore, normalizeHealthScoreCategoryV2 } from './insights.utils';
-
-describe('classifyHealthScore', () => {
-  it.each([
-    [100, 'excellent'],
-    [85, 'excellent'],
-    [84, 'healthy'],
-    [70, 'healthy'],
-    [69, 'fair'],
-    [50, 'fair'],
-    [49, 'concerning'],
-    [30, 'concerning'],
-    [29, 'critical'],
-    [0, 'critical'],
-  ] as const)('classifies %i as %s', (score, band) => {
-    expect(classifyHealthScore(score)).toBe(band);
-  });
-
-  it('places the five bands in a strictly worsening order as the score drops', () => {
-    const order = [90, 70, 50, 30, 10].map(classifyHealthScore);
-    expect(order).toEqual(['excellent', 'healthy', 'fair', 'concerning', 'critical']);
-  });
-});
+import { isPartialHealthScore, normalizeHealthScoreCategoryV2 } from './insights.utils';
 
 describe('isPartialHealthScore', () => {
   it.each([

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -82,7 +82,7 @@ export function normalizeHealthScoreCategoryV2(category: string | null | undefin
 }
 
 /**
- * Shared accessible summary for a health badge (#2096, contract §4) — the single rule behind the
+ * Shared accessible summary for a health badge — the single rule behind the
  * table and hero badge accessible names: `Health: {Label[- Partial]} ({score}/{max}). Maintainer
  * Health {x/40}, Security & Supply Chain {x/35}, Development Activity {x/25}.` A null label or score
  * renders `Health: Unavailable.` — the partial suffix never applies to unavailable.

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { LINKS_CONFIG } from '../constants/links.config';
-import { HEALTH_SCORE_LABELS, HEALTH_SCORE_PARTIAL_SUFFIX } from '../constants/org-lens-projects.constants';
+import { HEALTH_SCORE_CATEGORIES, HEALTH_SCORE_LABELS, HEALTH_SCORE_PARTIAL_SUFFIX } from '../constants/org-lens-projects.constants';
 import type { HealthScore } from '../interfaces';
 
 /**
@@ -65,7 +65,7 @@ export function isPartialHealthScore(coveredCategoryCount: number | null): boole
   return coveredCategoryCount === 2;
 }
 
-const HEALTH_SCORE_CATEGORIES = new Set<Exclude<HealthScore, 'unavailable'>>(['excellent', 'healthy', 'fair', 'concerning', 'critical']);
+const HEALTH_SCORE_BANDS = new Set<Exclude<HealthScore, 'unavailable'>>(['excellent', 'healthy', 'fair', 'concerning', 'critical']);
 
 /**
  * Normalizes the warehouse-computed `health_score_category_v2` column (lf-dbt's `get_health_score_category_v2`
@@ -78,7 +78,7 @@ export function normalizeHealthScoreCategoryV2(category: string | null | undefin
     return null;
   }
   const lower = category.toLowerCase() as Exclude<HealthScore, 'unavailable'>;
-  return HEALTH_SCORE_CATEGORIES.has(lower) ? lower : null;
+  return HEALTH_SCORE_BANDS.has(lower) ? lower : null;
 }
 
 /**
@@ -101,11 +101,7 @@ export function buildHealthAriaLabel(args: {
     return 'Health: Unavailable.';
   }
   const headline = `${HEALTH_SCORE_LABELS[label]}${isPartialHealthScore(args.coveredCount) ? HEALTH_SCORE_PARTIAL_SUFFIX : ''}`;
-  const rows = [
-    `Maintainer Health ${args.maintainer ?? '-'}/40`,
-    `Security & Supply Chain ${args.security ?? '-'}/35`,
-    `Development Activity ${args.development ?? '-'}/25`,
-  ].join(', ');
+  const rows = HEALTH_SCORE_CATEGORIES.map((c) => `${c.name} ${args[c.key] ?? '-'}/${c.max}`).join(', ');
   return `Health: ${headline} (${score}/${args.maxScore ?? 100}). ${rows}.`;
 }
 

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { LINKS_CONFIG } from '../constants/links.config';
+import { HEALTH_SCORE_LABELS, HEALTH_SCORE_PARTIAL_SUFFIX } from '../constants/org-lens-projects.constants';
 import type { HealthScore } from '../interfaces';
 
 /**
@@ -78,6 +79,34 @@ export function normalizeHealthScoreCategoryV2(category: string | null | undefin
   }
   const lower = category.toLowerCase() as Exclude<HealthScore, 'unavailable'>;
   return HEALTH_SCORE_CATEGORIES.has(lower) ? lower : null;
+}
+
+/**
+ * Shared accessible summary for a health badge (#2096, contract §4) — the single rule behind the
+ * table and hero badge accessible names: `Health: {Label[- Partial]} ({score}/{max}). Maintainer
+ * Health {x/40}, Security & Supply Chain {x/35}, Development Activity {x/25}.` A null label or score
+ * renders `Health: Unavailable.` — the partial suffix never applies to unavailable.
+ */
+export function buildHealthAriaLabel(args: {
+  label: Exclude<HealthScore, 'unavailable'> | null;
+  score: number | null;
+  maxScore: number | null;
+  coveredCount: number | null;
+  maintainer: number | null;
+  security: number | null;
+  development: number | null;
+}): string {
+  const { label, score } = args;
+  if (label == null || score == null) {
+    return 'Health: Unavailable.';
+  }
+  const headline = `${HEALTH_SCORE_LABELS[label]}${isPartialHealthScore(args.coveredCount) ? HEALTH_SCORE_PARTIAL_SUFFIX : ''}`;
+  const rows = [
+    `Maintainer Health ${args.maintainer ?? '-'}/40`,
+    `Security & Supply Chain ${args.security ?? '-'}/35`,
+    `Development Activity ${args.development ?? '-'}/25`,
+  ].join(', ');
+  return `Health: ${headline} (${score}/${args.maxScore ?? 100}). ${rows}.`;
 }
 
 function encodePathSegments(path: string): string {

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -55,31 +55,6 @@ export function buildLensAwareInsightsUrl(
 }
 
 /**
- * Classifies an LFX Insights project health score (0–100) into a band, matching lf-dbt's
- * `get_health_score_category_v2` macro and the Insights primary project Health Score component
- * (`health-score.vue`): `>= 85` Excellent, `>= 70` Healthy, `>= 50` Fair, `>= 30` Concerning, else
- * Critical. The `unavailable` state (no score) is handled by callers, so this returns only the five
- * scored bands. LFXV2-3379 removed the Org Lens Projects table's and project-detail hero's calls to
- * this legacy v1 classifier in favor of the warehouse-computed `health_score_category_v2` (see
- * `normalizeHealthScoreCategoryV2` below).
- */
-export function classifyHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
-  if (score >= 85) {
-    return 'excellent';
-  }
-  if (score >= 70) {
-    return 'healthy';
-  }
-  if (score >= 50) {
-    return 'fair';
-  }
-  if (score >= 30) {
-    return 'concerning';
-  }
-  return 'critical';
-}
-
-/**
  * A health score is partial when the warehouse's `covered_category_count_v2` reports exactly 2 of the
  * 3 CHAOSS categories covered (`health_max_score_v2` is 60/65/75 rather than 100). `< 2` categories
  * means no score at all (`health`/`healthMaxScore` are `null`/`unavailable`), and `3` is a full score —
@@ -94,8 +69,8 @@ const HEALTH_SCORE_CATEGORIES = new Set<Exclude<HealthScore, 'unavailable'>>(['e
 /**
  * Normalizes the warehouse-computed `health_score_category_v2` column (lf-dbt's `get_health_score_category_v2`
  * macro, e.g. "Excellent"/"Fair"/"Concerning") into the lowercase `HealthScore` band. Returns `null` for
- * unset/unrecognized values — callers must treat that as "no score" (`unavailable`), never fall back to
- * `classifyHealthScore` on the legacy v1 score; the warehouse is the sole source of truth for the label.
+ * unset/unrecognized values — callers must treat that as "no score" (`unavailable`); the warehouse is the
+ * sole source of truth for the label (#2096).
  */
 export function normalizeHealthScoreCategoryV2(category: string | null | undefined): Exclude<HealthScore, 'unavailable'> | null {
   if (!category) {


### PR DESCRIPTION
## Summary

Ports the LFX Insights Health Score v2 popup to Org Lens on both the **Projects table** badge and the **project-detail hero** badge: headline `Label (score/max)`, rescaled bar, generated description, and the three category rows (Maintainer Health /40, Security & Supply Chain /35, Development Activity /25). Header shell (`Health score` + `LFX Insights` link) is Org Lens; everything below is a 1:1 port of the Insights pill.

Refs #2096 — delivers the badge-popup surfaces (Projects table + project-detail hero) as scoped in spec 043; the issue also lists a project-detail Health metrics section, which is not in this PR (see review thread) and would close the issue in a follow-up.

## What changed

**BFF** (`org-lens-projects.service.ts`, `org-lens-project-detail.service.ts`)
- Select `HEALTH_OVERALL_SCORE_V2` + `HEALTH_MAINTAINER_V2` / `HEALTH_SECURITY_V2` / `HEALTH_DEVELOPMENT_V2` in both the main `ORG_LENS_PROJECTS` query and the `ONBOARDED_PROJECTS` fallback, and in the hero query — all from one same-date snapshot row.
- Availability = warehouse label normalizes **and** score non-null; `covered_category_count_v2 == 2` drives only the ` - Partial` suffix. The label is never derived from the score client-side.
- Deleted the v1 `healthMetrics` percentage mapping. Valkey keys bumped (`projects:v6`, `project-detail-hero:v3`).

**Shared** (`@lfx-one/shared`)
- `OrgLensProject` / `OrgLensProjectHero`: `+healthOverallScore/healthMaintainer/healthSecurity/healthDevelopment`, `-healthMetrics`.
- `getHealthScoreDescription` ported verbatim from Insights `health-breakdown-templates.ts` (the one nested ternary is an equivalent if-chain per repo style).
- `buildHealthAriaLabel` — single accessible-name rule for both badges. `HEALTH_SCORE_CATEGORIES` descriptor drives popup rows + aria rows.
- `classifyHealthScore` deleted (no callers remained).

**UI**
- New shared `OrgHealthPopupComponent` (PrimeNG Popover, `appendTo=body`, deferred hide, `DestroyRef` cleanup, focusable content group, named dialog).
- Table + hero badges are buttons (`aria-haspopup=dialog`, `aria-expanded`) opening the popup on hover / focus / click.
- CSV `Health Score` column uses the same label rule (partial suffix, `Unavailable`).

## Verification

| Check | Result |
|---|---|
| `yarn lint:check` / `check-types` / `format:check` / `build` | ✅ |
| `yarn test` | ✅ shared 72 files / 1678 · app 116 files / 3177 (vitest) · 147 files / 2481 (karma) |
| Port equivalence vs Insights source (17 output vectors) | ✅ identical |
| Live prod probe (Snowflake) | 7 v2 cols present on `ORG_LENS_PROJECTS` + `ONBOARDED_PROJECTS`; pinned rows read as expected |
| `yarn e2e` (`org-projects.spec.ts`, `org-project-detail.spec.ts`) | ❌ **not executed** — 129 tests listed/parse clean, but CI's e2e job is disabled (`quality-check.yml` `e2e-tests` commented out; `e2e-tests.yml` is `workflow_call`-only). Branch preview is live at https://ui-pr-2320.dev.v2.cluster.linuxfound.info; run from `apps/lfx-one`: `E2E_BASE_URL=https://ui-pr-2320.dev.v2.cluster.linuxfound.info TEST_USERNAME=… TEST_PASSWORD=… yarn exec playwright test e2e/org-projects.spec.ts e2e/org-project-detail.spec.ts --project=chromium --reporter=list --grep health` (creds: 1Password "LFX One Dev Environment") |

### Same-snapshot parity — warehouse values through the shipped code (2026-09-10)

| Slug | Headline | Bar | Rows | Description |
|---|---|---|---|---|
| `ojsf-jquery` | Healthy (79/100) | 79% | 34/40 · 26/35 · 19/25 | Solid maintainer coverage and development cadence. Security posture keeps the score from reaching Excellent. |
| `seapath` | Healthy - Partial (49/65) | 75.4% | 34/40 · -/35 · 15/25 | Solid maintainer coverage. Development cadence keeps the score from reaching Excellent. Security & Supply Chain is unavailable, so weights were redistributed. |
| `cnab` | — (unavailable) | — | — | Health score is unavailable for this project. |

Browser-side visual comparison against the Insights pill is pending (needs the app runtime). **Reviewer ask:** run the e2e command above against the preview before merge — CI will not, and the author's session has no 1Password sign-in.

## Notes for reviewers

- **Rolling-deploy window**: `healthMetrics` is removed from the wire payload in the same release the FE stops reading it. A pre-deploy SPA bundle that receives a new-BFF payload will throw in its `healthAriaLabel` until reload. Accepted per the clean-cutover design (no shim); flagging so it's a known transient.
- **Port fidelity**: `health-breakdown.utils.ts` deliberately keeps its own literal `CATEGORY_LABEL` / `CATEGORY_NAME` maps rather than deriving from `HEALTH_SCORE_CATEGORIES` — the port is locked verbatim.
- Data side landed in linuxfoundation/lf-dbt#2899 (warehouse columns this PR consumes).



