### PR TITLE
fix(dashboards): align health metrics overview with design spec

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -90,5 +90,4 @@
       }
     </div>
   </div>
-  <span class="text-[11px] text-gray-400">{{ asOfLabel() }}</span>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -19,9 +19,7 @@
         <div
           class="flex items-center gap-[3px]"
           [attr.role]="dots.caption ? 'img' : null"
-          [attr.aria-labelledby]="
-            dots.caption ? 'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-dots-caption' : null
-          "
+          [attr.aria-labelledby]="dots.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption' : null"
           [attr.aria-hidden]="dots.caption ? null : true"
           data-testid="health-metrics-overview-finding-dots">
           @for (filled of dots.dots; track $index) {
@@ -33,9 +31,7 @@
           }
         </div>
         @if (dots.caption) {
-          <span
-            class="text-[11px] text-gray-400"
-            [attr.id]="'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-dots-caption'">
+          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption'">
             {{ dots.caption }}
           </span>
         }
@@ -46,17 +42,13 @@
           [attr.aria-valuenow]="bar.fillPercent"
           aria-valuemin="0"
           aria-valuemax="100"
-          [attr.aria-labelledby]="
-            bar.caption ? 'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-bar-caption' : null
-          "
+          [attr.aria-labelledby]="bar.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-bar-caption' : null"
           [attr.aria-label]="bar.caption ? null : 'Progress'"
           data-testid="health-metrics-overview-finding-bar">
           <div class="h-full rounded-[3px]" [ngClass]="bar.toneClass" [style.width.%]="bar.fillPercent" aria-hidden="true"></div>
         </div>
         @if (bar.caption) {
-          <span
-            class="text-[11px] text-gray-400"
-            [attr.id]="'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-bar-caption'">
+          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-bar-caption'">
             {{ bar.caption }}
           </span>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -1,30 +1,61 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-2 rounded-lg border-l-4 border border-gray-200 bg-white p-4" [ngClass]="classificationMeta().accentClass">
-  <div class="flex flex-wrap items-start justify-between gap-3">
-    <div class="flex flex-col gap-1">
-      <div class="flex items-center gap-2 text-xs font-medium text-gray-500">
-        <span class="h-1.5 w-1.5 rounded-full" [ngClass]="classificationMeta().dotClass" aria-hidden="true"></span>
-        <span>{{ finding().areaLabel }}</span>
-      </div>
-      <p class="text-sm font-semibold text-gray-900">{{ finding().title }}</p>
-      <p class="text-sm text-gray-600" data-testid="health-metrics-overview-finding-sentence">
-        @for (segment of sentenceSegments(); track $index) {
-          <span [class.font-bold]="segment.bold">{{ segment.text }}</span>
-        }
-      </p>
+<div
+  class="flex flex-col gap-1 border-l-2 px-[26px] py-[16px]"
+  [ngClass]="classificationMeta().accentClass"
+  [class.border-b]="!isLast()"
+  [class.border-gray-200]="!isLast()">
+  <div class="flex items-start gap-6">
+    <div class="flex flex-[2] flex-col gap-1">
+      <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{{ finding().areaLabel }}</span>
+      <p class="text-[14px] font-semibold text-gray-900">{{ finding().title }}</p>
+      <p class="text-[12px] leading-[1.6] text-gray-500" data-testid="health-metrics-overview-finding-sentence">{{ finding().sentence }}</p>
     </div>
+    <div class="flex flex-[1] flex-col items-end gap-1 text-right">
+      <span class="text-[20px] font-semibold tracking-[-0.02em] text-gray-900">{{ finding().keyValue }}</span>
 
-    <div class="flex flex-col items-end gap-1 text-right">
-      <span class="text-lg font-semibold text-gray-900">{{ finding().keyValue }}</span>
-      <span class="text-xs text-gray-500">{{ finding().keyLabel }}</span>
+      @if (dotsVisual(); as dots) {
+        <div class="flex items-center gap-[3px]" data-testid="health-metrics-overview-finding-dots">
+          @for (filled of dots.dots; track $index) {
+            <span class="h-[9px] w-[9px] rounded-full" [ngClass]="filled ? classificationMeta().dotClass : 'bg-gray-300'" [attr.data-filled]="filled"></span>
+          }
+        </div>
+        @if (dots.caption) {
+          <span class="text-[11px] text-gray-400">{{ dots.caption }}</span>
+        }
+      } @else if (barVisual(); as bar) {
+        <div class="h-[5px] w-full rounded-[3px] bg-gray-200" data-testid="health-metrics-overview-finding-bar">
+          <div class="h-full rounded-[3px]" [ngClass]="bar.toneClass" [style.width.%]="bar.fillPercent"></div>
+        </div>
+        @if (bar.caption) {
+          <span class="text-[11px] text-gray-400">{{ bar.caption }}</span>
+        }
+      } @else if (bandVisual(); as band) {
+        <div class="relative h-[5px] w-full rounded-[3px] bg-gray-200" data-testid="health-metrics-overview-finding-band">
+          <div class="absolute inset-y-0 rounded-[3px] bg-gray-300" [style.left.%]="band.low" [style.width.%]="band.high - band.low"></div>
+          <div class="absolute inset-y-0 left-0 rounded-[3px]" [ngClass]="classificationMeta().dotClass" [style.width.%]="band.pred"></div>
+          <div class="absolute -top-[3px] h-[11px] w-0.5 bg-gray-900" [style.left.%]="band.goal"></div>
+        </div>
+        @if (band.caption) {
+          <span class="text-[11px] text-gray-400">{{ band.caption }}</span>
+        }
+      } @else if (tagsVisual(); as tags) {
+        <div class="flex flex-wrap justify-end gap-1" data-testid="health-metrics-overview-finding-tags">
+          @for (tag of tags; track tag) {
+            <span class="rounded bg-gray-200 px-1.5 py-0.5 text-[10.5px] font-semibold text-gray-600">{{ tag }}</span>
+          }
+        </div>
+      } @else {
+        <span class="text-[12px] text-gray-500">{{ finding().keyLabel }}</span>
+      }
+
       @if (finding().linkHref; as linkHref) {
         <a
           [href]="linkHref"
           [target]="finding().linkIsExternal ? '_blank' : '_self'"
           [rel]="finding().linkIsExternal ? 'noopener noreferrer' : null"
-          class="text-xs font-medium text-blue-600 hover:underline"
+          class="text-[12px] font-medium text-blue-600 hover:underline"
           [attr.data-testid]="'health-metrics-overview-finding-link-' + finding().sortRank">
           {{ finding().linkIsExternal ? 'View in LFX Insights' : 'View details' }}
           @if (finding().linkIsExternal) {
@@ -34,57 +65,5 @@
       }
     </div>
   </div>
-
-  @if (dotGroupsVisual(); as dotGroups) {
-    <div class="flex flex-col gap-1.5" data-testid="health-metrics-overview-finding-dots">
-      @for (group of dotGroups; track group.label) {
-        <div class="flex items-center gap-2">
-          <span class="w-40 shrink-0 text-xs text-gray-500">{{ group.label }}</span>
-          <div class="flex flex-wrap gap-1">
-            @for (filled of group.dots; track $index) {
-              <span
-                class="h-2 w-2 rounded-full"
-                [ngClass]="filled ? classificationMeta().dotClass : 'bg-gray-200'"
-                [attr.data-filled]="filled"
-                aria-hidden="true"></span>
-            }
-          </div>
-        </div>
-      }
-    </div>
-  } @else if (barVisual(); as bar) {
-    <div class="flex flex-col gap-1">
-      <div class="flex h-2 w-full overflow-hidden rounded-full bg-gray-100" data-testid="health-metrics-overview-finding-bar">
-        @for (part of bar.parts; track part.label) {
-          <div
-            role="img"
-            [ngClass]="part.toneClass"
-            [style.width.%]="part.value"
-            [attr.data-classification]="part.tone"
-            [attr.aria-label]="part.label + ': ' + part.value + '%'"></div>
-        }
-      </div>
-      @if (bar.caption) {
-        <span class="text-xs text-gray-500">{{ bar.caption }}</span>
-      }
-    </div>
-  } @else if (bandVisual(); as band) {
-    <div class="flex flex-col gap-1">
-      <div class="relative h-2 w-full rounded-full bg-gray-100">
-        <div class="absolute h-2 rounded-full" [ngClass]="classificationMeta().dotClass" [style.left.%]="band.low" [style.width.%]="band.high - band.low"></div>
-        <div class="absolute -top-0.5 h-3 w-0.5 -translate-x-1/2 bg-gray-400" [style.left.%]="band.goal" aria-hidden="true"></div>
-      </div>
-      @if (band.caption) {
-        <span class="text-xs text-gray-500">{{ band.caption }}</span>
-      }
-    </div>
-  } @else if (tagsVisual(); as tags) {
-    <div class="flex flex-wrap gap-1.5">
-      @for (tag of tags; track tag) {
-        <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">{{ tag }}</span>
-      }
-    </div>
-  }
-
-  <span class="text-xs text-gray-400">{{ asOfLabel() }}</span>
+  <span class="text-[11px] text-gray-400">{{ asOfLabel() }}</span>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -16,26 +16,45 @@
       <span class="text-[20px] font-semibold tracking-[-0.02em] text-gray-900">{{ finding().keyValue }}</span>
 
       @if (dotsVisual(); as dots) {
-        <div class="flex items-center gap-[3px]" data-testid="health-metrics-overview-finding-dots">
+        <div
+          class="flex items-center gap-[3px]"
+          [attr.role]="dots.caption ? 'img' : null"
+          [attr.aria-label]="dots.caption || null"
+          data-testid="health-metrics-overview-finding-dots">
           @for (filled of dots.dots; track $index) {
-            <span class="h-[9px] w-[9px] rounded-full" [ngClass]="filled ? classificationMeta().dotClass : 'bg-gray-300'" [attr.data-filled]="filled"></span>
+            <span
+              class="h-[9px] w-[9px] rounded-full"
+              [ngClass]="filled ? classificationMeta().dotClass : 'bg-gray-300'"
+              [attr.data-filled]="filled"
+              aria-hidden="true"></span>
           }
         </div>
         @if (dots.caption) {
           <span class="text-[11px] text-gray-400">{{ dots.caption }}</span>
         }
       } @else if (barVisual(); as bar) {
-        <div class="h-[5px] w-full rounded-[3px] bg-gray-200" data-testid="health-metrics-overview-finding-bar">
-          <div class="h-full rounded-[3px]" [ngClass]="bar.toneClass" [style.width.%]="bar.fillPercent"></div>
+        <div
+          class="h-[5px] w-full rounded-[3px] bg-gray-200"
+          role="progressbar"
+          [attr.aria-valuenow]="bar.fillPercent"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          [attr.aria-label]="bar.caption || null"
+          data-testid="health-metrics-overview-finding-bar">
+          <div class="h-full rounded-[3px]" [ngClass]="bar.toneClass" [style.width.%]="bar.fillPercent" aria-hidden="true"></div>
         </div>
         @if (bar.caption) {
           <span class="text-[11px] text-gray-400">{{ bar.caption }}</span>
         }
       } @else if (bandVisual(); as band) {
-        <div class="relative h-[5px] w-full rounded-[3px] bg-gray-200" data-testid="health-metrics-overview-finding-band">
-          <div class="absolute inset-y-0 rounded-[3px] bg-gray-300" [style.left.%]="band.low" [style.width.%]="band.high - band.low"></div>
-          <div class="absolute inset-y-0 left-0 rounded-[3px]" [ngClass]="classificationMeta().dotClass" [style.width.%]="band.pred"></div>
-          <div class="absolute -top-[3px] h-[11px] w-0.5 bg-gray-900" [style.left.%]="band.goal"></div>
+        <div
+          class="relative h-[5px] w-full rounded-[3px] bg-gray-200"
+          role="img"
+          aria-label="forecast versus goal"
+          data-testid="health-metrics-overview-finding-band">
+          <div class="absolute inset-y-0 rounded-[3px] bg-gray-300" [style.left.%]="band.low" [style.width.%]="band.high - band.low" aria-hidden="true"></div>
+          <div class="absolute inset-y-0 left-0 rounded-[3px]" [ngClass]="classificationMeta().dotClass" [style.width.%]="band.pred" aria-hidden="true"></div>
+          <div class="absolute -top-[3px] h-[11px] w-0.5 -translate-x-1/2 bg-gray-900" [style.left.%]="band.goal" aria-hidden="true"></div>
         </div>
         @if (band.caption) {
           <span class="text-[11px] text-gray-400">{{ band.caption }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -19,7 +19,8 @@
         <div
           class="flex items-center gap-[3px]"
           [attr.role]="dots.caption ? 'img' : null"
-          [attr.aria-label]="dots.caption || null"
+          [attr.aria-labelledby]="dots.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption' : null"
+          [attr.aria-hidden]="dots.caption ? null : true"
           data-testid="health-metrics-overview-finding-dots">
           @for (filled of dots.dots; track $index) {
             <span
@@ -30,7 +31,9 @@
           }
         </div>
         @if (dots.caption) {
-          <span class="text-[11px] text-gray-400">{{ dots.caption }}</span>
+          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption'">{{
+            dots.caption
+          }}</span>
         }
       } @else if (barVisual(); as bar) {
         <div
@@ -39,12 +42,13 @@
           [attr.aria-valuenow]="bar.fillPercent"
           aria-valuemin="0"
           aria-valuemax="100"
-          [attr.aria-label]="bar.caption || null"
+          [attr.aria-labelledby]="bar.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-bar-caption' : null"
+          [attr.aria-label]="bar.caption ? null : 'Progress'"
           data-testid="health-metrics-overview-finding-bar">
           <div class="h-full rounded-[3px]" [ngClass]="bar.toneClass" [style.width.%]="bar.fillPercent" aria-hidden="true"></div>
         </div>
         @if (bar.caption) {
-          <span class="text-[11px] text-gray-400">{{ bar.caption }}</span>
+          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-bar-caption'">{{ bar.caption }}</span>
         }
       } @else if (bandVisual(); as band) {
         <div

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -1,6 +1,8 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- Arbitrary [Npx] values throughout match the design's exact pixel sizes, per .claude/rules/styling.md's
+     rem-scale-undershoot exception (this app's 14px root font makes e.g. `text-xs` render ~10.5px, not 12px). -->
 <div
   class="flex flex-col gap-1 border-l-2 px-[26px] py-[16px]"
   [ngClass]="classificationMeta().accentClass"
@@ -17,7 +19,7 @@
 
       @if (dotsVisual(); as dots) {
         <div
-          class="flex items-center gap-[3px]"
+          class="flex flex-wrap items-center justify-end gap-[3px]"
           [attr.role]="dots.caption ? 'img' : null"
           [attr.aria-labelledby]="dots.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption' : null"
           [attr.aria-hidden]="dots.caption ? null : true"
@@ -56,14 +58,17 @@
         <div
           class="relative h-[5px] w-full rounded-[3px] bg-gray-200"
           role="img"
-          aria-label="forecast versus goal"
+          [attr.aria-labelledby]="band.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-band-caption' : null"
+          [attr.aria-label]="band.caption ? null : 'forecast versus goal'"
           data-testid="health-metrics-overview-finding-band">
           <div class="absolute inset-y-0 rounded-[3px] bg-gray-300" [style.left.%]="band.low" [style.width.%]="band.high - band.low" aria-hidden="true"></div>
           <div class="absolute inset-y-0 left-0 rounded-[3px]" [ngClass]="classificationMeta().dotClass" [style.width.%]="band.pred" aria-hidden="true"></div>
           <div class="absolute -top-[3px] h-[11px] w-0.5 -translate-x-1/2 bg-gray-900" [style.left.%]="band.goal" aria-hidden="true"></div>
         </div>
         @if (band.caption) {
-          <span class="text-[11px] text-gray-400">{{ band.caption }}</span>
+          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-band-caption'">
+            {{ band.caption }}
+          </span>
         }
       } @else if (tagsVisual(); as tags) {
         <div class="flex flex-wrap justify-end gap-1" data-testid="health-metrics-overview-finding-tags">

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.html
@@ -19,7 +19,9 @@
         <div
           class="flex items-center gap-[3px]"
           [attr.role]="dots.caption ? 'img' : null"
-          [attr.aria-labelledby]="dots.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption' : null"
+          [attr.aria-labelledby]="
+            dots.caption ? 'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-dots-caption' : null
+          "
           [attr.aria-hidden]="dots.caption ? null : true"
           data-testid="health-metrics-overview-finding-dots">
           @for (filled of dots.dots; track $index) {
@@ -31,9 +33,11 @@
           }
         </div>
         @if (dots.caption) {
-          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-dots-caption'">{{
-            dots.caption
-          }}</span>
+          <span
+            class="text-[11px] text-gray-400"
+            [attr.id]="'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-dots-caption'">
+            {{ dots.caption }}
+          </span>
         }
       } @else if (barVisual(); as bar) {
         <div
@@ -42,13 +46,19 @@
           [attr.aria-valuenow]="bar.fillPercent"
           aria-valuemin="0"
           aria-valuemax="100"
-          [attr.aria-labelledby]="bar.caption ? 'health-metrics-overview-finding-' + finding().sortRank + '-bar-caption' : null"
+          [attr.aria-labelledby]="
+            bar.caption ? 'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-bar-caption' : null
+          "
           [attr.aria-label]="bar.caption ? null : 'Progress'"
           data-testid="health-metrics-overview-finding-bar">
           <div class="h-full rounded-[3px]" [ngClass]="bar.toneClass" [style.width.%]="bar.fillPercent" aria-hidden="true"></div>
         </div>
         @if (bar.caption) {
-          <span class="text-[11px] text-gray-400" [attr.id]="'health-metrics-overview-finding-' + finding().sortRank + '-bar-caption'">{{ bar.caption }}</span>
+          <span
+            class="text-[11px] text-gray-400"
+            [attr.id]="'health-metrics-overview-finding-' + finding().classification + '-' + finding().sortRank + '-bar-caption'">
+            {{ bar.caption }}
+          </span>
         }
       } @else if (bandVisual(); as band) {
         <div

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
@@ -85,6 +85,26 @@ describe('HealthMetricsOverviewFindingItemComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-dots"]')).toBeNull();
   });
 
