### PR TITLE
fix(app): set per-page document titles (#2295)

### DIFF
--- a/apps/lfx-one/src/app/app.config.ts
+++ b/apps/lfx-one/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/
 import { ApplicationConfig, ErrorHandler, provideZonelessChangeDetection } from '@angular/core';
 import { provideClientHydration, withEventReplay, withIncrementalHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { provideRouter, withInMemoryScrolling, withPreloading } from '@angular/router';
+import { provideRouter, TitleStrategy, withInMemoryScrolling, withPreloading } from '@angular/router';
 import { lfxCardTheme, lfxDataTableTheme } from '@lfx-one/shared';
 import { lfxPreset } from '@linuxfoundation/lfx-ui-core';
 import { definePreset } from '@primeuix/themes';
@@ -21,6 +21,7 @@ import { provideFeatureFlags } from './shared/providers/feature-flag.provider';
 import { provideRuntimeConfig } from './shared/providers/runtime-config.provider';
 import { ChunkLoadErrorHandler } from './shared/utils/chunk-load-error.handler';
 import { CustomPreloadingStrategy } from './shared/strategies/custom-preloading.strategy';
+import { LfxTitleStrategy } from './shared/strategies/lfx-title.strategy';
 
 const customPreset = definePreset(Aura, {
   primitive: lfxPreset.primitive,
@@ -37,6 +38,7 @@ export const appConfig: ApplicationConfig = {
     provideZonelessChangeDetection(),
     { provide: ErrorHandler, useClass: ChunkLoadErrorHandler },
     provideRouter(routes, withPreloading(CustomPreloadingStrategy), withInMemoryScrolling({ scrollPositionRestoration: 'top', anchorScrolling: 'enabled' })),
+    { provide: TitleStrategy, useClass: LfxTitleStrategy },
     // `includeHeaders` selects which *response* headers get serialized into the transfer cache
     // state — it has no effect on which requests are eligible for caching. The prior
     // `includeHeaders: ['Authorization']` was the wrong option for its intended purpose (a no-op)

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -676,7 +676,7 @@ export const routes: Routes = [
     children: [
       {
         path: '**',
-        title: 'Page not found',
+        title: 'Page Not Found',
         loadComponent: () => import('./modules/not-found/not-found.component').then((m) => m.NotFoundComponent),
       },
     ],

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -1,7 +1,16 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { MKTG_OS_AGENTS_ROUTE_SEGMENT, ORG_EASYCLA_NEW_SEGMENT } from '@lfx-one/shared/constants';
+import {
+  COMMITTEE_LABEL,
+  DOCUMENT_LABEL,
+  MAILING_LIST_LABEL,
+  MKTG_OS_AGENTS_LABEL,
+  MKTG_OS_AGENTS_ROUTE_SEGMENT,
+  ORG_EASYCLA_NEW_SEGMENT,
+  SURVEY_LABEL,
+  VOTE_LABEL,
+} from '@lfx-one/shared/constants';
 import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
@@ -36,12 +45,14 @@ export const routes: Routes = [
       {
         path: '',
         pathMatch: 'full',
+        title: 'My Dashboard',
         data: { lens: 'me' },
         loadComponent: () => import('./modules/dashboards/dashboard.component').then((m) => m.DashboardComponent),
       },
       // Foundation Lens dashboard (placeholder — reuses DashboardComponent for now)
       {
         path: 'foundation/overview',
+        title: 'Foundation Dashboard',
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/dashboard.component').then((m) => m.DashboardComponent),
@@ -51,6 +62,7 @@ export const routes: Routes = [
       // keeps SSR and the post-hydration flag decision on the same DOM tree (see HealthMetricsGateComponent).
       {
         path: 'foundation/health-metrics',
+        title: 'Health Metrics',
         data: { lens: 'foundation' },
         canActivate: [dashboardAccessGuard, projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/health-metrics-gate/health-metrics-gate.component').then((m) => m.HealthMetricsGateComponent),
@@ -58,6 +70,7 @@ export const routes: Routes = [
       // Foundation Lens — Campaign Impact page (ED + LF Staff always; marketing_auditor when marketing-ops-fga-enabled is on — LF Staff still see only the Social Listening tab)
       {
         path: 'foundation/marketing-impact',
+        title: 'Campaign Impact',
         data: { lens: 'foundation' },
         canActivate: [marketingImpactAccessGuard, projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/marketing-impact/marketing-impact.component').then((m) => m.MarketingImpactComponent),
@@ -65,6 +78,7 @@ export const routes: Routes = [
       // Foundation Lens — Campaigns page (ED always; campaign_manager when marketing-ops-fga-enabled is on)
       {
         path: 'foundation/campaigns',
+        title: 'Campaigns',
         data: { lens: 'foundation' },
         canActivate: [campaignAccessGuard, projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/campaigns/campaigns.component').then((m) => m.CampaignsComponent),
@@ -72,6 +86,7 @@ export const routes: Routes = [
       // Foundation Lens — Social Listening page (ED + LF Staff)
       {
         path: 'foundation/social-listening',
+        title: 'Social Listening',
         data: { lens: 'foundation' },
         canActivate: [dashboardAccessGuard, projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/social-listening/social-listening.component').then((m) => m.SocialListeningComponent),
@@ -79,6 +94,7 @@ export const routes: Routes = [
       // Foundation Lens — Projects page
       {
         path: 'foundation/projects',
+        title: 'Projects',
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/foundation-projects/foundation-projects.component').then((m) => m.FoundationProjectsComponent),
@@ -86,6 +102,7 @@ export const routes: Routes = [
       // Project Lens dashboard (placeholder — reuses DashboardComponent for now)
       {
         path: 'project/overview',
+        title: 'Project Dashboard',
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadComponent: () => import('./modules/dashboards/dashboard.component').then((m) => m.DashboardComponent),
@@ -95,6 +112,7 @@ export const routes: Routes = [
       // invisible for a non-formation project or with the flag off.
       {
         path: 'project/formation',
+        title: 'Formation',
         data: { lens: 'project' },
         canMatch: [formationProjectEnabledGuard],
         canActivate: [projectQueryParamGuard],
@@ -281,30 +299,35 @@ export const routes: Routes = [
       // Foundation Lens — feature routes (lens-tagged so deep links restore the foundation lens)
       {
         path: 'foundation/meetings',
+        title: 'Foundation Meetings',
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/meetings/meetings.routes').then((m) => m.MEETING_ROUTES),
       },
       {
         path: 'foundation/events',
+        title: 'Foundation Events',
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
       },
       {
         path: 'foundation/mailing-lists',
+        title: `Foundation ${MAILING_LIST_LABEL.plural}`,
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/mailing-lists/mailing-lists.routes').then((m) => m.MAILING_LIST_ROUTES),
       },
       {
         path: 'foundation/groups',
+        title: `Foundation ${COMMITTEE_LABEL.plural}`,
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/committees/committees.routes').then((m) => m.COMMITTEE_ROUTES),
       },
       {
         path: 'foundation/documents',
+        title: `Foundation ${DOCUMENT_LABEL.plural}`,
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
@@ -315,6 +338,7 @@ export const routes: Routes = [
       // Linked from the dashboard's FormationEntryCardComponent (GH-1955), not from any nav item.
       {
         path: 'foundation/formations',
+        title: 'Formations',
         data: { lens: 'foundation' },
         canMatch: [formationEnabledGuard],
         canActivate: [formationsQueueAuditorGuard],
@@ -323,6 +347,7 @@ export const routes: Routes = [
       // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.
       {
         path: `foundation/${MKTG_OS_AGENTS_ROUTE_SEGMENT}`,
+        title: MKTG_OS_AGENTS_LABEL.nav,
         data: { lens: 'foundation' },
         canMatch: [mktgOsAgentsEnabledGuard],
         canActivate: [projectQueryParamGuard],
@@ -330,24 +355,28 @@ export const routes: Routes = [
       },
       {
         path: 'foundation/votes',
+        title: `Foundation ${VOTE_LABEL.plural}`,
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/votes/votes.routes').then((m) => m.VOTE_ROUTES),
       },
       {
         path: 'foundation/surveys',
+        title: `Foundation ${SURVEY_LABEL.plural}`,
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/surveys/surveys.routes').then((m) => m.SURVEY_ROUTES),
       },
       {
         path: 'foundation/newsletters',
+        title: 'Foundation Newsletters',
         data: { lens: 'foundation' },
         canActivate: [newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
         path: 'foundation/settings',
+        title: 'Permissions',
         data: { lens: 'foundation' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/settings/settings.routes').then((m) => m.SETTINGS_ROUTES),
@@ -355,24 +384,28 @@ export const routes: Routes = [
       // Project Lens — feature routes (lens-tagged so deep links restore the project lens)
       {
         path: 'project/meetings',
+        title: 'Project Meetings',
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/meetings/meetings.routes').then((m) => m.MEETING_ROUTES),
       },
       {
         path: 'project/mailing-lists',
+        title: `Project ${MAILING_LIST_LABEL.plural}`,
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/mailing-lists/mailing-lists.routes').then((m) => m.MAILING_LIST_ROUTES),
       },
       {
         path: 'project/groups',
+        title: `Project ${COMMITTEE_LABEL.plural}`,
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/committees/committees.routes').then((m) => m.COMMITTEE_ROUTES),
       },
       {
         path: 'project/documents',
+        title: `Project ${DOCUMENT_LABEL.plural}`,
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
@@ -380,6 +413,7 @@ export const routes: Routes = [
       // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.
       {
         path: `project/${MKTG_OS_AGENTS_ROUTE_SEGMENT}`,
+        title: MKTG_OS_AGENTS_LABEL.nav,
         data: { lens: 'project' },
         canMatch: [mktgOsAgentsEnabledGuard],
         canActivate: [projectQueryParamGuard],
@@ -387,55 +421,65 @@ export const routes: Routes = [
       },
       {
         path: 'project/votes',
+        title: `Project ${VOTE_LABEL.plural}`,
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/votes/votes.routes').then((m) => m.VOTE_ROUTES),
       },
       {
         path: 'project/surveys',
+        title: `Project ${SURVEY_LABEL.plural}`,
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/surveys/surveys.routes').then((m) => m.SURVEY_ROUTES),
       },
       {
         path: 'project/newsletters',
+        title: 'Project Newsletters',
         data: { lens: 'project' },
         canActivate: [newsletterAccessGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/newsletters/newsletters.routes').then((m) => m.NEWSLETTER_ROUTES),
       },
       {
         path: 'project/settings',
+        title: 'Permissions',
         data: { lens: 'project' },
         canActivate: [projectQueryParamGuard],
         loadChildren: () => import('./modules/settings/settings.routes').then((m) => m.SETTINGS_ROUTES),
       },
       {
         path: 'meetings',
+        title: 'My Meetings',
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/meetings/meetings.routes').then((m) => m.MEETING_ROUTES),
       },
       {
         path: 'meetups',
+        title: 'My Meetups',
         loadChildren: () => import('./modules/meetups/meetups.routes').then((m) => m.MEETUPS_ROUTES),
       },
       {
         path: 'groups',
+        title: `My ${COMMITTEE_LABEL.plural}`,
         canMatch: [authenticatedMatchGuard],
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/committees/committees.routes').then((m) => m.COMMITTEE_ROUTES),
       },
       {
         path: 'mailing-lists',
+        title: `My ${MAILING_LIST_LABEL.plural}`,
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/mailing-lists/mailing-lists.routes').then((m) => m.MAILING_LIST_ROUTES),
       },
       {
         path: 'votes',
+        title: `My ${VOTE_LABEL.plural}`,
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/votes/votes.routes').then((m) => m.VOTE_ROUTES),
       },
       {
         path: 'surveys',
+        title: `My ${SURVEY_LABEL.plural}`,
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/surveys/surveys.routes').then((m) => m.SURVEY_ROUTES),
       },
@@ -447,11 +491,13 @@ export const routes: Routes = [
         // authenticated user may view sent issues; drafts 404 in-place for
         // non-writers (enforced in the component).
         path: 'newsletters/:projectSlug/:id',
+        title: 'Newsletter',
         canActivate: [authGuard],
         loadComponent: () => import('./modules/newsletters/newsletter-reader/newsletter-reader.component').then((m) => m.NewsletterReaderComponent),
       },
       {
         path: 'newsletters',
+        title: 'Newsletters',
         // No newsletterAccessGuard at the mount: the Me-lens member feed
         // (/newsletters/my) must be reachable by regular committee members.
         // Every manager child route (list/create/edit/analytics) applies the
@@ -462,25 +508,30 @@ export const routes: Routes = [
       },
       {
         path: 'documents',
+        title: `My ${DOCUMENT_LABEL.plural}`,
         canActivate: [lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
       },
       {
         // Me lens → /profile/settings (canonical); foundation/project → lens-prefixed settings.
         path: 'settings',
+        title: 'Settings',
         canActivate: [settingsLensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/settings/settings.routes').then((m) => m.SETTINGS_ROUTES),
       },
       {
         path: 'profile',
+        title: 'Profile',
         loadChildren: () => import('./modules/profile/profile.routes').then((m) => m.PROFILE_ROUTES),
       },
       {
         path: 'me/training',
+        title: 'Training & Certifications',
         loadChildren: () => import('./modules/trainings/trainings.routes').then((m) => m.TRAINING_ROUTES),
       },
       {
         path: 'badges',
+        title: 'Badges',
         loadChildren: () => import('./modules/badges/badges.routes').then((m) => m.BADGE_ROUTES),
       },
       {
@@ -491,16 +542,19 @@ export const routes: Routes = [
       },
       {
         path: 'events',
+        title: 'My Events',
         canActivate: [myEventsRequestLensGuard, lensRedirectGuard, projectQueryParamGuard],
         loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
       },
       {
         path: 'crowdfunding',
+        title: 'Crowdfunding',
         data: { lens: 'me' },
         loadChildren: () => import('./modules/crowdfunding/crowdfunding.routes').then((m) => m.CROWDFUNDING_ROUTES),
       },
       {
         path: 'mentorship',
+        title: 'Mentorship',
         data: { lens: 'me' },
         canMatch: [mentorshipEnabledGuard],
         loadChildren: () => import('./modules/mentorship/mentorship.routes').then((m) => m.MENTORSHIP_ROUTES),
@@ -527,6 +581,7 @@ export const routes: Routes = [
       },
       {
         path: 'akrites',
+        title: 'Akrites Program',
         canMatch: [akritesEnabledGuard],
         loadChildren: () => import('./modules/akrites/akrites.routes').then((m) => m.AKRITES_ROUTES),
       },
@@ -540,23 +595,28 @@ export const routes: Routes = [
   // itself (research R6) so the URL is identical across auth states (FR-009c).
   {
     path: 'docs',
+    title: 'LFX Documentation',
     loadComponent: () => import('./layouts/docs-layout/docs-layout.component').then((m) => m.DocsLayoutComponent),
     loadChildren: () => import('./modules/docs/docs.routes').then((m) => m.DOCS_ROUTES),
   },
   {
     path: 'meetings/not-found',
+    title: 'Meeting Not Found',
     loadComponent: () => import('./modules/meetings/meeting-not-found/meeting-not-found.component').then((m) => m.MeetingNotFoundComponent),
   },
   {
     path: 'meetings/:id',
+    title: 'Meeting',
     loadComponent: () => import('./modules/meetings/meeting-join/meeting-join.component').then((m) => m.MeetingJoinComponent),
   },
   {
     path: 'groups/not-found',
+    title: 'Group Not Found',
     loadComponent: () => import('./modules/groups/group-not-found/group-not-found.component').then((m) => m.GroupNotFoundComponent),
   },
   {
     path: 'groups/:id',
+    title: COMMITTEE_LABEL.singular,
     loadComponent: () => import('./modules/groups/group-detail/group-detail.component').then((m) => m.GroupDetailComponent),
   },
   // Public contributor profile (LFXV2-2631). Sibling of the authGuard'd root so /u/:username
@@ -564,33 +624,39 @@ export const routes: Routes = [
   // (no reserved `/u/...` path), so a contributor whose username is e.g. `not-found` still resolves.
   {
     path: 'u/:username',
+    title: 'Profile',
     loadComponent: () => import('./modules/public-profile/public-profile-page/public-profile-page.component').then((m) => m.PublicProfilePageComponent),
   },
   // Public foundation groups directory — lists all public groups for a foundation (no auth required).
   {
     path: 'foundations/:foundationSlug/groups',
+    title: COMMITTEE_LABEL.plural,
     loadComponent: () => import('./modules/groups/public-foundation-groups/public-foundation-groups.component').then((m) => m.PublicFoundationGroupsComponent),
   },
   // Public project groups directory — lists all public groups for a project (no auth required).
   {
     path: 'projects/:projectSlug/groups',
+    title: COMMITTEE_LABEL.plural,
     loadComponent: () => import('./modules/groups/public-project-groups/public-project-groups.component').then((m) => m.PublicProjectGroupsComponent),
   },
   // Public project calendar — month/week calendar of a project's public meetings, optionally scoped
   // to a single committee via ?committee=<uid> (no auth required).
   {
     path: 'projects/:projectSlug/calendar',
+    title: 'Calendar',
     loadComponent: () => import('./modules/meetings/public-project-calendar/public-project-calendar.component').then((m) => m.PublicProjectCalendarComponent),
   },
   // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {
     path: 'invite',
+    title: 'Accept Invite',
     canActivate: [authGuard],
     loadComponent: () => import('./modules/invite/invite.component').then((m) => m.InviteComponent),
   },
   // Error page is outside the auth guard so expired/invalid links are visible without login.
   {
     path: 'invite/error',
+    title: 'Invite Error',
     loadComponent: () => import('./modules/invite/invite-error/invite-error.component').then((m) => m.InviteErrorComponent),
   },
   // Branded landing for browser-navigation auth failures (e.g. a Valkey session-store write
@@ -598,6 +664,7 @@ export const routes: Routes = [
   // auth guard since the whole point is reaching it without a valid session.
   {
     path: 'auth-error',
+    title: 'Sign-in Error',
     loadComponent: () => import('./modules/auth-error/auth-error.component').then((m) => m.AuthErrorComponent),
   },
   // Trailing in-shell catch-all — branded 404 in place (no redirect), inside the shell for the left nav.
@@ -609,6 +676,7 @@ export const routes: Routes = [
     children: [
       {
         path: '**',
+        title: 'Page not found',
         loadComponent: () => import('./modules/not-found/not-found.component').then((m) => m.NotFoundComponent),
       },
     ],

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -85,6 +85,7 @@ import {
 } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
 import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invite-organization-dialog/accept-invite-organization-dialog.component';
 import { JoinApplicationDialogComponent } from '../components/join-application-dialog/join-application-dialog.component';
@@ -435,6 +436,8 @@ export class CommitteeViewComponent {
     }
 
     syncEntityProjectContext(this.committee, this.projectContextService, this.router, this.destroyRef);
+
+    bindLfxDocumentTitle(computed(() => this.committee()?.name));
 
     toObservable(this.committee)
       .pipe(

--- a/apps/lfx-one/src/app/modules/committees/committees.routes.ts
+++ b/apps/lfx-one/src/app/modules/committees/committees.routes.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Routes } from '@angular/router';
+import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import { authGuard } from '@shared/guards/auth.guard';
 import { writerGuard } from '@shared/guards/writer.guard';
 
@@ -14,17 +15,20 @@ export const COMMITTEE_ROUTES: Routes = [
   },
   {
     path: 'create',
+    title: `Create ${COMMITTEE_LABEL.singular}`,
     loadComponent: () => import('./committee-manage/committee-manage.component').then((m) => m.CommitteeManageComponent),
     canActivate: [authGuard, writerGuard],
     data: { writeFeature: 'committees' },
   },
   {
     path: ':id',
+    title: COMMITTEE_LABEL.singular,
     loadComponent: () => import('./committee-view/committee-view.component').then((m) => m.CommitteeViewComponent),
     canActivate: [authGuard],
   },
   {
     path: ':id/edit',
+    title: `Edit ${COMMITTEE_LABEL.singular}`,
     loadComponent: () => import('./committee-manage/committee-manage.component').then((m) => m.CommitteeManageComponent),
     canActivate: [authGuard, writerGuard],
     // entityScopedSlug: writerGuard resolves the authorization slug from the committee itself on

--- a/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
+++ b/apps/lfx-one/src/app/modules/crowdfunding/crowdfunding.routes.ts
@@ -12,18 +12,22 @@ export const CROWDFUNDING_ROUTES: Routes = [
   },
   {
     path: 'initiatives',
+    title: 'My Initiatives',
     loadComponent: () => import('./my-initiatives/my-initiatives.component').then((m) => m.MyInitiativesComponent),
   },
   {
     path: 'initiatives/:slug',
+    title: 'Initiative',
     loadComponent: () => import('./initiative-detail/initiative-detail.component').then((m) => m.InitiativeDetailComponent),
   },
   {
     path: 'donations',
+    title: 'My Donations',
     loadComponent: () => import('./my-donations/my-donations.component').then((m) => m.MyDonationsComponent),
   },
   {
     path: 'donations/recurring/:id',
+    title: 'Recurring Donation',
     loadComponent: () => import('./recurring-donation-detail/recurring-donation-detail.component').then((m) => m.RecurringDonationDetailComponent),
     canActivate: [authGuard],
   },

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-project-detail/org-project-detail.component.ts
@@ -9,6 +9,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensProjectDetailService } from '@services/org-lens-project-detail.service';
 import { PersonDetailDrawerService } from '@services/person-detail-drawer.service';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 import { BreadcrumbComponent } from '@components/breadcrumb/breadcrumb.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -329,6 +330,7 @@ export class OrgProjectDetailComponent {
   protected readonly cardDetail = computed<OrgLensCardDetailSection | null>(() => this.drawerState().data);
 
   public constructor() {
+    bindLfxDocumentTitle(computed(() => this.hero()?.projectName));
     this.searchForm.controls.technical.valueChanges.pipe(debounceTime(250), takeUntilDestroyed()).subscribe((value) => this.techSearch.set(value));
     this.searchForm.controls.ecosystem.valueChanges.pipe(debounceTime(250), takeUntilDestroyed()).subscribe((value) => this.ecoSearch.set(value));
 

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.ts
@@ -9,6 +9,7 @@ import { formatAnnouncementDateLabel, isFormationStageGate } from '@lfx-one/shar
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 import { TagComponent } from '@components/tag/tag.component';
 import { SkeletonModule } from 'primeng/skeleton';
 import { BehaviorSubject, combineLatest, of, switchMap } from 'rxjs';
@@ -71,6 +72,7 @@ export class ProjectDashboardComponent {
 
   public constructor() {
     this.pendingActions = this.initPendingActions();
+    bindLfxDocumentTitle(computed(() => this.selectedProject()?.name));
   }
 
   public handleActionClick(): void {

--- a/apps/lfx-one/src/app/modules/docs/docs.routes.ts
+++ b/apps/lfx-one/src/app/modules/docs/docs.routes.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Routes } from '@angular/router';
+import { LFX_DOCUMENT_TITLE_DOCS_BRAND, LFX_DOCUMENT_TITLE_SEPARATOR } from '@lfx-one/shared/constants';
 
 import { docsArticleResolver } from './resolvers/docs-article.resolver';
 
@@ -30,7 +31,7 @@ export const DOCS_ROUTES: Routes = [
   },
   {
     path: 'not-found',
-    title: 'Page not found · LFX Documentation',
+    title: `Page Not Found${LFX_DOCUMENT_TITLE_SEPARATOR}${LFX_DOCUMENT_TITLE_DOCS_BRAND}`,
     loadComponent: () => import('./pages/docs-not-found/docs-not-found.component').then((m) => m.DocsNotFoundComponent),
   },
   {

--- a/apps/lfx-one/src/app/modules/docs/docs.routes.ts
+++ b/apps/lfx-one/src/app/modules/docs/docs.routes.ts
@@ -30,6 +30,7 @@ export const DOCS_ROUTES: Routes = [
   },
   {
     path: 'not-found',
+    title: 'Page not found · LFX Documentation',
     loadComponent: () => import('./pages/docs-not-found/docs-not-found.component').then((m) => m.DocsNotFoundComponent),
   },
   {

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-not-found/docs-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-not-found/docs-not-found.component.ts
@@ -5,6 +5,7 @@ import { DOCUMENT } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
+import { LFX_DOCUMENT_TITLE_DOCS_BRAND, LFX_DOCUMENT_TITLE_SEPARATOR } from '@lfx-one/shared/constants';
 import type { DocsTopic } from '@lfx-one/shared/interfaces';
 
 import { DocsManifestService } from '../../services/docs-manifest.service';
@@ -30,7 +31,7 @@ export class DocsNotFoundComponent implements OnInit {
   protected readonly topics: DocsTopic[] = this.docsManifest.getTopics();
 
   public ngOnInit(): void {
-    const title = 'Page not found · LFX Documentation';
+    const title = `Page Not Found${LFX_DOCUMENT_TITLE_SEPARATOR}${LFX_DOCUMENT_TITLE_DOCS_BRAND}`;
     const description = 'The documentation page you requested could not be found.';
 
     this.title.setTitle(title);

--- a/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/group-detail/group-detail.component.ts
@@ -17,6 +17,7 @@ import { IcalSubscribeDialogComponent } from '@modules/committees/components/ica
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { GroupService } from '@services/group.service';
 import { UserService } from '@services/user.service';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, filter, map, of, switchMap } from 'rxjs';
@@ -96,6 +97,10 @@ export class GroupDetailComponent {
     }
     return 'a member';
   });
+
+  public constructor() {
+    bindLfxDocumentTitle(computed(() => this.group()?.name));
+  }
 
   protected navigateToLogin(): void {
     if (isPlatformBrowser(this.platformId)) {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -28,6 +28,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { BehaviorSubject, catchError, combineLatest, of, switchMap } from 'rxjs';
 
 import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 
 import { MailingListMembersComponent } from '../components/mailing-list-members/mailing-list-members.component';
 
@@ -93,6 +94,7 @@ export class MailingListViewComponent {
       preferEntityKind: true,
       canonicalizeRoute: true,
     });
+    bindLfxDocumentTitle(computed(() => this.mailingList()?.title || this.mailingList()?.group_name));
   }
 
   public refreshData(): void {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-lists.routes.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Routes } from '@angular/router';
+import { MAILING_LIST_LABEL } from '@lfx-one/shared/constants';
 import { authGuard } from '@shared/guards/auth.guard';
 import { writerGuard } from '@shared/guards/writer.guard';
 
@@ -14,17 +15,20 @@ export const MAILING_LIST_ROUTES: Routes = [
   },
   {
     path: 'create',
+    title: `Create ${MAILING_LIST_LABEL.singular}`,
     loadComponent: () => import('./mailing-list-manage/mailing-list-manage.component').then((m) => m.MailingListManageComponent),
     canActivate: [authGuard, writerGuard],
     data: { preload: true, preloadDelay: 2000, writeFeature: 'mailing-lists' },
   },
   {
     path: ':id',
+    title: MAILING_LIST_LABEL.singular,
     loadComponent: () => import('./mailing-list-view/mailing-list-view.component').then((m) => m.MailingListViewComponent),
     canActivate: [authGuard],
   },
   {
     path: ':id/edit',
+    title: `Edit ${MAILING_LIST_LABEL.singular}`,
     loadComponent: () => import('./mailing-list-manage/mailing-list-manage.component').then((m) => m.MailingListManageComponent),
     canActivate: [authGuard, writerGuard],
     data: { writeFeature: 'mailing-lists', entityScopedSlug: true },

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -74,6 +74,7 @@ import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 import { MeetingService } from '@services/meeting.service';
 import { PlausibleService } from '@services/plausible.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -415,6 +416,7 @@ export class MeetingJoinComponent implements OnInit {
     this.meetingTypeBadge = this.initializeMeetingTypeBadge();
 
     this.meetingTitle = this.initializeMeetingTitle();
+    bindLfxDocumentTitle(this.meetingTitle);
     this.meetingDescription = this.initializeMeetingDescription();
     this.hasAiCompanion = this.initializeHasAiCompanion();
     this.isPastMeeting = this.initializeIsPastMeeting();

--- a/apps/lfx-one/src/app/modules/meetings/meetings.routes.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings.routes.ts
@@ -14,12 +14,14 @@ export const MEETING_ROUTES: Routes = [
   },
   {
     path: 'create',
+    title: 'Create Meeting',
     loadComponent: () => import('./meeting-manage/meeting-manage.component').then((m) => m.MeetingManageComponent),
     canActivate: [authGuard, writerGuard],
     data: { writeFeature: 'meetings' },
   },
   {
     path: ':id/edit',
+    title: 'Edit Meeting',
     loadComponent: () => import('./meeting-manage/meeting-manage.component').then((m) => m.MeetingManageComponent),
     canActivate: [authGuard, writerGuard],
     // entityScopedSlug: writerGuard resolves the authorization slug from the meeting itself on
@@ -29,6 +31,7 @@ export const MEETING_ROUTES: Routes = [
   },
   {
     path: ':id/details',
+    title: 'Meeting Details',
     loadComponent: () => import('./past-meeting-details/past-meeting-details.component').then((m) => m.PastMeetingDetailsComponent),
   },
 ];

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -40,6 +40,7 @@ import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { syncEntityProjectContext, syncEntityProjectContextFallback } from '@shared/utils/entity-project-context.util';
+import { bindLfxDocumentTitle } from '@shared/utils/document-title.util';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -167,6 +168,7 @@ export class PastMeetingDetailsComponent {
       entityKind: 'past meeting',
       freshFetch: (uid) => this.meetingService.getPastMeetingById(uid),
     });
+    bindLfxDocumentTitle(computed(() => this.meeting()?.title));
   }
 
   // Public methods

--- a/apps/lfx-one/src/app/modules/mentorship/mentorship.routes.ts
+++ b/apps/lfx-one/src/app/modules/mentorship/mentorship.routes.ts
@@ -11,20 +11,24 @@ export const MENTORSHIP_ROUTES: Routes = [
   },
   {
     path: 'admin',
+    title: 'Mentorship',
     loadComponent: () => import('./admin/admin.component').then((m) => m.AdminComponent),
   },
   {
     path: 'admin/enroll',
+    title: 'Enroll Program',
     loadComponent: () => import('./admin/enroll-program/enroll-program.component').then((m) => m.EnrollProgramComponent),
   },
   {
     path: 'admin/:programId',
+    title: 'Program',
     loadComponent: () => import('./admin/program-detail/program-detail.component').then((m) => m.ProgramDetailComponent),
   },
   {
     // Serves the Become a Mentor form until the profiles API can tell us the signed-in
     // user already has a mentor profile, at which point this path serves that instead.
     path: 'mentor',
+    title: 'Become a Mentor',
     loadComponent: () => import('./mentor/mentor-register/mentor-register.component').then((m) => m.MentorRegisterComponent),
   },
 ];

--- a/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents.routes.ts
+++ b/apps/lfx-one/src/app/modules/mktg-os-agents/mktg-os-agents.routes.ts
@@ -17,11 +17,13 @@ export const MKTG_OS_AGENTS_ROUTES: Routes = [
     // the two surfaces converge is a product decision, not resolved here.
     // Static path — must precede the `:agentId` matcher.
     path: 'brand-kit-form',
+    title: 'Brand Kit',
     loadComponent: () => import('./brand-kit-form/brand-kit-form.component').then((m) => m.BrandKitFormComponent),
     canActivate: [authGuard],
   },
   {
     path: ':agentId',
+    title: 'Agent',
     loadComponent: () => import('./mktg-agent-run/mktg-agent-run.component').then((m) => m.MktgAgentRunComponent),
     canActivate: [authGuard],
   },

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -13,12 +13,14 @@ export const NEWSLETTER_ROUTES: Routes = [
   },
   {
     path: 'list',
+    title: 'Newsletters',
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-list/newsletter-list.component').then((m) => m.NewsletterListComponent),
     data: { preload: false },
   },
   {
     path: 'create',
+    title: 'Create Newsletter',
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),
     data: { preload: false },
@@ -28,6 +30,7 @@ export const NEWSLETTER_ROUTES: Routes = [
     // memberships. authGuard only — newsletterAccessGuard is the manager
     // (ED/project-writer) gate and must not block regular committee members.
     path: 'my',
+    title: 'My Newsletters',
     canActivate: [authGuard],
     loadComponent: () => import('./my-newsletters/my-newsletters.component').then((m) => m.MyNewslettersComponent),
     data: { preload: false },
@@ -37,12 +40,14 @@ export const NEWSLETTER_ROUTES: Routes = [
     // context switch — the owning project travels with the link rather than being
     // re-derived from whatever context happens to be active when the route loads.
     path: ':projectUid/:id/edit',
+    title: 'Edit Newsletter',
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-manage/newsletter-manage.component').then((m) => m.NewsletterManageComponent),
     data: { preload: false },
   },
   {
     path: ':projectUid/:id/analytics',
+    title: 'Newsletter Analytics',
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-analytics/newsletter-analytics.component').then((m) => m.NewsletterAnalyticsComponent),
     data: { preload: false },

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -13,7 +13,8 @@ export const NEWSLETTER_ROUTES: Routes = [
   },
   {
     path: 'list',
-    title: 'Newsletters',
+    // No title: inherit the mount (`Newsletters` / `Foundation Newsletters` / `Project Newsletters`)
+    // so those history entries stay distinguishable.
     canActivate: [authGuard, newsletterAccessGuard],
     loadComponent: () => import('./newsletter-list/newsletter-list.component').then((m) => m.NewsletterListComponent),
     data: { preload: false },

--- a/apps/lfx-one/src/app/modules/profile/profile.routes.ts
+++ b/apps/lfx-one/src/app/modules/profile/profile.routes.ts
@@ -18,24 +18,28 @@ export const PROFILE_ROUTES: Routes = [
       // Work history & Affiliations tab (merges affiliations + work experience)
       {
         path: 'attributions',
+        title: 'Profile',
         loadComponent: () => import('./attribution/profile-attribution.component').then((m) => m.ProfileAttributionComponent),
       },
 
       // Identities tab
       {
         path: 'identities',
+        title: 'Identities',
         loadComponent: () => import('./identities/profile-identities.component').then((m) => m.ProfileIdentitiesComponent),
       },
 
       // Individual Enrollment tab
       {
         path: 'individual-enrollment',
+        title: 'Individual Enrollment',
         loadComponent: () => import('./individual-enrollment/profile-individual-enrollment.component').then((m) => m.ProfileIndividualEnrollmentComponent),
       },
 
       // CLAs tab — read-only EasyCLA agreements, dark-launched behind `my-clas-enabled` (CanMatch).
       {
         path: 'clas',
+        title: 'CLAs',
         canMatch: [myClasEnabledGuard],
         loadComponent: () => import('./clas/profile-clas.component').then((m) => m.ProfileClasComponent),
       },
@@ -44,6 +48,7 @@ export const PROFILE_ROUTES: Routes = [
       // `embedded` suppresses the component's own page header inside the profile shell.
       {
         path: 'transactions',
+        title: 'Transactions',
         data: { embedded: true },
         loadComponent: () => import('../transactions/transactions-dashboard/transactions-dashboard.component').then((m) => m.TransactionsDashboardComponent),
       },
@@ -52,6 +57,7 @@ export const PROFILE_ROUTES: Routes = [
       // `embedded` suppresses the component's own page header inside the profile shell.
       {
         path: 'settings',
+        title: 'Settings',
         data: { embedded: true },
         loadComponent: () => import('../settings/account-settings/account-settings.component').then((m) => m.AccountSettingsComponent),
       },

--- a/apps/lfx-one/src/app/modules/public-profile/public-profile-page/public-profile-page.component.ts
+++ b/apps/lfx-one/src/app/modules/public-profile/public-profile-page/public-profile-page.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { Meta, Title } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { PublicProfilePageState, ServerRequestContext } from '@lfx-one/shared/interfaces';
-import { formatAffiliation } from '@lfx-one/shared/utils';
+import { formatAffiliation, formatLfxDocumentTitle } from '@lfx-one/shared/utils';
 import { OsanoService } from '@services/osano.service';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, distinctUntilChanged, filter, map, of, startWith, switchMap, tap } from 'rxjs';
@@ -159,7 +159,7 @@ export class PublicProfilePageComponent {
     const description = basic.Bio?.trim() || formatAffiliation(basic) || `${name}'s public contributor profile on LFX.`;
     const image = basic.LogoURL?.trim() || '';
 
-    this.title.setTitle(`${name} · LFX`);
+    this.title.setTitle(formatLfxDocumentTitle(name));
     this.meta.updateTag({ name: 'description', content: description });
     this.meta.updateTag({ property: 'og:title', content: name });
     this.meta.updateTag({ property: 'og:description', content: description });
@@ -184,7 +184,7 @@ export class PublicProfilePageComponent {
   // Open Graph / Twitter tags so no prior contributor's card survives a client navigation.
   private resetMetadata(): void {
     const description = 'Public contributor profiles on LFX.';
-    this.title.setTitle('LFX');
+    this.title.setTitle(formatLfxDocumentTitle('Profile'));
     this.meta.updateTag({ name: 'description', content: description });
     this.meta.updateTag({ property: 'og:title', content: 'LFX' });
     this.meta.updateTag({ property: 'og:description', content: description });

--- a/apps/lfx-one/src/app/modules/surveys/surveys.routes.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys.routes.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Routes } from '@angular/router';
+import { SURVEY_LABEL } from '@lfx-one/shared/constants';
 import { authGuard } from '@shared/guards/auth.guard';
 import { writerGuard } from '@shared/guards/writer.guard';
 
@@ -14,12 +15,14 @@ export const SURVEY_ROUTES: Routes = [
   },
   {
     path: 'create',
+    title: `Create ${SURVEY_LABEL.singular}`,
     loadComponent: () => import('./survey-manage/survey-manage.component').then((m) => m.SurveyManageComponent),
     canActivate: [authGuard, writerGuard],
     data: { writeFeature: 'surveys' },
   },
   {
     path: ':id/edit',
+    title: `Edit ${SURVEY_LABEL.singular}`,
     loadComponent: () => import('./survey-manage/survey-manage.component').then((m) => m.SurveyManageComponent),
     canActivate: [authGuard, writerGuard],
     // entityScopedSlug: writerGuard resolves the authorization slug from the survey itself on

--- a/apps/lfx-one/src/app/modules/votes/votes.routes.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes.routes.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Routes } from '@angular/router';
+import { VOTE_LABEL } from '@lfx-one/shared/constants';
 import { authGuard } from '@shared/guards/auth.guard';
 import { writerGuard } from '@shared/guards/writer.guard';
 
@@ -14,12 +15,14 @@ export const VOTE_ROUTES: Routes = [
   },
   {
     path: 'create',
+    title: `Create ${VOTE_LABEL.singular}`,
     loadComponent: () => import('./vote-manage/vote-manage.component').then((m) => m.VoteManageComponent),
     canActivate: [authGuard, writerGuard],
     data: { preload: false, writeFeature: 'votes' },
   },
   {
     path: ':id/edit',
+    title: `Edit ${VOTE_LABEL.singular}`,
     loadComponent: () => import('./vote-manage/vote-manage.component').then((m) => m.VoteManageComponent),
     canActivate: [authGuard, writerGuard],
     // entityScopedSlug: writerGuard resolves the authorization slug from the vote itself; a route-data

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -7,6 +7,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { PLAUSIBLE_DOMAIN, PLAUSIBLE_SRC } from '@lfx-one/shared/constants';
 import { PlausibleCall, PlausiblePageviewContext } from '@lfx-one/shared/interfaces';
+import { afterRouterTitleApplied } from '@shared/utils/document-title.util';
 import { filter } from 'rxjs';
 
 import { LensService } from './lens.service';
@@ -188,7 +189,7 @@ export class PlausibleService {
         if (PlausibleService.deferredPageviewPattern.test(path)) {
           return;
         }
-        this.trackPage(this.buildContextProps());
+        afterRouterTitleApplied(() => this.trackPage(this.buildContextProps()));
       });
   }
 

--- a/apps/lfx-one/src/app/shared/services/segment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/segment.service.ts
@@ -6,6 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { LfxSegmentAnalytics } from '@lfx-one/shared/interfaces';
+import { afterRouterTitleApplied } from '@shared/utils/document-title.util';
 import { filter } from 'rxjs';
 
 /**
@@ -181,10 +182,12 @@ export class SegmentService {
           return;
         }
         const pageName = event.urlAfterRedirects.split('/').pop() || 'Home';
-        this.trackPage(pageName, {
-          path: event.urlAfterRedirects,
-          url: window.location.href,
-          title: document.title,
+        afterRouterTitleApplied(() => {
+          this.trackPage(pageName, {
+            path: event.urlAfterRedirects,
+            url: window.location.href,
+            title: document.title,
+          });
         });
       });
   }

--- a/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.spec.ts
+++ b/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.spec.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { provideLocationMocks } from '@angular/common/testing';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { provideRouter, Router, TitleStrategy } from '@angular/router';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { LfxTitleStrategy } from './lfx-title.strategy';
+
+@Component({ selector: 'lfx-title-host', standalone: true, template: '' })
+class TitleHostComponent {}
+
+describe('LfxTitleStrategy', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  async function navigate(routes: Parameters<typeof provideRouter>[0], url: string): Promise<string> {
+    TestBed.configureTestingModule({
+      providers: [provideRouter(routes), provideLocationMocks(), { provide: TitleStrategy, useClass: LfxTitleStrategy }],
+    });
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl(url);
+    return TestBed.inject(Title).getTitle();
+  }
+
+  it('applies a route title with the LFX suffix', async () => {
+    const title = await navigate([{ path: 'meetings', title: 'My Meetings', component: TitleHostComponent }], '/meetings');
+    expect(title).toBe('My Meetings · LFX');
+  });
+
+  it('falls back to data.title when the Angular title key is absent', async () => {
+    const title = await navigate([{ path: 'overview', data: { title: 'Org Overview' }, component: TitleHostComponent }], '/overview');
+    expect(title).toBe('Org Overview · LFX');
+  });
+
+  it('prefers the leaf route title over a parent title', async () => {
+    const title = await navigate(
+      [
+        {
+          path: 'meetings',
+          title: 'Project Meetings',
+          children: [{ path: 'create', title: 'Create Meeting', component: TitleHostComponent }],
+        },
+      ],
+      '/meetings/create'
+    );
+    expect(title).toBe('Create Meeting · LFX');
+  });
+
+  it('inherits the parent title when the leaf has none', async () => {
+    const title = await navigate(
+      [
+        {
+          path: 'meetings',
+          title: 'Project Meetings',
+          children: [{ path: '', component: TitleHostComponent }],
+        },
+      ],
+      '/meetings'
+    );
+    expect(title).toBe('Project Meetings · LFX');
+  });
+
+  it('does not double-suffix an already branded docs title', async () => {
+    const title = await navigate([{ path: 'docs', title: 'LFX Documentation', component: TitleHostComponent }], '/docs');
+    expect(title).toBe('LFX Documentation');
+  });
+});

--- a/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.spec.ts
+++ b/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.spec.ts
@@ -5,7 +5,8 @@ import { provideLocationMocks } from '@angular/common/testing';
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
-import { provideRouter, Router, TitleStrategy } from '@angular/router';
+import { NavigationEnd, provideRouter, Router, TitleStrategy } from '@angular/router';
+import { filter } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { LfxTitleStrategy } from './lfx-title.strategy';
@@ -68,5 +69,61 @@ describe('LfxTitleStrategy', () => {
   it('does not double-suffix an already branded docs title', async () => {
     const title = await navigate([{ path: 'docs', title: 'LFX Documentation', component: TitleHostComponent }], '/docs');
     expect(title).toBe('LFX Documentation');
+  });
+
+  it('does not clobber a component-applied title on same-route query changes', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'projects/:slug', title: 'Project Detail', component: TitleHostComponent },
+          { path: 'meetings', title: 'My Meetings', component: TitleHostComponent },
+        ]),
+        provideLocationMocks(),
+        { provide: TitleStrategy, useClass: LfxTitleStrategy },
+      ],
+    });
+    const router = TestBed.inject(Router);
+    const title = TestBed.inject(Title);
+
+    await router.navigateByUrl('/projects/k8s');
+    expect(title.getTitle()).toBe('Project Detail · LFX');
+
+    title.setTitle('Kubernetes · LFX');
+    await router.navigateByUrl('/projects/k8s?tab=technical');
+    expect(title.getTitle()).toBe('Kubernetes · LFX');
+
+    await router.navigateByUrl('/meetings');
+    expect(title.getTitle()).toBe('My Meetings · LFX');
+  });
+
+  it('exposes the new title on a microtask after NavigationEnd', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'meetings', title: 'My Meetings', component: TitleHostComponent },
+          { path: 'settings', title: 'Settings', component: TitleHostComponent },
+        ]),
+        provideLocationMocks(),
+        { provide: TitleStrategy, useClass: LfxTitleStrategy },
+      ],
+    });
+    const router = TestBed.inject(Router);
+    const title = TestBed.inject(Title);
+    await router.navigateByUrl('/meetings');
+
+    let titleDuringNavEnd = '';
+    let titleAfterMicrotask = '';
+    router.events.pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd)).subscribe(() => {
+      titleDuringNavEnd = title.getTitle();
+      queueMicrotask(() => {
+        titleAfterMicrotask = title.getTitle();
+      });
+    });
+
+    await router.navigateByUrl('/settings');
+    await Promise.resolve();
+
+    expect(titleDuringNavEnd).toBe('My Meetings · LFX');
+    expect(titleAfterMicrotask).toBe('Settings · LFX');
   });
 });

--- a/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.spec.ts
+++ b/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.spec.ts
@@ -71,7 +71,7 @@ describe('LfxTitleStrategy', () => {
     expect(title).toBe('LFX Documentation');
   });
 
-  it('does not clobber a component-applied title on same-route query changes', async () => {
+  it('preserves a component title on query changes but resets when the path param changes', async () => {
     TestBed.configureTestingModule({
       providers: [
         provideRouter([
@@ -91,6 +91,9 @@ describe('LfxTitleStrategy', () => {
     title.setTitle('Kubernetes · LFX');
     await router.navigateByUrl('/projects/k8s?tab=technical');
     expect(title.getTitle()).toBe('Kubernetes · LFX');
+
+    await router.navigateByUrl('/projects/nodejs');
+    expect(title.getTitle()).toBe('Project Detail · LFX');
 
     await router.navigateByUrl('/meetings');
     expect(title.getTitle()).toBe('My Meetings · LFX');

--- a/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.ts
+++ b/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.ts
@@ -11,17 +11,43 @@ import { formatLfxDocumentTitle } from '@lfx-one/shared/utils';
  *
  * Prefers Angular's route `title` (the first-class key). When a leaf has none, falls back to
  * `data.title` — many org-lens routes already store page-header copy there, and that wording
- * is the document title we want. The result is always formatted as `Page · LFX` unless the
+ * is the document title we want. The result is always formatted as `{Page} · LFX` unless the
  * value is already branded (docs / public profile).
  *
  * Leaves untitled routes at the brand (`LFX`) rather than keeping a previous page's title.
+ *
+ * Same-config-chain navigations (query params, path params on the same component tree) do not
+ * reset a title a component already applied via `bindLfxDocumentTitle` or `Title.setTitle`.
  */
 @Injectable({ providedIn: 'root' })
 export class LfxTitleStrategy extends TitleStrategy {
   private readonly title = inject(Title);
+  private lastChainKey: string | undefined;
+  private lastAppliedRouteTitle: string | undefined;
 
   public override updateTitle(routerState: RouterStateSnapshot): void {
-    this.title.setTitle(formatLfxDocumentTitle(this.resolvePageTitle(routerState)));
+    const chainKey = this.primaryConfigChain(routerState.root);
+    const sameChain = chainKey === this.lastChainKey;
+    this.lastChainKey = chainKey;
+
+    const next = formatLfxDocumentTitle(this.resolvePageTitle(routerState));
+    // A component (entity binder, docs article, public profile) already owns the title for
+    // this activation — keep it instead of flashing the static route title on ?tab= / ?step=.
+    if (sameChain && this.lastAppliedRouteTitle !== undefined && this.title.getTitle() !== this.lastAppliedRouteTitle) {
+      return;
+    }
+    this.lastAppliedRouteTitle = next;
+    this.title.setTitle(next);
+  }
+
+  private primaryConfigChain(root: ActivatedRouteSnapshot): string {
+    const parts: string[] = [];
+    let route: ActivatedRouteSnapshot | undefined = root;
+    while (route) {
+      parts.push(route.routeConfig?.path ?? '');
+      route = route.children.find((child) => child.outlet === PRIMARY_OUTLET);
+    }
+    return parts.join('/');
   }
 
   private resolvePageTitle(snapshot: RouterStateSnapshot): string | undefined {

--- a/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.ts
+++ b/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.ts
@@ -16,8 +16,9 @@ import { formatLfxDocumentTitle } from '@lfx-one/shared/utils';
  *
  * Leaves untitled routes at the brand (`LFX`) rather than keeping a previous page's title.
  *
- * Same-config-chain navigations (query params, path params on the same component tree) do not
- * reset a title a component already applied via `bindLfxDocumentTitle` or `Title.setTitle`.
+ * Query-only navigations on the same path (tab/filter/`?step=`) do not reset a title a
+ * component already applied via `bindLfxDocumentTitle` or `Title.setTitle`. A change in a
+ * consumed path segment (`/projects/k8s` → `/projects/nodejs`) is a new page and resets.
  */
 @Injectable({ providedIn: 'root' })
 export class LfxTitleStrategy extends TitleStrategy {
@@ -40,14 +41,21 @@ export class LfxTitleStrategy extends TitleStrategy {
     this.title.setTitle(next);
   }
 
+  /**
+   * Identity of the primary-outlet page: route templates plus consumed URL segments,
+   * without query parameters. `/projects/k8s` and `/projects/k8s?tab=` share a key;
+   * `/projects/nodejs` does not.
+   */
   private primaryConfigChain(root: ActivatedRouteSnapshot): string {
     const parts: string[] = [];
     let route: ActivatedRouteSnapshot | undefined = root;
     while (route) {
-      parts.push(route.routeConfig?.path ?? '');
+      const template = route.routeConfig?.path ?? '';
+      const consumed = route.url.map((segment) => segment.path).join('/');
+      parts.push(`${template}:${consumed}`);
       route = route.children.find((child) => child.outlet === PRIMARY_OUTLET);
     }
-    return parts.join('/');
+    return parts.join('|');
   }
 
   private resolvePageTitle(snapshot: RouterStateSnapshot): string | undefined {

--- a/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.ts
+++ b/apps/lfx-one/src/app/shared/strategies/lfx-title.strategy.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject, Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRouteSnapshot, PRIMARY_OUTLET, RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { formatLfxDocumentTitle } from '@lfx-one/shared/utils';
+
+/**
+ * Applies a per-route document title on every navigation (SSR and client).
+ *
+ * Prefers Angular's route `title` (the first-class key). When a leaf has none, falls back to
+ * `data.title` — many org-lens routes already store page-header copy there, and that wording
+ * is the document title we want. The result is always formatted as `Page · LFX` unless the
+ * value is already branded (docs / public profile).
+ *
+ * Leaves untitled routes at the brand (`LFX`) rather than keeping a previous page's title.
+ */
+@Injectable({ providedIn: 'root' })
+export class LfxTitleStrategy extends TitleStrategy {
+  private readonly title = inject(Title);
+
+  public override updateTitle(routerState: RouterStateSnapshot): void {
+    this.title.setTitle(formatLfxDocumentTitle(this.resolvePageTitle(routerState)));
+  }
+
+  private resolvePageTitle(snapshot: RouterStateSnapshot): string | undefined {
+    let page: string | undefined;
+    let route: ActivatedRouteSnapshot | undefined = snapshot.root;
+    while (route) {
+      const resolved = this.getResolvedTitleForRoute(route);
+      const dataTitle = route.data['title'];
+      const fromRoute = typeof resolved === 'string' ? resolved.trim() : '';
+      const fromData = typeof dataTitle === 'string' ? dataTitle.trim() : '';
+      const candidate = fromRoute || fromData;
+      if (candidate) {
+        page = candidate;
+      }
+      route = route.children.find((child) => child.outlet === PRIMARY_OUTLET);
+    }
+    return page;
+  }
+}

--- a/apps/lfx-one/src/app/shared/utils/document-title.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/document-title.util.ts
@@ -11,8 +11,8 @@ import { formatLfxDocumentTitle } from '@lfx-one/shared/utils';
  * (constructor / field initializer). Empty emissions are ignored so the route-level title
  * from `LfxTitleStrategy` stays in place until the name arrives.
  *
- * `LfxTitleStrategy` skips resetting the title on same-route query/param navigations once
- * this binder (or another `Title.setTitle` caller) has taken over.
+ * `LfxTitleStrategy` skips resetting the title on query-only navigations of the same path
+ * once this binder (or another `Title.setTitle` caller) has taken over.
  */
 export function bindLfxDocumentTitle(page: Signal<string | null | undefined>): void {
   const title = inject(Title);

--- a/apps/lfx-one/src/app/shared/utils/document-title.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/document-title.util.ts
@@ -10,6 +10,9 @@ import { formatLfxDocumentTitle } from '@lfx-one/shared/utils';
  * Keeps `document.title` in sync with a loaded entity name. Call from an injection context
  * (constructor / field initializer). Empty emissions are ignored so the route-level title
  * from `LfxTitleStrategy` stays in place until the name arrives.
+ *
+ * `LfxTitleStrategy` skips resetting the title on same-route query/param navigations once
+ * this binder (or another `Title.setTitle` caller) has taken over.
  */
 export function bindLfxDocumentTitle(page: Signal<string | null | undefined>): void {
   const title = inject(Title);
@@ -22,4 +25,13 @@ export function bindLfxDocumentTitle(page: Signal<string | null | undefined>): v
         title.setTitle(formatLfxDocumentTitle(next));
       }
     });
+}
+
+/**
+ * Angular emits `NavigationEnd` before `TitleStrategy.updateTitle`. Callers that read
+ * `document.title` for analytics must wait until after that synchronous strategy call —
+ * a microtask is enough.
+ */
+export function afterRouterTitleApplied(read: () => void): void {
+  queueMicrotask(read);
 }

--- a/apps/lfx-one/src/app/shared/utils/document-title.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/document-title.util.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DestroyRef, inject, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Title } from '@angular/platform-browser';
+import { formatLfxDocumentTitle } from '@lfx-one/shared/utils';
+
+/**
+ * Keeps `document.title` in sync with a loaded entity name. Call from an injection context
+ * (constructor / field initializer). Empty emissions are ignored so the route-level title
+ * from `LfxTitleStrategy` stays in place until the name arrives.
+ */
+export function bindLfxDocumentTitle(page: Signal<string | null | undefined>): void {
+  const title = inject(Title);
+  const destroyRef = inject(DestroyRef);
+  toObservable(page)
+    .pipe(takeUntilDestroyed(destroyRef))
+    .subscribe((value) => {
+      const next = value?.trim();
+      if (next) {
+        title.setTitle(formatLfxDocumentTitle(next));
+      }
+    });
+}

--- a/docs/architecture/frontend/angular-patterns.md
+++ b/docs/architecture/frontend/angular-patterns.md
@@ -249,7 +249,7 @@ Every navigable route gets a distinct `document.title` so browser history, tabs,
 Angular applies titles through a custom `TitleStrategy`:
 
 1. Declare `title: 'My Meetings'` on the route (first-class Angular key), **or** reuse an existing `data.title` used for page headers.
-2. `LfxTitleStrategy` (provided in `app.config.ts`) reads the deepest primary-outlet title on every navigation — including SSR — and suffixes ` · LFX` unless the value is already branded.
+2. `LfxTitleStrategy` (provided in `app.config.ts`) reads the deepest primary-outlet title on every navigation — including SSR — and appends the `· LFX` brand suffix unless the value is already branded. Same-route query or param updates do not overwrite a title a component already set.
 3. Pages whose title depends on loaded data (a project, group, meeting, or profile) call `bindLfxDocumentTitle(nameSignal)` once the name arrives. Empty emissions are ignored so the route-level title stays until then.
 
 Do not call `Title.setTitle('LFX')` as a reset — use `formatLfxDocumentTitle('Profile')` (or the route title) so history never collapses back to a bare `LFX`.

--- a/docs/architecture/frontend/angular-patterns.md
+++ b/docs/architecture/frontend/angular-patterns.md
@@ -249,7 +249,7 @@ Every navigable route gets a distinct `document.title` so browser history, tabs,
 Angular applies titles through a custom `TitleStrategy`:
 
 1. Declare `title: 'My Meetings'` on the route (first-class Angular key), **or** reuse an existing `data.title` used for page headers.
-2. `LfxTitleStrategy` (provided in `app.config.ts`) reads the deepest primary-outlet title on every navigation — including SSR — and appends the `· LFX` brand suffix unless the value is already branded. Same-route query or param updates do not overwrite a title a component already set.
+2. `LfxTitleStrategy` (provided in `app.config.ts`) reads the deepest primary-outlet title on every navigation — including SSR — and appends the `· LFX` brand suffix unless the value is already branded. Query-only updates on the same path do not overwrite a title a component already set; a path-param change does.
 3. Pages whose title depends on loaded data (a project, group, meeting, or profile) call `bindLfxDocumentTitle(nameSignal)` once the name arrives. Empty emissions are ignored so the route-level title stays until then.
 
 Do not call `Title.setTitle('LFX')` as a reset — use `formatLfxDocumentTitle('Profile')` (or the route title) so history never collapses back to a bare `LFX`.

--- a/docs/architecture/frontend/angular-patterns.md
+++ b/docs/architecture/frontend/angular-patterns.md
@@ -242,6 +242,29 @@ export class ExampleComponent {
 }
 ```
 
+## Document titles
+
+Every navigable route gets a distinct `document.title` so browser history, tabs, and analytics can tell pages apart. Titles follow the `{Page} · LFX` shape (the public profile page's existing convention). Docs articles keep `{Article} · LFX Documentation`.
+
+Angular applies titles through a custom `TitleStrategy`:
+
+1. Declare `title: 'My Meetings'` on the route (first-class Angular key), **or** reuse an existing `data.title` used for page headers.
+2. `LfxTitleStrategy` (provided in `app.config.ts`) reads the deepest primary-outlet title on every navigation — including SSR — and suffixes ` · LFX` unless the value is already branded.
+3. Pages whose title depends on loaded data (a project, group, meeting, or profile) call `bindLfxDocumentTitle(nameSignal)` once the name arrives. Empty emissions are ignored so the route-level title stays until then.
+
+Do not call `Title.setTitle('LFX')` as a reset — use `formatLfxDocumentTitle('Profile')` (or the route title) so history never collapses back to a bare `LFX`.
+
+```typescript
+// app.config.ts
+{ provide: TitleStrategy, useClass: LfxTitleStrategy }
+
+// feature.routes.ts
+{ path: 'create', title: 'Create Meeting', loadComponent: () => ... }
+
+// entity page constructor
+bindLfxDocumentTitle(computed(() => this.committee()?.name));
+```
+
 ## 🔄 Change Detection Strategy
 
 With zoneless change detection:

--- a/docs/architecture/frontend/lazy-loading-preloading-strategy.md
+++ b/docs/architecture/frontend/lazy-loading-preloading-strategy.md
@@ -181,11 +181,14 @@ ls -lh apps/lfx-one/dist/lfx-one/browser/    # inspect emitted chunks
 
 ```typescript
 // app.config.ts
+import { TitleStrategy } from '@angular/router';
 import { CustomPreloadingStrategy } from './shared/strategies/custom-preloading.strategy';
+import { LfxTitleStrategy } from './shared/strategies/lfx-title.strategy';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes, withPreloading(CustomPreloadingStrategy)),
+    { provide: TitleStrategy, useClass: LfxTitleStrategy },
     // ... other providers
   ],
 };

--- a/packages/shared/src/constants/document-title.constants.ts
+++ b/packages/shared/src/constants/document-title.constants.ts
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Brand segment used in every document `<title>` (`Page · LFX`). */
+export const LFX_DOCUMENT_TITLE_BRAND = 'LFX';
+
+/** Middle-dot separator between the page name and the brand. */
+export const LFX_DOCUMENT_TITLE_SEPARATOR = ' · ';
+
+/** Docs portal uses a dedicated brand segment so articles stay distinct from app pages. */
+export const LFX_DOCUMENT_TITLE_DOCS_BRAND = 'LFX Documentation';

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -53,6 +53,7 @@ export * from './lens.constants';
 export * from './badge.constants';
 export * from './training.constants';
 export * from './documents.constants';
+export * from './document-title.constants';
 export * from './transaction.constants';
 export * from './rewards.constants';
 export * from './regex.constants';

--- a/packages/shared/src/utils/document-title.utils.spec.ts
+++ b/packages/shared/src/utils/document-title.utils.spec.ts
@@ -1,0 +1,33 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { formatLfxDocumentTitle } from './document-title.utils';
+
+describe('formatLfxDocumentTitle', () => {
+  it('returns the brand when the page name is missing', () => {
+    expect(formatLfxDocumentTitle(undefined)).toBe('LFX');
+    expect(formatLfxDocumentTitle(null)).toBe('LFX');
+    expect(formatLfxDocumentTitle('')).toBe('LFX');
+    expect(formatLfxDocumentTitle('   ')).toBe('LFX');
+  });
+
+  it('returns the brand unchanged when the page is already the brand', () => {
+    expect(formatLfxDocumentTitle('LFX')).toBe('LFX');
+  });
+
+  it('appends the brand to a plain page name', () => {
+    expect(formatLfxDocumentTitle('My Meetings')).toBe('My Meetings · LFX');
+    expect(formatLfxDocumentTitle(' Kubernetes ')).toBe('Kubernetes · LFX');
+  });
+
+  it('does not double-suffix an already branded app title', () => {
+    expect(formatLfxDocumentTitle('Kubernetes · LFX')).toBe('Kubernetes · LFX');
+  });
+
+  it('leaves the docs portal brand and article titles alone', () => {
+    expect(formatLfxDocumentTitle('LFX Documentation')).toBe('LFX Documentation');
+    expect(formatLfxDocumentTitle('Getting Started · LFX Documentation')).toBe('Getting Started · LFX Documentation');
+  });
+});

--- a/packages/shared/src/utils/document-title.utils.ts
+++ b/packages/shared/src/utils/document-title.utils.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { LFX_DOCUMENT_TITLE_BRAND, LFX_DOCUMENT_TITLE_DOCS_BRAND, LFX_DOCUMENT_TITLE_SEPARATOR } from '../constants/document-title.constants';
+
+/**
+ * Formats a page name into the document title shown in tabs, history, and analytics.
+ *
+ * Already-branded values (the profile/docs `setTitle` callers, or a route that opted into the
+ * full string) are returned unchanged so we never produce `Page · LFX · LFX`.
+ */
+export function formatLfxDocumentTitle(page: string | null | undefined): string {
+  const trimmed = page?.trim() ?? '';
+  if (!trimmed || trimmed === LFX_DOCUMENT_TITLE_BRAND) {
+    return LFX_DOCUMENT_TITLE_BRAND;
+  }
+  if (trimmed === LFX_DOCUMENT_TITLE_DOCS_BRAND) {
+    return trimmed;
+  }
+  if (trimmed.endsWith(`${LFX_DOCUMENT_TITLE_SEPARATOR}${LFX_DOCUMENT_TITLE_BRAND}`)) {
+    return trimmed;
+  }
+  if (trimmed.endsWith(`${LFX_DOCUMENT_TITLE_SEPARATOR}${LFX_DOCUMENT_TITLE_DOCS_BRAND}`)) {
+    return trimmed;
+  }
+  return `${trimmed}${LFX_DOCUMENT_TITLE_SEPARATOR}${LFX_DOCUMENT_TITLE_BRAND}`;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './avatar.utils';
 export * from './color.utils';
 export * from './date-time.utils';
 export * from './docs.utils';
+export * from './document-title.utils';
 export * from './entity-route.utils';
 export * from './file.utils';
 export * from './form.utils';


### PR DESCRIPTION
## Summary
- Apply a distinct `{Page} · LFX` document title on every navigation (SSR and client) via a custom `TitleStrategy`, so browser history, tabs, and analytics are no longer a column of identical `LFX` entries.
- Declare titles on main-nav and feature routes (reusing existing `data.title` where present) and fold loaded entity names into project, group, meeting, mailing-list, and profile pages.
- Keep docs titles as `{Article} · LFX Documentation` without double-suffixing.

Fixes #2295

## Test plan
- [ ] Navigate across Me / Foundation / Project / Org pages and confirm tab titles follow `{Page} · LFX` (e.g. `Project Meetings · LFX`, `Org Overview · LFX`, `Settings · LFX`).
- [ ] Open the browser back-button menu after several navigations and confirm entries are distinguishable.
- [ ] Open a project dashboard and confirm the title becomes `{Project name} · LFX` once the project loads.
- [ ] Open a meeting join page, group detail, committee, mailing list, and public profile; confirm the entity name appears in the title after load.
- [ ] Open a docs article and confirm the title stays `{Article} · LFX Documentation` (not `… · LFX · LFX`).
- [ ] Hard-refresh a titled route and confirm SSR HTML includes the page-specific `<title>`.


Made with [Cursor](https://cursor.com)