### PR TITLE
refactor(profile): remove ecla terminology from clas ui, use ccla

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
@@ -139,6 +139,7 @@ describe('ContactClaManagerComponent', () => {
 
   it('posts removal when opened in removal mode', async () => {
     await setup('removal');
+    expect(query('contact-cla-manager-hint')?.textContent).toContain('remove your CCLA coverage for CNCF');
     expect(query('contact-cla-manager-hint')?.textContent).toContain('invalidate it on your behalf');
 
     send();

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
@@ -91,7 +91,7 @@ describe('ContactClaManagerComponent', () => {
   });
 
   it('shows v17 approval copy naming the project', () => {
-    expect(query('contact-cla-manager-hint')?.textContent).toContain('re-approve your ECLA for CNCF');
+    expect(query('contact-cla-manager-hint')?.textContent).toContain('re-approve your CCLA for CNCF');
   });
 
   it('leaves the message optional for approval, so it carries no aria-required', () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
@@ -91,7 +91,7 @@ describe('ContactClaManagerComponent', () => {
   });
 
   it('shows v17 approval copy naming the project', () => {
-    expect(query('contact-cla-manager-hint')?.textContent).toContain('re-approve your CCLA for CNCF');
+    expect(query('contact-cla-manager-hint')?.textContent).toContain('re-approve your CCLA coverage for CNCF');
   });
 
   it('leaves the message optional for approval, so it carries no aria-required', () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -40,7 +40,7 @@ SPDX-License-Identifier: MIT
   } @else {
     <lfx-message severity="info" [attr.data-testid]="'my-clas-info-banner'">
       <p class="text-sm">
-        Your signed ICLAs (Individual CLA) and CCLAs (Corporate CLA coverage), matched to your Identities. Missing one?
+        Your signed ICLAs (Individual CLA) and CCLA coverage (Corporate CLA), matched to your Identities. Missing one?
         <a class="font-semibold text-blue-600 hover:underline" routerLink="/profile/identities">Link your Email or GitHub accounts →</a>
       </p>
     </lfx-message>
@@ -49,7 +49,7 @@ SPDX-License-Identifier: MIT
       <lfx-empty-state
         icon="fa-light fa-file-signature"
         title="No CLAs on file yet"
-        subtitle="We haven't found any signed ICLAs or CCLAs for your linked identities."
+        subtitle="We haven't found any signed ICLAs or CCLA coverage for your linked identities."
         ctaLabel="Learn about CLAs"
         [ctaRoute]="['/docs', 'account', 'my-clas']"
         data-testid="my-clas-empty-state" />

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -40,7 +40,7 @@ SPDX-License-Identifier: MIT
   } @else {
     <lfx-message severity="info" [attr.data-testid]="'my-clas-info-banner'">
       <p class="text-sm">
-        Your signed ICLAs (Individual CLA) and ECLAs (Employee CLA), matched to your Identities. Missing one?
+        Your signed ICLAs (Individual CLA) and CCLAs (Corporate CLA coverage), matched to your Identities. Missing one?
         <a class="font-semibold text-blue-600 hover:underline" routerLink="/profile/identities">Link your Email or GitHub accounts →</a>
       </p>
     </lfx-message>
@@ -49,7 +49,7 @@ SPDX-License-Identifier: MIT
       <lfx-empty-state
         icon="fa-light fa-file-signature"
         title="No CLAs on file yet"
-        subtitle="We haven't found any signed ICLAs or ECLAs for your linked identities."
+        subtitle="We haven't found any signed ICLAs or CCLAs for your linked identities."
         ctaLabel="Learn about CLAs"
         [ctaRoute]="['/docs', 'account', 'my-clas']"
         data-testid="my-clas-empty-state" />
@@ -112,7 +112,7 @@ SPDX-License-Identifier: MIT
             <td class="px-5 py-3.5 align-middle">
               @if (row.agreement.kind === 'ECLA') {
                 <lfx-badge
-                  [value]="row.agreement.companyName ? 'ECLA · ' + row.agreement.companyName : 'ECLA'"
+                  [value]="row.agreement.companyName ? 'CCLA · ' + row.agreement.companyName : 'CCLA'"
                   severity="secondary"
                   styleClass="!bg-purple-100 !text-purple-800 !h-auto !min-h-5 !max-w-full !whitespace-normal !leading-snug !py-0.5"
                   [attr.data-testid]="'agreement-type-' + row.id" />

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -260,7 +260,7 @@ describe('ProfileClasComponent', () => {
     const badge = fixture.debugElement.query(By.css('[data-testid="agreement-type-s-long"]'));
     expect(badge).toBeTruthy();
     expect(badge.componentInstance).toBeInstanceOf(BadgeComponent);
-    expect(badge.componentInstance.value()).toBe(`ECLA · ${longCompanyName}`);
+    expect(badge.componentInstance.value()).toBe(`CCLA · ${longCompanyName}`);
     expect(badge.componentInstance.styleClass()).toContain('!h-auto');
     expect(badge.componentInstance.styleClass()).toContain('!whitespace-normal');
   });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -306,7 +306,7 @@ describe('SignIdentitySelectComponent', () => {
     const ICLA_ONLY = { iclaEnabled: true, cclaEnabled: false };
     const BOTH_TYPES = { iclaEnabled: true, cclaEnabled: true };
     const REASON = 'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.';
-    const BOTH_REASON = 'You already have an ICLA and an ECLA for this CLA group signed with this account. Choose another identity to sign again.';
+    const BOTH_REASON = 'You already have an ICLA and a CCLA for this CLA group signed with this account. Choose another identity to sign again.';
 
     it('grays out the account that already signed, and only that account', async () => {
       await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
@@ -500,7 +500,7 @@ describe('SignIdentitySelectComponent', () => {
 
       expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(
-        'You already have an ECLA for this CLA group signed with this account. Choose another identity to sign again.'
+        'You already have a CCLA for this CLA group signed with this account. Choose another identity to sign again.'
       );
     });
 
@@ -508,7 +508,7 @@ describe('SignIdentitySelectComponent', () => {
       await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedBoth('jdoe', 'gerrit'), ...BOTH_TYPES });
 
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-gerrit"]')).injector.get(Tooltip, null)?.content).toBe(
-        'You already have an ICLA and an ECLA for this CLA group signed with this account.'
+        'You already have an ICLA and a CCLA for this CLA group signed with this account.'
       );
     });
   });

--- a/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/sign-identity-select.component.spec.ts
@@ -306,7 +306,7 @@ describe('SignIdentitySelectComponent', () => {
     const ICLA_ONLY = { iclaEnabled: true, cclaEnabled: false };
     const BOTH_TYPES = { iclaEnabled: true, cclaEnabled: true };
     const REASON = 'You already have an ICLA for this CLA group signed with this account. Choose another identity to sign again.';
-    const BOTH_REASON = 'You already have an ICLA and a CCLA for this CLA group signed with this account. Choose another identity to sign again.';
+    const BOTH_REASON = 'You already have an ICLA signed with this account and CCLA coverage for this CLA group. Choose another identity to sign again.';
 
     it('grays out the account that already signed, and only that account', async () => {
       await setup({ claGroupAgreements: signedAs('octocat'), ...ICLA_ONLY });
@@ -500,7 +500,7 @@ describe('SignIdentitySelectComponent', () => {
 
       expect(query('sign-identity-select-github-12345')?.getAttribute('aria-disabled')).toBe('true');
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-github-12345"]')).injector.get(Tooltip, null)?.content).toBe(
-        'You already have a CCLA for this CLA group signed with this account. Choose another identity to sign again.'
+        'You already have CCLA coverage for this CLA group linked to this account. Choose another identity to sign again.'
       );
     });
 
@@ -508,7 +508,7 @@ describe('SignIdentitySelectComponent', () => {
       await setup({ variant: 'gerrit', accounts: [], gerritUsername: GERRIT_USER, claGroupAgreements: signedBoth('jdoe', 'gerrit'), ...BOTH_TYPES });
 
       expect(fixture.debugElement.query(By.css('[data-testid="sign-identity-select-gerrit"]')).injector.get(Tooltip, null)?.content).toBe(
-        'You already have an ICLA and a CCLA for this CLA group signed with this account.'
+        'You already have an ICLA signed with this account and CCLA coverage for this CLA group.'
       );
     });
   });

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -171,7 +171,8 @@ export const CLA_MANAGER_MODAL_COPY = {
   },
   removal: {
     title: 'Request Removal',
-    hint: (project: string) => `Ask the CLA manager(s) below to remove your CCLA coverage for ${project}. This starts the process to invalidate it on your behalf.`,
+    hint: (project: string) =>
+      `Ask the CLA manager(s) below to remove your CCLA coverage for ${project}. This starts the process to invalidate it on your behalf.`,
     receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   contact: {

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -166,12 +166,12 @@ const CLA_MANAGER_REQUEST_RECEIPT = {
 export const CLA_MANAGER_MODAL_COPY = {
   approval: {
     title: 'Request approval',
-    hint: (project: string) => `Ask the CLA manager(s) below to re-approve your CCLA for ${project}.`,
+    hint: (project: string) => `Ask the CLA manager(s) below to re-approve your CCLA coverage for ${project}.`,
     receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   removal: {
     title: 'Request Removal',
-    hint: (project: string) => `Ask the CLA manager(s) below to remove your CCLA for ${project}. This starts the process to invalidate it on your behalf.`,
+    hint: (project: string) => `Ask the CLA manager(s) below to remove your CCLA coverage for ${project}. This starts the process to invalidate it on your behalf.`,
     receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   contact: {

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -166,12 +166,12 @@ const CLA_MANAGER_REQUEST_RECEIPT = {
 export const CLA_MANAGER_MODAL_COPY = {
   approval: {
     title: 'Request approval',
-    hint: (project: string) => `Ask the CLA manager(s) below to re-approve your ECLA for ${project}.`,
+    hint: (project: string) => `Ask the CLA manager(s) below to re-approve your CCLA for ${project}.`,
     receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   removal: {
     title: 'Request Removal',
-    hint: (project: string) => `Ask the CLA manager(s) below to remove your ECLA for ${project}. This starts the process to invalidate it on your behalf.`,
+    hint: (project: string) => `Ask the CLA manager(s) below to remove your CCLA for ${project}. This starts the process to invalidate it on your behalf.`,
     receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   contact: {

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -351,7 +351,7 @@ describe('alreadySignedGroupTooltip', () => {
 
   it('names the employer when an ECLA has no signed-as identity', () => {
     expect(alreadySignedGroupTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }), 'github')).toBe(
-      'You already have a CCLA for this CLA group, covered by Acme. If you have another identity linked, you can still sign with it.'
+      'You already have CCLA coverage for this CLA group through Acme. If you have another identity linked, you can still sign with it.'
     );
   });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -538,13 +538,13 @@ describe('alreadySignedIdentityTooltip', () => {
 
   it('names both kinds when the identity holds an ICLA and an ECLA', () => {
     expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), true, ['ICLA', 'ECLA'])).toBe(
-      'You already have an ICLA and a CCLA for this CLA group signed with this account. Choose another identity to sign again.'
+      'You already have an ICLA signed with this account and CCLA coverage for this CLA group. Choose another identity to sign again.'
     );
   });
 
   it('still drops the other-identity sentence when both kinds are held and nothing else is selectable', () => {
     expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), false, ['ICLA', 'ECLA'])).toBe(
-      'You already have an ICLA and a CCLA for this CLA group signed with this account.'
+      'You already have an ICLA signed with this account and CCLA coverage for this CLA group.'
     );
   });
 });

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -351,7 +351,7 @@ describe('alreadySignedGroupTooltip', () => {
 
   it('names the employer when an ECLA has no signed-as identity', () => {
     expect(alreadySignedGroupTooltip(agreement({ kind: 'ECLA', companyName: 'Acme', pdfAvailable: false }), 'github')).toBe(
-      'You already have an ECLA for this CLA group, covered by Acme. If you have another identity linked, you can still sign with it.'
+      'You already have a CCLA for this CLA group, covered by Acme. If you have another identity linked, you can still sign with it.'
     );
   });
 
@@ -538,13 +538,13 @@ describe('alreadySignedIdentityTooltip', () => {
 
   it('names both kinds when the identity holds an ICLA and an ECLA', () => {
     expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), true, ['ICLA', 'ECLA'])).toBe(
-      'You already have an ICLA and an ECLA for this CLA group signed with this account. Choose another identity to sign again.'
+      'You already have an ICLA and a CCLA for this CLA group signed with this account. Choose another identity to sign again.'
     );
   });
 
   it('still drops the other-identity sentence when both kinds are held and nothing else is selectable', () => {
     expect(alreadySignedIdentityTooltip(agreement({ kind: 'ICLA' }), false, ['ICLA', 'ECLA'])).toBe(
-      'You already have an ICLA and an ECLA for this CLA group signed with this account.'
+      'You already have an ICLA and a CCLA for this CLA group signed with this account.'
     );
   });
 });

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -397,9 +397,11 @@ export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
  * is the most this can honestly claim; the identity step is what knows which ones are refused.
  */
 export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaSignRoute): string {
-  const kind = agreement.kind === 'ECLA' ? 'a CCLA' : 'an ICLA';
   const company = agreement.kind === 'ECLA' ? agreement.companyName?.trim() : undefined;
-  const held = company ? `You already have ${kind} for this CLA group, covered by ${company}.` : `You already have ${kind} for this CLA group.`;
+  let held: string;
+  if (agreement.kind === 'ECLA')
+    held = company ? `You already have CCLA coverage for this CLA group through ${company}.` : 'You already have CCLA coverage for this CLA group.';
+  else held = 'You already have an ICLA for this CLA group.';
   const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
   const offersOneIdentityAtMost = route === 'gerrit' || route === 'gitlab-unsupported';
   const another = offersOneIdentityAtMost ? '' : ' If you have another identity linked, you can still sign with it.';

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -517,10 +517,10 @@ export function alreadySignedAgreementForIdentity(
 export function alreadySignedIdentityTooltip(agreement: MyClaAgreement, anotherSelectable: boolean, heldKinds: readonly ClaKind[] = [agreement.kind]): string {
   const hasIcla = heldKinds.includes('ICLA');
   const hasEcla = heldKinds.includes('ECLA');
-  let kind = 'an ICLA';
-  if (hasIcla && hasEcla) kind = 'an ICLA and a CCLA';
-  else if (hasEcla) kind = 'a CCLA';
-  const held = `You already have ${kind} for this CLA group signed with this account.`;
+  let held: string;
+  if (hasIcla && hasEcla) held = 'You already have an ICLA signed with this account and CCLA coverage for this CLA group.';
+  else if (hasEcla) held = 'You already have CCLA coverage for this CLA group linked to this account.';
+  else held = 'You already have an ICLA for this CLA group signed with this account.';
 
   return anotherSelectable ? `${held} Choose another identity to sign again.` : held;
 }

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -397,7 +397,7 @@ export function alreadySignedChipLabel(agreement: MyClaAgreement): string {
  * is the most this can honestly claim; the identity step is what knows which ones are refused.
  */
 export function alreadySignedGroupTooltip(agreement: MyClaAgreement, route: ClaSignRoute): string {
-  const kind = agreement.kind === 'ECLA' ? 'an ECLA' : 'an ICLA';
+  const kind = agreement.kind === 'ECLA' ? 'a CCLA' : 'an ICLA';
   const company = agreement.kind === 'ECLA' ? agreement.companyName?.trim() : undefined;
   const held = company ? `You already have ${kind} for this CLA group, covered by ${company}.` : `You already have ${kind} for this CLA group.`;
   const signed = signedAsLine(agreement.signedVia, agreement.signedAs);
@@ -518,8 +518,8 @@ export function alreadySignedIdentityTooltip(agreement: MyClaAgreement, anotherS
   const hasIcla = heldKinds.includes('ICLA');
   const hasEcla = heldKinds.includes('ECLA');
   let kind = 'an ICLA';
-  if (hasIcla && hasEcla) kind = 'an ICLA and an ECLA';
-  else if (hasEcla) kind = 'an ECLA';
+  if (hasIcla && hasEcla) kind = 'an ICLA and a CCLA';
+  else if (hasEcla) kind = 'a CCLA';
   const held = `You already have ${kind} for this CLA group signed with this account.`;
 
   return anotherSelectable ? `${held} Choose another identity to sign again.` : held;


### PR DESCRIPTION
## Summary
- Removes "ECLA" from every user-facing string in the Me Lens CLAs tab (info banner, empty-state text, row-type badge, request-approval/removal hint dialogs, sign/identity tooltips) and displays "CCLA" instead
- Internal identifiers are unchanged by design: the `ClaKind` type, `kind === 'ECLA'` comparisons, and internal names (`eclas`, `hasEcla`, `ECLA_COVERED_DOWNLOAD_LABEL`) — only the rendered text changed
- Follows the docs-only change in #2322; this closes out the remaining Me Lens UI portion of the ticket

Closes #2294

## Test plan
- [x] `yarn check-types` passes
- [x] `yarn lint` passes
- [x] `yarn build` passes (SSR bundle included)
- [x] Updated unit tests pass: 230 tests in `apps/lfx-one` (clas module) + 95 tests in `packages/shared` (`cla-view.utils.spec.ts`)
- [x] `git grep` sanity check confirms no remaining rendered "ECLA" strings outside the intentionally-excluded internal identifiers/types