### PR TITLE
fix(committees): rename manage permission label to manager

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -325,7 +325,7 @@ export class CommitteeMembersComponent implements OnInit {
   public getMemberPermissionLabel(permission: CommitteePermissionLevel, inherited = false): string {
     // Inherited grants only apply to manage/review; 'member' never carries the suffix.
     const suffix = inherited ? ' (inherited)' : '';
-    if (permission === 'manage') return `Manage${suffix}`;
+    if (permission === 'manage') return `Manager${suffix}`;
     if (permission === 'review') return `Reviewer${suffix}`;
     return 'Member';
   }

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
@@ -249,7 +249,7 @@
         appendTo="body"
         id="permission"
         data-testid="member-form-permission"></lfx-select>
-      <p class="text-xs text-gray-400">Manage — can edit group settings. Review — read-only access to all content. Member — standard access.</p>
+      <p class="text-xs text-gray-400">Manager — can edit group settings. Reviewer — read-only access to all content. Member — standard access.</p>
     </div>
   }
 

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -2166,14 +2166,14 @@ export class CommitteeService {
 
   /**
    * Collects the manage/review grants the committee inherits from its project ancestry so the
-   * members roster can label users who hold a "Manage" / "Reviewer" grant at the project or
+   * members roster can label users who hold a "Manager" / "Reviewer" grant at the project or
    * foundation level rather than directly on the committee (LFXV2-2059).
    *
    * Walks the chain `committee's project_uid -> parent -> ... -> foundation root`, reading each
    * level's project settings and unioning the writers/auditors. This mirrors the authorization
    * model, which inherits at every hop (`committee#writer` derives from `writer from project`,
    * and `project#writer` from `writer from parent`), so a grant anywhere up the chain — most
-   * importantly a foundation-level "Manage" — is an effective committee grant. Reading only the
+   * importantly a foundation-level "Manager" — is an effective committee grant. Reading only the
    * immediate project (the round-1 behaviour) missed grants stored higher up, which is why a
    * foundation manager still showed as a plain member.
    *

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -559,7 +559,7 @@ export const COMMITTEE_SETTINGS_FEATURES = [
 export const COMMITTEE_PERMISSION_OPTIONS = [
   { label: 'Member', value: 'member' },
   { label: 'Reviewer', value: 'review' },
-  { label: 'Manage', value: 'manage' },
+  { label: 'Manager', value: 'manage' },
 ] as const;
 
 /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -468,12 +468,12 @@ export interface Committee {
 
   /**
    * Users with write (manage) access *inherited* from the committee's project/foundation
-   * ancestry (e.g. a foundation-level "Manage" grant). Populated by the BFF, which walks the
+   * ancestry (e.g. a foundation-level "Manager" grant). Populated by the BFF, which walks the
    * project ancestry (`project_uid → parent → … → foundation`) and unions each level's
    * permission list — response-only, display purposes only. The committee's effective `writer`
    * boolean already reflects this inheritance via the authorization model (`committee#writer`
    * derives from `writer from project`, and `project#writer` from `writer from parent`); this
-   * field exists so the per-member roster can label such users "Manage" even though they are
+   * field exists so the per-member roster can label such users "Manager" even though they are
    * absent from the committee-scoped `writers` list. Empty/absent for the levels the caller
    * cannot read (best-effort).
    */

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -187,8 +187,8 @@ export function matchesCommitteeUser(member: Pick<CommitteeMember, 'username' | 
  *
  * Committee-scoped grants (`writers` / `auditors`) take precedence; when the member holds no
  * committee-scoped role, falls back to grants inherited from the project/foundation ancestry
- * (`inherited_writers` / `inherited_auditors`) so a foundation-level "Manage" user is shown as
- * Manage rather than a plain member (LFXV2-2059). Manage outranks Reviewer at every level.
+ * (`inherited_writers` / `inherited_auditors`) so a foundation-level "Manager" user is shown as
+ * Manager rather than a plain member (LFXV2-2059). Manager outranks Reviewer at every level.
  *
  * `inherited` is true only when the member has no direct committee role but matches an inherited
  * grant — it drives the "(inherited)" label suffix.


### PR DESCRIPTION
## Summary
- Rename the committee member permission display label from **Manage** to **Manager** so it matches the noun pattern of **Member** and **Reviewer** ([#2245](https://github.com/linuxfoundation/lfx-self-serve/issues/2245)).
- Update the add/edit member dropdown, roster tags (including `Manager (inherited)`), and the permission help text. The stored `CommitteePermissionLevel` value remains `'manage'`.
- Align comments that described the old user-facing label.

## Test plan
- [ ] Open a committee members roster and confirm a manage-level member shows **Manager** (and **Manager (inherited)** when the grant is inherited).
- [ ] Open add/edit member and confirm the permission dropdown option is **Manager**, value still `manage`.
- [ ] Confirm the help text reads: `Manager — can edit group settings. Reviewer — read-only access to all content. Member — standard access.`
- [ ] Confirm project settings still use **Manage** vs **View** (unrelated permission system).

Fixes #2245

Made with [Cursor](https://cursor.com)