+  it('budgets each group proportionally to its own total when the combined total exceeds the cap, instead of letting one group crowd out the rest', async () => {
+    // Combined total (50) exceeds MAX_RENDERED_DOTS (20): a naive cap-per-group-then-slice would let
+    // this fully-filled 40-total group alone fill all 20 rendered dots, silently dropping the second
+    // group. Proportional budgeting gives it only 16 (40/50 share of 20), leaving 4 for the other group.
+    await render({
+      visual: {
+        kind: 'dots',
+        groups: [
+          { label: 'A', filled: 40, total: 40 },
+          { label: 'B', filled: 0, total: 10 },
+        ],
+      },
+    });
+
+    const dots = fixture.nativeElement.querySelectorAll('[data-testid="health-metrics-overview-finding-dots"] span[data-filled]');
+    const filledDots = Array.from<Element>(dots).filter((dot) => dot.getAttribute('data-filled') === 'true');
+    expect(dots.length).toBe(20);
+    expect(filledDots.length).toBe(16);
+  });
+
   it('flattens every dot group into one row with the first group as the trailing caption', async () => {
     await render({
       visual: {

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
@@ -172,4 +172,42 @@ describe('HealthMetricsOverviewFindingItemComponent', () => {
 
     expect(fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-link-42"]')).not.toBeNull();
   });
+
+  it('points the dots visual at its visible caption via aria-labelledby instead of duplicating the text', async () => {
+    await render({ visual: { kind: 'dots', groups: [{ label: 'Renewals', filled: 1, total: 4 }], caption: 'Renewals' } });
+
+    const dots: HTMLElement = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-dots"]');
+    const labelledBy = dots.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(dots.getAttribute('aria-label')).toBeNull();
+    expect(fixture.nativeElement.querySelector(`#${labelledBy}`)?.textContent?.trim()).toBe('Renewals');
+  });
+
+  it('hides the dots visual from assistive tech when neither an authored caption nor a group label is available', async () => {
+    // caption falls back to `groups[0].label`, so this branch is only reachable with an empty label — see
+    // `initDotsVisual`'s `visual.caption ?? groups[0].label`.
+    await render({ visual: { kind: 'dots', groups: [{ label: '', filled: 1, total: 4 }] } });
+
+    const dots: HTMLElement = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-dots"]');
+    expect(dots.getAttribute('aria-hidden')).toBe('true');
+    expect(dots.getAttribute('aria-labelledby')).toBeNull();
+  });
+
+  it('points the bar visual at its visible caption via aria-labelledby instead of duplicating the text', async () => {
+    await render({ visual: { kind: 'bar', parts: [{ label: 'Healthy', value: 40, tone: 'act' }], caption: 'Healthy' } });
+
+    const bar: HTMLElement = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-bar"]');
+    const labelledBy = bar.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(bar.getAttribute('aria-label')).toBeNull();
+    expect(fixture.nativeElement.querySelector(`#${labelledBy}`)?.textContent?.trim()).toBe('Healthy');
+  });
+
+  it('falls back to a generic aria-label on the bar when it has no caption', async () => {
+    await render({ visual: { kind: 'bar', parts: [{ label: 'Healthy', value: 40, tone: 'act' }] } });
+
+    const bar: HTMLElement = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-bar"]');
+    expect(bar.getAttribute('aria-label')).toBe('Progress');
+    expect(bar.getAttribute('aria-labelledby')).toBeNull();
+  });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
@@ -101,7 +101,7 @@ describe('HealthMetricsOverviewFindingItemComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('At risk');
   });
 
-  it('renders a single fill sized to the sum of the parts, tinted with the finding classification', async () => {
+  it('renders a single fill sized to only the parts matching the finding classification, tinted with that tone', async () => {
     await render({
       classification: 'ok',
       visual: {
@@ -114,8 +114,24 @@ describe('HealthMetricsOverviewFindingItemComponent', () => {
     });
 
     const fill = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-bar"] > div');
-    expect(fill.style.width).toBe('85%');
+    expect(fill.style.width).toBe('20%');
     expect(fill.classList.contains('bg-emerald-500')).toBe(true);
+  });
+
+  it('falls back to summing every part when none carry the finding classification tone', async () => {
+    await render({
+      classification: 'watch',
+      visual: {
+        kind: 'bar',
+        parts: [
+          { label: 'At risk', value: 65, tone: 'act' },
+          { label: 'Healthy', value: 20, tone: 'ok' },
+        ],
+      },
+    });
+
+    const fill = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-bar"] > div');
+    expect(fill.style.width).toBe('85%');
   });
 
   it('clamps the bar fill to 100% when the parts sum past it', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.spec.ts
@@ -38,28 +38,18 @@ describe('HealthMetricsOverviewFindingItemComponent', () => {
     return fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-sentence"]');
   }
 
-  it('renders a plain sentence with no bold segment when there is no emphasis', async () => {
-    await render();
-
-    const paragraph = sentenceEl();
-    expect(paragraph.textContent?.trim()).toBe('Plain sentence with no emphasis.');
-    expect(paragraph.querySelector('.font-bold')).toBeNull();
-  });
-
-  it('renders the emphasis substring in bold and leaves the rest as plain text', async () => {
+  it('renders the sentence as plain text, matching the design (no inline bolding)', async () => {
     await render({ sentence: 'Lowest is TAG App Delivery at 29%.', emphasis: 'TAG App Delivery' });
 
     const paragraph = sentenceEl();
-    expect(paragraph.querySelector('.font-bold')?.textContent).toBe('TAG App Delivery');
     expect(paragraph.textContent?.trim()).toBe('Lowest is TAG App Delivery at 29%.');
+    expect(paragraph.querySelector('.font-bold')).toBeNull();
   });
 
-  it('falls back to plain text when the emphasis substring is not found in the sentence', async () => {
-    await render({ sentence: 'Nothing matches here.', emphasis: 'missing' });
+  it('shows the keyLabel only when the finding has no visual', async () => {
+    await render();
 
-    const paragraph = sentenceEl();
-    expect(paragraph.querySelector('.font-bold')).toBeNull();
-    expect(paragraph.textContent?.trim()).toBe('Nothing matches here.');
+    expect(fixture.nativeElement.textContent).toContain('below 50%');
   });
 
   it('caps rendered dots at 20 and clamps a non-zero filled count to at least one dot', async () => {
@@ -95,39 +85,69 @@ describe('HealthMetricsOverviewFindingItemComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-dots"]')).toBeNull();
   });
 
-  it('resolves each bar part to its classification tone', async () => {
+  it('flattens every dot group into one row with the first group as the trailing caption', async () => {
     await render({
       visual: {
-        kind: 'bar',
-        parts: [
-          { label: 'At risk', value: 65, tone: 'act' },
-          { label: 'Healthy', value: 35, tone: 'ok' },
+        kind: 'dots',
+        groups: [
+          { label: 'At risk', filled: 2, total: 4 },
+          { label: 'Healthy', filled: 3, total: 4 },
         ],
       },
     });
 
-    const parts = fixture.nativeElement.querySelectorAll('[data-testid="health-metrics-overview-finding-bar"] > div');
-    expect(parts[0].getAttribute('data-classification')).toBe('act');
-    expect(parts[1].getAttribute('data-classification')).toBe('ok');
-    expect(parts[0].classList.contains('bg-red-500')).toBe(true);
-    expect(parts[1].classList.contains('bg-emerald-500')).toBe(true);
+    const dots = fixture.nativeElement.querySelectorAll('[data-testid="health-metrics-overview-finding-dots"] span[data-filled]');
+    expect(dots.length).toBe(8);
+    expect(fixture.nativeElement.textContent).toContain('At risk');
   });
 
-  it('positions the band fill and goal marker from low/high/goal', async () => {
-    await render({ visual: { kind: 'band', low: 55, high: 70, goal: 100 } });
+  it('renders a single fill sized to the sum of the parts, tinted with the finding classification', async () => {
+    await render({
+      classification: 'ok',
+      visual: {
+        kind: 'bar',
+        parts: [
+          { label: 'At risk', value: 65, tone: 'act' },
+          { label: 'Healthy', value: 20, tone: 'ok' },
+        ],
+      },
+    });
 
-    const [fill, marker] = fixture.nativeElement.querySelectorAll('.relative > div');
-    expect(fill.style.left).toBe('55%');
-    expect(fill.style.width).toBe('15%');
-    expect(marker.style.left).toBe('100%');
+    const fill = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-bar"] > div');
+    expect(fill.style.width).toBe('85%');
+    expect(fill.classList.contains('bg-emerald-500')).toBe(true);
+  });
+
+  it('clamps the bar fill to 100% when the parts sum past it', async () => {
+    await render({
+      visual: {
+        kind: 'bar',
+        parts: [
+          { label: 'A', value: 70, tone: 'act' },
+          { label: 'B', value: 60, tone: 'act' },
+        ],
+      },
+    });
+
+    const fill = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-bar"] > div');
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('positions the predicted range, point-prediction fill, and goal tick from low/high/pred/goal', async () => {
+    await render({ visual: { kind: 'band', low: 55, high: 70, goal: 100, pred: 62 } });
+
+    const band = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-finding-band"]');
+    const [range, pred, goal] = band.querySelectorAll(':scope > div');
+    expect(range.style.left).toBe('55%');
+    expect(range.style.width).toBe('15%');
+    expect(pred.style.width).toBe('62%');
+    expect(goal.style.left).toBe('100%');
   });
 
   it('renders one chip per tag', async () => {
     await render({ visual: { kind: 'tags', tags: ['Cloud', 'Fintech'] } });
 
-    const chips = Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('span')).filter((span) =>
-      ['Cloud', 'Fintech'].includes(span.textContent?.trim() ?? '')
-    );
+    const chips = Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('[data-testid="health-metrics-overview-finding-tags"] span'));
     expect(chips.map((chip) => chip.textContent?.trim())).toEqual(['Cloud', 'Fintech']);
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
@@ -57,8 +57,10 @@ export class HealthMetricsOverviewFindingItemComponent {
       }
       // The design flattens every group into one dots row (worst state first, per authoring order) with one
       // free-text caption below it (`fviz`'s `z.sub`) — independent of any per-group label, so a multi-group
-      // visual isn't captioned with just the first group's own label.
-      return { dots: groups.flatMap((group) => group.dots), caption: visual.caption ?? groups[0].label };
+      // visual isn't captioned with just the first group's own label. Cap applies to the flattened row as a
+      // whole (not per group) so a multi-group finding never renders more than MAX_RENDERED_DOTS dots total.
+      const dots = groups.flatMap((group) => group.dots).slice(0, MAX_RENDERED_DOTS);
+      return { dots, caption: visual.caption ?? groups[0].label };
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
@@ -57,8 +57,10 @@ export class HealthMetricsOverviewFindingItemComponent {
       if (groups.length === 0) {
         return null;
       }
-      // The design flattens every group into one dots row (worst state first, per authoring order) with one caption below it.
-      return { dots: groups.flatMap((group) => group.dots), caption: groups[0].label };
+      // The design flattens every group into one dots row (worst state first, per authoring order) with one
+      // free-text caption below it (`fviz`'s `z.sub`) — independent of any per-group label, so a multi-group
+      // visual isn't captioned with just the first group's own label.
+      return { dots: groups.flatMap((group) => group.dots), caption: visual.caption ?? groups[0].label };
     });
   }
 
@@ -84,15 +86,19 @@ export class HealthMetricsOverviewFindingItemComponent {
     return { label: group.label, dots: Array.from({ length: shown }, (_unused, index) => index < filledShown) };
   }
 
-  // A bar is a single fill sized to the sum of the authored parts (design's `fviz()`), clamped to
-  // 100 and tinted with the finding's own classification tone — never per-part colors.
+  // A bar is a single fill sized to the parts that share the finding's own classification tone
+  // (e.g. "65% at risk" out of an at-risk/healthy split), tinted with that tone — never per-part
+  // colors. Falls back to summing every part when none carry a matching tone, so an
+  // authoring-only breakdown still renders something rather than a zero-width bar.
   private static toBarViewModel(
     bar: HealthMetricsFindingVisualBar,
     classification: HealthMetricsOverviewClassification
   ): HealthMetricsFindingVisualBarViewModel {
+    const matchingParts = bar.parts.filter((part) => part.tone === classification);
+    const partsToSum = matchingParts.length > 0 ? matchingParts : bar.parts;
     const fillPercent = Math.min(
       100,
-      bar.parts.reduce((sum, part) => sum + part.value, 0)
+      partsToSum.reduce((sum, part) => sum + part.value, 0)
     );
     return {
       fillPercent,

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
@@ -4,7 +4,6 @@
 import { NgClass } from '@angular/common';
 import { Component, computed, input, Signal } from '@angular/core';
 import { HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS } from '@lfx-one/shared/constants';
-import { formatHealthMetricsOverviewAsOfLabel } from '@lfx-one/shared/utils';
 
 import type {
   HealthMetricsFindingVisualBar,
@@ -32,7 +31,6 @@ export class HealthMetricsOverviewFindingItemComponent {
   protected readonly classificationMeta = computed(
     () => HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[this.finding().classification] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none
   );
-  protected readonly asOfLabel = computed(() => formatHealthMetricsOverviewAsOfLabel(this.finding().evaluatedAt));
 
   protected readonly dotsVisual: Signal<HealthMetricsFindingVisualDotsViewModel | null> = this.initDotsVisual();
   protected readonly barVisual: Signal<HealthMetricsFindingVisualBarViewModel | null> = this.initBarVisual();

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
@@ -51,15 +51,21 @@ export class HealthMetricsOverviewFindingItemComponent {
       if (visual?.kind !== 'dots') {
         return null;
       }
-      const groups = visual.groups.map(HealthMetricsOverviewFindingItemComponent.toDotsGroupViewModel).filter((group) => group !== null);
-      if (groups.length === 0) {
+      const rawGroups = visual.groups.filter((group) => group.total > 0);
+      if (rawGroups.length === 0) {
         return null;
       }
       // The design flattens every group into one dots row (worst state first, per authoring order) with one
       // free-text caption below it (`fviz`'s `z.sub`) — independent of any per-group label, so a multi-group
-      // visual isn't captioned with just the first group's own label. Cap applies to the flattened row as a
-      // whole (not per group) so a multi-group finding never renders more than MAX_RENDERED_DOTS dots total.
-      const dots = groups.flatMap((group) => group.dots).slice(0, MAX_RENDERED_DOTS);
+      // visual isn't captioned with just the first group's own label. Each group's own dot count is budgeted
+      // proportionally to its share of MAX_RENDERED_DOTS (rather than capped-then-sliced independently), so a
+      // large first group can't crowd out later groups entirely.
+      const budgets = HealthMetricsOverviewFindingItemComponent.allocateDotsBudget(
+        rawGroups.map((group) => group.total),
+        MAX_RENDERED_DOTS
+      );
+      const groups = rawGroups.map((group, index) => HealthMetricsOverviewFindingItemComponent.toDotsGroupViewModel(group, budgets[index]));
+      const dots = groups.flatMap((group) => group.dots);
       return { dots, caption: visual.caption ?? groups[0].label };
     });
   }
@@ -74,16 +80,32 @@ export class HealthMetricsOverviewFindingItemComponent {
     });
   }
 
-  // A group with no dots to render (total 0) is skipped rather than shown empty. A non-zero
-  // `filled` is clamped to at least 1 rendered dot so e.g. "1 of 60" doesn't round down to none.
-  private static toDotsGroupViewModel(group: HealthMetricsFindingVisualDotGroup): { label: string; dots: boolean[] } | null {
-    if (group.total <= 0) {
-      return null;
-    }
-    const shown = Math.min(group.total, MAX_RENDERED_DOTS);
+  // `budget` is this group's own share of MAX_RENDERED_DOTS (see allocateDotsBudget) — a group with
+  // no dots to render (total 0) is filtered out before this runs. A non-zero `filled` is clamped to
+  // at least 1 rendered dot so e.g. "1 of 60" doesn't round down to none, unless its budget is 0.
+  private static toDotsGroupViewModel(group: HealthMetricsFindingVisualDotGroup, budget: number): { label: string; dots: boolean[] } {
+    const shown = Math.min(group.total, budget);
     const rawFilledShown = Math.round((group.filled / group.total) * shown);
-    const filledShown = group.filled > 0 ? Math.max(1, rawFilledShown) : rawFilledShown;
+    const filledShown = group.filled > 0 ? Math.min(shown, Math.max(1, rawFilledShown)) : rawFilledShown;
     return { label: group.label, dots: Array.from({ length: shown }, (_unused, index) => index < filledShown) };
+  }
+
+  // Splits MAX_RENDERED_DOTS proportionally across groups by each group's share of the combined
+  // total (largest-remainder method), rather than letting each group claim up to the full cap
+  // independently. Groups whose combined total already fits within the cap keep their full total.
+  private static allocateDotsBudget(totals: number[], cap: number): number[] {
+    const combinedTotal = totals.reduce((sum, total) => sum + total, 0);
+    if (combinedTotal <= cap) {
+      return totals;
+    }
+    const rawShares = totals.map((total) => (total / combinedTotal) * cap);
+    const budgets = rawShares.map(Math.floor);
+    const shortfall = cap - budgets.reduce((sum, budget) => sum + budget, 0);
+    const byRemainderDesc = rawShares.map((share, index) => ({ index, remainder: share - Math.floor(share) })).sort((a, b) => b.remainder - a.remainder);
+    for (let i = 0; i < shortfall; i++) {
+      budgets[byRemainderDesc[i].index] += 1;
+    }
+    return budgets;
   }
 
   // A bar is a single fill sized to the parts that share the finding's own classification tone

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-finding-item/health-metrics-overview-finding-item.component.ts
@@ -10,9 +10,9 @@ import type {
   HealthMetricsFindingVisualBar,
   HealthMetricsFindingVisualBarViewModel,
   HealthMetricsFindingVisualDotGroup,
-  HealthMetricsFindingVisualDotsGroupViewModel,
+  HealthMetricsFindingVisualDotsViewModel,
+  HealthMetricsOverviewClassification,
   HealthMetricsOverviewFindingViewModel,
-  HealthMetricsSentenceSegment,
 } from '@lfx-one/shared/interfaces';
 
 // Dot clusters are capped so a "5 of 62" finding doesn't render 62 individual dots.
@@ -26,14 +26,15 @@ const MAX_RENDERED_DOTS = 20;
 })
 export class HealthMetricsOverviewFindingItemComponent {
   public readonly finding = input.required<HealthMetricsOverviewFindingViewModel>();
+  /** Set by the parent's `@for ... let last = $last` — suppresses the row divider on the group's last row. */
+  public readonly isLast = input(false);
 
   protected readonly classificationMeta = computed(
     () => HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[this.finding().classification] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none
   );
   protected readonly asOfLabel = computed(() => formatHealthMetricsOverviewAsOfLabel(this.finding().evaluatedAt));
 
-  protected readonly sentenceSegments: Signal<HealthMetricsSentenceSegment[]> = this.initSentenceSegments();
-  protected readonly dotGroupsVisual: Signal<HealthMetricsFindingVisualDotsGroupViewModel[] | null> = this.initDotGroupsVisual();
+  protected readonly dotsVisual: Signal<HealthMetricsFindingVisualDotsViewModel | null> = this.initDotsVisual();
   protected readonly barVisual: Signal<HealthMetricsFindingVisualBarViewModel | null> = this.initBarVisual();
 
   protected readonly bandVisual = computed(() => {
@@ -46,35 +47,18 @@ export class HealthMetricsOverviewFindingItemComponent {
     return visual?.kind === 'tags' ? visual.tags : null;
   });
 
-  private initSentenceSegments(): Signal<HealthMetricsSentenceSegment[]> {
-    return computed(() => {
-      const { sentence, emphasis } = this.finding();
-      const start = emphasis ? sentence.indexOf(emphasis) : -1;
-      if (!emphasis || start === -1) {
-        return [{ text: sentence, bold: false }];
-      }
-
-      const segments: HealthMetricsSentenceSegment[] = [];
-      if (start > 0) {
-        segments.push({ text: sentence.slice(0, start), bold: false });
-      }
-      segments.push({ text: sentence.slice(start, start + emphasis.length), bold: true });
-      const rest = sentence.slice(start + emphasis.length);
-      if (rest) {
-        segments.push({ text: rest, bold: false });
-      }
-      return segments;
-    });
-  }
-
-  private initDotGroupsVisual(): Signal<HealthMetricsFindingVisualDotsGroupViewModel[] | null> {
+  private initDotsVisual(): Signal<HealthMetricsFindingVisualDotsViewModel | null> {
     return computed(() => {
       const visual = this.finding().visual;
       if (visual?.kind !== 'dots') {
         return null;
       }
       const groups = visual.groups.map(HealthMetricsOverviewFindingItemComponent.toDotsGroupViewModel).filter((group) => group !== null);
-      return groups.length > 0 ? groups : null;
+      if (groups.length === 0) {
+        return null;
+      }
+      // The design flattens every group into one dots row (worst state first, per authoring order) with one caption below it.
+      return { dots: groups.flatMap((group) => group.dots), caption: groups[0].label };
     });
   }
 
@@ -84,13 +68,13 @@ export class HealthMetricsOverviewFindingItemComponent {
       if (visual?.kind !== 'bar') {
         return null;
       }
-      return HealthMetricsOverviewFindingItemComponent.toBarViewModel(visual);
+      return HealthMetricsOverviewFindingItemComponent.toBarViewModel(visual, this.finding().classification);
     });
   }
 
   // A group with no dots to render (total 0) is skipped rather than shown empty. A non-zero
   // `filled` is clamped to at least 1 rendered dot so e.g. "1 of 60" doesn't round down to none.
-  private static toDotsGroupViewModel(group: HealthMetricsFindingVisualDotGroup): HealthMetricsFindingVisualDotsGroupViewModel | null {
+  private static toDotsGroupViewModel(group: HealthMetricsFindingVisualDotGroup): { label: string; dots: boolean[] } | null {
     if (group.total <= 0) {
       return null;
     }
@@ -100,12 +84,19 @@ export class HealthMetricsOverviewFindingItemComponent {
     return { label: group.label, dots: Array.from({ length: shown }, (_unused, index) => index < filledShown) };
   }
 
-  private static toBarViewModel(bar: HealthMetricsFindingVisualBar): HealthMetricsFindingVisualBarViewModel {
+  // A bar is a single fill sized to the sum of the authored parts (design's `fviz()`), clamped to
+  // 100 and tinted with the finding's own classification tone — never per-part colors.
+  private static toBarViewModel(
+    bar: HealthMetricsFindingVisualBar,
+    classification: HealthMetricsOverviewClassification
+  ): HealthMetricsFindingVisualBarViewModel {
+    const fillPercent = Math.min(
+      100,
+      bar.parts.reduce((sum, part) => sum + part.value, 0)
+    );
     return {
-      parts: bar.parts.map((part) => ({
-        ...part,
-        toneClass: (HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[part.tone] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none).dotClass,
-      })),
+      fillPercent,
+      toneClass: (HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[classification] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none).dotClass,
       caption: bar.caption,
     };
   }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -14,13 +14,13 @@
     <span class="text-[20px] font-semibold text-gray-900">{{ totalLabel() }}</span>
 
     <div class="my-4 flex h-[6px] overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Revenue by stream">
-      @for (stream of streams(); track stream.label) {
+      @for (stream of streams(); track stream.key) {
         <div [ngClass]="stream.dotClass" [style.width.%]="stream.widthPercent" aria-hidden="true"></div>
       }
     </div>
 
     <div class="flex flex-col gap-1.5">
-      @for (stream of streams(); track stream.label) {
+      @for (stream of streams(); track stream.key) {
         <div class="flex items-center gap-2 text-[12px] text-gray-600">
           <span class="h-1.5 w-1.5 rounded-full" [ngClass]="stream.dotClass" aria-hidden="true"></span>
           <span class="flex-1">{{ stream.label }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -15,7 +15,7 @@
 
     <div class="my-4 flex h-[6px] overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Revenue by stream">
       @for (stream of streams(); track stream.label) {
-        <div [ngClass]="stream.dotClass" [style.width.%]="stream.percent" aria-hidden="true"></div>
+        <div [ngClass]="stream.dotClass" [style.width.%]="stream.widthPercent" aria-hidden="true"></div>
       }
     </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -1,0 +1,63 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<aside
+  class="flex flex-col gap-4 rounded-xl bg-white p-[16px] shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]"
+  data-testid="health-metrics-overview-rail">
+  <div class="flex flex-col gap-2 border-b border-gray-100 pb-4">
+    <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Foundation Revenue</span>
+    <span class="text-[20px] font-semibold text-gray-900">{{ totalLabel() }}</span>
+
+    <div class="flex h-[6px] overflow-hidden rounded-full bg-gray-100">
+      @for (stream of streams(); track stream.label) {
+        <div [ngClass]="stream.dotClass" [style.width.%]="stream.percent"></div>
+      }
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      @for (stream of streams(); track stream.label) {
+        <div class="flex items-center gap-2 text-[12px] text-gray-600">
+          <span class="h-1.5 w-1.5 rounded-full" [ngClass]="stream.dotClass" aria-hidden="true"></span>
+          <span class="flex-1">{{ stream.label }}</span>
+          <span class="text-gray-400">{{ stream.percent }}%</span>
+          <span class="font-semibold text-gray-900">{{ stream.valueLabel }}</span>
+        </div>
+      }
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-2 border-b border-gray-100 pb-4">
+    <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Foundation</span>
+    <div class="flex flex-col gap-1.5 text-[12px]">
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-gray-500">Size</span>
+        <span class="font-semibold text-gray-900">{{ foundationSummary().size }}</span>
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-gray-500">Projects</span>
+        <span class="font-semibold text-gray-900">{{ foundationSummary().projects }}</span>
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-gray-500">Membership tiers</span>
+        <span class="font-semibold text-gray-900">{{ foundationSummary().tiers }}</span>
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-gray-500">Board</span>
+        <span class="font-semibold text-gray-900">{{ foundationSummary().board }}</span>
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        <span class="text-gray-500">Next renewals</span>
+        <span class="font-semibold text-gray-900">{{ foundationSummary().nextRenewals }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Data sources</span>
+    <div class="flex flex-wrap gap-1.5">
+      @for (source of dataSources; track source) {
+        <span class="rounded bg-gray-100 px-2 py-1 text-[11px] font-medium text-gray-600">{{ source }}</span>
+      }
+    </div>
+  </div>
+</aside>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -1,16 +1,17 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<aside
-  class="flex flex-col gap-4 rounded-xl bg-white p-[16px] shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]"
-  data-testid="health-metrics-overview-rail">
-  <div class="flex flex-col gap-2 border-b border-gray-100 pb-4">
-    <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Foundation Revenue</span>
+<aside class="flex flex-col gap-[16px]" data-testid="health-metrics-overview-rail">
+  <div class="flex flex-col p-[20px]">
+    <div class="mb-[16px] flex items-center gap-[10px]">
+      <span class="text-[12px] font-semibold uppercase text-gray-600">Foundation Revenue</span>
+      <span class="h-px flex-1 bg-gray-300" aria-hidden="true"></span>
+    </div>
     <span class="text-[20px] font-semibold text-gray-900">{{ totalLabel() }}</span>
 
-    <div class="flex h-[6px] overflow-hidden rounded-full bg-gray-100">
+    <div class="my-4 flex h-[6px] overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Revenue by stream">
       @for (stream of streams(); track stream.label) {
-        <div [ngClass]="stream.dotClass" [style.width.%]="stream.percent"></div>
+        <div [ngClass]="stream.dotClass" [style.width.%]="stream.percent" aria-hidden="true"></div>
       }
     </div>
 
@@ -26,8 +27,11 @@
     </div>
   </div>
 
-  <div class="flex flex-col gap-2 border-b border-gray-100 pb-4">
-    <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Foundation</span>
+  <div class="flex flex-col p-[20px]">
+    <div class="mb-[16px] flex items-center gap-[10px]">
+      <span class="text-[12px] font-semibold uppercase text-gray-600">Foundation</span>
+      <span class="h-px flex-1 bg-gray-300" aria-hidden="true"></span>
+    </div>
     <div class="flex flex-col gap-1.5 text-[12px]">
       <div class="flex items-center justify-between gap-2">
         <span class="text-gray-500">Size</span>
@@ -52,8 +56,11 @@
     </div>
   </div>
 
-  <div class="flex flex-col gap-2">
-    <span class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Data sources</span>
+  <div class="flex flex-col p-[20px]">
+    <div class="mb-[16px] flex items-center gap-[10px]">
+      <span class="text-[12px] font-semibold uppercase text-gray-600">Data sources</span>
+      <span class="h-px flex-1 bg-gray-300" aria-hidden="true"></span>
+    </div>
     <div class="flex flex-wrap gap-1.5">
       @for (source of dataSources; track source) {
         <span class="rounded bg-gray-100 px-2 py-1 text-[11px] font-medium text-gray-600">{{ source }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -1,6 +1,8 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- Blocks below are intentionally surfaceless (no border/shadow), only padded — matches the design's
+     `#viewC .rblk,#viewB .rblk{background:transparent;box-shadow:none;padding:20px}` rule. -->
 <aside class="flex flex-col gap-[16px]" data-testid="health-metrics-overview-rail">
   <div class="flex flex-col p-[20px]">
     <div class="mb-[16px] flex items-center gap-[10px]">

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -3,7 +3,9 @@
 
 <!-- Blocks below are intentionally surfaceless (no border/shadow), only padded — matches the design's
      `#viewC .rblk,#viewB .rblk{background:transparent;box-shadow:none;padding:20px}` rule. -->
-<aside class="flex flex-col gap-[16px]" data-testid="health-metrics-overview-rail">
+<!-- Sticky lives here (not on the host) — this element's own height is its natural content height,
+     giving it room to travel and pin within the host's taller (grid-stretched) box; see topPx doc. -->
+<aside class="flex flex-col gap-[16px] lg:sticky" [style.top.px]="topPx()" data-testid="health-metrics-overview-rail">
   <div class="flex flex-col p-[20px]">
     <div class="mb-[16px] flex items-center gap-[10px]">
       <span class="text-[12px] font-semibold uppercase text-gray-600">Foundation Revenue</span>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.html
@@ -65,7 +65,7 @@
       <span class="text-[12px] font-semibold uppercase text-gray-600">Data sources</span>
       <span class="h-px flex-1 bg-gray-300" aria-hidden="true"></span>
     </div>
-    <div class="flex flex-wrap gap-1.5">
+    <div class="flex flex-wrap gap-1.5" data-testid="health-metrics-overview-rail-data-sources">
       @for (source of dataSources; track source) {
         <span class="rounded bg-gray-100 px-2 py-1 text-[11px] font-medium text-gray-600">{{ source }}</span>
       }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.scss
@@ -1,0 +1,6 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.spec.ts
@@ -33,6 +33,7 @@ describe('HealthMetricsOverviewRailComponent', () => {
     fixture = TestBed.createComponent(HealthMetricsOverviewRailComponent);
     fixture.componentRef.setInput('revenue', revenue);
     fixture.componentRef.setInput('foundationSummary', foundationSummary);
+    fixture.componentRef.setInput('topPx', 88);
     fixture.detectChanges();
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.spec.ts
@@ -40,7 +40,10 @@ describe('HealthMetricsOverviewRailComponent', () => {
   it('renders the formatted revenue total and a percent-share legend row per stream', async () => {
     await render();
 
-    const text = fixture.nativeElement.textContent;
+    const rootEl: HTMLElement = fixture.nativeElement;
+    expect(rootEl.textContent).toContain('$1M');
+
+    const text = rootEl.textContent;
     expect(text).toContain('Memberships');
     expect(text).toContain('60%');
     expect(text).toContain('Events');
@@ -58,7 +61,17 @@ describe('HealthMetricsOverviewRailComponent', () => {
     expect(text).toContain('4 tiers');
     expect(text).toContain('12 seats');
     expect(text).toContain('5 in the next 30 days');
-    expect(text).toContain('Membership');
-    expect(text).toContain('LFX Insights');
+
+    const dataSourceTags: string[] = Array.from(fixture.nativeElement.querySelectorAll('[data-testid="health-metrics-overview-rail-data-sources"] span')).map(
+      (el) => (el as HTMLElement).textContent?.trim()
+    );
+    expect(dataSourceTags).toEqual(['Membership', 'Meetings', 'Events', 'Surveys', 'LFX Insights']);
+  });
+
+  it('applies the topPx input as the sticky offset', async () => {
+    await render();
+
+    const aside: HTMLElement = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-rail"]');
+    expect(aside.style.top).toBe('88px');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.spec.ts
@@ -1,0 +1,63 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { HealthMetricsOverviewRailComponent } from './health-metrics-overview-rail.component';
+
+import type { HealthMetricsOverviewFoundationSummary, HealthMetricsOverviewRevenue } from '@lfx-one/shared/interfaces';
+
+describe('HealthMetricsOverviewRailComponent', () => {
+  let fixture: ComponentFixture<HealthMetricsOverviewRailComponent>;
+
+  const revenue: HealthMetricsOverviewRevenue = {
+    total: 1_000_000,
+    streams: [
+      { key: 'memberships', value: 600_000 },
+      { key: 'events', value: 300_000 },
+      { key: 'training', value: 100_000 },
+    ],
+  };
+
+  const foundationSummary: HealthMetricsOverviewFoundationSummary = {
+    size: 'Large',
+    projects: 14,
+    tiers: '4 tiers',
+    board: '12 seats',
+    nextRenewals: '5 in the next 30 days',
+  };
+
+  async function render(): Promise<void> {
+    await TestBed.configureTestingModule({ imports: [HealthMetricsOverviewRailComponent] }).compileComponents();
+    fixture = TestBed.createComponent(HealthMetricsOverviewRailComponent);
+    fixture.componentRef.setInput('revenue', revenue);
+    fixture.componentRef.setInput('foundationSummary', foundationSummary);
+    fixture.detectChanges();
+  }
+
+  it('renders the formatted revenue total and a percent-share legend row per stream', async () => {
+    await render();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Memberships');
+    expect(text).toContain('60%');
+    expect(text).toContain('Events');
+    expect(text).toContain('30%');
+    expect(text).toContain('Training');
+    expect(text).toContain('10%');
+  });
+
+  it('renders the foundation summary fields and the fixed data-sources tag list', async () => {
+    await render();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Large');
+    expect(text).toContain('14');
+    expect(text).toContain('4 tiers');
+    expect(text).toContain('12 seats');
+    expect(text).toContain('5 in the next 30 days');
+    expect(text).toContain('Membership');
+    expect(text).toContain('LFX Insights');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.ts
@@ -26,6 +26,13 @@ import type {
 export class HealthMetricsOverviewRailComponent {
   public readonly revenue = input.required<HealthMetricsOverviewRevenue>();
   public readonly foundationSummary = input.required<HealthMetricsOverviewFoundationSummary>();
+  /**
+   * Sticky offset (px) from the viewport top, measured by the parent from the page header's real
+   * height. Applied to this component's own root element (not the host) — the host is a grid item
+   * stretched to the row's full height (see the parent template), so it has no slack of its own to
+   * travel within; sticky only has room to engage on a naturally-sized child inside it.
+   */
+  public readonly topPx = input.required<number>();
 
   protected readonly dataSources = HEALTH_METRICS_OVERVIEW_DATA_SOURCES;
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-rail/health-metrics-overview-rail.component.ts
@@ -1,0 +1,34 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, input, Signal } from '@angular/core';
+import { HEALTH_METRICS_OVERVIEW_DATA_SOURCES } from '@lfx-one/shared/constants';
+import { buildHealthMetricsOverviewRevenueStreams, formatCurrency } from '@lfx-one/shared/utils';
+
+import type {
+  HealthMetricsOverviewFoundationSummary,
+  HealthMetricsOverviewRevenue,
+  HealthMetricsOverviewRevenueStreamViewModel,
+} from '@lfx-one/shared/interfaces';
+
+/**
+ * Rail/sidebar matching the design's `railHTML(d)`: Foundation Revenue (total + segmented bar +
+ * per-stream legend), Foundation (size/projects/tiers/board/next renewals), and a fixed Data
+ * sources tag list. Rendered alongside the tile strip + findings list on wide viewports.
+ */
+@Component({
+  selector: 'lfx-health-metrics-overview-rail',
+  imports: [NgClass],
+  templateUrl: './health-metrics-overview-rail.component.html',
+  styleUrl: './health-metrics-overview-rail.component.scss',
+})
+export class HealthMetricsOverviewRailComponent {
+  public readonly revenue = input.required<HealthMetricsOverviewRevenue>();
+  public readonly foundationSummary = input.required<HealthMetricsOverviewFoundationSummary>();
+
+  protected readonly dataSources = HEALTH_METRICS_OVERVIEW_DATA_SOURCES;
+
+  protected readonly totalLabel = computed(() => formatCurrency(this.revenue().total));
+  protected readonly streams: Signal<HealthMetricsOverviewRevenueStreamViewModel[]> = computed(() => buildHealthMetricsOverviewRevenueStreams(this.revenue()));
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-tile/health-metrics-overview-tile.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-tile/health-metrics-overview-tile.component.html
@@ -1,15 +1,15 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-3 rounded-lg border-l-4 border border-gray-200 bg-white p-4" [ngClass]="classificationMeta().accentClass">
+<div class="flex flex-col gap-3 p-[16px]">
   <div class="flex items-center gap-2">
     <i [class]="tile().icon + ' text-sm text-gray-500'" aria-hidden="true"></i>
-    <span class="text-sm font-medium text-gray-600">{{ tile().name }}</span>
+    <span class="text-[12px] font-semibold text-gray-900">{{ tile().name }}</span>
   </div>
 
   <div class="flex flex-col gap-0.5">
-    <span class="text-2xl font-semibold text-gray-900">{{ tile().statValue }}</span>
-    <span class="text-xs text-gray-500">{{ tile().statLabel }}</span>
+    <span class="text-[24px] font-medium text-gray-900">{{ tile().statValue }}</span>
+    <span class="text-[12px] text-gray-600">{{ tile().statLabel }}</span>
   </div>
 
   <div class="flex items-center justify-between gap-2">
@@ -24,7 +24,7 @@
       </a>
     } @else {
       <span class="flex items-center gap-1.5 text-xs font-medium" [ngClass]="classificationMeta().textClass">
-        <span class="h-1.5 w-1.5 rounded-full" [ngClass]="classificationMeta().dotClass" aria-hidden="true"></span>
+        <i [class]="classificationMeta().icon" aria-hidden="true"></i>
         {{ classificationMeta().label }}
       </span>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-tile/health-metrics-overview-tile.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-tile/health-metrics-overview-tile.component.html
@@ -1,6 +1,8 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- Arbitrary [Npx] values throughout match the design's exact pixel sizes, per .claude/rules/styling.md's
+     rem-scale-undershoot exception (this app's 14px root font makes e.g. `text-xs` render ~10.5px, not 12px). -->
 <div class="flex flex-col gap-3 p-[16px]">
   <div class="flex items-center gap-2">
     <i [class]="tile().icon + ' text-sm text-gray-500'" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-tile/health-metrics-overview-tile.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview-tile/health-metrics-overview-tile.component.html
@@ -12,7 +12,7 @@
     <span class="text-[12px] text-gray-600">{{ tile().statLabel }}</span>
   </div>
 
-  <div class="flex items-center justify-between gap-2">
+  <div class="flex flex-wrap items-center justify-between gap-2">
     @if (tile().insightsUrl; as insightsUrl) {
       <a
         [href]="insightsUrl"

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -16,7 +16,7 @@
       <p class="text-sm text-gray-500">A snapshot of foundation health across engagement, events, members, non-members, training, and code.</p>
     </div>
 
-    <div class="flex items-center gap-2">
+    <div class="flex flex-wrap items-center gap-2">
       <!-- Visual only for now — mirrors the design's project drill-down pill (`.projsel`/`.pstrig`);
            no per-project data exists yet to scope by (LFXV2-3364 stand-in fixture is foundation-wide). -->
       <button

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -15,6 +15,8 @@
           <button
             type="button"
             disabled
+            [attr.aria-pressed]="period === selectedPeriod"
+            [attr.data-testid]="'health-metrics-overview-period-' + period"
             class="rounded-full px-3 py-1 text-[12px] font-medium disabled:cursor-default"
             [ngClass]="period === selectedPeriod ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'">
             {{ period }}
@@ -33,45 +35,43 @@
     </div>
   </header>
 
-  <div class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
-    <div class="flex min-w-0 flex-col gap-6">
-      <section
-        class="grid grid-cols-1 divide-x divide-y divide-gray-100 overflow-hidden rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6"
-        data-testid="health-metrics-overview-tile-strip">
-        @for (tile of tiles(); track tile.area) {
-          <lfx-health-metrics-overview-tile [tile]="tile" [attr.data-testid]="'health-metrics-overview-tile-' + tile.area" />
-        }
-      </section>
+  <section
+    class="tile-strip overflow-hidden rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]"
+    data-testid="health-metrics-overview-tile-strip">
+    @for (tile of tiles(); track tile.area) {
+      <lfx-health-metrics-overview-tile [tile]="tile" [attr.data-testid]="'health-metrics-overview-tile-' + tile.area" />
+    }
+  </section>
 
-      <section data-testid="health-metrics-overview-findings-list">
-        @if (hasFindings()) {
-          <div
-            class="flex flex-col rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]">
-            @for (findingGroup of findingGroups(); track findingGroup.group) {
-              <div [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.group">
-                <div class="flex items-center gap-2 px-[26px] pt-4 pb-2">
-                  <i [class]="findingGroup.groupIcon" [ngClass]="findingGroup.groupTextClass" aria-hidden="true"></i>
-                  <h2 class="text-[11px] font-semibold tracking-wide uppercase" [ngClass]="findingGroup.groupTextClass">{{ findingGroup.group }}</h2>
-                  <span class="h-px flex-1 bg-gray-200" aria-hidden="true"></span>
-                </div>
-                @for (finding of findingGroup.findings; track finding.sortRank; let last = $last) {
-                  <lfx-health-metrics-overview-finding-item
-                    [finding]="finding"
-                    [isLast]="last"
-                    [attr.data-testid]="'health-metrics-overview-finding-' + finding.sortRank" />
-                }
+  <div class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+    <section class="min-w-0" data-testid="health-metrics-overview-findings-list">
+      @if (hasFindings()) {
+        <div
+          class="flex flex-col rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]">
+          @for (findingGroup of findingGroups(); track findingGroup.group) {
+            <div [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.group">
+              <div class="flex items-center gap-2 px-[26px] pt-4 pb-2">
+                <i [class]="findingGroup.groupIcon" [ngClass]="findingGroup.groupTextClass" aria-hidden="true"></i>
+                <h2 class="text-[11px] font-semibold tracking-wide uppercase" [ngClass]="findingGroup.groupTextClass">{{ findingGroup.group }}</h2>
+                <span class="h-px flex-1 bg-gray-200" aria-hidden="true"></span>
               </div>
-            }
-          </div>
-        } @else {
-          <div class="flex flex-col items-center gap-2 rounded-lg border border-gray-200 py-12 text-center" data-testid="health-metrics-overview-all-clear">
-            <i class="fa-light fa-circle-check text-2xl text-emerald-500" aria-hidden="true"></i>
-            <p class="text-sm font-medium text-gray-700">Nothing needs your attention right now.</p>
-            <p class="text-sm text-gray-500">All tracked areas are going well or awaiting their next data refresh.</p>
-          </div>
-        }
-      </section>
-    </div>
+              @for (finding of findingGroup.findings; track finding.sortRank; let last = $last) {
+                <lfx-health-metrics-overview-finding-item
+                  [finding]="finding"
+                  [isLast]="last"
+                  [attr.data-testid]="'health-metrics-overview-finding-' + finding.sortRank" />
+              }
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex flex-col items-center gap-2 rounded-lg border border-gray-200 py-12 text-center" data-testid="health-metrics-overview-all-clear">
+          <i class="fa-light fa-circle-check text-2xl text-emerald-500" aria-hidden="true"></i>
+          <p class="text-sm font-medium text-gray-700">Nothing needs your attention right now.</p>
+          <p class="text-sm text-gray-500">All tracked areas are going well or awaiting their next data refresh.</p>
+        </div>
+      }
+    </section>
 
     <lfx-health-metrics-overview-rail [revenue]="revenue()" [foundationSummary]="foundationSummary()" />
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -21,22 +21,24 @@
            no per-project data exists yet to scope by (LFXV2-3364 stand-in fixture is foundation-wide). -->
       <button
         type="button"
-        disabled
-        class="flex h-[36px] items-center gap-[8px] rounded-full border border-gray-200 bg-white px-[12px] text-[14px] font-medium text-gray-900 disabled:cursor-default"
+        aria-disabled="true"
+        class="flex h-[36px] cursor-default items-center gap-[8px] rounded-full border border-gray-200 bg-white px-[12px] text-[14px] font-medium text-gray-900"
         data-testid="health-metrics-overview-project-selector">
         <i class="fa-light fa-diagram-project text-gray-500" aria-hidden="true"></i>
         All projects
         <i class="fa-light fa-chevron-down text-[12px] text-gray-500" aria-hidden="true"></i>
       </button>
-      <!-- Visual only for now — period stays pinned to YTD until a real backend supports re-filtering. -->
+      <!-- Visual only for now — period stays pinned to YTD until a real backend supports re-filtering.
+           aria-disabled (not the native `disabled` attribute) keeps these buttons focusable and in the
+           accessibility tree, so aria-pressed still announces which period is selected to AT users. -->
       <div class="flex items-center gap-1 rounded-full bg-gray-100 p-1" data-testid="health-metrics-overview-period-selector">
         @for (period of periods; track period) {
           <button
             type="button"
-            disabled
+            aria-disabled="true"
             [attr.aria-pressed]="period === selectedPeriod"
             [attr.data-testid]="'health-metrics-overview-period-' + period"
-            class="rounded-full px-3 py-1 text-[12px] font-medium disabled:cursor-default"
+            class="cursor-default rounded-full px-3 py-1 text-[12px] font-medium"
             [ngClass]="period === selectedPeriod ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'">
             {{ period }}
           </button>
@@ -45,8 +47,8 @@
       <!-- Visual only for now — no export wired up yet. -->
       <button
         type="button"
-        disabled
-        class="flex items-center gap-1.5 rounded-full px-3 py-2 text-[14px] font-semibold text-gray-900 disabled:cursor-default"
+        aria-disabled="true"
+        class="flex cursor-default items-center gap-1.5 rounded-full px-3 py-2 text-[14px] font-semibold text-gray-900"
         data-testid="health-metrics-overview-export">
         <i class="fa-light fa-arrow-down-to-line" aria-hidden="true"></i>
         Export
@@ -54,9 +56,7 @@
     </div>
   </header>
 
-  <section
-    class="tile-strip overflow-hidden rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]"
-    data-testid="health-metrics-overview-tile-strip">
+  <section class="tile-strip surface-card overflow-hidden rounded-xl bg-white" data-testid="health-metrics-overview-tile-strip">
     @for (tile of tiles(); track tile.area) {
       <lfx-health-metrics-overview-tile [tile]="tile" [attr.data-testid]="'health-metrics-overview-tile-' + tile.area" />
     }
@@ -65,8 +65,7 @@
   <div class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-stretch">
     <section class="min-w-0" data-testid="health-metrics-overview-findings-list">
       @if (hasFindings()) {
-        <div
-          class="flex flex-col rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]">
+        <div class="surface-card flex flex-col rounded-xl bg-white">
           @for (findingGroup of findingGroups(); track findingGroup.classification) {
             <div [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.classification">
               <div class="flex items-center gap-2 px-[26px] pt-4 pb-2">

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -59,7 +59,7 @@
                 <lfx-health-metrics-overview-finding-item
                   [finding]="finding"
                   [isLast]="last"
-                  [attr.data-testid]="'health-metrics-overview-finding-' + finding.sortRank" />
+                  [attr.data-testid]="'health-metrics-overview-finding-row-' + finding.sortRank" />
               }
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -1,36 +1,78 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex flex-col gap-8 p-6" data-testid="health-metrics-overview-page">
-  <header class="flex flex-col gap-1">
-    <h1 class="text-xl font-semibold text-gray-900">Health Metrics</h1>
-    <p class="text-sm text-gray-500">A snapshot of foundation health across engagement, events, members, non-members, training, and code.</p>
+<div class="flex flex-col gap-6 p-6" data-testid="health-metrics-overview-page">
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-xl font-semibold text-gray-900">Health Metrics</h1>
+      <p class="text-sm text-gray-500">A snapshot of foundation health across engagement, events, members, non-members, training, and code.</p>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <!-- Visual only for now — period stays pinned to YTD until a real backend supports re-filtering. -->
+      <div class="flex items-center gap-1 rounded-full bg-gray-100 p-1" data-testid="health-metrics-overview-period-selector">
+        @for (period of periods; track period) {
+          <button
+            type="button"
+            disabled
+            class="rounded-full px-3 py-1 text-[12px] font-medium disabled:cursor-default"
+            [ngClass]="period === selectedPeriod ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'">
+            {{ period }}
+          </button>
+        }
+      </div>
+      <!-- Visual only for now — no export wired up yet. -->
+      <button
+        type="button"
+        disabled
+        class="flex items-center gap-1.5 rounded-full px-3 py-2 text-[14px] font-semibold text-gray-900 disabled:cursor-default"
+        data-testid="health-metrics-overview-export">
+        <i class="fa-light fa-arrow-down-to-line" aria-hidden="true"></i>
+        Export
+      </button>
+    </div>
   </header>
 
-  <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6" data-testid="health-metrics-overview-tile-strip">
-    @for (tile of tiles(); track tile.area) {
-      <lfx-health-metrics-overview-tile [tile]="tile" [attr.data-testid]="'health-metrics-overview-tile-' + tile.area" />
-    }
-  </section>
+  <div class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+    <div class="flex min-w-0 flex-col gap-6">
+      <section
+        class="grid grid-cols-1 divide-x divide-y divide-gray-100 overflow-hidden rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6"
+        data-testid="health-metrics-overview-tile-strip">
+        @for (tile of tiles(); track tile.area) {
+          <lfx-health-metrics-overview-tile [tile]="tile" [attr.data-testid]="'health-metrics-overview-tile-' + tile.area" />
+        }
+      </section>
 
-  <section class="flex flex-col gap-6" data-testid="health-metrics-overview-findings-list">
-    @if (hasFindings()) {
-      @for (findingGroup of findingGroups(); track findingGroup.group) {
-        <div class="flex flex-col gap-3" [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.group">
-          <h2 class="text-sm font-semibold text-gray-700">{{ findingGroup.group }}</h2>
-          <div class="flex flex-col gap-2">
-            @for (finding of findingGroup.findings; track finding.sortRank) {
-              <lfx-health-metrics-overview-finding-item [finding]="finding" [attr.data-testid]="'health-metrics-overview-finding-' + finding.sortRank" />
+      <section data-testid="health-metrics-overview-findings-list">
+        @if (hasFindings()) {
+          <div
+            class="flex flex-col rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]">
+            @for (findingGroup of findingGroups(); track findingGroup.group) {
+              <div [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.group">
+                <div class="flex items-center gap-2 px-[26px] pt-4 pb-2">
+                  <i [class]="findingGroup.groupIcon" [ngClass]="findingGroup.groupTextClass" aria-hidden="true"></i>
+                  <h2 class="text-[11px] font-semibold tracking-wide uppercase" [ngClass]="findingGroup.groupTextClass">{{ findingGroup.group }}</h2>
+                  <span class="h-px flex-1 bg-gray-200" aria-hidden="true"></span>
+                </div>
+                @for (finding of findingGroup.findings; track finding.sortRank; let last = $last) {
+                  <lfx-health-metrics-overview-finding-item
+                    [finding]="finding"
+                    [isLast]="last"
+                    [attr.data-testid]="'health-metrics-overview-finding-' + finding.sortRank" />
+                }
+              </div>
             }
           </div>
-        </div>
-      }
-    } @else {
-      <div class="flex flex-col items-center gap-2 rounded-lg border border-gray-200 py-12 text-center" data-testid="health-metrics-overview-all-clear">
-        <i class="fa-light fa-circle-check text-2xl text-emerald-500" aria-hidden="true"></i>
-        <p class="text-sm font-medium text-gray-700">Nothing needs your attention right now.</p>
-        <p class="text-sm text-gray-500">All tracked areas are going well or awaiting their next data refresh.</p>
-      </div>
-    }
-  </section>
+        } @else {
+          <div class="flex flex-col items-center gap-2 rounded-lg border border-gray-200 py-12 text-center" data-testid="health-metrics-overview-all-clear">
+            <i class="fa-light fa-circle-check text-2xl text-emerald-500" aria-hidden="true"></i>
+            <p class="text-sm font-medium text-gray-700">Nothing needs your attention right now.</p>
+            <p class="text-sm text-gray-500">All tracked areas are going well or awaiting their next data refresh.</p>
+          </div>
+        }
+      </section>
+    </div>
+
+    <lfx-health-metrics-overview-rail [revenue]="revenue()" [foundationSummary]="foundationSummary()" />
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -48,8 +48,8 @@
       @if (hasFindings()) {
         <div
           class="flex flex-col rounded-xl bg-white shadow-[inset_0_0_0_1px_theme(colors.gray.100),0px_1px_2px_-1px_rgb(0_0_0_/_0.05),0px_1px_3px_rgb(0_0_0_/_0.05)]">
-          @for (findingGroup of findingGroups(); track findingGroup.group) {
-            <div [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.group">
+          @for (findingGroup of findingGroups(); track findingGroup.classification) {
+            <div [attr.data-testid]="'health-metrics-overview-findings-group-' + findingGroup.classification">
               <div class="flex items-center gap-2 px-[26px] pt-4 pb-2">
                 <i [class]="findingGroup.groupIcon" [ngClass]="findingGroup.groupTextClass" aria-hidden="true"></i>
                 <h2 class="text-[11px] font-semibold tracking-wide uppercase" [ngClass]="findingGroup.groupTextClass">{{ findingGroup.group }}</h2>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.html
@@ -2,13 +2,32 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6 p-6" data-testid="health-metrics-overview-page">
-  <header class="flex flex-wrap items-center justify-between gap-3">
+  <!-- Stays pinned above the scrolling content at the wide layout, matching the design's `.stickyhead`
+       (its own `margin-top:-32px;padding-top:32px` trick, mirrored below) — the rail's sticky offset
+       is measured from this element's rendered height. -mt-12/pt-12 cancel out the two ancestor top
+       paddings above this element (main-layout's router-outlet wrapper `py-6` + this page's own `p-6`
+       = 3rem total) so the header has zero distance to travel before it locks — otherwise it would
+       visibly shift up by that 3rem on the first bit of scroll before sticking. -->
+  <header
+    #pageHeader
+    class="flex flex-wrap items-center justify-between gap-3 lg:sticky lg:top-0 lg:z-10 lg:-mt-12 lg:border-b lg:border-gray-100 lg:bg-white lg:pt-12 lg:pb-2">
     <div class="flex flex-col gap-1">
       <h1 class="text-xl font-semibold text-gray-900">Health Metrics</h1>
       <p class="text-sm text-gray-500">A snapshot of foundation health across engagement, events, members, non-members, training, and code.</p>
     </div>
 
     <div class="flex items-center gap-2">
+      <!-- Visual only for now — mirrors the design's project drill-down pill (`.projsel`/`.pstrig`);
+           no per-project data exists yet to scope by (LFXV2-3364 stand-in fixture is foundation-wide). -->
+      <button
+        type="button"
+        disabled
+        class="flex h-[36px] items-center gap-[8px] rounded-full border border-gray-200 bg-white px-[12px] text-[14px] font-medium text-gray-900 disabled:cursor-default"
+        data-testid="health-metrics-overview-project-selector">
+        <i class="fa-light fa-diagram-project text-gray-500" aria-hidden="true"></i>
+        All projects
+        <i class="fa-light fa-chevron-down text-[12px] text-gray-500" aria-hidden="true"></i>
+      </button>
       <!-- Visual only for now — period stays pinned to YTD until a real backend supports re-filtering. -->
       <div class="flex items-center gap-1 rounded-full bg-gray-100 p-1" data-testid="health-metrics-overview-period-selector">
         @for (period of periods; track period) {
@@ -43,7 +62,7 @@
     }
   </section>
 
-  <div class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+  <div class="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-stretch">
     <section class="min-w-0" data-testid="health-metrics-overview-findings-list">
       @if (hasFindings()) {
         <div
@@ -73,6 +92,11 @@
       }
     </section>
 
-    <lfx-health-metrics-overview-rail [revenue]="revenue()" [foundationSummary]="foundationSummary()" />
+    <!-- lg:items-stretch above gives this a row-tall grid cell (the rail applies its own sticky
+         internally, on a naturally-sized child — see health-metrics-overview-rail.component.html —
+         since a stretched grid item has no room of its own to travel within). It sticks just below
+         the header on scroll and only releases once that tall cell's bottom is reached, matching
+         the design. -->
+    <lfx-health-metrics-overview-rail [topPx]="railTopPx()" [revenue]="revenue()" [foundationSummary]="foundationSummary()" />
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.scss
@@ -4,3 +4,52 @@
 :host {
   display: block;
 }
+
+// Tile-strip grid + per-cell divider rules, ported 1:1 from the design's `.tilestrip .tiles`
+// breakpoints (`health-metrics.css`) — the design's 1250px/820px cuts don't align with Tailwind's
+// default screens, so this mirrors the design's own max-width queries directly instead of
+// approximating with `sm:`/`lg:`/`xl:` variants (which don't respect grid geometry either).
+.tile-strip {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+
+  > * {
+    border-left: 1px solid theme('colors.gray.100');
+
+    &:first-child {
+      border-left: 0;
+    }
+  }
+
+  @media (max-width: 1250px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+
+    > * {
+      &:nth-child(3n + 1) {
+        border-left: 0;
+      }
+
+      &:nth-child(n + 4) {
+        border-top: 1px solid theme('colors.gray.100');
+      }
+    }
+  }
+
+  @media (max-width: 820px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+
+    > * {
+      &:nth-child(3n + 1) {
+        border-left: 1px solid theme('colors.gray.100');
+      }
+
+      &:nth-child(2n + 1) {
+        border-left: 0;
+      }
+
+      &:nth-child(n + 3) {
+        border-top: 1px solid theme('colors.gray.100');
+      }
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.scss
@@ -5,6 +5,15 @@
   display: block;
 }
 
+// Shared card surface (design's `--shadow-card`: inset 1px gray-100 ring + soft drop shadow) for the
+// tile strip and the findings list — extracted so the ~90-char shadow value is written once.
+.surface-card {
+  box-shadow:
+    inset 0 0 0 1px theme('colors.gray.100'),
+    0px 1px 2px -1px rgb(0 0 0 / 0.05),
+    0px 1px 3px rgb(0 0 0 / 0.05);
+}
+
 // Tile-strip grid + per-cell divider rules, ported 1:1 from the design's `.tilestrip .tiles`
 // breakpoints (`health-metrics.css`) — the design's 1250px/820px cuts don't align with Tailwind's
 // default screens, so this mirrors the design's own max-width queries directly instead of

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
@@ -4,7 +4,7 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProjectContextService } from '@services/project-context.service';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { HealthMetricsOverviewComponent } from './health-metrics-overview.component';
 
@@ -27,6 +27,40 @@ describe('HealthMetricsOverviewComponent', () => {
     fixture = TestBed.createComponent(HealthMetricsOverviewComponent);
     fixture.detectChanges();
   }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('measures the sticky header via ResizeObserver and feeds its height into the rail offset', async () => {
+    let observedCallback: ResizeObserverCallback | undefined;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        public constructor(callback: ResizeObserverCallback) {
+          observedCallback = callback;
+        }
+        public observe(): void {
+          /* no-op — the fake reports height only via the manually-invoked callback below */
+        }
+        public disconnect(): void {
+          /* no-op */
+        }
+      }
+    );
+
+    await render(null, null);
+    // afterNextRender (which calls observeHeaderHeight) only fires once the render is stable.
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(observedCallback).toBeDefined();
+    observedCallback?.([{ borderBoxSize: [{ blockSize: 120 }] } as unknown as ResizeObserverEntry], {} as ResizeObserver);
+    fixture.detectChanges();
+
+    const rail: HTMLElement = fixture.nativeElement.querySelector('[data-testid="health-metrics-overview-rail"]');
+    expect(rail.style.top).toBe('136px'); // headerHeightPx (120) + 16, per railTopPx()
+  });
 
   it('renders findings groups in the fixed order', async () => {
     await render(null, null);

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
@@ -45,10 +45,16 @@ describe('HealthMetricsOverviewComponent', () => {
   it('sorts findings within a group by sortRank', async () => {
     await render(null, null);
 
+    // The prefix selector also matches each row's inner elements (-sentence, -dots, -bar, -link-<rank>), which
+    // aren't rows themselves — filter to the row's own `-<rank>` testid before reading order.
     const rows = fixture.nativeElement.querySelectorAll(
       '[data-testid="health-metrics-overview-findings-group-act"] [data-testid^="health-metrics-overview-finding-"]'
     );
-    const ranks = Array.from<Element>(rows).map((el) => Number(el.getAttribute('data-testid')?.split('-').pop()));
+    const ranks = Array.from<Element>(rows)
+      .map((el) => el.getAttribute('data-testid') ?? '')
+      .filter((testid) => /^health-metrics-overview-finding-\d+$/.test(testid))
+      .map((testid) => Number(testid.split('-').pop()));
+    expect(ranks.length).toBeGreaterThan(1);
     expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
@@ -34,11 +34,11 @@ describe('HealthMetricsOverviewComponent', () => {
     const groupEls = fixture.nativeElement.querySelectorAll('[data-testid^="health-metrics-overview-findings-group-"]');
     const order = Array.from<Element>(groupEls).map((el) => el.getAttribute('data-testid'));
     expect(order).toEqual([
-      'health-metrics-overview-findings-group-Needs action',
-      'health-metrics-overview-findings-group-Needs attention',
-      'health-metrics-overview-findings-group-Opportunities',
-      'health-metrics-overview-findings-group-Going well',
-      'health-metrics-overview-findings-group-Awaiting data',
+      'health-metrics-overview-findings-group-act',
+      'health-metrics-overview-findings-group-watch',
+      'health-metrics-overview-findings-group-opp',
+      'health-metrics-overview-findings-group-ok',
+      'health-metrics-overview-findings-group-none',
     ]);
   });
 
@@ -46,7 +46,7 @@ describe('HealthMetricsOverviewComponent', () => {
     await render(null, null);
 
     const rows = fixture.nativeElement.querySelectorAll(
-      '[data-testid="health-metrics-overview-findings-group-Needs action"] [data-testid^="health-metrics-overview-finding-"]'
+      '[data-testid="health-metrics-overview-findings-group-act"] [data-testid^="health-metrics-overview-finding-"]'
     );
     const ranks = Array.from<Element>(rows).map((el) => Number(el.getAttribute('data-testid')?.split('-').pop()));
     expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
@@ -123,8 +123,8 @@ describe('HealthMetricsOverviewComponent', () => {
 
     const groupEls = fixture.nativeElement.querySelectorAll('[data-testid^="health-metrics-overview-findings-group-"]');
     expect(Array.from<Element>(groupEls).map((el) => el.getAttribute('data-testid'))).toEqual([
-      'health-metrics-overview-findings-group-Needs action',
-      'health-metrics-overview-findings-group-Going well',
+      'health-metrics-overview-findings-group-act',
+      'health-metrics-overview-findings-group-ok',
     ]);
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.spec.ts
@@ -45,15 +45,10 @@ describe('HealthMetricsOverviewComponent', () => {
   it('sorts findings within a group by sortRank', async () => {
     await render(null, null);
 
-    // The prefix selector also matches each row's inner elements (-sentence, -dots, -bar, -link-<rank>), which
-    // aren't rows themselves — filter to the row's own `-<rank>` testid before reading order.
     const rows = fixture.nativeElement.querySelectorAll(
-      '[data-testid="health-metrics-overview-findings-group-act"] [data-testid^="health-metrics-overview-finding-"]'
+      '[data-testid="health-metrics-overview-findings-group-act"] [data-testid^="health-metrics-overview-finding-row-"]'
     );
-    const ranks = Array.from<Element>(rows)
-      .map((el) => el.getAttribute('data-testid') ?? '')
-      .filter((testid) => /^health-metrics-overview-finding-\d+$/.test(testid))
-      .map((testid) => Number(testid.split('-').pop()));
+    const ranks = Array.from<Element>(rows).map((el) => Number(el.getAttribute('data-testid')?.split('-').pop()));
     expect(ranks.length).toBeGreaterThan(1);
     expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
   });

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, input, Signal } from '@angular/core';
+import { afterNextRender, Component, computed, DestroyRef, ElementRef, inject, input, Signal, signal, viewChild } from '@angular/core';
 import { HEALTH_METRICS_OVERVIEW_AREAS, HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET, HEALTH_METRICS_OVERVIEW_PERIODS } from '@lfx-one/shared/constants';
 import {
   buildHealthMetricsOverviewPccUrl,
@@ -43,6 +43,7 @@ import type {
 })
 export class HealthMetricsOverviewComponent {
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Default to the temporary fixture (LFXV2-3364 will replace it); overridable via setInput so
   // specs can pin the empty/missing-area/unsorted branches the fixture itself can't exercise.
@@ -55,12 +56,35 @@ export class HealthMetricsOverviewComponent {
   // Non-functional for now (see HEALTH_METRICS_OVERVIEW_PERIODS doc comment) — always YTD, never reassigned.
   protected readonly selectedPeriod: (typeof HEALTH_METRICS_OVERVIEW_PERIODS)[number] = 'YTD';
 
+  protected readonly pageHeader = viewChild<ElementRef<HTMLElement>>('pageHeader');
+  // Measured client-side from the sticky header (see observeHeaderHeight); this fallback only shows
+  // pre-hydration and approximates the header's real rendered height.
+  protected readonly headerHeightPx = signal(72);
+  protected readonly railTopPx = computed(() => this.headerHeightPx() + 16);
+
   protected readonly tiles: Signal<HealthMetricsOverviewTileViewModel[]> = this.initTiles();
   protected readonly findingGroups: Signal<HealthMetricsOverviewFindingGroup[]> = this.initFindingGroups();
 
   protected readonly hasFindings = computed(() => this.findingGroups().length > 0);
 
   private static readonly areaNameByKey = new Map(HEALTH_METRICS_OVERVIEW_AREAS.map((areaMeta) => [areaMeta.key, areaMeta.name]));
+
+  constructor() {
+    // afterNextRender only runs client-side, never during SSR — safe without an isPlatformBrowser guard.
+    afterNextRender(() => this.observeHeaderHeight());
+  }
+
+  private observeHeaderHeight(): void {
+    const header = this.pageHeader()?.nativeElement;
+    // afterNextRender guarantees client-side execution, but not that ResizeObserver exists there
+    // (e.g. jsdom in specs) — guard per .claude/rules/ssr-safety.md.
+    if (!header || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) => this.headerHeightPx.set(entry.contentRect.height));
+    observer.observe(header);
+    this.destroyRef.onDestroy(() => observer.disconnect());
+  }
 
   private initTiles(): Signal<HealthMetricsOverviewTileViewModel[]> {
     return computed(() => {

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NgClass } from '@angular/common';
 import { Component, computed, inject, input, Signal } from '@angular/core';
 import { HEALTH_METRICS_OVERVIEW_AREAS, HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET } from '@lfx-one/shared/constants';
 import {
@@ -8,12 +9,19 @@ import {
   buildHealthMetricsOverviewTiles,
   buildLensAwareInsightsUrl,
   groupHealthMetricsOverviewFindings,
+  resolveHealthMetricsOverviewGroupMeta,
 } from '@lfx-one/shared/utils';
 import { ProjectContextService } from '@services/project-context.service';
 import { environment } from '@environments/environment';
 
-import { HEALTH_METRICS_OVERVIEW_FIXTURE_AREA_STATE, HEALTH_METRICS_OVERVIEW_FIXTURE_FINDINGS } from './health-metrics-overview.fixture';
+import {
+  HEALTH_METRICS_OVERVIEW_FIXTURE_AREA_STATE,
+  HEALTH_METRICS_OVERVIEW_FIXTURE_FINDINGS,
+  HEALTH_METRICS_OVERVIEW_FIXTURE_FOUNDATION_SUMMARY,
+  HEALTH_METRICS_OVERVIEW_FIXTURE_REVENUE,
+} from './health-metrics-overview.fixture';
 import { HealthMetricsOverviewFindingItemComponent } from './health-metrics-overview-finding-item/health-metrics-overview-finding-item.component';
+import { HealthMetricsOverviewRailComponent } from './health-metrics-overview-rail/health-metrics-overview-rail.component';
 import { HealthMetricsOverviewTileComponent } from './health-metrics-overview-tile/health-metrics-overview-tile.component';
 
 import type {
@@ -21,13 +29,18 @@ import type {
   HealthMetricsFinding,
   HealthMetricsOverviewFindingGroup,
   HealthMetricsOverviewFindingViewModel,
+  HealthMetricsOverviewFoundationSummary,
+  HealthMetricsOverviewRevenue,
   HealthMetricsOverviewTileViewModel,
   ProjectContext,
 } from '@lfx-one/shared/interfaces';
 
+/** Non-functional visual-only period selector (design's `.per`) — pinned to YTD until a real backend supports re-filtering. */
+const PERIODS = ['2023', '2024', '2025', 'YTD'] as const;
+
 @Component({
   selector: 'lfx-health-metrics-overview',
-  imports: [HealthMetricsOverviewTileComponent, HealthMetricsOverviewFindingItemComponent],
+  imports: [NgClass, HealthMetricsOverviewTileComponent, HealthMetricsOverviewFindingItemComponent, HealthMetricsOverviewRailComponent],
   templateUrl: './health-metrics-overview.component.html',
   styleUrl: './health-metrics-overview.component.scss',
 })
@@ -38,6 +51,12 @@ export class HealthMetricsOverviewComponent {
   // specs can pin the empty/missing-area/unsorted branches the fixture itself can't exercise.
   public readonly areaStates = input<HealthMetricsAreaState[]>(HEALTH_METRICS_OVERVIEW_FIXTURE_AREA_STATE);
   public readonly findings = input<HealthMetricsFinding[]>(HEALTH_METRICS_OVERVIEW_FIXTURE_FINDINGS);
+  public readonly revenue = input<HealthMetricsOverviewRevenue>(HEALTH_METRICS_OVERVIEW_FIXTURE_REVENUE);
+  public readonly foundationSummary = input<HealthMetricsOverviewFoundationSummary>(HEALTH_METRICS_OVERVIEW_FIXTURE_FOUNDATION_SUMMARY);
+
+  protected readonly periods = PERIODS;
+  // Non-functional for now (see PERIODS doc comment) — always YTD, never reassigned.
+  protected readonly selectedPeriod: (typeof PERIODS)[number] = 'YTD';
 
   protected readonly tiles: Signal<HealthMetricsOverviewTileViewModel[]> = this.initTiles();
   protected readonly findingGroups: Signal<HealthMetricsOverviewFindingGroup[]> = this.initFindingGroups();
@@ -59,10 +78,15 @@ export class HealthMetricsOverviewComponent {
       const foundation = this.projectContextService.selectedFoundation();
       const foundationSfid = this.projectContextService.selectedFoundationSfid();
 
-      return groupHealthMetricsOverviewFindings(this.findings()).map((groupRows) => ({
-        group: groupRows.group,
-        findings: groupRows.findings.map((finding) => HealthMetricsOverviewComponent.toFindingViewModel(finding, foundation, foundationSfid)),
-      }));
+      return groupHealthMetricsOverviewFindings(this.findings()).map((groupRows) => {
+        const groupMeta = resolveHealthMetricsOverviewGroupMeta(groupRows.group);
+        return {
+          group: groupRows.group,
+          groupTextClass: groupMeta.textClass,
+          groupIcon: groupMeta.icon,
+          findings: groupRows.findings.map((finding) => HealthMetricsOverviewComponent.toFindingViewModel(finding, foundation, foundationSfid)),
+        };
+      });
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
@@ -69,21 +69,9 @@ export class HealthMetricsOverviewComponent {
 
   private static readonly areaNameByKey = new Map(HEALTH_METRICS_OVERVIEW_AREAS.map((areaMeta) => [areaMeta.key, areaMeta.name]));
 
-  constructor() {
+  public constructor() {
     // afterNextRender only runs client-side, never during SSR — safe without an isPlatformBrowser guard.
     afterNextRender(() => this.observeHeaderHeight());
-  }
-
-  private observeHeaderHeight(): void {
-    const header = this.pageHeader()?.nativeElement;
-    // afterNextRender guarantees client-side execution, but not that ResizeObserver exists there
-    // (e.g. jsdom in specs) — guard per .claude/rules/ssr-safety.md.
-    if (!header || typeof ResizeObserver === 'undefined') {
-      return;
-    }
-    const observer = new ResizeObserver(([entry]) => this.headerHeightPx.set(entry.contentRect.height));
-    observer.observe(header);
-    this.destroyRef.onDestroy(() => observer.disconnect());
   }
 
   private initTiles(): Signal<HealthMetricsOverviewTileViewModel[]> {
@@ -112,6 +100,24 @@ export class HealthMetricsOverviewComponent {
     });
   }
 
+  private observeHeaderHeight(): void {
+    const header = this.pageHeader()?.nativeElement;
+    // afterNextRender guarantees client-side execution, but not that ResizeObserver exists there
+    // (e.g. jsdom in specs) — guard per .claude/rules/ssr-safety.md.
+    if (!header || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) => {
+      // contentRect is the content box only (excludes padding/border); this header has vertical
+      // padding, so border-box size is required to get its true rendered height. borderBoxSize
+      // isn't implemented in every engine (e.g. older Safari/jsdom) — fall back to getBoundingClientRect.
+      const height = entry.borderBoxSize?.[0]?.blockSize ?? header.getBoundingClientRect().height;
+      this.headerHeightPx.set(height);
+    });
+    observer.observe(header);
+    this.destroyRef.onDestroy(() => observer.disconnect());
+  }
+
   private static toFindingViewModel(
     finding: HealthMetricsFinding,
     foundation: ProjectContext | null,
@@ -130,6 +136,7 @@ export class HealthMetricsOverviewComponent {
       areaLabel: HealthMetricsOverviewComponent.areaNameByKey.get(finding.area) ?? finding.area,
       title: finding.title,
       sentence: finding.sentence,
+      // Carried through though the finding-item component doesn't render it — see HealthMetricsFinding.emphasis doc comment.
       emphasis: finding.emphasis,
       keyValue: finding.keyValue,
       keyLabel: finding.keyLabel,

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.component.ts
@@ -3,7 +3,7 @@
 
 import { NgClass } from '@angular/common';
 import { Component, computed, inject, input, Signal } from '@angular/core';
-import { HEALTH_METRICS_OVERVIEW_AREAS, HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET } from '@lfx-one/shared/constants';
+import { HEALTH_METRICS_OVERVIEW_AREAS, HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET, HEALTH_METRICS_OVERVIEW_PERIODS } from '@lfx-one/shared/constants';
 import {
   buildHealthMetricsOverviewPccUrl,
   buildHealthMetricsOverviewTiles,
@@ -35,9 +35,6 @@ import type {
   ProjectContext,
 } from '@lfx-one/shared/interfaces';
 
-/** Non-functional visual-only period selector (design's `.per`) — pinned to YTD until a real backend supports re-filtering. */
-const PERIODS = ['2023', '2024', '2025', 'YTD'] as const;
-
 @Component({
   selector: 'lfx-health-metrics-overview',
   imports: [NgClass, HealthMetricsOverviewTileComponent, HealthMetricsOverviewFindingItemComponent, HealthMetricsOverviewRailComponent],
@@ -54,9 +51,9 @@ export class HealthMetricsOverviewComponent {
   public readonly revenue = input<HealthMetricsOverviewRevenue>(HEALTH_METRICS_OVERVIEW_FIXTURE_REVENUE);
   public readonly foundationSummary = input<HealthMetricsOverviewFoundationSummary>(HEALTH_METRICS_OVERVIEW_FIXTURE_FOUNDATION_SUMMARY);
 
-  protected readonly periods = PERIODS;
-  // Non-functional for now (see PERIODS doc comment) — always YTD, never reassigned.
-  protected readonly selectedPeriod: (typeof PERIODS)[number] = 'YTD';
+  protected readonly periods = HEALTH_METRICS_OVERVIEW_PERIODS;
+  // Non-functional for now (see HEALTH_METRICS_OVERVIEW_PERIODS doc comment) — always YTD, never reassigned.
+  protected readonly selectedPeriod: (typeof HEALTH_METRICS_OVERVIEW_PERIODS)[number] = 'YTD';
 
   protected readonly tiles: Signal<HealthMetricsOverviewTileViewModel[]> = this.initTiles();
   protected readonly findingGroups: Signal<HealthMetricsOverviewFindingGroup[]> = this.initFindingGroups();
@@ -79,9 +76,10 @@ export class HealthMetricsOverviewComponent {
       const foundationSfid = this.projectContextService.selectedFoundationSfid();
 
       return groupHealthMetricsOverviewFindings(this.findings()).map((groupRows) => {
-        const groupMeta = resolveHealthMetricsOverviewGroupMeta(groupRows.group);
+        const groupMeta = resolveHealthMetricsOverviewGroupMeta(groupRows.classification);
         return {
           group: groupRows.group,
+          classification: groupRows.classification,
           groupTextClass: groupMeta.textClass,
           groupIcon: groupMeta.icon,
           findings: groupRows.findings.map((finding) => HealthMetricsOverviewComponent.toFindingViewModel(finding, foundation, foundationSfid)),

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.fixture.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.fixture.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HealthMetricsAreaState, HealthMetricsFinding } from '@lfx-one/shared/interfaces';
+import { HealthMetricsAreaState, HealthMetricsFinding, HealthMetricsOverviewFoundationSummary, HealthMetricsOverviewRevenue } from '@lfx-one/shared/interfaces';
 
 /**
  * Static fixture data standing in for LFXV2-3364's `hm_area_state` / `hm_findings` tables until
@@ -73,7 +73,7 @@ export const HEALTH_METRICS_OVERVIEW_FIXTURE_FINDINGS: HealthMetricsFinding[] = 
     linkTarget: 'evt.forecast',
     sortRank: 30,
     evaluatedAt: '2026-09-01',
-    visual: { kind: 'band', low: 55, high: 70, goal: 100, caption: 'Registration forecast vs. goal' },
+    visual: { kind: 'band', low: 55, high: 70, goal: 100, pred: 62, caption: 'Registration forecast vs. goal' },
   },
   {
     classification: 'watch',
@@ -124,3 +124,22 @@ export const HEALTH_METRICS_OVERVIEW_FIXTURE_FINDINGS: HealthMetricsFinding[] = 
     evaluatedAt: '2026-09-01',
   },
 ];
+
+/** Rail "Foundation Revenue" stand-in — mirrors the design's `d.revenue`. See the file header note on LFXV2-3364. */
+export const HEALTH_METRICS_OVERVIEW_FIXTURE_REVENUE: HealthMetricsOverviewRevenue = {
+  total: 2_450_000,
+  streams: [
+    { key: 'memberships', value: 1_680_000 },
+    { key: 'events', value: 540_000 },
+    { key: 'training', value: 230_000 },
+  ],
+};
+
+/** Rail "Foundation" block stand-in — mirrors the design's `RAIL[CUR]`. See the file header note on LFXV2-3364. */
+export const HEALTH_METRICS_OVERVIEW_FIXTURE_FOUNDATION_SUMMARY: HealthMetricsOverviewFoundationSummary = {
+  size: 'Large',
+  projects: 14,
+  tiers: '4 tiers',
+  board: '12 seats',
+  nextRenewals: '5 in the next 30 days',
+};

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.fixture.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics-overview/health-metrics-overview.fixture.ts
@@ -40,7 +40,7 @@ export const HEALTH_METRICS_OVERVIEW_FIXTURE_FINDINGS: HealthMetricsFinding[] = 
     linkTarget: 'eng.groups',
     sortRank: 10,
     evaluatedAt: '2026-09-01',
-    visual: { kind: 'dots', groups: [{ label: 'Groups below 50% attendance', filled: 8, total: 31 }] },
+    visual: { kind: 'dots', groups: [{ label: 'Groups below 50% attendance', filled: 8, total: 31 }], caption: 'Groups below 50% attendance' },
   },
   {
     classification: 'act',

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -14,6 +14,7 @@ import {
   GRID_DIVIDER_CLASS,
   GROUPS_ENGAGEMENT_ICON_CLASS,
   HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS,
+  HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS,
   lfxColors,
   lfxFontSizes,
   MENTION_PLATFORM_CONFIG,
@@ -109,6 +110,10 @@ export default {
     // Health Metrics Overview classification accents (HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS in
     // @lfx-one/shared, not scanned here) — applied via [ngClass] on tiles and finding rows.
     ...Object.values(HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS).flatMap((c) => [c.dotClass, c.accentClass, c.textClass].flatMap((s) => s.split(' '))),
+    // Health Metrics Overview revenue-stream legend dots (HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS in
+    // @lfx-one/shared, not scanned here) plus the UNKNOWN_REVENUE_STREAM_META fallback's bg-gray-400.
+    ...Object.values(HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS).flatMap((s) => s.dotClass.split(' ')),
+    'bg-gray-400',
   ],
   theme: {
     // `container.screens` only sizes the `.container` utility's max-width per breakpoint — it does

--- a/packages/shared/src/constants/health-metrics-overview.constants.ts
+++ b/packages/shared/src/constants/health-metrics-overview.constants.ts
@@ -7,24 +7,61 @@
  * Order here is the tile-strip render order — never re-sorted.
  */
 export const HEALTH_METRICS_OVERVIEW_AREAS = [
-  { key: 'eng', name: 'Engagement', icon: 'fa-light fa-handshake' },
+  { key: 'eng', name: 'Engagement', icon: 'fa-light fa-users' },
   { key: 'evt', name: 'Events', icon: 'fa-light fa-calendar' },
   { key: 'mem', name: 'Members', icon: 'fa-light fa-building' },
-  { key: 'non', name: 'Non-Members', icon: 'fa-light fa-magnifying-glass' },
+  { key: 'non', name: 'Non-Members', icon: 'fa-light fa-handshake' },
   { key: 'trn', name: 'Training', icon: 'fa-light fa-graduation-cap' },
   { key: 'code', name: 'Code', icon: 'fa-light fa-code-branch' },
 ] as const;
 
 /**
  * Urgency classification only — never category or size (logic spec hard constraint). Group name
- * is the fixed findings-list section a classification's rows render under.
+ * is the fixed findings-list section a classification's rows render under. `icon` matches the
+ * design's `TTONE`/group-header icon set 1:1 — the same icon drives both the tile status row and
+ * the finding-group heading.
  */
 export const HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS = {
-  act: { label: 'Needs action', group: 'Needs action', dotClass: 'bg-red-500', accentClass: 'border-l-red-500', textClass: 'text-red-600' },
-  watch: { label: 'Needs attention', group: 'Needs attention', dotClass: 'bg-amber-500', accentClass: 'border-l-amber-500', textClass: 'text-amber-600' },
-  opp: { label: 'Opportunity', group: 'Opportunities', dotClass: 'bg-blue-500', accentClass: 'border-l-blue-500', textClass: 'text-blue-600' },
-  ok: { label: 'Going well', group: 'Going well', dotClass: 'bg-emerald-500', accentClass: 'border-l-emerald-500', textClass: 'text-emerald-600' },
-  none: { label: 'Awaiting data', group: 'Awaiting data', dotClass: 'bg-gray-400', accentClass: 'border-l-gray-400', textClass: 'text-gray-500' },
+  act: {
+    label: 'Needs action',
+    group: 'Needs action',
+    icon: 'fa-light fa-circle-exclamation',
+    dotClass: 'bg-red-500',
+    accentClass: 'border-l-red-500',
+    textClass: 'text-red-600',
+  },
+  watch: {
+    label: 'Needs attention',
+    group: 'Needs attention',
+    icon: 'fa-light fa-triangle-exclamation',
+    dotClass: 'bg-amber-500',
+    accentClass: 'border-l-amber-500',
+    textClass: 'text-amber-600',
+  },
+  opp: {
+    label: 'Opportunity',
+    group: 'Opportunities',
+    icon: 'fa-light fa-lightbulb',
+    dotClass: 'bg-blue-500',
+    accentClass: 'border-l-blue-500',
+    textClass: 'text-blue-600',
+  },
+  ok: {
+    label: 'Going well',
+    group: 'Going well',
+    icon: 'fa-light fa-circle-check',
+    dotClass: 'bg-emerald-500',
+    accentClass: 'border-l-emerald-500',
+    textClass: 'text-emerald-600',
+  },
+  none: {
+    label: 'Awaiting data',
+    group: 'Awaiting data',
+    icon: 'fa-light fa-circle-info',
+    dotClass: 'bg-gray-400',
+    accentClass: 'border-l-gray-400',
+    textClass: 'text-gray-500',
+  },
 } as const;
 
 /** Findings-list section order — fixed, always rendered in this sequence; empty groups are hidden. */
@@ -56,3 +93,17 @@ export const HEALTH_METRICS_OVERVIEW_LINK_TARGETS = {
 
 /** The one `link_target` that opens externally (LFX Insights) instead of a PCC anchor. */
 export const HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET = 'code.insights';
+
+/**
+ * Rail revenue-stream metadata, keyed to match `railHTML()`'s fixed 3-stream legend. Colors mirror
+ * the design's `STREAM_COLOR` map (`#009aff`/`#00bc7d`/`#8e51ff`) — the closest `lfxColors` scales
+ * to those hexes are blue/emerald/violet-500, so the rail never hard-codes a hex value.
+ */
+export const HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS = {
+  memberships: { label: 'Memberships', dotClass: 'bg-blue-500' },
+  events: { label: 'Events', dotClass: 'bg-emerald-500' },
+  training: { label: 'Training', dotClass: 'bg-violet-500' },
+} as const;
+
+/** Fixed 5-tag "Data sources" list in the rail — same tags for every foundation, per `railHTML()`. */
+export const HEALTH_METRICS_OVERVIEW_DATA_SOURCES = ['Membership', 'Meetings', 'Events', 'Surveys', 'LFX Insights'] as const;

--- a/packages/shared/src/constants/health-metrics-overview.constants.ts
+++ b/packages/shared/src/constants/health-metrics-overview.constants.ts
@@ -64,14 +64,12 @@ export const HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS = {
   },
 } as const;
 
-/** Findings-list section order — fixed, always rendered in this sequence; empty groups are hidden. */
-export const HEALTH_METRICS_OVERVIEW_GROUP_ORDER = [
-  HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.act.group,
-  HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.watch.group,
-  HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.opp.group,
-  HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.ok.group,
-  HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none.group,
-] as const;
+/**
+ * Findings-list section order — fixed, always rendered in this sequence; empty groups are hidden.
+ * Classification keys (not display-string group labels) so a lookup back to tone/icon never has to
+ * reverse a label into a key.
+ */
+export const HEALTH_METRICS_OVERVIEW_GROUP_ORDER: (keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS)[] = ['act', 'watch', 'opp', 'ok', 'none'];
 
 /**
  * `link_target` → PCC anchor path, joined onto `…/project/{pcc_project_id}/reports/health-metrics`.
@@ -107,3 +105,6 @@ export const HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS = {
 
 /** Fixed 5-tag "Data sources" list in the rail — same tags for every foundation, per `railHTML()`. */
 export const HEALTH_METRICS_OVERVIEW_DATA_SOURCES = ['Membership', 'Meetings', 'Events', 'Surveys', 'LFX Insights'] as const;
+
+/** Non-functional visual-only period selector (design's `.per`) — pinned to YTD until a real backend supports re-filtering. */
+export const HEALTH_METRICS_OVERVIEW_PERIODS = ['2023', '2024', '2025', 'YTD'] as const;

--- a/packages/shared/src/constants/health-metrics-overview.constants.ts
+++ b/packages/shared/src/constants/health-metrics-overview.constants.ts
@@ -69,7 +69,13 @@ export const HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS = {
  * Classification keys (not display-string group labels) so a lookup back to tone/icon never has to
  * reverse a label into a key.
  */
-export const HEALTH_METRICS_OVERVIEW_GROUP_ORDER: (keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS)[] = ['act', 'watch', 'opp', 'ok', 'none'];
+export const HEALTH_METRICS_OVERVIEW_GROUP_ORDER = [
+  'act',
+  'watch',
+  'opp',
+  'ok',
+  'none',
+] as const satisfies readonly (keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS)[];
 
 /**
  * `link_target` → PCC anchor path, joined onto `…/project/{pcc_project_id}/reports/health-metrics`.

--- a/packages/shared/src/interfaces/health-metrics-overview.interface.ts
+++ b/packages/shared/src/interfaces/health-metrics-overview.interface.ts
@@ -63,7 +63,7 @@ export interface HealthMetricsFinding {
  * `low`–`high` predicted-range band) — all four values are percentages (0-100) on the same axis.
  */
 export type HealthMetricsFindingVisual =
-  | { kind: 'dots'; groups: HealthMetricsFindingVisualDotGroup[] }
+  | { kind: 'dots'; groups: HealthMetricsFindingVisualDotGroup[]; caption?: string }
   | ({ kind: 'bar' } & HealthMetricsFindingVisualBar)
   | { kind: 'band'; low: number; high: number; goal: number; pred: number; caption?: string }
   | { kind: 'tags'; tags: string[] };
@@ -120,6 +120,8 @@ export interface HealthMetricsOverviewFindingViewModel {
 /** One fixed findings-list section (per {@link HEALTH_METRICS_OVERVIEW_GROUP_ORDER}); hidden when empty. */
 export interface HealthMetricsOverviewFindingGroup {
   group: string;
+  /** The section's classification key — a stable lookup key for its tone/icon, independent of the display-string `group` label. */
+  classification: HealthMetricsOverviewClassification;
   /** The section's classification tone, as a Tailwind text-color class — colors the group heading. */
   groupTextClass: string;
   /** The section's classification icon (design's `TTONE`/group-header icon set) — same icon as the matching tile's status row. */
@@ -130,6 +132,7 @@ export interface HealthMetricsOverviewFindingGroup {
 /** Raw-{@link HealthMetricsFinding} counterpart of {@link HealthMetricsOverviewFindingGroup}, returned by `groupHealthMetricsOverviewFindings` before per-finding view-model mapping (link resolution needs foundation context the pure grouping function doesn't have). */
 export interface HealthMetricsOverviewFindingGroupRows {
   group: string;
+  classification: HealthMetricsOverviewClassification;
   findings: HealthMetricsFinding[];
 }
 

--- a/packages/shared/src/interfaces/health-metrics-overview.interface.ts
+++ b/packages/shared/src/interfaces/health-metrics-overview.interface.ts
@@ -52,6 +52,12 @@ export interface HealthMetricsFinding {
   keyValue: string;
   keyLabel: string;
   linkTarget: HealthMetricsOverviewLinkTarget;
+  /**
+   * Display order. Must be unique across the whole findings set (page-wide, not just within one
+   * classification group) — {@link HealthMetricsOverviewFindingViewModel.sortRank} relies on this
+   * for row-scoped ids. Whatever service layer maps `hm_findings.sort_rank` into this field must
+   * preserve that global uniqueness.
+   */
   sortRank: number;
   evaluatedAt: string;
   visual?: HealthMetricsFindingVisual;

--- a/packages/shared/src/interfaces/health-metrics-overview.interface.ts
+++ b/packages/shared/src/interfaces/health-metrics-overview.interface.ts
@@ -139,9 +139,10 @@ export interface HealthMetricsOverviewFindingGroupRows {
 /**
  * Precomputed dots-visual view model for `lfx-health-metrics-overview-finding-item`. Per the
  * design's `fviz()`, all of a finding's dot groups render as ONE flat row (not one row per group) —
- * `dots[i]` is `true` when that dot renders filled; `caption` is the first group's label, shown
- * below the row like the design's universal `fvs` sub-caption. Rendered dot count is capped and
- * proportionally scaled; see `health-metrics-overview-finding-item.component.ts`.
+ * `dots[i]` is `true` when that dot renders filled; `caption` is the visual's own free-text caption
+ * (design's `fvs` sub-caption), falling back to the first group's label when the finding didn't
+ * author one. Rendered dot count is capped and proportionally scaled; see
+ * `health-metrics-overview-finding-item.component.ts`.
  */
 export interface HealthMetricsFindingVisualDotsViewModel {
   dots: boolean[];
@@ -150,9 +151,10 @@ export interface HealthMetricsFindingVisualDotsViewModel {
 
 /**
  * Precomputed bar-visual view model for `lfx-health-metrics-overview-finding-item`. Per the
- * design's `fviz()`, a bar renders as a SINGLE fill sized to the sum of the authored parts'
- * `value`s (clamped to 100) in the finding's own classification tone — `parts[].tone` is authored
- * data (kept for a future per-segment rendering) but never individually rendered today.
+ * design's `fviz()`, a bar renders as a SINGLE fill in the finding's own classification tone,
+ * sized to the sum of the authored parts' `value`s whose `tone` matches that classification
+ * (clamped to 100) — falling back to summing every part when none match, so an authoring-only
+ * breakdown still renders something rather than a zero-width bar.
  */
 export interface HealthMetricsFindingVisualBarViewModel {
   fillPercent: number;

--- a/packages/shared/src/interfaces/health-metrics-overview.interface.ts
+++ b/packages/shared/src/interfaces/health-metrics-overview.interface.ts
@@ -185,6 +185,8 @@ export interface HealthMetricsOverviewFoundationSummary {
 
 /** Precomputed "Foundation Revenue" legend row for `lfx-health-metrics-overview-rail`. */
 export interface HealthMetricsOverviewRevenueStreamViewModel {
+  /** The raw `stream.key` — kept for `@for track`, since multiple degraded/unknown streams share the same fallback `label`. */
+  key: string;
   label: string;
   dotClass: string;
   /** Rounded, for the "N%" legend text only — see {@link HealthMetricsOverviewRevenueStreamViewModel.widthPercent} for the bar segment. */

--- a/packages/shared/src/interfaces/health-metrics-overview.interface.ts
+++ b/packages/shared/src/interfaces/health-metrics-overview.interface.ts
@@ -187,6 +187,9 @@ export interface HealthMetricsOverviewFoundationSummary {
 export interface HealthMetricsOverviewRevenueStreamViewModel {
   label: string;
   dotClass: string;
+  /** Rounded, for the "N%" legend text only — see {@link HealthMetricsOverviewRevenueStreamViewModel.widthPercent} for the bar segment. */
   percent: number;
+  /** Unrounded percent share, for the segmented bar's `[style.width.%]` — rounding each stream independently before sizing can leave a visible gap even when the raw shares sum to 100%. */
+  widthPercent: number;
   valueLabel: string;
 }

--- a/packages/shared/src/interfaces/health-metrics-overview.interface.ts
+++ b/packages/shared/src/interfaces/health-metrics-overview.interface.ts
@@ -6,6 +6,7 @@ import type {
   HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS,
   HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET,
   HEALTH_METRICS_OVERVIEW_LINK_TARGETS,
+  HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS,
 } from '../constants/health-metrics-overview.constants';
 
 /** Area key, fixed order per LFXV2-3365: Engagement, Events, Members, Non-Members, Training, Code. */
@@ -13,6 +14,9 @@ export type HealthMetricsOverviewArea = (typeof HEALTH_METRICS_OVERVIEW_AREAS)[n
 
 /** Urgency classification — never a category or a composite score, per the logic spec's hard constraints. */
 export type HealthMetricsOverviewClassification = keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS;
+
+/** A rail revenue-stream key — fixed 3-stream set per `railHTML()`'s legend. */
+export type HealthMetricsOverviewRevenueStreamKey = keyof typeof HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS;
 
 /** A recognized `hm_findings.link_target` value — every PCC anchor key plus the one external Insights target. */
 export type HealthMetricsOverviewLinkTarget = keyof typeof HEALTH_METRICS_OVERVIEW_LINK_TARGETS | typeof HEALTH_METRICS_OVERVIEW_INSIGHTS_LINK_TARGET;
@@ -35,8 +39,9 @@ export interface HealthMetricsAreaState {
  * Mirrors the `hm_findings` dbt table (LFXV2-3364) — one row per triggered rule per area/entity.
  * Fields are camelCase here; the mapping from the table's snake_case columns (`key_value`,
  * `link_target`, `sort_rank`, ...) is the responsibility of whatever service layer calls the API.
- * `sentence` is plain text with no markup; `emphasis`, when present, names the exact substring of
- * `sentence` the UI should render in bold — see `sentenceSegments` in the finding-item component.
+ * `sentence` is plain text with no markup. `emphasis`, when present, names a substring of `sentence`
+ * of potential future interest to callers — the finding-item component renders `sentence` as plain
+ * text (matching the design) and does not use this field.
  */
 export interface HealthMetricsFinding {
   classification: HealthMetricsOverviewClassification;
@@ -52,11 +57,15 @@ export interface HealthMetricsFinding {
   visual?: HealthMetricsFindingVisual;
 }
 
-/** Optional per-finding visual encoding (logic spec §8.7) — omitted for "good"/"none" classification findings. */
+/**
+ * Optional per-finding visual encoding (logic spec §8.7) — omitted for "good"/"none" classification
+ * findings. `band`'s `pred` is the point-prediction fill (design's `fband-pred`, painted over the
+ * `low`–`high` predicted-range band) — all four values are percentages (0-100) on the same axis.
+ */
 export type HealthMetricsFindingVisual =
   | { kind: 'dots'; groups: HealthMetricsFindingVisualDotGroup[] }
   | ({ kind: 'bar' } & HealthMetricsFindingVisualBar)
-  | { kind: 'band'; low: number; high: number; goal: number; caption?: string }
+  | { kind: 'band'; low: number; high: number; goal: number; pred: number; caption?: string }
   | { kind: 'tags'; tags: string[] };
 
 export interface HealthMetricsFindingVisualDotGroup {
@@ -111,6 +120,10 @@ export interface HealthMetricsOverviewFindingViewModel {
 /** One fixed findings-list section (per {@link HEALTH_METRICS_OVERVIEW_GROUP_ORDER}); hidden when empty. */
 export interface HealthMetricsOverviewFindingGroup {
   group: string;
+  /** The section's classification tone, as a Tailwind text-color class — colors the group heading. */
+  groupTextClass: string;
+  /** The section's classification icon (design's `TTONE`/group-header icon set) — same icon as the matching tile's status row. */
+  groupIcon: string;
   findings: HealthMetricsOverviewFindingViewModel[];
 }
 
@@ -120,25 +133,49 @@ export interface HealthMetricsOverviewFindingGroupRows {
   findings: HealthMetricsFinding[];
 }
 
-/** One segment of a finding's `sentence`, split around its optional `emphasis` substring — lets the template render bold text via interpolation instead of `[innerHTML]`. */
-export interface HealthMetricsSentenceSegment {
-  text: string;
-  bold: boolean;
-}
-
-/** Precomputed dot-cluster group ready for iteration — `dots[i]` is `true` when that dot renders filled. Rendered dot count is capped and proportionally scaled; see `health-metrics-overview-finding-item.component.ts`. */
-export interface HealthMetricsFindingVisualDotsGroupViewModel {
-  label: string;
+/**
+ * Precomputed dots-visual view model for `lfx-health-metrics-overview-finding-item`. Per the
+ * design's `fviz()`, all of a finding's dot groups render as ONE flat row (not one row per group) —
+ * `dots[i]` is `true` when that dot renders filled; `caption` is the first group's label, shown
+ * below the row like the design's universal `fvs` sub-caption. Rendered dot count is capped and
+ * proportionally scaled; see `health-metrics-overview-finding-item.component.ts`.
+ */
+export interface HealthMetricsFindingVisualDotsViewModel {
   dots: boolean[];
-}
-
-/** A {@link HealthMetricsFindingVisualBarPart} with its classification tone pre-resolved to a Tailwind color class, so the template never calls a method to look it up. */
-export interface HealthMetricsFindingVisualBarPartViewModel extends HealthMetricsFindingVisualBarPart {
-  toneClass: string;
-}
-
-/** Precomputed bar-visual view model for `lfx-health-metrics-overview-finding-item`. */
-export interface HealthMetricsFindingVisualBarViewModel {
-  parts: HealthMetricsFindingVisualBarPartViewModel[];
   caption?: string;
+}
+
+/**
+ * Precomputed bar-visual view model for `lfx-health-metrics-overview-finding-item`. Per the
+ * design's `fviz()`, a bar renders as a SINGLE fill sized to the sum of the authored parts'
+ * `value`s (clamped to 100) in the finding's own classification tone — `parts[].tone` is authored
+ * data (kept for a future per-segment rendering) but never individually rendered today.
+ */
+export interface HealthMetricsFindingVisualBarViewModel {
+  fillPercent: number;
+  toneClass: string;
+  caption?: string;
+}
+
+/** Rail "Foundation Revenue" raw data (LFXV2-3364 stand-in) — mirrors the design's `d.revenue`. */
+export interface HealthMetricsOverviewRevenue {
+  total: number;
+  streams: { key: HealthMetricsOverviewRevenueStreamKey; value: number }[];
+}
+
+/** Rail "Foundation" block raw data (LFXV2-3364 stand-in) — mirrors the design's `RAIL[CUR]` plus `d.code.projects`. */
+export interface HealthMetricsOverviewFoundationSummary {
+  size: string;
+  projects: number;
+  tiers: string;
+  board: string;
+  nextRenewals: string;
+}
+
+/** Precomputed "Foundation Revenue" legend row for `lfx-health-metrics-overview-rail`. */
+export interface HealthMetricsOverviewRevenueStreamViewModel {
+  label: string;
+  dotClass: string;
+  percent: number;
+  valueLabel: string;
 }

--- a/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
@@ -149,14 +149,30 @@ describe('buildHealthMetricsOverviewRevenueStreams', () => {
   it('computes each stream’s percent share of the total and formats its value', () => {
     const streams = buildHealthMetricsOverviewRevenueStreams(revenue());
     expect(streams).toEqual([
-      { label: 'Memberships', dotClass: 'bg-blue-500', percent: 60, valueLabel: expect.any(String) },
-      { label: 'Events', dotClass: 'bg-emerald-500', percent: 40, valueLabel: expect.any(String) },
+      { label: 'Memberships', dotClass: 'bg-blue-500', percent: 60, widthPercent: 60, valueLabel: expect.any(String) },
+      { label: 'Events', dotClass: 'bg-emerald-500', percent: 40, widthPercent: 40, valueLabel: expect.any(String) },
     ]);
   });
 
   it('reports 0% for every stream when the total is 0, instead of dividing by zero', () => {
     const streams = buildHealthMetricsOverviewRevenueStreams(revenue({ total: 0, streams: [{ key: 'training', value: 0 }] }));
     expect(streams[0].percent).toBe(0);
+    expect(streams[0].widthPercent).toBe(0);
+  });
+
+  it('keeps widthPercent unrounded so independently-rounded segments cannot leave the bar short of 100%', () => {
+    const streams = buildHealthMetricsOverviewRevenueStreams(
+      revenue({
+        total: 3,
+        streams: [
+          { key: 'memberships', value: 1 },
+          { key: 'events', value: 1 },
+          { key: 'training', value: 1 },
+        ],
+      })
+    );
+    expect(streams.map((stream) => stream.percent)).toEqual([33, 33, 33]);
+    expect(streams.reduce((sum, stream) => sum + stream.widthPercent, 0)).toBeCloseTo(100);
   });
 
   it('degrades an out-of-contract stream key to a fallback label/color instead of throwing', () => {

--- a/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
@@ -3,9 +3,15 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { buildHealthMetricsOverviewPccUrl, buildHealthMetricsOverviewTiles, groupHealthMetricsOverviewFindings } from './health-metrics-overview.utils';
+import {
+  buildHealthMetricsOverviewPccUrl,
+  buildHealthMetricsOverviewRevenueStreams,
+  buildHealthMetricsOverviewTiles,
+  groupHealthMetricsOverviewFindings,
+  resolveHealthMetricsOverviewGroupMeta,
+} from './health-metrics-overview.utils';
 
-import type { HealthMetricsAreaState, HealthMetricsFinding } from '../interfaces/health-metrics-overview.interface';
+import type { HealthMetricsAreaState, HealthMetricsFinding, HealthMetricsOverviewRevenue } from '../interfaces/health-metrics-overview.interface';
 
 function areaState(overrides: Partial<HealthMetricsAreaState> = {}): HealthMetricsAreaState {
   return {
@@ -65,6 +71,7 @@ describe('groupHealthMetricsOverviewFindings', () => {
   it('hides a group with no findings this period', () => {
     const groups = groupHealthMetricsOverviewFindings([finding({ classification: 'act' }), finding({ classification: 'ok' })]);
     expect(groups.map((group) => group.group)).toEqual(['Needs action', 'Going well']);
+    expect(groups.map((group) => group.classification)).toEqual(['act', 'ok']);
   });
 
   it('sorts findings within a group by sortRank, independent of input order', () => {
@@ -104,5 +111,44 @@ describe('buildHealthMetricsOverviewPccUrl', () => {
 
   it('returns undefined for a missing project id', () => {
     expect(buildHealthMetricsOverviewPccUrl('https://pcc.lfx.dev', '', 'eng.groups')).toBeUndefined();
+  });
+});
+
+describe('resolveHealthMetricsOverviewGroupMeta', () => {
+  it('resolves a known classification to its tone/icon', () => {
+    expect(resolveHealthMetricsOverviewGroupMeta('act')).toEqual({ textClass: 'text-red-600', icon: 'fa-light fa-circle-exclamation' });
+  });
+
+  it('degrades an out-of-contract classification to the neutral tone/icon instead of throwing', () => {
+    expect(resolveHealthMetricsOverviewGroupMeta('unknown' as HealthMetricsFinding['classification'])).toEqual({
+      textClass: 'text-gray-500',
+      icon: 'fa-light fa-circle-info',
+    });
+  });
+});
+
+describe('buildHealthMetricsOverviewRevenueStreams', () => {
+  function revenue(overrides: Partial<HealthMetricsOverviewRevenue> = {}): HealthMetricsOverviewRevenue {
+    return {
+      total: 100,
+      streams: [
+        { key: 'memberships', value: 60 },
+        { key: 'events', value: 40 },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('computes each stream’s percent share of the total and formats its value', () => {
+    const streams = buildHealthMetricsOverviewRevenueStreams(revenue());
+    expect(streams).toEqual([
+      { label: 'Memberships', dotClass: 'bg-blue-500', percent: 60, valueLabel: expect.any(String) },
+      { label: 'Events', dotClass: 'bg-emerald-500', percent: 40, valueLabel: expect.any(String) },
+    ]);
+  });
+
+  it('reports 0% for every stream when the total is 0, instead of dividing by zero', () => {
+    const streams = buildHealthMetricsOverviewRevenueStreams(revenue({ total: 0, streams: [{ key: 'training', value: 0 }] }));
+    expect(streams[0].percent).toBe(0);
   });
 });

--- a/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
@@ -3,6 +3,8 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS, HEALTH_METRICS_OVERVIEW_GROUP_ORDER } from '../constants/health-metrics-overview.constants';
+
 import {
   buildHealthMetricsOverviewPccUrl,
   buildHealthMetricsOverviewRevenueStreams,
@@ -11,7 +13,12 @@ import {
   resolveHealthMetricsOverviewGroupMeta,
 } from './health-metrics-overview.utils';
 
-import type { HealthMetricsAreaState, HealthMetricsFinding, HealthMetricsOverviewRevenue } from '../interfaces/health-metrics-overview.interface';
+import type {
+  HealthMetricsAreaState,
+  HealthMetricsFinding,
+  HealthMetricsOverviewRevenue,
+  HealthMetricsOverviewRevenueStreamKey,
+} from '../interfaces/health-metrics-overview.interface';
 
 function areaState(overrides: Partial<HealthMetricsAreaState> = {}): HealthMetricsAreaState {
   return {
@@ -150,5 +157,17 @@ describe('buildHealthMetricsOverviewRevenueStreams', () => {
   it('reports 0% for every stream when the total is 0, instead of dividing by zero', () => {
     const streams = buildHealthMetricsOverviewRevenueStreams(revenue({ total: 0, streams: [{ key: 'training', value: 0 }] }));
     expect(streams[0].percent).toBe(0);
+  });
+
+  it('degrades an out-of-contract stream key to a fallback label/color instead of throwing', () => {
+    const streams = buildHealthMetricsOverviewRevenueStreams(revenue({ streams: [{ key: 'unknown' as HealthMetricsOverviewRevenueStreamKey, value: 60 }] }));
+    expect(streams[0].label).toBe('Other');
+    expect(streams[0].dotClass).toBe('bg-gray-400');
+  });
+});
+
+describe('HEALTH_METRICS_OVERVIEW_GROUP_ORDER', () => {
+  it('is a permutation of every classification key, so the render order never silently drops a group', () => {
+    expect([...HEALTH_METRICS_OVERVIEW_GROUP_ORDER].sort()).toEqual(Object.keys(HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS).sort());
   });
 });

--- a/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.spec.ts
@@ -149,8 +149,8 @@ describe('buildHealthMetricsOverviewRevenueStreams', () => {
   it('computes each stream’s percent share of the total and formats its value', () => {
     const streams = buildHealthMetricsOverviewRevenueStreams(revenue());
     expect(streams).toEqual([
-      { label: 'Memberships', dotClass: 'bg-blue-500', percent: 60, widthPercent: 60, valueLabel: expect.any(String) },
-      { label: 'Events', dotClass: 'bg-emerald-500', percent: 40, widthPercent: 40, valueLabel: expect.any(String) },
+      { key: 'memberships', label: 'Memberships', dotClass: 'bg-blue-500', percent: 60, widthPercent: 60, valueLabel: expect.any(String) },
+      { key: 'events', label: 'Events', dotClass: 'bg-emerald-500', percent: 40, widthPercent: 40, valueLabel: expect.any(String) },
     ]);
   });
 
@@ -179,6 +179,19 @@ describe('buildHealthMetricsOverviewRevenueStreams', () => {
     const streams = buildHealthMetricsOverviewRevenueStreams(revenue({ streams: [{ key: 'unknown' as HealthMetricsOverviewRevenueStreamKey, value: 60 }] }));
     expect(streams[0].label).toBe('Other');
     expect(streams[0].dotClass).toBe('bg-gray-400');
+  });
+
+  it('preserves each stream’s own raw key even when two degrade to the same fallback label, so @for can track by a unique value', () => {
+    const streams = buildHealthMetricsOverviewRevenueStreams(
+      revenue({
+        streams: [
+          { key: 'unknown-a' as HealthMetricsOverviewRevenueStreamKey, value: 30 },
+          { key: 'unknown-b' as HealthMetricsOverviewRevenueStreamKey, value: 30 },
+        ],
+      })
+    );
+    expect(streams.map((stream) => stream.label)).toEqual(['Other', 'Other']);
+    expect(streams.map((stream) => stream.key)).toEqual(['unknown-a', 'unknown-b']);
   });
 });
 

--- a/packages/shared/src/utils/health-metrics-overview.utils.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.ts
@@ -6,15 +6,19 @@ import {
   HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS,
   HEALTH_METRICS_OVERVIEW_GROUP_ORDER,
   HEALTH_METRICS_OVERVIEW_LINK_TARGETS,
+  HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS,
 } from '../constants/health-metrics-overview.constants';
 
 import { formatIsoDateLabel } from './date-time.utils';
+import { formatCurrency } from './number.utils';
 
 import type {
   HealthMetricsAreaState,
   HealthMetricsFinding,
   HealthMetricsOverviewFindingGroupRows,
   HealthMetricsOverviewLinkTarget,
+  HealthMetricsOverviewRevenue,
+  HealthMetricsOverviewRevenueStreamViewModel,
   HealthMetricsOverviewTileViewModel,
 } from '../interfaces/health-metrics-overview.interface';
 
@@ -81,4 +85,29 @@ export function groupHealthMetricsOverviewFindings(findings: HealthMetricsFindin
 /** Shared `as of <date>` label for the overview tile strip and finding rows, so the copy never drifts between the two components. */
 export function formatHealthMetricsOverviewAsOfLabel(evaluatedAt: string): string {
   return `as of ${formatIsoDateLabel(evaluatedAt)}`;
+}
+
+// Group names are 1:1 with classifications (`HEALTH_METRICS_OVERVIEW_GROUP_ORDER` is built directly
+// from them), so this reverses that mapping once rather than re-scanning per render.
+const CLASSIFICATION_BY_GROUP = new Map<string, (typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS)[keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS]>(
+  Object.values(HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS).map((classification) => [classification.group, classification])
+);
+
+/** Resolves a findings-list group name to its classification's tone/icon, for the group heading. */
+export function resolveHealthMetricsOverviewGroupMeta(group: string): { textClass: string; icon: string } {
+  const classification = CLASSIFICATION_BY_GROUP.get(group) ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none;
+  return { textClass: classification.textClass, icon: classification.icon };
+}
+
+/** Builds the rail's "Foundation Revenue" legend rows — percent share and formatted total per stream. */
+export function buildHealthMetricsOverviewRevenueStreams(revenue: HealthMetricsOverviewRevenue): HealthMetricsOverviewRevenueStreamViewModel[] {
+  return revenue.streams.map((stream) => {
+    const meta = HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS[stream.key];
+    return {
+      label: meta.label,
+      dotClass: meta.dotClass,
+      percent: revenue.total > 0 ? Math.round((stream.value / revenue.total) * 100) : 0,
+      valueLabel: formatCurrency(stream.value),
+    };
+  });
 }

--- a/packages/shared/src/utils/health-metrics-overview.utils.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.ts
@@ -75,7 +75,7 @@ export function buildHealthMetricsOverviewTiles(areaStates: HealthMetricsAreaSta
  */
 export function groupHealthMetricsOverviewFindings(findings: HealthMetricsFinding[]): HealthMetricsOverviewFindingGroupRows[] {
   const resolvedClassification = (finding: HealthMetricsFinding): keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS =>
-    HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[finding.classification] ? finding.classification : 'none';
+    Object.hasOwn(HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS, finding.classification) ? finding.classification : 'none';
 
   return HEALTH_METRICS_OVERVIEW_GROUP_ORDER.map((classification) => ({
     group: HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[classification].group,
@@ -94,7 +94,9 @@ export function resolveHealthMetricsOverviewGroupMeta(classification: keyof type
   textClass: string;
   icon: string;
 } {
-  const meta = HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[classification] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none;
+  const meta = Object.hasOwn(HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS, classification)
+    ? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[classification]
+    : HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none;
   return { textClass: meta.textClass, icon: meta.icon };
 }
 
@@ -104,11 +106,17 @@ const UNKNOWN_REVENUE_STREAM_META = { label: 'Other', dotClass: 'bg-gray-400' } 
 /** Builds the rail's "Foundation Revenue" legend rows — percent share and formatted total per stream. */
 export function buildHealthMetricsOverviewRevenueStreams(revenue: HealthMetricsOverviewRevenue): HealthMetricsOverviewRevenueStreamViewModel[] {
   return revenue.streams.map((stream) => {
-    const meta = HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS[stream.key] ?? UNKNOWN_REVENUE_STREAM_META;
+    const meta = Object.hasOwn(HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS, stream.key)
+      ? HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS[stream.key]
+      : UNKNOWN_REVENUE_STREAM_META;
+    // widthPercent stays unrounded for the bar segment — rounding each stream independently (as
+    // `percent`, kept for the legend text) before sizing can leave the segmented bar short of 100%.
+    const widthPercent = revenue.total > 0 ? (stream.value / revenue.total) * 100 : 0;
     return {
       label: meta.label,
       dotClass: meta.dotClass,
-      percent: revenue.total > 0 ? Math.round((stream.value / revenue.total) * 100) : 0,
+      percent: Math.round(widthPercent),
+      widthPercent,
       valueLabel: formatCurrency(stream.value),
     };
   });

--- a/packages/shared/src/utils/health-metrics-overview.utils.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.ts
@@ -74,11 +74,13 @@ export function buildHealthMetricsOverviewTiles(areaStates: HealthMetricsAreaSta
  * out-of-contract classification degrades to the neutral 'none' group instead of throwing.
  */
 export function groupHealthMetricsOverviewFindings(findings: HealthMetricsFinding[]): HealthMetricsOverviewFindingGroupRows[] {
-  return HEALTH_METRICS_OVERVIEW_GROUP_ORDER.map((group) => ({
-    group,
-    findings: findings
-      .filter((finding) => (HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[finding.classification] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none).group === group)
-      .sort((a, b) => a.sortRank - b.sortRank),
+  const resolvedClassification = (finding: HealthMetricsFinding): keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS =>
+    HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[finding.classification] ? finding.classification : 'none';
+
+  return HEALTH_METRICS_OVERVIEW_GROUP_ORDER.map((classification) => ({
+    group: HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[classification].group,
+    classification,
+    findings: findings.filter((finding) => resolvedClassification(finding) === classification).sort((a, b) => a.sortRank - b.sortRank),
   })).filter((groupRows) => groupRows.findings.length > 0);
 }
 
@@ -87,16 +89,13 @@ export function formatHealthMetricsOverviewAsOfLabel(evaluatedAt: string): strin
   return `as of ${formatIsoDateLabel(evaluatedAt)}`;
 }
 
-// Group names are 1:1 with classifications (`HEALTH_METRICS_OVERVIEW_GROUP_ORDER` is built directly
-// from them), so this reverses that mapping once rather than re-scanning per render.
-const CLASSIFICATION_BY_GROUP = new Map<string, (typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS)[keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS]>(
-  Object.values(HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS).map((classification) => [classification.group, classification])
-);
-
-/** Resolves a findings-list group name to its classification's tone/icon, for the group heading. */
-export function resolveHealthMetricsOverviewGroupMeta(group: string): { textClass: string; icon: string } {
-  const classification = CLASSIFICATION_BY_GROUP.get(group) ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none;
-  return { textClass: classification.textClass, icon: classification.icon };
+/** Resolves a findings-list group's classification key to its tone/icon, for the group heading. */
+export function resolveHealthMetricsOverviewGroupMeta(classification: keyof typeof HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS): {
+  textClass: string;
+  icon: string;
+} {
+  const meta = HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS[classification] ?? HEALTH_METRICS_OVERVIEW_CLASSIFICATIONS.none;
+  return { textClass: meta.textClass, icon: meta.icon };
 }
 
 /** Builds the rail's "Foundation Revenue" legend rows — percent share and formatted total per stream. */

--- a/packages/shared/src/utils/health-metrics-overview.utils.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.ts
@@ -113,6 +113,7 @@ export function buildHealthMetricsOverviewRevenueStreams(revenue: HealthMetricsO
     // `percent`, kept for the legend text) before sizing can leave the segmented bar short of 100%.
     const widthPercent = revenue.total > 0 ? (stream.value / revenue.total) * 100 : 0;
     return {
+      key: stream.key,
       label: meta.label,
       dotClass: meta.dotClass,
       percent: Math.round(widthPercent),

--- a/packages/shared/src/utils/health-metrics-overview.utils.ts
+++ b/packages/shared/src/utils/health-metrics-overview.utils.ts
@@ -98,10 +98,13 @@ export function resolveHealthMetricsOverviewGroupMeta(classification: keyof type
   return { textClass: meta.textClass, icon: meta.icon };
 }
 
+/** Fallback legend metadata for a `stream.key` outside the fixed 3-stream set, so a degraded upstream row still renders instead of throwing. */
+const UNKNOWN_REVENUE_STREAM_META = { label: 'Other', dotClass: 'bg-gray-400' } as const;
+
 /** Builds the rail's "Foundation Revenue" legend rows — percent share and formatted total per stream. */
 export function buildHealthMetricsOverviewRevenueStreams(revenue: HealthMetricsOverviewRevenue): HealthMetricsOverviewRevenueStreamViewModel[] {
   return revenue.streams.map((stream) => {
-    const meta = HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS[stream.key];
+    const meta = HEALTH_METRICS_OVERVIEW_REVENUE_STREAMS[stream.key] ?? UNKNOWN_REVENUE_STREAM_META;
     return {
       label: meta.label,
       dotClass: meta.dotClass,


### PR DESCRIPTION
## Summary

- Add a rail/sidebar (Foundation Revenue, Foundation summary, Data sources) alongside the tile strip and findings list, matching the design's two-column layout
- Add a visual-only period selector (2023/2024/2025/YTD) and Export button to the page header — non-functional until a real backend supports filtering/export
- Restructure the tile strip and findings list into shared bordered cards with dividers, replacing individual per-item borders/shadows
- Fix typography, spacing, and chart visuals (dots/bar/band/tags) across tiles and finding rows to match the design's exact values
- Color findings-group headers per classification tone with a trailing divider line; thin the findings' left accent from 4px to 2px, and drop it entirely from tiles
- Swap the Engagement/Non-Members icons to match the design's assignment
- Fix a sticky-header height measurement bug (border-box vs. content-box) and related accessibility gaps (aria-disabled vs. disabled, aria-labelledby wiring on chart captions, ARIA roles on visuals)
- Extend unit test coverage across the touched components and shared utils

Refs LFXV2-3365