### PR TITLE
feat(formation): wire the live checklist read

### DIFF
--- a/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-backend.helper.ts
@@ -11,14 +11,12 @@
  * now `fail()`s Helm rendering if it's set, so `FORMATION_BACKEND=live` is the only arm reachable in
  * any Helm-deployed environment (staging/prod). Keep the two in sync if either changes.
  *
- * This is the **only** switch — `getFormationsQueue`, every item mutation
- * (`completeFormationItem`/`skipFormationItem`/`requestFormationItem`/`updateFormationItem`/
- * `updateFormationItemStatus`/`acceptFormationItem`/`rejectFormationItem`/`reopenFormationItem`)
- * branches on it. `getProjectFormation` does not yet — its live branch is
- * `// TODO(GH-2267 Phase 1 remainder)` and unconditionally throws, so flipping this on before that
- * lands 404s the checklist read while everything else goes live. Per Phase 7 of GH-2267, this stays
- * the single documented switch for a staged cutover; if no staged rollout turns out to be needed,
- * delete this helper entirely and call the real proxy directly.
+ * This is the **only** switch — `getFormationsQueue`, `getProjectFormation`'s checklist read, and
+ * every item mutation (`completeFormationItem`/`skipFormationItem`/`requestFormationItem`/
+ * `updateFormationItem`/`updateFormationItemStatus`/`acceptFormationItem`/`rejectFormationItem`/
+ * `reopenFormationItem`) all branch on it. Per Phase 7 of GH-2267, this stays the single documented
+ * switch for a staged cutover; if no staged rollout turns out to be needed, delete this helper
+ * entirely and call the real proxy directly.
  *
  * No `NODE_ENV==='production'` hard-block (unlike the mock-backend precedents `isEngagementMockBackend()`/
  * `WEEKLY_BRIEF_BACKEND`): production isn't "reachable with a misconfigured env var flipping on

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { FORMATION_TEMPLATE } from '@lfx-one/shared/constants';
-import { FormationTemplateSectionKey, ProjectStage } from '@lfx-one/shared/enums';
+import { ProjectStage } from '@lfx-one/shared/enums';
 import type {
   Formation,
   FormationChecklistMapContext,
@@ -15,7 +15,7 @@ import type {
   UpstreamFormationChecklist,
   UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
-import { deriveFormationReadinessSummary, isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
+import { deriveFormationBlockingItemTitle, deriveFormationReadinessSummary, isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
 
 /**
  * Maps `lfx-v2-formation-service`'s wire shapes (GH-2267 Phase 0's contract table, source of truth
@@ -145,10 +145,11 @@ export function sectionTitlesFromChecklist(raw: UpstreamFormationChecklist): Map
  * reach the UI without a BFF redeploy. Each section's `items: []` is deliberate:
  * `FormationTemplateSection.items` is never read anywhere downstream (`groupFormationItemsBySection`
  * only reads `key`/`title`), and every per-item template fact `mapUpstreamFormationItem` needs comes
- * from `TEMPLATE_ITEMS_BY_KEY`, not from this shape. The section `key` cast to
- * `FormationTemplateSectionKey` mirrors the same cast `FORMATION_ORPHAN_SECTION` uses in
- * `formation-checklist.utils.ts` — an upstream section key this BFF doesn't recognize yet is a
- * display gap, not a type error. `template.name` still comes from the seeded `FORMATION_TEMPLATE`
+ * from `TEMPLATE_ITEMS_BY_KEY`, not from this shape. The section `key` is passed through as the
+ * upstream string verbatim — no cast needed, since `FormationTemplateSection.key` is typed
+ * `FormationTemplateSectionKey | string` for exactly this reason (see its doc comment); an upstream
+ * section key this BFF doesn't recognize yet is a display gap (falls into `FORMATION_ORPHAN_SECTION`
+ * downstream), not a type error. `template.name` still comes from the seeded `FORMATION_TEMPLATE`
  * constant — the wire shape (`UpstreamFormationChecklist`) has no template-name field to source it
  * from, only `template_uid`/`template_version`.
  *
@@ -175,17 +176,11 @@ export function mapUpstreamFormationChecklist(
     uid: raw.template_uid,
     version: raw.template_version,
     name: FORMATION_TEMPLATE.name,
-    sections: [...raw.sections]
-      .sort((a, b) => a.position - b.position)
-      .map((section) => ({ key: section.key as unknown as FormationTemplateSectionKey, title: section.title, items: [] })),
+    sections: [...raw.sections].sort((a, b) => a.position - b.position).map((section) => ({ key: section.key, title: section.title, items: [] })),
   };
 
   const { openGatingItems, totalGatingItems } = deriveFormationReadinessSummary(ctx.items, ctx.announcementDate);
-  // Blocking column reflects items actually in `blocked` status, same distinction
-  // FormationService.refreshFormationReadiness draws (not "first not-done gating item") — not part
-  // of deriveFormationReadinessSummary's own rollup, so computed separately here.
-  const blockedGatingItems = ctx.items.filter((item) => item.is_gating && item.status === 'blocked');
-  const blockingItemTitle = blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null;
+  const blockingItemTitle = deriveFormationBlockingItemTitle(ctx.items);
 
   const formation: Formation = {
     parent_project_uid: raw.project_uid,

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -5,17 +5,17 @@ import { FORMATION_TEMPLATE } from '@lfx-one/shared/constants';
 import { FormationTemplateSectionKey, ProjectStage } from '@lfx-one/shared/enums';
 import type {
   Formation,
+  FormationChecklistMapContext,
   FormationItem,
   FormationItemLink,
   FormationItemMapContext,
   FormationSubItem,
   FormationSubStage,
   FormationTemplate,
-  Project,
   UpstreamFormationChecklist,
   UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
-import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
+import { deriveFormationReadinessSummary, isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
 
 /**
  * Maps `lfx-v2-formation-service`'s wire shapes (GH-2267 Phase 0's contract table, source of truth
@@ -26,9 +26,9 @@ import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
  * copies verbatim (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream
  * source at all — see the GH-2267 plan's Phase 5 "checklist read" section for why each one is
  * derived from the seeded `FORMATION_TEMPLATE` instead. The raw upstream shapes themselves
- * (`UpstreamFormationItem`/`UpstreamFormationChecklist`/`FormationItemMapContext`) live in
- * `@lfx-one/shared/interfaces` rather than here, per this repo's "no local interface in
- * apps/lfx-one" convention.
+ * (`UpstreamFormationItem`/`UpstreamFormationChecklist`/`FormationItemMapContext`/
+ * `FormationChecklistMapContext`) live in `@lfx-one/shared/interfaces` rather than here, per this
+ * repo's "no local interface in apps/lfx-one" convention.
  */
 
 const TEMPLATE_ITEMS_BY_KEY = new Map(FORMATION_TEMPLATE.sections.flatMap((section) => section.items.map((item) => [item.key, item])));
@@ -106,7 +106,7 @@ export function mapUpstreamFormationItem(raw: UpstreamFormationItem, ctx: Format
     project_uid: ctx.projectUid,
     template_item_key: raw.item_key,
     section_key: raw.section_key,
-    section_title: TEMPLATE_SECTION_TITLES_BY_KEY.get(raw.section_key) ?? raw.section_key,
+    section_title: ctx.sectionTitles?.get(raw.section_key) ?? TEMPLATE_SECTION_TITLES_BY_KEY.get(raw.section_key) ?? raw.section_key,
     title: raw.title,
     status: raw.status,
     is_gating: raw.gate,
@@ -128,17 +128,12 @@ export function mapUpstreamFormationItem(raw: UpstreamFormationItem, ctx: Format
 }
 
 /**
- * Everything `mapUpstreamFormationChecklist` needs beyond the raw checklist itself — the project
- * record (for name/slug/stage), the already ROOT-collapsed `parent_uid` ({@link
- * collapseRootParentUid}), the mapped items (to derive gating counts from), and the
- * `announcement_date` (no upstream source on the checklist read itself — see
- * `FormationService.getProjectFormation`'s doc comment for where it comes from instead).
+ * Builds the per-checklist section-title map ({@link FormationItemMapContext.sectionTitles}) from
+ * this same response's own `sections[]`, so a renamed section reads the same in the template
+ * header and every item row it maps — see `mapUpstreamFormationItem`'s `section_title` fallback.
  */
-export interface FormationChecklistMapContext {
-  project: Pick<Project, 'slug' | 'name' | 'stage'>;
-  parentUid: string | null;
-  announcementDate: string | null;
-  items: FormationItem[];
+export function sectionTitlesFromChecklist(raw: UpstreamFormationChecklist): Map<string, string> {
+  return new Map(raw.sections.map((section) => [section.key, section.title]));
 }
 
 /**
@@ -151,12 +146,24 @@ export interface FormationChecklistMapContext {
  * from `TEMPLATE_ITEMS_BY_KEY`, not from this shape. The section `key` cast to
  * `FormationTemplateSectionKey` mirrors the same cast `FORMATION_ORPHAN_SECTION` uses in
  * `formation-checklist.utils.ts` — an upstream section key this BFF doesn't recognize yet is a
- * display gap, not a type error.
+ * display gap, not a type error. `template.name` still comes from the seeded `FORMATION_TEMPLATE`
+ * constant — the wire shape (`UpstreamFormationChecklist`) has no template-name field to source it
+ * from, only `template_uid`/`template_version`.
  *
  * `formation.uid`/`created_at`/`updated_at` are left `undefined` — all three are optional
  * specifically because the checklist read doesn't return them (see their doc comments on
  * `Formation`); synthesizing a fake `uid` here would disagree with the queue read's real
  * `formation_uid` for the same project.
+ *
+ * `ctx.items` must be the **pre-enrichment** mapped items, not the caller's enriched response
+ * array — `FormationService.enrichItems` can drop an item on an access-check failure, and this
+ * rollup must reflect the checklist's real gating state regardless of that per-item enrichment
+ * outcome (an enrichment hiccup on the one open gating item must not report the formation as fully
+ * gated). `gating_items_open`/`gating_items_total` reuse the shared `deriveFormationReadinessSummary`
+ * rollup (`formation-checklist.utils.ts`) so this path and the client can't drift on the "skipped
+ * counts as resolved" rule; `is_activating` is taken from `raw.is_activating` verbatim rather than
+ * re-derived — see {@link Formation.is_activating}'s doc comment for why the two formulas disagree
+ * and why upstream's is authoritative here.
  */
 export function mapUpstreamFormationChecklist(
   raw: UpstreamFormationChecklist,
@@ -171,11 +178,11 @@ export function mapUpstreamFormationChecklist(
       .map((section) => ({ key: section.key as unknown as FormationTemplateSectionKey, title: section.title, items: [] })),
   };
 
-  // Same rollup rules as FormationService.refreshFormationReadiness (fixture path) and
-  // deriveFormationReadinessSummary (client) — a skipped gating item counts as resolved, not open.
-  const gatingItems = ctx.items.filter((item) => item.is_gating);
-  const openGatingItems = gatingItems.filter((item) => item.status !== 'done' && item.status !== 'skipped');
-  const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
+  const { openGatingItems, totalGatingItems } = deriveFormationReadinessSummary(ctx.items, ctx.announcementDate);
+  // Blocking column reflects items actually in `blocked` status, same distinction
+  // FormationService.refreshFormationReadiness draws (not "first not-done gating item") — not part
+  // of deriveFormationReadinessSummary's own rollup, so computed separately here.
+  const blockedGatingItems = ctx.items.filter((item) => item.is_gating && item.status === 'blocked');
   const blockingItemTitle = blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null;
 
   const formation: Formation = {
@@ -189,8 +196,8 @@ export function mapUpstreamFormationChecklist(
     sub_stage: deriveFormationSubStage(ctx.project.stage),
     announcement_date: ctx.announcementDate,
     is_activating: raw.is_activating,
-    gating_items_open: openGatingItems.length,
-    gating_items_total: gatingItems.length,
+    gating_items_open: openGatingItems,
+    gating_items_total: totalGatingItems,
     blocking_item_title: blockingItemTitle,
     subtitle: null,
   };

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -15,7 +15,7 @@ import type {
   UpstreamFormationChecklist,
   UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
-import { deriveFormationBlockingItemTitle, deriveFormationReadinessSummary, isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
+import { computeIsFoundation, deriveFormationBlockingItemTitle, isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
 
 /**
  * Maps `lfx-v2-formation-service`'s wire shapes (GH-2267 Phase 0's contract table, source of truth
@@ -158,15 +158,31 @@ export function sectionTitlesFromChecklist(raw: UpstreamFormationChecklist): Map
  * `Formation`); synthesizing a fake `uid` here would disagree with the queue read's real
  * `formation_uid` for the same project.
  *
+ * `is_foundation` is computed via the shared `computeIsFoundation` classifier rather than derived
+ * from `!ctx.parentUid` — foundation status and hierarchy depth are independent axes (see
+ * `deriveFormationEntityType`, which branches on both `is_foundation` and `parent_uid`
+ * separately): a top-level project with no parent is not necessarily a foundation, and a foundation
+ * can in principle sit under a collapsed ROOT parent. `computeIsFoundation` is the same
+ * non-hierarchy-based classifier already used elsewhere in this codebase
+ * (`packages/shared/src/utils/project.utils.ts`).
+ *
  * `ctx.items` must be the **pre-enrichment** mapped items, not the caller's enriched response
  * array — `FormationService.enrichItems` can drop an item on an access-check failure, and this
  * rollup must reflect the checklist's real gating state regardless of that per-item enrichment
  * outcome (an enrichment hiccup on the one open gating item must not report the formation as fully
- * gated). `gating_items_open`/`gating_items_total` reuse the shared `deriveFormationReadinessSummary`
- * rollup (`formation-checklist.utils.ts`) so this path and the client can't drift on the "skipped
- * counts as resolved" rule; `is_activating` is taken from `raw.is_activating` verbatim rather than
- * re-derived — see {@link Formation.is_activating}'s doc comment for why the two formulas disagree
- * and why upstream's is authoritative here.
+ * gated). `gating_items_open`/`gating_items_total` are computed here directly from `ctx.items`
+ * rather than via the shared `deriveFormationReadinessSummary` rollup
+ * (`formation-checklist.utils.ts`) — that helper treats `done` OR `skipped` as resolved, which is
+ * the fixture generator's intentional escape-hatch design, but upstream's own gate accounting
+ * (`lfx-v2-formation-service`'s `internal/service/progress.go#gateSummaryFromItems` and
+ * `internal/service/readiness.go#isActivating`) treats a skipped gating item as still outstanding:
+ * only `status === 'done'` clears a gate. The live queue's `gates_cleared` field is sourced verbatim
+ * from that same upstream projection, so this live checklist path must match upstream's semantics
+ * exactly rather than reuse the fixture helper — reusing it here would silently disagree with the
+ * queue screen for any project with a skipped gating item, the same cross-screen-mismatch bug class
+ * as the earlier `announcement_date` incident. `is_activating` is taken from `raw.is_activating`
+ * verbatim rather than re-derived — see {@link Formation.is_activating}'s doc comment for why the
+ * two formulas disagree and why upstream's is authoritative here.
  */
 export function mapUpstreamFormationChecklist(
   raw: UpstreamFormationChecklist,
@@ -179,14 +195,16 @@ export function mapUpstreamFormationChecklist(
     sections: [...raw.sections].sort((a, b) => a.position - b.position).map((section) => ({ key: section.key, title: section.title, items: [] })),
   };
 
-  const { openGatingItems, totalGatingItems } = deriveFormationReadinessSummary(ctx.items, ctx.announcementDate);
+  const gatingItems = ctx.items.filter((item) => item.is_gating);
+  const totalGatingItems = gatingItems.length;
+  const openGatingItems = gatingItems.filter((item) => item.status !== 'done').length;
   const blockingItemTitle = deriveFormationBlockingItemTitle(ctx.items);
 
   const formation: Formation = {
     parent_project_uid: raw.project_uid,
     parent_project_slug: ctx.project.slug,
     parent_project_name: ctx.project.name,
-    is_foundation: !ctx.parentUid,
+    is_foundation: computeIsFoundation(ctx.project),
     parent_uid: ctx.parentUid,
     template_uid: raw.template_uid,
     template_version: raw.template_version,

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -128,9 +128,11 @@ export function mapUpstreamFormationItem(raw: UpstreamFormationItem, ctx: Format
 }
 
 /**
- * Builds the per-checklist section-title map ({@link FormationItemMapContext.sectionTitles}) from
- * this same response's own `sections[]`, so a renamed section reads the same in the template
- * header and every item row it maps — see `mapUpstreamFormationItem`'s `section_title` fallback.
+ * Builds the per-project section-title map ({@link FormationItemMapContext.sectionTitles}) from
+ * this checklist response's own `sections[]`. `FormationService` caches the result per project
+ * (`sectionTitlesByRequestCache`) so a renamed section reads the same in the template header, the
+ * checklist read's items, and every later mutation response mapped in the same request — see
+ * `mapUpstreamFormationItem`'s `section_title` fallback.
  */
 export function sectionTitlesFromChecklist(raw: UpstreamFormationChecklist): Map<string, string> {
   return new Map(raw.sections.map((section) => [section.key, section.title]));

--- a/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-mapper.helper.ts
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: MIT
 
 import { FORMATION_TEMPLATE } from '@lfx-one/shared/constants';
-import { ProjectStage } from '@lfx-one/shared/enums';
+import { FormationTemplateSectionKey, ProjectStage } from '@lfx-one/shared/enums';
 import type {
+  Formation,
   FormationItem,
   FormationItemLink,
   FormationItemMapContext,
   FormationSubItem,
   FormationSubStage,
+  FormationTemplate,
+  Project,
+  UpstreamFormationChecklist,
   UpstreamFormationItem,
 } from '@lfx-one/shared/interfaces';
 import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
@@ -16,12 +20,12 @@ import { isRelativeInAppPath, isValidUrl } from '@lfx-one/shared/utils';
 /**
  * Maps `lfx-v2-formation-service`'s wire shapes (GH-2267 Phase 0's contract table, source of truth
  * `cmd/formation-api/design/design.go` at `linuxfoundation/lfx-v2-formation-service@main`) onto
- * this repo's `FormationItem` shared type — `mapUpstreamFormationItem`, one upstream item at a time.
- * Formation-level mapping (`UpstreamFormationChecklist` → `Formation`) is deferred; see the trailing
- * note at the bottom of this file. Every field this file derives rather than copies verbatim
- * (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream source at all — see
- * the GH-2267 plan's Phase 5 "checklist read" section for why each one is derived from the seeded
- * `FORMATION_TEMPLATE` instead. The raw upstream shapes themselves
+ * this repo's shared types — `mapUpstreamFormationItem` for one upstream item at a time, and
+ * `mapUpstreamFormationChecklist` (GH-2267 Phase 1 remainder) for the `Formation`/`FormationTemplate`
+ * pair the checklist read assembles around those items. Every field this file derives rather than
+ * copies verbatim (`section_title`, `action`, `action_href`, `links`, `detail`) has no upstream
+ * source at all — see the GH-2267 plan's Phase 5 "checklist read" section for why each one is
+ * derived from the seeded `FORMATION_TEMPLATE` instead. The raw upstream shapes themselves
  * (`UpstreamFormationItem`/`UpstreamFormationChecklist`/`FormationItemMapContext`) live in
  * `@lfx-one/shared/interfaces` rather than here, per this repo's "no local interface in
  * apps/lfx-one" convention.
@@ -123,6 +127,73 @@ export function mapUpstreamFormationItem(raw: UpstreamFormationItem, ctx: Format
   };
 }
 
-// Note: `getProjectFormation`'s live branch (mapping `UpstreamFormationChecklist` onto `Formation`)
-// is not yet wired — see the GH-2267 plan's Phase 1 remainder. A `mapUpstreamFormationChecklist`
-// helper belongs here once that lands, matching `mapUpstreamFormationItem`'s shape.
+/**
+ * Everything `mapUpstreamFormationChecklist` needs beyond the raw checklist itself — the project
+ * record (for name/slug/stage), the already ROOT-collapsed `parent_uid` ({@link
+ * collapseRootParentUid}), the mapped items (to derive gating counts from), and the
+ * `announcement_date` (no upstream source on the checklist read itself — see
+ * `FormationService.getProjectFormation`'s doc comment for where it comes from instead).
+ */
+export interface FormationChecklistMapContext {
+  project: Pick<Project, 'slug' | 'name' | 'stage'>;
+  parentUid: string | null;
+  announcementDate: string | null;
+  items: FormationItem[];
+}
+
+/**
+ * Maps `GET /formations/{project_uid}`'s response onto this repo's `Formation`/`FormationTemplate`
+ * pair (GH-2267 Phase 1 remainder). `template` is built from the checklist's own `sections` rather
+ * than the seeded `FORMATION_TEMPLATE` constant — a template revision on the service side must
+ * reach the UI without a BFF redeploy. Each section's `items: []` is deliberate:
+ * `FormationTemplateSection.items` is never read anywhere downstream (`groupFormationItemsBySection`
+ * only reads `key`/`title`), and every per-item template fact `mapUpstreamFormationItem` needs comes
+ * from `TEMPLATE_ITEMS_BY_KEY`, not from this shape. The section `key` cast to
+ * `FormationTemplateSectionKey` mirrors the same cast `FORMATION_ORPHAN_SECTION` uses in
+ * `formation-checklist.utils.ts` — an upstream section key this BFF doesn't recognize yet is a
+ * display gap, not a type error.
+ *
+ * `formation.uid`/`created_at`/`updated_at` are left `undefined` — all three are optional
+ * specifically because the checklist read doesn't return them (see their doc comments on
+ * `Formation`); synthesizing a fake `uid` here would disagree with the queue read's real
+ * `formation_uid` for the same project.
+ */
+export function mapUpstreamFormationChecklist(
+  raw: UpstreamFormationChecklist,
+  ctx: FormationChecklistMapContext
+): { formation: Formation; template: FormationTemplate } {
+  const template: FormationTemplate = {
+    uid: raw.template_uid,
+    version: raw.template_version,
+    name: FORMATION_TEMPLATE.name,
+    sections: [...raw.sections]
+      .sort((a, b) => a.position - b.position)
+      .map((section) => ({ key: section.key as unknown as FormationTemplateSectionKey, title: section.title, items: [] })),
+  };
+
+  // Same rollup rules as FormationService.refreshFormationReadiness (fixture path) and
+  // deriveFormationReadinessSummary (client) — a skipped gating item counts as resolved, not open.
+  const gatingItems = ctx.items.filter((item) => item.is_gating);
+  const openGatingItems = gatingItems.filter((item) => item.status !== 'done' && item.status !== 'skipped');
+  const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
+  const blockingItemTitle = blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null;
+
+  const formation: Formation = {
+    parent_project_uid: raw.project_uid,
+    parent_project_slug: ctx.project.slug,
+    parent_project_name: ctx.project.name,
+    is_foundation: !ctx.parentUid,
+    parent_uid: ctx.parentUid,
+    template_uid: raw.template_uid,
+    template_version: raw.template_version,
+    sub_stage: deriveFormationSubStage(ctx.project.stage),
+    announcement_date: ctx.announcementDate,
+    is_activating: raw.is_activating,
+    gating_items_open: openGatingItems.length,
+    gating_items_total: gatingItems.length,
+    blocking_item_title: blockingItemTitle,
+    subtitle: null,
+  };
+
+  return { formation, template };
+}

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -731,6 +731,23 @@ describe('FormationService', () => {
       expect(patchCall![6]).toEqual({ 'If-Match': '3' });
     });
 
+    it("completeFormationItem's response resolves section_title from the same checklist the pre-read cached, not the seeded template", async () => {
+      const item = rawItem({ status: 'in_progress', gate: true, section_key: 'section-1' });
+      const renamedChecklist: UpstreamFormationChecklist = {
+        ...checklist([item]),
+        sections: [{ key: 'section-1', title: 'Renamed Section', position: 1 }],
+      };
+      proxyRequest.mockImplementation((_req, _service, path: string, method: string) => {
+        if (method === 'GET') return Promise.resolve(renamedChecklist);
+        if (method === 'PATCH') return Promise.resolve({ ...item, status: 'done', version: 4 });
+        throw new Error(`unexpected call: ${method} ${path}`);
+      });
+
+      const result = await service.completeFormationItem(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.section_title).toBe('Renamed Section');
+    });
+
     it('maps a 412 from a live mutation to PreconditionFailedError', async () => {
       const item = rawItem({ status: 'in_progress', gate: true });
       proxyRequest.mockImplementation((_req, _service, _path: string, method: string) => {
@@ -1145,6 +1162,28 @@ describe('FormationService', () => {
 
       expect(result.formation.announcement_date).toBeNull();
       expect(result.data_source).toBe('live');
+    });
+
+    it("prefers this response's own section title over the seeded template's when upstream has renamed a section", async () => {
+      proxyRequest.mockResolvedValue(
+        checklist({
+          sections: [{ key: 'legal_and_entity', title: 'Legal & Entity (renamed)', position: 1 }],
+          items: [rawItem({ section_key: 'legal_and_entity' })],
+        })
+      );
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.items[0].section_title).toBe('Legal & Entity (renamed)');
+      expect(result.template?.sections[0].title).toBe('Legal & Entity (renamed)');
+    });
+
+    it('falls back to the raw section_key when a section is not in this response', async () => {
+      proxyRequest.mockResolvedValue(checklist({ items: [rawItem({ section_key: 'unrecognized-section' })] }));
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.items[0].section_title).toBe('unrecognized-section');
     });
 
     it('keeps gating counts derived from the checklist, not the post-enrichment array, when a gating item is dropped by enrichItems', async () => {

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -1143,8 +1143,17 @@ describe('FormationService', () => {
       expect((forbidden as Error).message).toBe((notFound as Error).message);
     });
 
-    it('collapses a ROOT-parented project to parent_uid null and is_foundation true', async () => {
-      getProjectById.mockResolvedValue({ slug: 'live-project', name: 'Live Project', parent_uid: 'root-uid', writer: true });
+    it('collapses a ROOT-parented project to parent_uid null, independent of is_foundation', async () => {
+      getProjectById.mockResolvedValue({
+        slug: 'live-project',
+        name: 'Live Project',
+        parent_uid: 'root-uid',
+        writer: true,
+        stage: 'Active',
+        legal_entity_type: 'Corporation',
+        funding: 'Funded',
+        funding_model: ['Membership'],
+      });
       natsRequest.mockResolvedValue({ data: 'root-uid' });
       proxyRequest.mockResolvedValue(checklist());
 
@@ -1152,6 +1161,32 @@ describe('FormationService', () => {
 
       expect(result.formation.parent_uid).toBeNull();
       expect(result.formation.is_foundation).toBe(true);
+    });
+
+    it('reports is_foundation false for a top-level project that fails computeIsFoundation, despite parent_uid null', async () => {
+      // parent_uid collapsing to null must not itself imply is_foundation — the two are independent
+      // axes (see deriveFormationEntityType). A project missing computeIsFoundation's criteria
+      // (no stage/funding/funding_model set here) stays is_foundation:false even with no parent.
+      getProjectById.mockResolvedValue({ slug: 'live-project', name: 'Live Project', parent_uid: null, writer: true });
+      proxyRequest.mockResolvedValue(checklist());
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.formation.parent_uid).toBeNull();
+      expect(result.formation.is_foundation).toBe(false);
+    });
+
+    it('counts a skipped gating item as still outstanding, matching upstream gate accounting', async () => {
+      // Upstream's own gate accounting (gateSummaryFromItems/isActivating) treats `skipped` as not
+      // yet done — only `status === 'done'` clears a gate. The live queue's gates_cleared is sourced
+      // from that same projection, so this checklist path must agree rather than reuse the fixture
+      // helper's "done OR skipped" rule.
+      proxyRequest.mockResolvedValue(checklist({ items: [rawItem({ status: 'skipped', skip_reason: 'Not applicable' })] }));
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.formation.gating_items_total).toBe(1);
+      expect(result.formation.gating_items_open).toBe(1);
     });
 
     it('degrades announcement_date to null when the project-settings read fails', async () => {

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -698,7 +698,7 @@ describe('FormationService', () => {
       project_uid: 'live-project-1',
       template_uid: 'template-1',
       template_version: 1,
-      lifecycle: 'formation',
+      lifecycle: 'live',
       sections: [{ key: 'section-1', title: 'Section', position: 1 }],
       items,
       is_activating: false,
@@ -871,7 +871,7 @@ describe('FormationService', () => {
         is_foundation: false,
         parent_uid: null,
         sub_stage: 'engaged' as const,
-        lifecycle: 'formation',
+        lifecycle: 'live',
         gates_cleared: false,
         is_activating: false,
         announcement_date: null,
@@ -898,7 +898,7 @@ describe('FormationService', () => {
         is_foundation: false,
         parent_uid: '',
         sub_stage: 'engaged' as const,
-        lifecycle: 'formation',
+        lifecycle: 'live',
         gates_cleared: false,
         is_activating: false,
       };
@@ -922,7 +922,7 @@ describe('FormationService', () => {
         is_foundation: false,
         parent_uid: null,
         sub_stage: 'engaged' as const,
-        lifecycle: 'formation',
+        lifecycle: 'live',
         gates_cleared: false,
         is_activating: false,
         announcement_date: null,
@@ -1073,7 +1073,7 @@ describe('FormationService', () => {
       project_uid: 'live-project-1',
       template_uid: 'template-1',
       template_version: 1,
-      lifecycle: 'formation',
+      lifecycle: 'live',
       sections: [{ key: 'legal_and_entity', title: 'Legal and entity', position: 1 }],
       items: [rawItem()],
       is_activating: false,
@@ -1145,6 +1145,20 @@ describe('FormationService', () => {
 
       expect(result.formation.announcement_date).toBeNull();
       expect(result.data_source).toBe('live');
+    });
+
+    it('keeps gating counts derived from the checklist, not the post-enrichment array, when a gating item is dropped by enrichItems', async () => {
+      // The one gating item's own canComplete enrichment rejects, so enrichItems drops it from
+      // `items[]` (Promise.allSettled graceful-degradation) — the rollup on `formation` must still
+      // reflect the checklist's real gating state (1 total, 1 open), not the post-drop empty array.
+      canComplete.mockRejectedValueOnce(new Error('access-check backend unavailable'));
+      proxyRequest.mockResolvedValue(checklist());
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.items).toHaveLength(0);
+      expect(result.formation.gating_items_total).toBe(1);
+      expect(result.formation.gating_items_open).toBe(1);
     });
   });
 });

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -16,6 +16,7 @@ import { ServiceValidationError } from '../errors/service-validation.error';
 const getProjectById = vi.fn();
 const getProjectIdBySlug = vi.fn();
 const getProjects = vi.fn();
+const getProjectSettings = vi.fn();
 const canComplete = vi.fn();
 const natsRequest = vi.fn();
 const proxyRequest = vi.fn();
@@ -26,6 +27,7 @@ vi.mock('./project.service', () => ({
     public getProjectById = getProjectById;
     public getProjectIdBySlug = getProjectIdBySlug;
     public getProjects = getProjects;
+    public getProjectSettings = getProjectSettings;
   },
 }));
 vi.mock('./microservice-proxy.service', () => ({
@@ -184,6 +186,7 @@ describe('FormationService', () => {
     getProjectById.mockReset();
     getProjectIdBySlug.mockReset();
     getProjects.mockReset();
+    getProjectSettings.mockReset();
     canComplete.mockReset();
     vi.mocked(logger.info).mockClear();
     natsRequest.mockReset();
@@ -704,6 +707,8 @@ describe('FormationService', () => {
     beforeEach(() => {
       isFormationServiceLive.mockReturnValue(true);
       getProjectById.mockResolvedValue({ slug: 'live-project', name: 'Live Project', parent_uid: null, writer: true });
+      getProjectIdBySlug.mockResolvedValue({ uid: 'live-project-1', exists: true });
+      getProjectSettings.mockResolvedValue({ announcement_date: null });
       canComplete.mockResolvedValue(true);
     });
 
@@ -1044,6 +1049,102 @@ describe('FormationService', () => {
 
       expect(result).toEqual({ formations: [], items: [], data_source: 'fixture' });
       expect(getProjects).toHaveBeenCalledWith(expect.anything(), { cel_filter: 'data.stage.startsWith("Formation - ")' }, true);
+    });
+  });
+
+  describe('getProjectFormation (live)', () => {
+    const rawItem = (overrides: Partial<UpstreamFormationItem> = {}): UpstreamFormationItem => ({
+      uid: 'formation-item:live-project-1:item-key-1',
+      item_key: 'item-key-1',
+      section_key: 'section-1',
+      position: 1,
+      title: 'Some gating item',
+      gate: true,
+      requires_writer: false,
+      status_source: 'manual',
+      is_required: true,
+      checklist_type: 'manual',
+      status: 'not_started',
+      version: 1,
+      ...overrides,
+    });
+
+    const checklist = (overrides: Partial<UpstreamFormationChecklist> = {}): UpstreamFormationChecklist => ({
+      project_uid: 'live-project-1',
+      template_uid: 'template-1',
+      template_version: 1,
+      lifecycle: 'formation',
+      sections: [{ key: 'legal_and_entity', title: 'Legal and entity', position: 1 }],
+      items: [rawItem()],
+      is_activating: false,
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      isFormationServiceLive.mockReturnValue(true);
+      getProjectById.mockResolvedValue({ slug: 'live-project', name: 'Live Project', parent_uid: null, writer: true });
+      getProjectIdBySlug.mockResolvedValue({ uid: 'live-project-1', exists: true });
+      getProjectSettings.mockResolvedValue({ announcement_date: '2026-10-01' });
+      canComplete.mockResolvedValue(true);
+    });
+
+    it('maps a live checklist read to FormationChecklistResponse with data_source live', async () => {
+      proxyRequest.mockResolvedValue(checklist());
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.data_source).toBe('live');
+      expect(result.template).not.toBeNull();
+      expect(result.template?.uid).toBe('template-1');
+      expect(result.template?.sections).toEqual([{ key: 'legal_and_entity', title: 'Legal and entity', items: [] }]);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].template_item_key).toBe('item-key-1');
+      expect(result.formation.announcement_date).toBe('2026-10-01');
+      expect(result.formation.gating_items_total).toBe(1);
+      expect(result.formation.gating_items_open).toBe(1);
+
+      // ?v=1 is appended by MicroserviceProxyService.proxyRequest itself (DEFAULT_QUERY_PARAMS), not
+      // by this call site — the path carries no query string of its own.
+      const getCall = proxyRequest.mock.calls.find((call) => call[3] === 'GET' || call[3] === undefined);
+      expect(getCall![2]).toBe('/formations/live-project-1');
+    });
+
+    it('masks an upstream 404 on the checklist read as a not-found Formation', async () => {
+      proxyRequest.mockRejectedValue(new MicroserviceError('not found', 404, 'NOT_FOUND'));
+
+      await expect(service.getProjectFormation(buildReq(), 'live-project')).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('masks an upstream 403 on the checklist read identically to a 404 (enumeration-oracle guard)', async () => {
+      proxyRequest.mockRejectedValue(new MicroserviceError('forbidden', 403, 'FORBIDDEN'));
+      const forbidden = await service.getProjectFormation(buildReq(), 'live-project').catch((error: Error) => error);
+
+      proxyRequest.mockRejectedValue(new MicroserviceError('not found', 404, 'NOT_FOUND'));
+      const notFound = await service.getProjectFormation(buildReq(), 'live-project').catch((error: Error) => error);
+
+      expect(forbidden).toMatchObject({ statusCode: 404 });
+      expect((forbidden as Error).message).toBe((notFound as Error).message);
+    });
+
+    it('collapses a ROOT-parented project to parent_uid null and is_foundation true', async () => {
+      getProjectById.mockResolvedValue({ slug: 'live-project', name: 'Live Project', parent_uid: 'root-uid', writer: true });
+      natsRequest.mockResolvedValue({ data: 'root-uid' });
+      proxyRequest.mockResolvedValue(checklist());
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.formation.parent_uid).toBeNull();
+      expect(result.formation.is_foundation).toBe(true);
+    });
+
+    it('degrades announcement_date to null when the project-settings read fails', async () => {
+      getProjectSettings.mockRejectedValue(new Error('settings service unavailable'));
+      proxyRequest.mockResolvedValue(checklist());
+
+      const result = await service.getProjectFormation(buildReq(), 'live-project');
+
+      expect(result.formation.announcement_date).toBeNull();
+      expect(result.data_source).toBe('live');
     });
   });
 });

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -27,7 +27,7 @@ import { Request } from 'express';
 import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError, ConflictError } from '../errors';
 import { isFormationServiceLive } from '../helpers/formation-backend.helper';
 import { generateMockFormation, SEEDED_FORMATION_TEMPLATE, STATIC_QUEUE_FORMATIONS } from '../helpers/formation-fixture.helper';
-import { mapUpstreamFormationItem } from '../helpers/formation-mapper.helper';
+import { mapUpstreamFormationChecklist, mapUpstreamFormationItem } from '../helpers/formation-mapper.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { collapseRootParentUid, resolveRootProjectUid } from '../helpers/root-project.helper';
 import { getEffectiveUsername, stripAuthPrefix } from '../utils/auth-helper';
@@ -50,14 +50,14 @@ import { ProjectService } from './project.service';
 
 /**
  * BFF service for the Formation Checklist section and Formations queue (GH-1958/GH-2267). All eight
- * item mutations (complete/skip/request/status/update/accept/reject/reopen) and the queue read
- * {@link getFormationsQueue} branch on {@link isFormationServiceLive} and call the real
- * `lfx-v2-formation-service` when it is live. {@link getProjectFormation} is the one method still
- * fixture-only — its live branch is `// TODO(GH-2267 Phase 1 remainder)` and unconditionally throws
- * until the checklist read is wired. {@link getFormationItemOrThrow}/{@link getFormationItemDetail}
- * resolve against whatever the store already holds and need no swap marker of their own. The fixture
- * generator's return shape already matches `Formation`/`FormationItem[]`, so downstream code
- * (controllers, Angular services) needs no change when the remaining swap happens.
+ * item mutations (complete/skip/request/status/update/accept/reject/reopen), the queue read
+ * {@link getFormationsQueue}, and now {@link getProjectFormation}'s checklist read branch on
+ * {@link isFormationServiceLive} and call the real `lfx-v2-formation-service` when it is live.
+ * {@link getFormationItemOrThrow}/{@link getFormationItemDetail} resolve against whatever the store
+ * already holds (fixture) or the live checklist (real) and need no swap marker of their own. The
+ * fixture generator's return shape already matches `Formation`/`FormationItem[]`, so downstream
+ * code (controllers, Angular services) needed no change when this swap happened. Remaining fixture
+ * surface (activity/history, the fixture item store itself) is deleted in GH-2267 Phase 7, not here.
  */
 export class FormationService {
   private readonly projectService = new ProjectService();
@@ -78,9 +78,9 @@ export class FormationService {
       throw new ResourceNotFoundError('Project', projectSlug, { operation: 'get_project_formation', service: 'formation_service', path: req.path });
     }
 
-    // TODO(#1957): swap for a NATS/HTTP call to lfx-v2-formation-service once it ships. The
-    // fixture generator's return shape already matches Formation/FormationItem[], so nothing
-    // downstream of this branch needs to change.
+    // Fixture fallback — used only when isFormationServiceLive() is false. The fixture generator's
+    // return shape already matches Formation/FormationItem[], so nothing downstream of this branch
+    // needs to change when it's eventually deleted (GH-2267 Phase 7).
     if (!isFormationServiceLive()) {
       const project = await this.projectService.getProjectById(req, uid, false);
       if (!isFormationStageGate(project.stage)) {
@@ -114,13 +114,47 @@ export class FormationService {
       };
     }
 
-    // TODO(GH-2267 Phase 1 remainder): the checklist read (Formation + FormationTemplate assembly)
-    // is deliberately not wired yet — this pass covers getFormationsQueue and the 8 mutation
-    // methods only (see the GH-2267 plan's PR A §5 for what that live branch still needs: a
-    // FormationTemplate built from the response's sections/items, and the still-open
-    // announcement_date/uid/created_at/updated_at sourcing gaps). getFormationItemOrThrow below is
-    // wired for the mutation pre-read path.
-    throw new ResourceNotFoundError('Formation', projectSlug, { operation: 'get_project_formation', service: 'formation_service', path: req.path });
+    // Live path (GH-2267 Phase 1 remainder). Reuses fetchLiveChecklistOrDenyNotFound — the same
+    // GET/mask this service already uses for the mutation pre-read — parameterized to mask as
+    // 'Formation' rather than 'FormationItem' so a non-existent or inaccessible formation surfaces
+    // the same way the fixture branch's stage-gate throw above does.
+    const checklist = await this.fetchLiveChecklistOrDenyNotFound(req, uid, projectSlug, {
+      resource: 'Formation',
+      operation: 'get_project_formation',
+    });
+    const project = await this.getProjectByIdCached(req, uid);
+
+    // ROOT collapse (GH-2267 Phase 4) — same rationale as the fixture branch above.
+    const rootUid = await resolveRootProjectUid(req, this.natsService);
+    const parentUid = collapseRootParentUid(project.parent_uid || null, rootUid) ?? null;
+
+    // announcement_date has no field on the checklist read itself (upstream's checklist_reader.go
+    // reads it from project settings but doesn't return it) — read it from the same source the
+    // indexer projection uses for the queue's own announcement_date, so the checklist and
+    // /foundation/formations agree by construction. A settings-read failure degrades to null
+    // rather than failing the whole checklist (precedent: CommitteeService's inherited-permissions
+    // walk).
+    const announcementDate = await this.projectService
+      .getProjectSettings(req, uid)
+      .then((settings) => settings.announcement_date ?? null)
+      .catch((error) => {
+        logger.warning(req, 'get_project_formation', 'Failed to read project settings for announcement_date, defaulting to null', {
+          projectSlug,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      });
+
+    const items = await this.enrichItems(
+      req,
+      checklist.items.map((raw) => mapUpstreamFormationItem(raw, { formationUid: `formation:${uid}`, projectUid: uid, projectSlug: project.slug }))
+    );
+
+    const { formation, template } = mapUpstreamFormationChecklist(checklist, { project, parentUid, announcementDate, items });
+
+    logger.debug(req, 'get_project_formation', 'Returning live formation checklist', { projectSlug, item_count: items.length });
+
+    return { formation, template, items, data_source: 'live' };
   }
 
   /**
@@ -151,7 +185,10 @@ export class FormationService {
       return item;
     }
 
-    const checklist = await this.fetchLiveChecklistOrDenyNotFound(req, projectUid, itemAddress);
+    const checklist = await this.fetchLiveChecklistOrDenyNotFound(req, projectUid, itemAddress, {
+      resource: 'FormationItem',
+      operation: 'get_formation_item',
+    });
     const raw = checklist.items.find((candidate) => candidate.item_key === itemKey);
     if (!raw) {
       throw new ResourceNotFoundError('FormationItem', itemAddress, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
@@ -831,13 +868,22 @@ export class FormationService {
   }
 
   /**
-   * Live-mode pre-read for a mutation's project-visibility + item-existence check, and the source of
-   * the item's current `version` for `If-Match` (GH-2267 Phase 1). Mirrors `assertItemProjectAccess`'s
-   * masking invariant: a 403/404 from the auditor-gated `GET /formations/{project_uid}` is
-   * indistinguishable from "no such formation" to the caller — this pre-read doubles as that access
-   * check for the live path, so mutation methods don't call `assertItemProjectAccess` separately.
+   * Live-mode GET of the full checklist, shared by two callers: a mutation's pre-read (project-
+   * visibility + item-existence check, and the source of the item's current `version` for
+   * `If-Match`) and {@link getProjectFormation}'s own checklist read. Mirrors
+   * `assertItemProjectAccess`'s masking invariant: a 403/404 from the auditor-gated
+   * `GET /formations/{project_uid}` is indistinguishable from "no such formation"/"no such item" to
+   * the caller — this doubles as that access check for the live path, so mutation methods don't call
+   * `assertItemProjectAccess` separately. `deny` lets each caller mask as the resource type it
+   * actually addresses (`FormationItem` for the item-scoped callers, `Formation` for the checklist
+   * read itself) while sharing one transport and one masking rule.
    */
-  private async fetchLiveChecklistOrDenyNotFound(req: Request, projectUid: string, itemAddress: string): Promise<UpstreamFormationChecklist> {
+  private async fetchLiveChecklistOrDenyNotFound(
+    req: Request,
+    projectUid: string,
+    address: string,
+    deny: { resource: 'Formation' | 'FormationItem'; operation: string }
+  ): Promise<UpstreamFormationChecklist> {
     try {
       return await this.microserviceProxy.proxyRequest<UpstreamFormationChecklist>(
         req,
@@ -847,8 +893,8 @@ export class FormationService {
       );
     } catch (error) {
       if (isMicroserviceError(error) && (error.statusCode === 403 || error.statusCode === 404)) {
-        logger.debug(req, 'get_formation_item', 'Denying formation-item access', { item_address: itemAddress, err: error });
-        throw new ResourceNotFoundError('FormationItem', itemAddress, { operation: 'get_formation_item', service: 'formation_service', path: req.path });
+        logger.debug(req, deny.operation, `Denying ${deny.resource.toLowerCase()} access`, { address, err: error });
+        throw new ResourceNotFoundError(deny.resource, address, { operation: deny.operation, service: 'formation_service', path: req.path });
       }
       throw error;
     }

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -69,6 +69,12 @@ export class FormationService {
   // getFormationItemOrThrow, then the mutation result) purely to read project.slug — this avoids
   // fanning that into two-plus NATS project reads for one user action.
   private readonly projectByRequestCache = new WeakMap<Request, Map<string, Project>>();
+  // Per-request memoization of each project's section-title map, same rationale as
+  // {@link projectByRequestCache}. Populated by {@link fetchLiveChecklistOrDenyNotFound} (every live
+  // mutation calls it first, via `getFormationItemOrThrow`'s pre-read) and read by {@link mapLiveItem}
+  // so a mutation response resolves `section_title` from the same upstream `sections[]` the checklist
+  // read used, instead of silently falling back to the seeded template and disagreeing with it.
+  private readonly sectionTitlesByRequestCache = new WeakMap<Request, Map<string, Map<string, string>>>();
 
   public async getProjectFormation(req: Request, projectSlug: string): Promise<FormationChecklistResponse> {
     logger.debug(req, 'get_project_formation', 'Fetching formation checklist', { projectSlug });
@@ -893,12 +899,19 @@ export class FormationService {
     deny: { resource: 'Formation' | 'FormationItem'; operation: string }
   ): Promise<UpstreamFormationChecklist> {
     try {
-      return await this.microserviceProxy.proxyRequest<UpstreamFormationChecklist>(
+      const checklist = await this.microserviceProxy.proxyRequest<UpstreamFormationChecklist>(
         req,
         'LFX_V2_FORMATION_SERVICE',
         `/formations/${encodeURIComponent(projectUid)}`,
         'GET'
       );
+      let byProject = this.sectionTitlesByRequestCache.get(req);
+      if (!byProject) {
+        byProject = new Map<string, Map<string, string>>();
+        this.sectionTitlesByRequestCache.set(req, byProject);
+      }
+      byProject.set(projectUid, sectionTitlesFromChecklist(checklist));
+      return checklist;
     } catch (error) {
       if (isMicroserviceError(error) && (error.statusCode === 403 || error.statusCode === 404)) {
         logger.debug(req, deny.operation, `Denying ${deny.resource.toLowerCase()} access`, { address, err: error });
@@ -912,10 +925,16 @@ export class FormationService {
    * Maps one live checklist item onto `FormationItem`. `formation_uid` has no upstream source on
    * this path (gap 3) — synthesized deterministically from `projectUid`, mirroring the fixture
    * generator's own `formation:<project_uid>` convention so both backends agree on the shape.
+   * `sectionTitles` comes from {@link sectionTitlesByRequestCache} rather than a fresh checklist
+   * fetch — every caller of this method reaches it only after `getFormationItemOrThrow`'s pre-read
+   * already populated the cache for this `projectUid` via `fetchLiveChecklistOrDenyNotFound` — so a
+   * mutation response resolves the same `section_title` the checklist read would, instead of the
+   * seeded template's stale one.
    */
   private async mapLiveItem(req: Request, projectUid: string, raw: UpstreamFormationItem): Promise<FormationItem> {
     const project = await this.getProjectByIdCached(req, projectUid);
-    const ctx: FormationItemMapContext = { formationUid: `formation:${projectUid}`, projectUid, projectSlug: project.slug };
+    const sectionTitles = this.sectionTitlesByRequestCache.get(req)?.get(projectUid);
+    const ctx: FormationItemMapContext = { formationUid: `formation:${projectUid}`, projectUid, projectSlug: project.slug, sectionTitles };
     return mapUpstreamFormationItem(raw, ctx);
   }
 

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -934,6 +934,13 @@ export class FormationService {
   private async mapLiveItem(req: Request, projectUid: string, raw: UpstreamFormationItem): Promise<FormationItem> {
     const project = await this.getProjectByIdCached(req, projectUid);
     const sectionTitles = this.sectionTitlesByRequestCache.get(req)?.get(projectUid);
+    if (!sectionTitles) {
+      // Should be unreachable — every caller reaches this only after getFormationItemOrThrow's
+      // pre-read populates the cache for this projectUid. Warn rather than silently falling back
+      // to the seeded template, so a future call site that skips the pre-read is observable in
+      // logs instead of just reading as a stale section title.
+      logger.warning(req, 'map_live_item', 'No cached section titles for project; falling back to seeded template', { projectUid });
+    }
     const ctx: FormationItemMapContext = { formationUid: `formation:${projectUid}`, projectUid, projectSlug: project.slug, sectionTitles };
     return mapUpstreamFormationItem(raw, ctx);
   }

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -20,7 +20,13 @@ import type {
 } from '@lfx-one/shared/interfaces';
 import { FORMATION_QUEUE_SUB_STAGES } from '@lfx-one/shared/constants';
 import { QueryServiceResponse } from '@lfx-one/shared/interfaces';
-import { deriveFormationEntityType, isAssignedItemOpen, isFormationStageGate, summarizeMyFormationItems } from '@lfx-one/shared/utils';
+import {
+  deriveFormationBlockingItemTitle,
+  deriveFormationEntityType,
+  isAssignedItemOpen,
+  isFormationStageGate,
+  summarizeMyFormationItems,
+} from '@lfx-one/shared/utils';
 import crypto from 'crypto';
 import { Request } from 'express';
 
@@ -124,35 +130,49 @@ export class FormationService {
     // GET/mask this service already uses for the mutation pre-read — parameterized to mask as
     // 'Formation' rather than 'FormationItem' so a non-existent or inaccessible formation surfaces
     // the same way the fixture branch's stage-gate throw above does.
+    //
+    // Deliberately no isFormationStageGate(project.stage) check here, unlike the fixture branch
+    // above: that check is a fixture-only stand-in for "does a formation exist for this project" —
+    // the fixture generator has no other way to answer that question. Upstream answers it directly:
+    // a project with no formation record 404s from this GET, which fetchLiveChecklistOrDenyNotFound
+    // already masks identically to the stage-gate throw.
     const checklist = await this.fetchLiveChecklistOrDenyNotFound(req, uid, projectSlug, {
       resource: 'Formation',
       operation: 'get_project_formation',
     });
-    const project = await this.getProjectByIdCached(req, uid);
+
+    // The checklist read above must stay first — it's the masking read (403/404 → the same
+    // not-found), and nothing below should run before that gate is cleared. Everything after it is
+    // independent of the others, so they run concurrently rather than as three sequential round
+    // trips: the project read, the ROOT-collapse lookup, and the settings read for announcement_date
+    // (which degrades to null on its own failure — see its .catch() below — independently of the
+    // other two).
+    const [project, rootUid, announcementDate] = await Promise.all([
+      this.getProjectByIdCached(req, uid),
+      resolveRootProjectUid(req, this.natsService),
+      // announcement_date has no field on the checklist read itself (upstream's checklist_reader.go
+      // reads it from project settings but doesn't return it) — read it from the same source the
+      // indexer projection uses for the queue's own announcement_date, so the checklist and
+      // /foundation/formations agree by construction. A settings-read failure degrades to null
+      // rather than failing the whole checklist (precedent: CommitteeService's inherited-permissions
+      // walk). No auditor-vs-writer auth-tier mismatch here: `lfx-v2-helm`'s generated
+      // `PERMISSIONS.md` ("View project settings" row) grants Auditor the same unconditional read
+      // access as Writer/Executive Director, so a checklist reader who could reach this far can
+      // always read settings too — the .catch() below is for genuine failures, not routine 403s.
+      this.projectService
+        .getProjectSettings(req, uid)
+        .then((settings) => settings.announcement_date ?? null)
+        .catch((error) => {
+          logger.warning(req, 'get_project_formation', 'Failed to read project settings for announcement_date, defaulting to null', {
+            projectSlug,
+            err: error,
+          });
+          return null;
+        }),
+    ]);
 
     // ROOT collapse (GH-2267 Phase 4) — same rationale as the fixture branch above.
-    const rootUid = await resolveRootProjectUid(req, this.natsService);
     const parentUid = collapseRootParentUid(project.parent_uid || null, rootUid) ?? null;
-
-    // announcement_date has no field on the checklist read itself (upstream's checklist_reader.go
-    // reads it from project settings but doesn't return it) — read it from the same source the
-    // indexer projection uses for the queue's own announcement_date, so the checklist and
-    // /foundation/formations agree by construction. A settings-read failure degrades to null
-    // rather than failing the whole checklist (precedent: CommitteeService's inherited-permissions
-    // walk). No auditor-vs-writer auth-tier mismatch here: `lfx-v2-helm`'s generated
-    // `PERMISSIONS.md` ("View project settings" row) grants Auditor the same unconditional read
-    // access as Writer/Executive Director, so a checklist reader who could reach this far can
-    // always read settings too — the .catch() below is for genuine failures, not routine 403s.
-    const announcementDate = await this.projectService
-      .getProjectSettings(req, uid)
-      .then((settings) => settings.announcement_date ?? null)
-      .catch((error) => {
-        logger.warning(req, 'get_project_formation', 'Failed to read project settings for announcement_date, defaulting to null', {
-          projectSlug,
-          err: error,
-        });
-        return null;
-      });
 
     // Mapped before enrichment, and kept around for mapUpstreamFormationChecklist's gating rollup
     // below — enrichItems can drop an item on a per-item access-check failure (a real possibility,
@@ -1203,10 +1223,7 @@ export class FormationService {
     const openGatingItems = gatingItems.filter((item) => item.status !== 'done' && item.status !== 'skipped');
     const hasAnnounced = !!formation.announcement_date && Date.parse(formation.announcement_date) <= Date.now();
     const isActivating = (gatingItems.length > 0 && openGatingItems.length === 0) || hasAnnounced;
-    // Blocking column reflects items actually in `blocked` status specifically, not "first not-done
-    // gating item" — `awaiting_acceptance`/`in_progress`/`not_started` items are open but not blocking.
-    const blockedGatingItems = gatingItems.filter((item) => item.status === 'blocked');
-    const blockingItemTitle = blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null;
+    const blockingItemTitle = deriveFormationBlockingItemTitle(items);
 
     putStoredFormation({
       ...formation,

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -27,7 +27,7 @@ import { Request } from 'express';
 import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError, ConflictError } from '../errors';
 import { isFormationServiceLive } from '../helpers/formation-backend.helper';
 import { generateMockFormation, SEEDED_FORMATION_TEMPLATE, STATIC_QUEUE_FORMATIONS } from '../helpers/formation-fixture.helper';
-import { mapUpstreamFormationChecklist, mapUpstreamFormationItem } from '../helpers/formation-mapper.helper';
+import { mapUpstreamFormationChecklist, mapUpstreamFormationItem, sectionTitlesFromChecklist } from '../helpers/formation-mapper.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { collapseRootParentUid, resolveRootProjectUid } from '../helpers/root-project.helper';
 import { getEffectiveUsername, stripAuthPrefix } from '../utils/auth-helper';
@@ -133,24 +133,32 @@ export class FormationService {
     // indexer projection uses for the queue's own announcement_date, so the checklist and
     // /foundation/formations agree by construction. A settings-read failure degrades to null
     // rather than failing the whole checklist (precedent: CommitteeService's inherited-permissions
-    // walk).
+    // walk). No auditor-vs-writer auth-tier mismatch here: `lfx-v2-helm`'s generated
+    // `PERMISSIONS.md` ("View project settings" row) grants Auditor the same unconditional read
+    // access as Writer/Executive Director, so a checklist reader who could reach this far can
+    // always read settings too — the .catch() below is for genuine failures, not routine 403s.
     const announcementDate = await this.projectService
       .getProjectSettings(req, uid)
       .then((settings) => settings.announcement_date ?? null)
       .catch((error) => {
         logger.warning(req, 'get_project_formation', 'Failed to read project settings for announcement_date, defaulting to null', {
           projectSlug,
-          error: error instanceof Error ? error.message : String(error),
+          err: error,
         });
         return null;
       });
 
-    const items = await this.enrichItems(
-      req,
-      checklist.items.map((raw) => mapUpstreamFormationItem(raw, { formationUid: `formation:${uid}`, projectUid: uid, projectSlug: project.slug }))
+    // Mapped before enrichment, and kept around for mapUpstreamFormationChecklist's gating rollup
+    // below — enrichItems can drop an item on a per-item access-check failure (a real possibility,
+    // not merely defensive), and the rollup must reflect the checklist's actual gating state
+    // regardless of that outcome, not a state that lost whichever gating item failed enrichment.
+    const sectionTitles = sectionTitlesFromChecklist(checklist);
+    const mappedItems = checklist.items.map((raw) =>
+      mapUpstreamFormationItem(raw, { formationUid: `formation:${uid}`, projectUid: uid, projectSlug: project.slug, sectionTitles })
     );
+    const items = await this.enrichItems(req, mappedItems);
 
-    const { formation, template } = mapUpstreamFormationChecklist(checklist, { project, parentUid, announcementDate, items });
+    const { formation, template } = mapUpstreamFormationChecklist(checklist, { project, parentUid, announcementDate, items: mappedItems });
 
     logger.debug(req, 'get_project_formation', 'Returning live formation checklist', { projectSlug, item_count: items.length });
 

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -393,7 +393,15 @@ export interface UpstreamFormationChecklist {
   project_uid: string;
   template_uid: string;
   template_version: number;
-  /** Upstream's `dsl.Enum("live", "completed", "frozen")` (`cmd/formation-api/design/design.go`). Unread by this repo today — nothing derives `Formation`/`FormationItem` state from it. */
+  /**
+   * Upstream's `dsl.Enum("live", "completed", "frozen")` (`cmd/formation-api/design/design.go`).
+   * Unread by this repo today — nothing derives `Formation`/`FormationItem` state from it. The
+   * union is trusted from `proxyRequest`'s unchecked cast, same as every other field on this wire
+   * shape; if a future consumer branches on `lifecycle`, a 4th upstream enum value would violate
+   * this type without a runtime guard — same caveat as `sections[].key`'s cast in
+   * `mapUpstreamFormationChecklist`, but unlike that field this one has no unrecognized-value
+   * fallback path today because nothing reads it yet.
+   */
   lifecycle: 'live' | 'completed' | 'frozen';
   sections: { key: string; title: string; position: number }[];
   items: UpstreamFormationItem[];
@@ -406,11 +414,13 @@ export interface FormationItemMapContext {
   projectUid: string;
   projectSlug: string;
   /**
-   * Per-checklist section titles from this same `GET /formations/{project_uid}` response
+   * Per-project section titles sourced from a `GET /formations/{project_uid}` response
    * (`raw.sections[].title`, keyed by `key`) — takes priority over the seeded template's section
-   * title so a renamed section reads consistently between the template header and every item row
-   * in the same response. Omitted only by fixture-path callers, which have no upstream `sections[]`
-   * to build this from and fall back to the seeded template map entirely.
+   * title so a renamed section reads consistently across every item row that resolves it, whether
+   * from the checklist read itself or a live mutation response mapped afterward (both read from the
+   * same per-request cache — see `FormationService.mapLiveItem`'s doc comment). Omitted only by
+   * fixture-path callers, which have no upstream `sections[]` to build this from and fall back to
+   * the seeded template map entirely.
    */
   sectionTitles?: Map<string, string>;
 }

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -265,7 +265,15 @@ export interface FormationTemplate {
 }
 
 export interface FormationTemplateSection {
-  key: FormationTemplateSectionKey;
+  /**
+   * `FormationTemplateSectionKey` covers every section the seeded static template defines, but a
+   * live checklist's `sections[]` (`UpstreamFormationChecklist.sections[].key`) comes from the
+   * upstream template revision, not this enum — an upstream section this BFF doesn't recognize yet
+   * is a display gap (falls into `FORMATION_ORPHAN_SECTION`, see `groupFormationItemsBySection`),
+   * not a type error, so this stays the wider `string` rather than forcing an unsound
+   * `as unknown as` cast at either call site.
+   */
+  key: FormationTemplateSectionKey | string;
   title: string;
   items: FormationTemplateItem[];
 }

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -418,9 +418,10 @@ export interface FormationItemMapContext {
    * (`raw.sections[].title`, keyed by `key`) — takes priority over the seeded template's section
    * title so a renamed section reads consistently across every item row that resolves it, whether
    * from the checklist read itself or a live mutation response mapped afterward (both read from the
-   * same per-request cache — see `FormationService.mapLiveItem`'s doc comment). Omitted only by
-   * fixture-path callers, which have no upstream `sections[]` to build this from and fall back to
-   * the seeded template map entirely.
+   * same per-request cache — see `FormationService.mapLiveItem`'s doc comment). No live-path caller
+   * omits it in practice — `mapLiveItem` always looks the cache up first — but it stays optional
+   * since a cache miss (a future call site that skips the `getFormationItemOrThrow` pre-read) still
+   * falls back to the seeded template map rather than throwing.
    */
   sectionTitles?: Map<string, string>;
 }

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -406,9 +406,10 @@ export interface UpstreamFormationChecklist {
    * Unread by this repo today — nothing derives `Formation`/`FormationItem` state from it. The
    * union is trusted from `proxyRequest`'s unchecked cast, same as every other field on this wire
    * shape; if a future consumer branches on `lifecycle`, a 4th upstream enum value would violate
-   * this type without a runtime guard — same caveat as `sections[].key`'s cast in
-   * `mapUpstreamFormationChecklist`, but unlike that field this one has no unrecognized-value
-   * fallback path today because nothing reads it yet.
+   * this type without a runtime guard — unlike `sections[].key`, which is typed
+   * `FormationTemplateSectionKey | string` precisely so an unrecognized section falls into
+   * `FORMATION_ORPHAN_SECTION` instead of violating its type, `lifecycle` has no such fallback path
+   * today because nothing reads it yet.
    */
   lifecycle: 'live' | 'completed' | 'frozen';
   sections: { key: string; title: string; position: number }[];
@@ -436,13 +437,15 @@ export interface FormationItemMapContext {
 
 /**
  * Everything `mapUpstreamFormationChecklist` needs beyond the raw checklist itself — the project
- * record (for name/slug/stage), the already ROOT-collapsed `parent_uid` (see the
+ * record (for name/slug/stage, plus `legal_entity_type`/`funding`/`funding_model` so
+ * `computeIsFoundation` can classify it — `is_foundation` is independent of hierarchy depth, so it
+ * must not be derived from `parentUid`), the already ROOT-collapsed `parent_uid` (see the
  * `root-project.helper.ts` collapse helpers in `apps/lfx-one`), the mapped items (to derive gating
  * counts from), and the `announcement_date` (no upstream source on the checklist read itself — see
  * `FormationService.getProjectFormation`'s doc comment for where it comes from instead).
  */
 export interface FormationChecklistMapContext {
-  project: Pick<Project, 'slug' | 'name' | 'stage'>;
+  project: Pick<Project, 'slug' | 'name' | 'stage' | 'legal_entity_type' | 'funding' | 'funding_model'>;
   parentUid: string | null;
   announcementDate: string | null;
   items: FormationItem[];

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { FormationActionType, FormationOwnerTeam, FormationTemplateSectionKey } from '../enums/formation.enum';
+import { Project } from './project.interface';
 
 /**
  * Formation domain types (GH-2163, epic #1965). Mirrors the object shapes planned for
@@ -93,8 +94,19 @@ export interface Formation {
   /** ISO date. Null until a gating item sets it. */
   announcement_date: string | null;
   /**
-   * Derived: every gating item `done` (and at least one gating item exists). An `awaiting_acceptance`
-   * gating item does not count as `done`, so it keeps this false. TODO(#1957): backend-derived once real.
+   * Fixture path (`FormationService.refreshFormationReadiness`) and the client
+   * (`deriveFormationReadinessSummary`) derive this as: every gating item `done` (and at least one
+   * gating item exists) **OR** `announcement_date` has passed — an `awaiting_acceptance` gating
+   * item does not count as `done`, so it alone keeps this false.
+   *
+   * The live checklist read (GH-2267 Phase 1) instead takes upstream's own `is_activating` verbatim
+   * rather than re-deriving it, and upstream's contract is narrower: every gating item done, at
+   * least one gating item exists, **AND** the project has an announcement date (`cmd/formation-api/
+   * design/design.go`, `linuxfoundation/lfx-v2-formation-service`). The two paths can therefore
+   * disagree for a formation with every gate cleared but no announcement date yet — live reports
+   * `false`, the fixture/client formula would report `true`. Tracked for reconciliation alongside
+   * Phase 5/6 (activity/badge work); do not silently pick one formula over the other without
+   * checking both call sites above.
    */
   is_activating: boolean;
   gating_items_open: number;
@@ -381,7 +393,8 @@ export interface UpstreamFormationChecklist {
   project_uid: string;
   template_uid: string;
   template_version: number;
-  lifecycle: string;
+  /** Upstream's `dsl.Enum("live", "completed", "frozen")` (`cmd/formation-api/design/design.go`). Unread by this repo today — nothing derives `Formation`/`FormationItem` state from it. */
+  lifecycle: 'live' | 'completed' | 'frozen';
   sections: { key: string; title: string; position: number }[];
   items: UpstreamFormationItem[];
   is_activating: boolean;
@@ -392,6 +405,28 @@ export interface FormationItemMapContext {
   formationUid: string;
   projectUid: string;
   projectSlug: string;
+  /**
+   * Per-checklist section titles from this same `GET /formations/{project_uid}` response
+   * (`raw.sections[].title`, keyed by `key`) — takes priority over the seeded template's section
+   * title so a renamed section reads consistently between the template header and every item row
+   * in the same response. Omitted only by fixture-path callers, which have no upstream `sections[]`
+   * to build this from and fall back to the seeded template map entirely.
+   */
+  sectionTitles?: Map<string, string>;
+}
+
+/**
+ * Everything `mapUpstreamFormationChecklist` needs beyond the raw checklist itself — the project
+ * record (for name/slug/stage), the already ROOT-collapsed `parent_uid` (see the
+ * `root-project.helper.ts` collapse helpers in `apps/lfx-one`), the mapped items (to derive gating
+ * counts from), and the `announcement_date` (no upstream source on the checklist read itself — see
+ * `FormationService.getProjectFormation`'s doc comment for where it comes from instead).
+ */
+export interface FormationChecklistMapContext {
+  project: Pick<Project, 'slug' | 'name' | 'stage'>;
+  parentUid: string | null;
+  announcementDate: string | null;
+  items: FormationItem[];
 }
 
 /**

--- a/packages/shared/src/utils/formation-checklist.utils.ts
+++ b/packages/shared/src/utils/formation-checklist.utils.ts
@@ -61,6 +61,19 @@ export function deriveFormationReadinessSummary(items: FormationItem[], announce
 }
 
 /**
+ * The readiness strip's "blocked on…" title(s) — every gating item actually in `blocked` status,
+ * joined for display, or `null` when none are blocked. Deliberately not "first not-done gating
+ * item": `awaiting_acceptance`/`in_progress`/`not_started` items are open but not blocking, only
+ * `blocked` is. Shared by the fixture path's `FormationService.refreshFormationReadiness` and the
+ * live path's `mapUpstreamFormationChecklist` so the two rollups can't drift on the join format —
+ * `FormationService.toQueueRow` depends on that exact `', '` join by reversing it with `.split(', ')`.
+ */
+export function deriveFormationBlockingItemTitle(items: FormationItem[]): string | null {
+  const blockedGatingItems = items.filter((item) => item.is_gating && item.status === 'blocked');
+  return blockedGatingItems.length > 0 ? blockedGatingItems.map((item) => item.title).join(', ') : null;
+}
+
+/**
  * Items whose `section_key` matches none of the template's current sections — exactly what a
  * template section rename produces for items still carrying the old key. Shared between
  * `groupFormationItemsBySection` (bucketing) and the caller that logs a template/item drift, so

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -42,7 +42,7 @@ const FOUNDATION_NAME_OVERRIDES = new Set(['Test Project Group IT', 'Test Projec
  * Includes both live (Active) and pre-launch (Formation - Engaged) foundations.
  * PCC test projects also qualify.
  */
-export function computeIsFoundation(project: Project | null): boolean {
+export function computeIsFoundation(project: Pick<Project, 'name' | 'stage' | 'legal_entity_type' | 'funding' | 'funding_model'> | null): boolean {
   if (!project) {
     return false;
   }


### PR DESCRIPTION
## Summary

Wires `getProjectFormation`'s live branch to a real `GET /formations/{project_uid}` through `MicroserviceProxyService`, replacing the unconditional throw left by #2292 (PR A). Maps the payload to `FormationChecklistResponse` (`data_source: 'live'`) via a new `mapUpstreamFormationChecklist` helper alongside the existing `mapUpstreamFormationItem`, reusing `fetchLiveChecklistOrDenyNotFound` for the same 403/404 → masked-not-found collapse the mutation pre-read already uses, and applies ROOT collapse via `root-project.helper.ts`.

Fixture branch is untouched (Phase 7 deletes it, not this PR). Out of scope: activity/history reconciliation (Phase 5), the `data_source` badge (Phase 6), fixture removal (Phase 7).

- `announcement_date` is read from `ProjectService.getProjectSettings`, the same source the indexer projection uses for the queue, so the checklist and `/foundation/formations` agree by construction; a settings-read failure degrades to `null` rather than failing the whole read.
- `fetchLiveChecklistOrDenyNotFound` now takes a `deny{resource,operation}` param so both the mutation pre-read and this checklist read share one transport and one masking rule (masks as `Formation` here, `FormationItem` for mutations).
- Section titles from the checklist's own `sections[]` take priority over the seeded template, cached per-request so a renamed section reads consistently across the checklist read and every later mutation response.
- Addressed a full-branch review pass: widened `FormationTemplateSection.key` to drop an `as unknown as` cast on untrusted upstream section keys, deduped the `blocking_item_title` rollup (fixture path's `refreshFormationReadiness` and the live path's `mapUpstreamFormationChecklist`) into a shared `deriveFormationBlockingItemTitle` helper, documented why the live path has no stage gate (upstream's own 404 substitutes for it), and parallelized the live checklist read's independent round trips (project/ROOT/settings reads) behind the masking GET.

## Report, not fix (deferred / out of scope)

- **History panel is empty in live mode** — `getFormationItemDetail` still reads history from the fixture activity store; that's Phase 5.
- **A "Mark blocked…" reason is discarded in live mode** — upstream has no field for it beyond the drawer's persistent `note`.
- **The queue renders ~125 rows sorted client-side** (built/tested against four) — state as-is rather than fixing pagination here.
- **`FormationReadinessStripComponent`/`FormationEntryCardComponent` still derive readiness client-side** via `deriveFormationReadinessSummary` (done-OR-skipped semantics), not the new authoritative `Formation.gating_items_*`/`is_activating` this PR now computes correctly server-side (done-only, matching upstream). Pre-existing `TODO(#1957)` already tracks switching these two components to the backend rollup; this PR is what finally makes that backend value trustworthy, but doesn't switch the client consumers over. A live formation with a skipped gating item can show a mismatched readiness state between the checklist strip/card and the queue/checklist response until that follow-up lands.
- **`UpstreamFormationChecklist.lifecycle` (`'live' | 'completed' | 'frozen'`) remains unread**, as documented on the field since #2292. A completed/frozen checklist is returned with the same actionable-looking DTO as a live one; the route guard admits every `Formation - *` stage including Disengaged. Upstream's own `checklist_read_only` rejection is the only backstop today. Propagating `lifecycle` into the response and gating all 8 mutation endpoints is separate follow-up work, not part of this checklist-read commit.
- **Live browser verification was not performed.** This session's environment cannot reach the local Authelia/OrbStack stack (OIDC issuer discovery to `auth.k8s.orb.local` fails). Evidence relies on the mocked spec coverage below instead — a manual side-by-side check of `/project/<slug>/formation` vs `/foundation/formations` against `FORMATION_BACKEND=live` is still recommended before merge.

## Test plan

- [x] `yarn test` — 2684/2684 passing, including new live-checklist-read cases (success mapping, 404/403 masking parity, ROOT-parented project, settings-read failure degrading to null)
- [x] `yarn build` — SSR + client bundles compile clean
- [x] `yarn lint` — no errors (one pre-existing, unrelated warning)
- [x] `./check-headers.sh` — clean
- [ ] Manual live-mode browser check — not performed in this environment (see above)

Refs #2267
