### PR TITLE
fix(groups): keep public directory pages on SSR content at hydration

### DIFF
--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -3,14 +3,14 @@
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef, makeStateKey, PLATFORM_ID, TransferState } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, ParamMap, provideRouter } from '@angular/router';
+import type { PublicGroupDirectoryPageState, PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
 import { GroupService } from '@services/group.service';
 import { headerTestProviders, installMatchMediaShim } from '@shared/testing/header-test-providers';
-import { of } from 'rxjs';
-import { beforeAll, describe, expect, it } from 'vitest';
-
-import type { PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PublicFoundationGroupsComponent } from './public-foundation-groups.component';
 
@@ -41,11 +41,11 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
       imports: [PublicFoundationGroupsComponent],
       providers: [
         { provide: GroupService, useValue: { getPublicFoundationGroups: () => of(response) } },
-        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['foundationSlug', slug]])) } },
         ...headerTestProviders(),
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['foundationSlug', slug]])) } },
       ],
     }).compileComponents();
 
@@ -184,5 +184,149 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     const rowClasses = (row?.className ?? '').split(/\s+/);
     expect(rowClasses).toContain('has-[.peer:hover]:border-blue-200');
     expect(rowClasses).toContain('has-[.peer:hover]:bg-blue-50/30');
+  });
+});
+
+const FOUNDATION_GROUPS_STATE_KEY = makeStateKey<PublicGroupDirectoryPageState>('publicFoundationGroupsState');
+
+describe('PublicFoundationGroupsComponent — TransferState seeding (GH-2081 companion)', () => {
+  let getPublicFoundationGroups: ReturnType<typeof vi.fn>;
+  let paramMap$: BehaviorSubject<ParamMap>;
+
+  const directory = (): PublicGroupDirectoryResponse => ({ groups: [group()], total: 1 });
+  const seededSuccess = (): PublicGroupDirectoryPageState => ({ loading: false, error: false, directory: directory() });
+  const seededError = (): PublicGroupDirectoryPageState => ({ loading: false, error: true, directory: null });
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    paramMap$ = new BehaviorSubject<ParamMap>(convertToParamMap({ foundationSlug: 'uepf' }));
+    getPublicFoundationGroups = vi.fn(() => of(directory()));
+
+    await TestBed.configureTestingModule({
+      imports: [PublicFoundationGroupsComponent],
+      providers: [
+        { provide: GroupService, useValue: { getPublicFoundationGroups } },
+        ...headerTestProviders(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+      ],
+    }).compileComponents();
+  });
+
+  it('paints synchronously from a browser TransferState seed with no skeleton flash', () => {
+    const transferState = TestBed.inject(TransferState);
+    transferState.set(FOUNDATION_GROUPS_STATE_KEY, seededSuccess());
+
+    const fixture = TestBed.createComponent(PublicFoundationGroupsComponent);
+    const component = fixture.componentInstance as unknown as { loading: () => boolean; fetchError: () => boolean };
+
+    // Assert before any stabilization — the regression this guards against only reproduces if
+    // the seed lands after the first CD pass.
+    expect(component.loading()).toBe(false);
+    expect(component.fetchError()).toBe(false);
+    expect(transferState.get(FOUNDATION_GROUPS_STATE_KEY, null)).toBeNull();
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]')).not.toBeNull();
+  });
+
+  it('shows the skeleton on the initial render when there is no seed and the fetch has not resolved yet', () => {
+    getPublicFoundationGroups.mockReturnValue(new Subject<PublicGroupDirectoryResponse>());
+
+    const fixture = TestBed.createComponent(PublicFoundationGroupsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-list"]')).toBeNull();
+  });
+
+  it('holds the seeded directory, without an intermediate skeleton flash, while the hydration refetch is in flight', async () => {
+    // Held open so there is an in-flight window between the first paint and the refetch settling —
+    // otherwise a startWith(loading) + sync of() would both land in one tick and hide a regression.
+    const refetch$ = new Subject<PublicGroupDirectoryResponse>();
+    getPublicFoundationGroups.mockReturnValue(refetch$);
+
+    TestBed.inject(TransferState).set(FOUNDATION_GROUPS_STATE_KEY, seededSuccess());
+
+    const fixture = TestBed.createComponent(PublicFoundationGroupsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]')).not.toBeNull();
+
+    refetch$.next(directory());
+    refetch$.complete();
+    await TestBed.inject(ApplicationRef).whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]')).not.toBeNull();
+  });
+
+  it('paints the error branch synchronously from a seeded terminal-error transfer state, with no skeleton flash', () => {
+    const refetch$ = new Subject<PublicGroupDirectoryResponse>();
+    getPublicFoundationGroups.mockReturnValue(refetch$);
+
+    TestBed.inject(TransferState).set(FOUNDATION_GROUPS_STATE_KEY, seededError());
+
+    const fixture = TestBed.createComponent(PublicFoundationGroupsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-error"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).toBeNull();
+  });
+
+  it('persists the resolved directory to TransferState on the server once the fetch settles', async () => {
+    TestBed.overrideProvider(PLATFORM_ID, { useValue: 'server' });
+
+    TestBed.createComponent(PublicFoundationGroupsComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const seeded = TestBed.inject(TransferState).get(FOUNDATION_GROUPS_STATE_KEY, null);
+    expect(seeded?.loading).toBe(false);
+    expect(seeded?.error).toBe(false);
+    expect(seeded?.directory?.total).toBe(1);
+    expect(seeded?.directory?.groups[0]?.uid).toBe('g1');
+  });
+
+  it('persists the error branch to TransferState on the server on a fetch failure', async () => {
+    TestBed.overrideProvider(PLATFORM_ID, { useValue: 'server' });
+    getPublicFoundationGroups.mockReturnValue(throwError(() => ({ status: 500 })));
+
+    TestBed.createComponent(PublicFoundationGroupsComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const seeded = TestBed.inject(TransferState).get(FOUNDATION_GROUPS_STATE_KEY, null);
+    expect(seeded?.loading).toBe(false);
+    expect(seeded?.error).toBe(true);
+    expect(seeded?.directory).toBeNull();
+  });
+
+  it('re-enters loading when the foundation slug changes after the seeded first paint', async () => {
+    TestBed.inject(TransferState).set(FOUNDATION_GROUPS_STATE_KEY, seededSuccess());
+    getPublicFoundationGroups.mockReturnValue(new Subject<PublicGroupDirectoryResponse>());
+
+    const fixture = TestBed.createComponent(PublicFoundationGroupsComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]')).not.toBeNull();
+
+    const nextFetch$ = new Subject<PublicGroupDirectoryResponse>();
+    getPublicFoundationGroups.mockReturnValue(nextFetch$);
+    paramMap$.next(convertToParamMap({ foundationSlug: 'cncf' }));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-list"]')).toBeNull();
+
+    nextFetch$.next({ groups: [group({ uid: 'g2', name: 'WG Observability' })], total: 1 });
+    nextFetch$.complete();
+    await TestBed.inject(ApplicationRef).whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g2"]')).not.toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.ts
@@ -1,18 +1,18 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { Component, computed, inject, makeStateKey, PLATFORM_ID, Signal, TransferState } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { BEHAVIORAL_CLASS_CONFIG, JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
-import type { GroupBehavioralClass, PublicGroupDirectoryVm } from '@lfx-one/shared/interfaces';
+import type { GroupBehavioralClass, PublicGroupDirectoryPageState, PublicGroupDirectoryVm } from '@lfx-one/shared/interfaces';
 import { TagComponent } from '@components/tag/tag.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { HeaderComponent } from '@components/header/header.component';
 import { GroupService } from '@services/group.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, distinctUntilChanged, map, of, startWith, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'lfx-public-foundation-groups',
@@ -22,39 +22,62 @@ import { catchError, map, of, switchMap } from 'rxjs';
 export class PublicFoundationGroupsComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly groupService = inject(GroupService);
+  private readonly transferState = inject(TransferState);
+  private readonly platformId = inject(PLATFORM_ID);
 
-  protected readonly loading = signal(true);
-  protected readonly fetchError = signal(false);
+  // Persists the SSR-resolved directory so the client's first paint matches the server DOM instead
+  // of tearing it down at hydration (companion to GH-2081). Same pattern as `PublicProfilePageComponent`.
+  private readonly stateKey = makeStateKey<PublicGroupDirectoryPageState>('publicFoundationGroupsState');
 
-  private readonly directoryData = toSignal(
-    this.route.paramMap.pipe(
-      map((params) => params.get('foundationSlug') ?? ''),
-      switchMap((slug) => {
-        this.loading.set(true);
-        this.fetchError.set(false);
-        return this.groupService.getPublicFoundationGroups(slug).pipe(
-          map((response) => {
-            this.loading.set(false);
-            return response;
-          }),
-          catchError(() => {
-            this.loading.set(false);
-            this.fetchError.set(true);
-            return of(null);
-          })
-        );
-      })
-    )
-  );
+  // Single source of truth for the async page state; loading/error/directory derive from it.
+  private readonly state: Signal<PublicGroupDirectoryPageState> = this.initDirectory();
+
+  protected readonly loading = computed(() => this.state().loading);
+  protected readonly fetchError = computed(() => this.state().error);
 
   protected readonly groupsVm: Signal<PublicGroupDirectoryVm[]> = computed(() =>
-    (this.directoryData()?.groups ?? []).map((g) => ({
+    (this.state().directory?.groups ?? []).map((g) => ({
       ...g,
       classConfig: BEHAVIORAL_CLASS_CONFIG[g.behavioral_class as GroupBehavioralClass] ?? BEHAVIORAL_CLASS_CONFIG['other'],
       joinLabel: g.join_mode ? JOIN_MODE_LABELS[g.join_mode] : undefined,
     }))
   );
 
-  protected readonly total: Signal<number> = computed(() => this.directoryData()?.total ?? 0);
-  protected readonly foundationName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_name ?? '');
+  protected readonly total: Signal<number> = computed(() => this.state().directory?.total ?? 0);
+  protected readonly foundationName: Signal<string> = computed(() => this.state().directory?.groups[0]?.context?.foundation_name ?? '');
+
+  private initDirectory(): Signal<PublicGroupDirectoryPageState> {
+    const initial: PublicGroupDirectoryPageState = { loading: true, error: false, directory: null };
+    // Seed the client's first paint from the SSR-serialized state (matches the server's resolved
+    // branch, no skeleton flash). Null on the server and on client navigations with no prior SSR state.
+    const transferred = this.transferState.get(this.stateKey, null);
+    // Consume the SSR state exactly once so a later re-creation of this component (e.g. a different
+    // `/foundations/:foundationSlug/groups`) can't paint the previous foundation's directory under the new URL.
+    if (isPlatformBrowser(this.platformId) && transferred) {
+      this.transferState.remove(this.stateKey);
+    }
+    return toSignal(
+      this.route.paramMap.pipe(
+        map((params) => params.get('foundationSlug') ?? ''),
+        distinctUntilChanged(),
+        switchMap((slug, index) =>
+          this.groupService.getPublicFoundationGroups(slug).pipe(
+            map((directory): PublicGroupDirectoryPageState => ({ loading: false, error: false, directory })),
+            catchError(() => of<PublicGroupDirectoryPageState>({ loading: false, error: true, directory: null })),
+            // During SSR, persist each resolved (non-loading) state so the client can hydrate to the
+            // same branch. Angular defers serialization until this tracked HTTP call settles.
+            tap((state) => {
+              if (isPlatformServer(this.platformId) && !state.loading) {
+                this.transferState.set(this.stateKey, state);
+              }
+            }),
+            // Seed the first client emission from the SSR state to avoid a loading flash and a
+            // hydration mismatch; every later fetch (and each client-side navigation) re-enters loading.
+            startWith(index === 0 && transferred ? transferred : initial)
+          )
+        )
+      ),
+      { initialValue: transferred ?? initial }
+    );
+  }
 }

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -3,14 +3,14 @@
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef, makeStateKey, PLATFORM_ID, TransferState } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, ParamMap, provideRouter } from '@angular/router';
+import type { PublicGroupDirectoryPageState, PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
 import { GroupService } from '@services/group.service';
 import { headerTestProviders, installMatchMediaShim } from '@shared/testing/header-test-providers';
-import { of } from 'rxjs';
-import { beforeAll, describe, expect, it } from 'vitest';
-
-import type { PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PublicProjectGroupsComponent } from './public-project-groups.component';
 
@@ -44,11 +44,11 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
       imports: [PublicProjectGroupsComponent],
       providers: [
         { provide: GroupService, useValue: { getPublicProjectGroups: () => of(response) } },
-        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['projectSlug', slug]])) } },
         ...headerTestProviders(),
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['projectSlug', slug]])) } },
       ],
     }).compileComponents();
 
