### PR TITLE
feat(dashboards): cap my formations card at 5 with show-all toggle

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.html
@@ -61,5 +61,23 @@
         </div>
       }
     </div>
+
+    @if (hiddenCount() > 0) {
+      <button
+        type="button"
+        class="inline-flex w-fit items-center gap-1.5 bg-transparent p-0 text-xs font-semibold text-blue-600 hover:underline"
+        [attr.aria-expanded]="expanded()"
+        [attr.aria-label]="toggleAriaLabel()"
+        data-testid="me-formations-card-toggle"
+        (click)="toggleExpanded()">
+        @if (expanded()) {
+          <i class="fa-light fa-chevron-up text-[10px]" aria-hidden="true"></i>
+          Show fewer
+        } @else {
+          <i class="fa-light fa-chevron-down text-[10px]" aria-hidden="true"></i>
+          Show all {{ totalCount() }}
+        }
+      </button>
+    }
   </section>
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
@@ -12,6 +12,12 @@ import { of } from 'rxjs';
 
 import { MyFormationsCardComponent } from './my-formations-card.component';
 
+function rowNames(fixture: ComponentFixture<MyFormationsCardComponent>): string[] {
+  return Array.from(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).map(
+    (row) => (row as HTMLElement).getAttribute('data-testid') ?? ''
+  );
+}
+
 const formation = (overrides: Partial<MyFormationSummary> = {}): MyFormationSummary => ({
   formation_uid: 'formation-1',
   project_uid: 'project-1',
@@ -80,5 +86,80 @@ describe('MyFormationsCardComponent (GH-1956)', () => {
     const fixture = await render([formation()], false);
 
     expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card"]')).toBeNull();
+  });
+
+  it('renders exactly the cap (N=5) with no toggle', async () => {
+    const fixture = await render([
+      formation({ formation_uid: 'formation-1' }),
+      formation({ formation_uid: 'formation-2' }),
+      formation({ formation_uid: 'formation-3' }),
+      formation({ formation_uid: 'formation-4' }),
+      formation({ formation_uid: 'formation-5' }),
+    ]);
+
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(5);
+    expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card-toggle"]')).toBeNull();
+  });
+
+  it('caps at 5 above the cap (N=6), then expands to all and collapses back', async () => {
+    const fixture = await render([
+      formation({ formation_uid: 'formation-1' }),
+      formation({ formation_uid: 'formation-2' }),
+      formation({ formation_uid: 'formation-3' }),
+      formation({ formation_uid: 'formation-4' }),
+      formation({ formation_uid: 'formation-5' }),
+      formation({ formation_uid: 'formation-6' }),
+    ]);
+
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(5);
+
+    const toggle = fixture.nativeElement.querySelector('[data-testid="me-formations-card-toggle"]') as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.textContent).toContain('Show all 6');
+
+    toggle.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(6);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle.textContent).toContain('Show fewer');
+
+    toggle.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(5);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('orders rows by most assigned_to_do first, blocked before unblocked, then nearer announcement_date, then name', async () => {
+    // Deliberately fed out of order — the wrong-order fixture the ordering rule must correct.
+    const fixture = await render([
+      formation({ formation_uid: 'few-todo', project_name: 'Few Todo', assigned_to_do: 1, announcement_date: '2026-01-01' }),
+      formation({
+        formation_uid: 'unblocked-far',
+        project_name: 'Unblocked Far',
+        assigned_to_do: 3,
+        blocking_item_title: null,
+        announcement_date: '2026-12-01',
+      }),
+      formation({
+        formation_uid: 'blocked-near',
+        project_name: 'Blocked Near',
+        assigned_to_do: 3,
+        blocking_item_title: 'Waiting on legal',
+        announcement_date: '2026-06-01',
+      }),
+      formation({ formation_uid: 'b-name', project_name: 'B Name', assigned_to_do: 3, blocking_item_title: 'x', announcement_date: null }),
+      formation({ formation_uid: 'a-name', project_name: 'A Name', assigned_to_do: 3, blocking_item_title: 'x', announcement_date: null }),
+    ]);
+
+    expect(rowNames(fixture)).toEqual([
+      'me-formations-card-row-blocked-near',
+      'me-formations-card-row-a-name',
+      'me-formations-card-row-b-name',
+      'me-formations-card-row-unblocked-far',
+      'me-formations-card-row-few-todo',
+    ]);
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.spec.ts
@@ -101,17 +101,21 @@ describe('MyFormationsCardComponent (GH-1956)', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="me-formations-card-toggle"]')).toBeNull();
   });
 
-  it('caps at 5 above the cap (N=6), then expands to all and collapses back', async () => {
+  it('caps at 5 above the cap (N=6), keeping the highest-priority 5 visible, then expands and collapses back', async () => {
     const fixture = await render([
-      formation({ formation_uid: 'formation-1' }),
-      formation({ formation_uid: 'formation-2' }),
-      formation({ formation_uid: 'formation-3' }),
-      formation({ formation_uid: 'formation-4' }),
-      formation({ formation_uid: 'formation-5' }),
-      formation({ formation_uid: 'formation-6' }),
+      formation({ formation_uid: 'formation-1', assigned_to_do: 1 }),
+      formation({ formation_uid: 'formation-2', assigned_to_do: 1 }),
+      formation({ formation_uid: 'formation-3', assigned_to_do: 1 }),
+      formation({ formation_uid: 'formation-4', assigned_to_do: 1 }),
+      formation({ formation_uid: 'formation-5', assigned_to_do: 1 }),
+      formation({ formation_uid: 'formation-6-top-priority', assigned_to_do: 9, blocking_item_title: 'Waiting on legal' }),
     ]);
 
-    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(5);
+    const visibleRows = () => rowNames(fixture);
+
+    expect(visibleRows()).toHaveLength(5);
+    expect(visibleRows()).toContain('me-formations-card-row-formation-6-top-priority');
+    expect(visibleRows()).not.toContain('me-formations-card-row-formation-5');
 
     const toggle = fixture.nativeElement.querySelector('[data-testid="me-formations-card-toggle"]') as HTMLButtonElement;
     expect(toggle).not.toBeNull();
@@ -121,14 +125,14 @@ describe('MyFormationsCardComponent (GH-1956)', () => {
     toggle.click();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(6);
+    expect(visibleRows()).toHaveLength(6);
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
     expect(toggle.textContent).toContain('Show fewer');
 
     toggle.click();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelectorAll('[data-testid^="me-formations-card-row-"]')).toHaveLength(5);
+    expect(visibleRows()).toHaveLength(5);
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -74,24 +74,6 @@ export class MyFormationsCardComponent {
     this.expanded.update((value) => !value);
   }
 
-  // Ordering rule for GH-2331 — see the class doc comment. Compares `MyFormationSummary` fields
-  // directly so it can run ahead of decoration in `initDecoratedFormations`.
-  private static compareByNeed(a: MyFormationSummary, b: MyFormationSummary): number {
-    if (a.assigned_to_do !== b.assigned_to_do) return b.assigned_to_do - a.assigned_to_do;
-
-    const aBlocked = a.blocking_item_title ? 0 : 1;
-    const bBlocked = b.blocking_item_title ? 0 : 1;
-    if (aBlocked !== bBlocked) return aBlocked - bBlocked;
-
-    const aDate = a.announcement_date ?? '￿';
-    const bDate = b.announcement_date ?? '￿';
-    if (aDate !== bDate) return aDate < bDate ? -1 : 1;
-
-    if (a.project_name !== b.project_name) return a.project_name.localeCompare(b.project_name);
-
-    return a.formation_uid.localeCompare(b.formation_uid);
-  }
-
   private initDecoratedFormations(): Signal<DecoratedMyFormation[]> {
     return computed(() =>
       [...this.formations()].sort(MyFormationsCardComponent.compareByNeed).map((formation) => ({
@@ -143,5 +125,23 @@ export class MyFormationsCardComponent {
       ),
       { initialValue: [] as MyFormationSummary[] }
     );
+  }
+
+  // Ordering rule for GH-2331 — see the class doc comment. Compares `MyFormationSummary` fields
+  // directly so it can run ahead of decoration in `initDecoratedFormations`.
+  private static compareByNeed(a: MyFormationSummary, b: MyFormationSummary): number {
+    if (a.assigned_to_do !== b.assigned_to_do) return b.assigned_to_do - a.assigned_to_do;
+
+    const aBlocked = a.blocking_item_title ? 0 : 1;
+    const bBlocked = b.blocking_item_title ? 0 : 1;
+    if (aBlocked !== bBlocked) return aBlocked - bBlocked;
+
+    const aDate = a.announcement_date ?? '￿';
+    const bDate = b.announcement_date ?? '￿';
+    if (aDate !== bDate) return aDate < bDate ? -1 : 1;
+
+    if (a.project_name !== b.project_name) return a.project_name.localeCompare(b.project_name);
+
+    return a.formation_uid.localeCompare(b.formation_uid);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -33,8 +33,8 @@ import { catchError, filter, map, of, switchMap, take, tap } from 'rxjs';
  *   2. A present `blocking_item_title` sorts ahead of one that's absent (a formation blocked on the
  *      caller needs attention over one merely waiting).
  *   3. Nearer `announcement_date` first, nulls last (ISO `YYYY-MM-DD` strings compare lexically).
- *   4. `project_name` as the final deterministic tiebreak, so the capped set never reshuffles between
- *      renders of the same data.
+ *   4. `project_name`, then `formation_uid`, as deterministic tiebreaks, so the capped set never
+ *      reshuffles between renders of the same data even when two formations share a project name.
  */
 @Component({
   selector: 'lfx-my-formations-card',
@@ -87,7 +87,9 @@ export class MyFormationsCardComponent {
     const bDate = b.announcement_date ?? '￿';
     if (aDate !== bDate) return aDate < bDate ? -1 : 1;
 
-    return a.project_name.localeCompare(b.project_name);
+    if (a.project_name !== b.project_name) return a.project_name.localeCompare(b.project_name);
+
+    return a.formation_uid.localeCompare(b.formation_uid);
   }
 
   private initDecoratedFormations(): Signal<DecoratedMyFormation[]> {

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -24,6 +24,17 @@ import { catchError, filter, map, of, switchMap, take, tap } from 'rxjs';
  * The card renders nothing (returns to the DOM as empty) once the flag is off, the fetch errored, or
  * there are no formations to show — an Active project drops out of the response entirely, so this
  * is also how the card disappears once the caller's last formation goes Active.
+ *
+ * GH-2331 — capped at `collapsedRowCap` rows with a "Show all N" toggle that expands in place (see
+ * `events-attention-section.component.ts` for the precedent this mirrors). Capping turns row order
+ * into the card's answer to "what needs me most", so the sort in `initDecoratedFormations` is
+ * deliberate, not incidental — do not reorder it without updating this comment:
+ *   1. Most `assigned_to_do` first — the caller's own open work is the primary signal.
+ *   2. A present `blocking_item_title` sorts ahead of one that's absent (a formation blocked on the
+ *      caller needs attention over one merely waiting).
+ *   3. Nearer `announcement_date` first, nulls last (ISO `YYYY-MM-DD` strings compare lexically).
+ *   4. `project_name` as the final deterministic tiebreak, so the capped set never reshuffles between
+ *      renders of the same data.
  */
 @Component({
   selector: 'lfx-my-formations-card',
@@ -31,6 +42,9 @@ import { catchError, filter, map, of, switchMap, take, tap } from 'rxjs';
   templateUrl: './my-formations-card.component.html',
 })
 export class MyFormationsCardComponent {
+  /** Rows rendered before the "Show all N" toggle appears (GH-2331). */
+  private static readonly collapsedRowCap = 5;
+
   private readonly featureFlagService = inject(FeatureFlagService);
   private readonly formationService = inject(FormationService);
 
@@ -40,18 +54,45 @@ export class MyFormationsCardComponent {
   // instead of flashing the skeleton back in.
   protected readonly loading = signal(true);
   protected readonly hasError = signal(false);
+  /** Whether the capped card has been expanded to show every formation (GH-2331). */
+  protected readonly expanded = signal(false);
 
   private readonly formations: Signal<MyFormationSummary[]> = this.initFormations();
   protected readonly visible = computed(() => this.formationFlagEnabled() && !this.loading() && !this.hasError() && this.formations().length > 0);
   protected readonly showSkeleton = computed(() => this.formationFlagEnabled() && this.loading());
+
+  private readonly decoratedFormations: Signal<DecoratedMyFormation[]> = this.initDecoratedFormations();
   protected readonly visibleFormations: Signal<DecoratedMyFormation[]> = this.initVisibleFormations();
+  protected readonly totalCount = computed(() => this.decoratedFormations().length);
+  protected readonly hiddenCount = computed(() => Math.max(0, this.totalCount() - MyFormationsCardComponent.collapsedRowCap));
+  protected readonly toggleAriaLabel = computed(() => (this.expanded() ? 'Show fewer formations' : `Show all ${this.totalCount()} formations`));
 
   protected readonly stageLabels = FORMATION_SUB_STAGE_LABELS;
   protected readonly stageSeverities = FORMATION_SUB_STAGE_SEVERITY;
 
-  private initVisibleFormations(): Signal<DecoratedMyFormation[]> {
+  protected toggleExpanded(): void {
+    this.expanded.update((value) => !value);
+  }
+
+  // Ordering rule for GH-2331 — see the class doc comment. Compares `MyFormationSummary` fields
+  // directly so it can run ahead of decoration in `initDecoratedFormations`.
+  private static compareByNeed(a: MyFormationSummary, b: MyFormationSummary): number {
+    if (a.assigned_to_do !== b.assigned_to_do) return b.assigned_to_do - a.assigned_to_do;
+
+    const aBlocked = a.blocking_item_title ? 0 : 1;
+    const bBlocked = b.blocking_item_title ? 0 : 1;
+    if (aBlocked !== bBlocked) return aBlocked - bBlocked;
+
+    const aDate = a.announcement_date ?? '￿';
+    const bDate = b.announcement_date ?? '￿';
+    if (aDate !== bDate) return aDate < bDate ? -1 : 1;
+
+    return a.project_name.localeCompare(b.project_name);
+  }
+
+  private initDecoratedFormations(): Signal<DecoratedMyFormation[]> {
     return computed(() =>
-      this.formations().map((formation) => ({
+      [...this.formations()].sort(MyFormationsCardComponent.compareByNeed).map((formation) => ({
         ...formation,
         subtitle: formatMyFormationSubtitle({
           assigned_to_do: formation.assigned_to_do,
@@ -63,6 +104,10 @@ export class MyFormationsCardComponent {
         announcementLabel: formatFormationAnnouncementLabel(formation.announcement_date),
       }))
     );
+  }
+
+  private initVisibleFormations(): Signal<DecoratedMyFormation[]> {
+    return computed(() => (this.expanded() ? this.decoratedFormations() : this.decoratedFormations().slice(0, MyFormationsCardComponent.collapsedRowCap)));
   }
 
   // Gated on the flag so a disabled flag never issues the request — mirrors

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-formations-card/my-formations-card.component.ts
@@ -30,8 +30,9 @@ import { catchError, filter, map, of, switchMap, take, tap } from 'rxjs';
  * into the card's answer to "what needs me most", so the sort in `initDecoratedFormations` is
  * deliberate, not incidental — do not reorder it without updating this comment:
  *   1. Most `assigned_to_do` first — the caller's own open work is the primary signal.
- *   2. A present `blocking_item_title` sorts ahead of one that's absent (a formation blocked on the
- *      caller needs attention over one merely waiting).
+ *   2. A present `blocking_item_title` sorts ahead of one that's absent — it names the formation's
+ *      first not-done gating item (a rollup over the whole formation, not the caller's own
+ *      assignments), so a formation with an open gate needs attention over one merely waiting.
  *   3. Nearer `announcement_date` first, nulls last (ISO `YYYY-MM-DD` strings compare lexically).
  *   4. `project_name`, then `formation_uid`, as deterministic tiebreaks, so the capped set never
  *      reshuffles between renders of the same data even when two formations share a project name.


### PR DESCRIPTION
## Summary

Caps `MyFormationsCardComponent` at 5 rows with a "Show all N" toggle that expands in place. Client-only — `formation.service.ts`, `formation-mapper.helper.ts`, `formation.interface.ts` and `formation-checklist.utils.ts` are untouched since they're all in #2324's path (open, awaiting review).

## What changed

- **Cap:** 5 rows before the toggle appears (`collapsedRowCap`).
- **Toggle:** "Show all N" / "Show fewer" button, `aria-expanded` + a label naming the count. Expands in place — no navigation, since there's no "all my formations" route and `/foundation/formations` is the auditor-gated staff queue over every formation, not the caller's own.
- **Ordering (the real design decision):** capped rows now answer "what needs me most" — sorted by most `assigned_to_do` first, a present `blocking_item_title` ahead of none, nearer `announcement_date`, then `project_name` as a deterministic tiebreak. Documented in the class doc comment so it isn't reordered by accident.
- **Unchanged:** `gating_done`/`gating_total` render exactly as they arrive — #2329 owns whether done-or-skipped vs done-only is the right semantics for "required for Active". The per-row `progressbar` aria-label is untouched. N=1 still renders as the single full-width row with no toggle; the card still renders nothing when the flag is off, the fetch errored, or there are no formations; the skeleton state is untouched.

## What it looks like

- **N=1–5:** identical to before — all rows render, no toggle (`hiddenCount() === 0`).
- **N=40:** 5 rows render (the 5 the ordering rule ranks highest), followed by a "Show all 40" button; clicking it renders all 40 with `aria-expanded="true"` and relabels to "Show fewer"; clicking again collapses back to 5.

## Verification

- `yarn check-types`, `yarn test` (2697 tests, all pass), `yarn lint` (0 errors — 1 pre-existing unrelated warning), `./check-headers.sh` — all clean.
- New specs: exactly-at-cap (N=5, no toggle), above-cap (N=6, toggle appears/expands/collapses), and an ordering test with a fixture fed deliberately out of order.

## Findings to report, not fixed here (per the ticket)

1. **The server does not cap `getMyFormationWork`.** `formation.service.ts:681` loops every Formation-stage project with no limit; the upstream fetch drains every page (`page_size: 500`, no `maxResults`). The endpoint reads no `limit` query param and the client sends none. The cap belongs there too — a large response is built and shipped only to be sliced in the browser. Left for a follow-up commit after #2324 merges (that file is in #2324's path). Note the live branch (`isFormationServiceLive()`) currently returns an empty response, so this only bites the fixture path today.
2. **Why a staff account has assigned items on so many formations.** `FormationService.isAssignedToCaller` (`formation.service.ts:828`) is a deterministic SHA-256 hash over `username:item.uid` that marks ~30% of any fixture formation's 20-item template as "assigned" to any caller, independent of the item's real owner. That's synthetic-fixture behavior, not a data bug in the reconcile — but it means nearly every Formation-stage project the caller can read produces a row, so the real fix (once #1957's live assignment source lands) is gating on actual project access/assignment, not just a bigger cap.
3. **Pending Actions rows have the same class of problem, partially.** The inline list *is* capped (`displayLimit = input<number>(2)`, sliced in `pending-actions.component.ts`), and neither Me dashboard overrides it. The **drawer** ("View all") is not capped — it receives the unwindowed list and only filters/maps, no slice; the server supports an optional `limit` but the client never sends one. Worst case: up to 20 × (readable Formation-stage projects) formation rows, plus every invitation/RSVP/vote/survey/meeting row, in the drawer. Also: `user.service.ts:1380`'s comment still says "the 5-item display cap" while the component's actual default is 2 — stale, worth a follow-up fix.

Refs #2331

🤖 Generated with [Claude Code](https://claude.com/claude-code)