@@ -173,5 +173,149 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     const rowClasses = (row?.className ?? '').split(/\s+/);
     expect(rowClasses).toContain('has-[.peer:hover]:border-blue-200');
     expect(rowClasses).toContain('has-[.peer:hover]:bg-blue-50/30');
+  });
+});
+
+const PROJECT_GROUPS_STATE_KEY = makeStateKey<PublicGroupDirectoryPageState>('publicProjectGroupsState');
+
+describe('PublicProjectGroupsComponent — TransferState seeding (GH-2081)', () => {
+  let getPublicProjectGroups: ReturnType<typeof vi.fn>;
+  let paramMap$: BehaviorSubject<ParamMap>;
+
+  const directory = (): PublicGroupDirectoryResponse => ({ groups: [group()], total: 1 });
+  const seededSuccess = (): PublicGroupDirectoryPageState => ({ loading: false, error: false, directory: directory() });
+  const seededError = (): PublicGroupDirectoryPageState => ({ loading: false, error: true, directory: null });
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    paramMap$ = new BehaviorSubject<ParamMap>(convertToParamMap({ projectSlug: 'kubernetes' }));
+    getPublicProjectGroups = vi.fn(() => of(directory()));
+
+    await TestBed.configureTestingModule({
+      imports: [PublicProjectGroupsComponent],
+      providers: [
+        { provide: GroupService, useValue: { getPublicProjectGroups } },
+        ...headerTestProviders(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
+      ],
+    }).compileComponents();
+  });
+
+  it('paints synchronously from a browser TransferState seed with no skeleton flash', () => {
+    const transferState = TestBed.inject(TransferState);
+    transferState.set(PROJECT_GROUPS_STATE_KEY, seededSuccess());
+
+    const fixture = TestBed.createComponent(PublicProjectGroupsComponent);
+    const component = fixture.componentInstance as unknown as { loading: () => boolean; fetchError: () => boolean };
+
+    // Assert before any stabilization — the regression this guards against only reproduces if
+    // the seed lands after the first CD pass.
+    expect(component.loading()).toBe(false);
+    expect(component.fetchError()).toBe(false);
+    expect(transferState.get(PROJECT_GROUPS_STATE_KEY, null)).toBeNull();
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]')).not.toBeNull();
+  });
+
+  it('shows the skeleton on the initial render when there is no seed and the fetch has not resolved yet', () => {
+    getPublicProjectGroups.mockReturnValue(new Subject<PublicGroupDirectoryResponse>());
+
+    const fixture = TestBed.createComponent(PublicProjectGroupsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-list"]')).toBeNull();
+  });
+
+  it('holds the seeded directory, without an intermediate skeleton flash, while the hydration refetch is in flight', async () => {
+    // Held open so there is an in-flight window between the first paint and the refetch settling —
+    // otherwise a startWith(loading) + sync of() would both land in one tick and hide a regression.
+    const refetch$ = new Subject<PublicGroupDirectoryResponse>();
+    getPublicProjectGroups.mockReturnValue(refetch$);
+
+    TestBed.inject(TransferState).set(PROJECT_GROUPS_STATE_KEY, seededSuccess());
+
+    const fixture = TestBed.createComponent(PublicProjectGroupsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]')).not.toBeNull();
+
+    refetch$.next(directory());
+    refetch$.complete();
+    await TestBed.inject(ApplicationRef).whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]')).not.toBeNull();
+  });
+
+  it('paints the error branch synchronously from a seeded terminal-error transfer state, with no skeleton flash', () => {
+    const refetch$ = new Subject<PublicGroupDirectoryResponse>();
+    getPublicProjectGroups.mockReturnValue(refetch$);
+
+    TestBed.inject(TransferState).set(PROJECT_GROUPS_STATE_KEY, seededError());
+
+    const fixture = TestBed.createComponent(PublicProjectGroupsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-error"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).toBeNull();
+  });
+
+  it('persists the resolved directory to TransferState on the server once the fetch settles', async () => {
+    TestBed.overrideProvider(PLATFORM_ID, { useValue: 'server' });
+
+    TestBed.createComponent(PublicProjectGroupsComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const seeded = TestBed.inject(TransferState).get(PROJECT_GROUPS_STATE_KEY, null);
+    expect(seeded?.loading).toBe(false);
+    expect(seeded?.error).toBe(false);
+    expect(seeded?.directory?.total).toBe(1);
+    expect(seeded?.directory?.groups[0]?.uid).toBe('g1');
+  });
+
+  it('persists the error branch to TransferState on the server on a fetch failure', async () => {
+    TestBed.overrideProvider(PLATFORM_ID, { useValue: 'server' });
+    getPublicProjectGroups.mockReturnValue(throwError(() => ({ status: 500 })));
+
+    TestBed.createComponent(PublicProjectGroupsComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    const seeded = TestBed.inject(TransferState).get(PROJECT_GROUPS_STATE_KEY, null);
+    expect(seeded?.loading).toBe(false);
+    expect(seeded?.error).toBe(true);
+    expect(seeded?.directory).toBeNull();
+  });
+
+  it('re-enters loading when the project slug changes after the seeded first paint', async () => {
+    TestBed.inject(TransferState).set(PROJECT_GROUPS_STATE_KEY, seededSuccess());
+    getPublicProjectGroups.mockReturnValue(new Subject<PublicGroupDirectoryResponse>());
+
+    const fixture = TestBed.createComponent(PublicProjectGroupsComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]')).not.toBeNull();
+
+    const nextFetch$ = new Subject<PublicGroupDirectoryResponse>();
+    getPublicProjectGroups.mockReturnValue(nextFetch$);
+    paramMap$.next(convertToParamMap({ projectSlug: 'prometheus' }));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-list"]')).toBeNull();
+
+    nextFetch$.next({ groups: [group({ uid: 'g2', name: 'WG Observability' })], total: 1 });
+    nextFetch$.complete();
+    await TestBed.inject(ApplicationRef).whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-skeleton"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g2"]')).not.toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.ts
@@ -1,18 +1,18 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { Component, computed, inject, makeStateKey, PLATFORM_ID, Signal, TransferState } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { BEHAVIORAL_CLASS_CONFIG, JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
-import type { GroupBehavioralClass, PublicGroupDirectoryVm } from '@lfx-one/shared/interfaces';
+import type { GroupBehavioralClass, PublicGroupDirectoryPageState, PublicGroupDirectoryVm } from '@lfx-one/shared/interfaces';
 import { TagComponent } from '@components/tag/tag.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { HeaderComponent } from '@components/header/header.component';
 import { GroupService } from '@services/group.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, distinctUntilChanged, map, of, startWith, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'lfx-public-project-groups',
@@ -22,40 +22,63 @@ import { catchError, map, of, switchMap } from 'rxjs';
 export class PublicProjectGroupsComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly groupService = inject(GroupService);
+  private readonly transferState = inject(TransferState);
+  private readonly platformId = inject(PLATFORM_ID);
 
-  protected readonly loading = signal(true);
-  protected readonly fetchError = signal(false);
+  // Persists the SSR-resolved directory so the client's first paint matches the server DOM instead
+  // of tearing it down at hydration (GH-2081). Same pattern as `PublicProfilePageComponent`.
+  private readonly stateKey = makeStateKey<PublicGroupDirectoryPageState>('publicProjectGroupsState');
 
-  private readonly directoryData = toSignal(
-    this.route.paramMap.pipe(
-      map((params) => params.get('projectSlug') ?? ''),
-      switchMap((slug) => {
-        this.loading.set(true);
-        this.fetchError.set(false);
-        return this.groupService.getPublicProjectGroups(slug).pipe(
-          map((response) => {
-            this.loading.set(false);
-            return response;
-          }),
-          catchError(() => {
-            this.loading.set(false);
-            this.fetchError.set(true);
-            return of(null);
-          })
-        );
-      })
-    )
-  );
+  // Single source of truth for the async page state; loading/error/directory derive from it.
+  private readonly state: Signal<PublicGroupDirectoryPageState> = this.initDirectory();
+
+  protected readonly loading = computed(() => this.state().loading);
+  protected readonly fetchError = computed(() => this.state().error);
 
   protected readonly groupsVm: Signal<PublicGroupDirectoryVm[]> = computed(() =>
-    (this.directoryData()?.groups ?? []).map((g) => ({
+    (this.state().directory?.groups ?? []).map((g) => ({
       ...g,
       classConfig: BEHAVIORAL_CLASS_CONFIG[g.behavioral_class as GroupBehavioralClass] ?? BEHAVIORAL_CLASS_CONFIG['other'],
       joinLabel: g.join_mode ? JOIN_MODE_LABELS[g.join_mode] : undefined,
     }))
   );
 
-  protected readonly total: Signal<number> = computed(() => this.directoryData()?.total ?? 0);
-  protected readonly projectName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.project_name ?? '');
-  protected readonly foundationName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_name ?? '');
+  protected readonly total: Signal<number> = computed(() => this.state().directory?.total ?? 0);
+  protected readonly projectName: Signal<string> = computed(() => this.state().directory?.groups[0]?.context?.project_name ?? '');
+  protected readonly foundationName: Signal<string> = computed(() => this.state().directory?.groups[0]?.context?.foundation_name ?? '');
+
+  private initDirectory(): Signal<PublicGroupDirectoryPageState> {
+    const initial: PublicGroupDirectoryPageState = { loading: true, error: false, directory: null };
+    // Seed the client's first paint from the SSR-serialized state (matches the server's resolved
+    // branch, no skeleton flash). Null on the server and on client navigations with no prior SSR state.
+    const transferred = this.transferState.get(this.stateKey, null);
+    // Consume the SSR state exactly once so a later re-creation of this component (e.g. a different
+    // `/projects/:projectSlug/groups`) can't paint the previous project's directory under the new URL.
+    if (isPlatformBrowser(this.platformId) && transferred) {
+      this.transferState.remove(this.stateKey);
+    }
+    return toSignal(
+      this.route.paramMap.pipe(
+        map((params) => params.get('projectSlug') ?? ''),
+        distinctUntilChanged(),
+        switchMap((slug, index) =>
+          this.groupService.getPublicProjectGroups(slug).pipe(
+            map((directory): PublicGroupDirectoryPageState => ({ loading: false, error: false, directory })),
+            catchError(() => of<PublicGroupDirectoryPageState>({ loading: false, error: true, directory: null })),
+            // During SSR, persist each resolved (non-loading) state so the client can hydrate to the
+            // same branch. Angular defers serialization until this tracked HTTP call settles.
+            tap((state) => {
+              if (isPlatformServer(this.platformId) && !state.loading) {
+                this.transferState.set(this.stateKey, state);
+              }
+            }),
+            // Seed the first client emission from the SSR state to avoid a loading flash and a
+            // hydration mismatch; every later fetch (and each client-side navigation) re-enters loading.
+            startWith(index === 0 && transferred ? transferred : initial)
+          )
+        )
+      ),
+      { initialValue: transferred ?? initial }
+    );
+  }
 }

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -70,6 +70,19 @@ export interface PublicGroupDirectoryResponse {
   total: number;
 }
 
+/**
+ * SSR-serialized state for public group directory pages (GH-2081 and the companion foundation
+ * page), following the same TransferState pattern as {@link PublicProfilePageState}: seeds the
+ * client's first paint from the server's resolved branch so hydration keeps the SSR-rendered
+ * directory on screen while the client confirms it with its own fetch, instead of tearing it down
+ * for a skeleton until that refetch resolves.
+ */
+export interface PublicGroupDirectoryPageState {
+  loading: boolean;
+  error: boolean;
+  directory: PublicGroupDirectoryResponse | null;
+}
+
 /** Frontend view model — extends PublicGroupSummary with pre-computed display metadata. */
 export interface PublicGroupDirectoryVm extends PublicGroupSummary {
   classConfig: BehavioralClassDisplayConfig;


### PR DESCRIPTION
## Summary
- Seed the public project and foundation group directory pages from `TransferState` so hydration keeps the SSR-rendered list (or error) instead of flashing the loading skeleton (`loading` no longer starts `true` on a fresh client instance).
- Follows the same page-state pattern as the public profile page and meeting join (#2041): consume-once TransferState, `toSignal` `initialValue`, `startWith` of the transferred non-loading state on the first fetch, skeleton only on later slug changes.
- Adds first-paint regression specs for both pages (seeded success/error, in-flight refetch hold, server persist, slug-change loading).

Fixes #2081
Related: #2082

## Test plan
- [ ] Hard-refresh `/projects/<slug>/groups` as an anonymous visitor and confirm the directory does not flash to the skeleton after SSR HTML appears
- [ ] Hard-refresh `/foundations/<slug>/groups` and confirm the same (no content → skeleton → content swap)
- [ ] Client-navigate between two project (or foundation) slugs and confirm the skeleton still appears while the new directory loads
- [ ] Force the directory API to fail during SSR and confirm the error empty state hydrates without a skeleton flash
- [ ] `yarn test:app --include='src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts' --include='src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts'` (26 passing locally)


Made with [Cursor](https://cursor.com)