### PR TITLE
feat(easycla): match org lens sign CLA picker to My CLA

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -171,7 +171,7 @@ SPDX-License-Identifier: MIT
                   [attr.aria-expanded]="option.expanded"
                   [attr.data-testid]="'org-easycla-group-orgs-toggle-' + option.claGroupId"
                   (click)="toggleOrgs($event, option)"
-                  (keydown)="$event.stopPropagation()">
+                  (keydown.enter)="$event.stopPropagation()">
                   <i class="fa-light" [class.fa-chevron-right]="!option.expanded" [class.fa-chevron-down]="option.expanded" aria-hidden="true"></i>
                   {{ option.orgViews.length }} linked orgs
                 </button>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -169,7 +169,7 @@ SPDX-License-Identifier: MIT
                   type="button"
                   class="flex w-full cursor-pointer items-center gap-1.5 px-4 pb-2.5 text-left text-xs text-slate-500 hover:text-slate-700"
                   [attr.aria-expanded]="option.expanded"
-                  [attr.aria-controls]="'org-easycla-group-orgs-' + option.claGroupId"
+                  [attr.aria-controls]="option.expanded ? 'org-easycla-group-orgs-' + option.claGroupId : null"
                   [attr.data-testid]="'org-easycla-group-orgs-toggle-' + option.claGroupId"
                   (click)="toggleOrgs($event, option)"
                   (keydown.enter)="$event.stopPropagation()">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -170,6 +170,7 @@ SPDX-License-Identifier: MIT
                   class="flex w-full cursor-pointer items-center gap-1.5 px-4 pb-2.5 text-left text-xs text-slate-500 hover:text-slate-700"
                   [attr.aria-expanded]="option.expanded"
                   [attr.aria-controls]="option.expanded ? 'org-easycla-group-orgs-' + option.claGroupId : null"
+                  [attr.aria-label]="orgsToggleLabel(option)"
                   [attr.data-testid]="'org-easycla-group-orgs-toggle-' + option.claGroupId"
                   (click)="toggleOrgs($event, option)"
                   (keydown.enter)="$event.stopPropagation()">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -169,6 +169,7 @@ SPDX-License-Identifier: MIT
                   type="button"
                   class="flex w-full cursor-pointer items-center gap-1.5 px-4 pb-2.5 text-left text-xs text-slate-500 hover:text-slate-700"
                   [attr.aria-expanded]="option.expanded"
+                  [attr.aria-controls]="'org-easycla-group-orgs-' + option.claGroupId"
                   [attr.data-testid]="'org-easycla-group-orgs-toggle-' + option.claGroupId"
                   (click)="toggleOrgs($event, option)"
                   (keydown.enter)="$event.stopPropagation()">
@@ -176,7 +177,10 @@ SPDX-License-Identifier: MIT
                   {{ option.orgViews.length }} linked orgs
                 </button>
                 @if (option.expanded) {
-                  <ul class="px-4 pb-2.5 pl-9" [attr.data-testid]="'org-easycla-group-orgs-' + option.claGroupId">
+                  <ul
+                    class="px-4 pb-2.5 pl-9"
+                    [id]="'org-easycla-group-orgs-' + option.claGroupId"
+                    [attr.data-testid]="'org-easycla-group-orgs-' + option.claGroupId">
                     @for (org of option.orgViews; track org.source + '/' + org.name) {
                       <li class="flex items-center gap-1.5 py-0.5 text-xs text-slate-500">
                         <i [class]="org.sourceIcon + ' text-slate-400'" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -62,7 +62,7 @@ SPDX-License-Identifier: MIT
     <div class="mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg" data-testid="org-easycla-group-select-panel">
       @if (error()) {
         <div role="alert" class="flex items-center justify-between gap-3 px-4 py-3 text-sm text-slate-600" data-testid="org-easycla-group-select-error">
-          <span>Couldn't load CLA groups.</span>
+          <span>Couldn't load projects.</span>
           <lfx-button
             label="Retry"
             size="small"
@@ -102,7 +102,7 @@ SPDX-License-Identifier: MIT
             Searching…
           </div>
         }
-        <div id="org-easycla-group-select-results" role="listbox" aria-label="Matching CLA groups" data-testid="org-easycla-group-select-results">
+        <div id="org-easycla-group-select-results" role="listbox" aria-label="Matching projects" data-testid="org-easycla-group-select-results">
           @for (option of options(); track option.claGroupId; let index = $index) {
             <!--
               A row that cannot be signed keeps its place and states why, rather than disappearing.
@@ -123,9 +123,16 @@ SPDX-License-Identifier: MIT
               [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
               [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
               (click)="onSelect(option)">
-              <span class="block text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
+              <span class="block min-w-0 truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
               @if (option.secondaryName) {
-                <span class="block text-xs text-slate-500">{{ option.secondaryName }}</span>
+                <span class="block truncate text-xs text-slate-500">{{ option.secondaryName }}</span>
+              }
+              @if (option.matchTypeLabels.length) {
+                <span class="mt-1 flex flex-wrap gap-1" [attr.data-testid]="'org-easycla-group-match-types-' + option.claGroupId">
+                  @for (label of option.matchTypeLabels; track label) {
+                    <span class="rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-600">{{ label }}</span>
+                  }
+                </span>
               }
               <!--
                 Shown only for a repository match, where the row would otherwise contain nothing the
@@ -139,6 +146,36 @@ SPDX-License-Identifier: MIT
                   <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
                   <span class="truncate">{{ option.matchedRepositoryName }}</span>
                 </span>
+              }
+              @if (option.orgViews.length === 1) {
+                @let org = option.orgViews[0];
+                <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-org-' + option.claGroupId">
+                  <i [class]="org.sourceIcon + ' text-slate-400'" aria-hidden="true"></i>
+                  <span class="truncate">{{ org.name }}</span>
+                  <span class="text-slate-400">{{ org.sourceLabel }}</span>
+                </span>
+              }
+              @if (option.orgViews.length > 1) {
+                <button
+                  type="button"
+                  class="mt-1 flex w-full cursor-pointer items-center gap-1.5 text-left text-xs text-slate-500 hover:text-slate-700"
+                  [attr.aria-expanded]="option.expanded"
+                  [attr.data-testid]="'org-easycla-group-orgs-toggle-' + option.claGroupId"
+                  (click)="toggleOrgs($event, option)">
+                  <i class="fa-light" [class.fa-chevron-right]="!option.expanded" [class.fa-chevron-down]="option.expanded" aria-hidden="true"></i>
+                  {{ option.orgViews.length }} linked orgs
+                </button>
+                @if (option.expanded) {
+                  <ul class="mt-1 pl-5" [attr.data-testid]="'org-easycla-group-orgs-' + option.claGroupId">
+                    @for (org of option.orgViews; track org.source + '/' + org.name) {
+                      <li class="flex items-center gap-1.5 py-0.5 text-xs text-slate-500">
+                        <i [class]="org.sourceIcon + ' text-slate-400'" aria-hidden="true"></i>
+                        <span class="truncate">{{ org.name }}</span>
+                        <span class="text-slate-400">{{ org.sourceLabel }}</span>
+                      </li>
+                    }
+                  </ul>
+                }
               }
               @if (option.disabledReason) {
                 <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
@@ -154,7 +191,7 @@ SPDX-License-Identifier: MIT
         -->
         @if (truncated()) {
           <div class="px-4 py-2 text-xs text-slate-500" data-testid="org-easycla-group-select-truncated">
-            More CLA groups matched than can be shown. Narrow your search.
+            More projects matched than we can show. Narrow the search to see the rest.
           </div>
         }
       }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.html
@@ -110,63 +110,73 @@ SPDX-License-Identifier: MIT
               would never reach a viewer who cannot hover. It is inside the option, so the reason is
               part of the row's accessible name and is read when the highlight arrives.
             -->
-            <div
-              role="option"
-              [id]="'org-easycla-group-option-' + option.claGroupId"
-              [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
-              [attr.aria-disabled]="!!option.disabledReason || stale()"
-              class="border-b border-slate-100 px-4 py-2.5 text-left last:border-b-0"
-              [class.cursor-pointer]="!option.disabledReason && !stale()"
-              [class.hover:bg-slate-50]="!option.disabledReason && !stale()"
-              [class.cursor-not-allowed]="!!option.disabledReason || stale()"
-              [class.opacity-60]="!!option.disabledReason || stale()"
-              [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
-              [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
-              (click)="onSelect(option)">
-              <span class="block min-w-0 truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
-              @if (option.secondaryName) {
-                <span class="block truncate text-xs text-slate-500">{{ option.secondaryName }}</span>
-              }
-              @if (option.matchTypeLabels.length) {
-                <span class="mt-1 flex flex-wrap gap-1" [attr.data-testid]="'org-easycla-group-match-types-' + option.claGroupId">
-                  @for (label of option.matchTypeLabels; track label) {
-                    <span class="rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-600">{{ label }}</span>
-                  }
-                </span>
-              }
-              <!--
-                Shown only for a repository match, where the row would otherwise contain nothing the
-                viewer typed: pasting a repo link resolves to the CLA Group covering it, whose project
-                and group names need share no text with the address. Without this the row reads as an
-                unrelated result. It is inside the option, so it is part of the accessible name and is
-                read when the highlight arrives.
-              -->
-              @if (option.matchedRepositoryName) {
-                <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-matched-repo-' + option.claGroupId">
-                  <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
-                  <span class="truncate">{{ option.matchedRepositoryName }}</span>
-                </span>
-              }
-              @if (option.orgViews.length === 1) {
-                @let org = option.orgViews[0];
-                <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-org-' + option.claGroupId">
-                  <i [class]="org.sourceIcon + ' text-slate-400'" aria-hidden="true"></i>
-                  <span class="truncate">{{ org.name }}</span>
-                  <span class="text-slate-400">{{ org.sourceLabel }}</span>
-                </span>
-              }
+            <div class="border-b border-slate-100 last:border-b-0">
+              <div
+                role="option"
+                [id]="'org-easycla-group-option-' + option.claGroupId"
+                [attr.aria-selected]="selected()?.claGroupId === option.claGroupId"
+                [attr.aria-disabled]="!!option.disabledReason || stale()"
+                class="px-4 py-2.5 text-left"
+                [class.cursor-pointer]="!option.disabledReason && !stale()"
+                [class.hover:bg-slate-50]="!option.disabledReason && !stale()"
+                [class.cursor-not-allowed]="!!option.disabledReason || stale()"
+                [class.opacity-60]="!!option.disabledReason || stale()"
+                [class.bg-slate-50]="selected()?.claGroupId === option.claGroupId || highlightedIndex() === index"
+                [attr.data-testid]="'org-easycla-group-select-' + option.claGroupId"
+                (click)="onSelect(option)">
+                <span class="block min-w-0 truncate text-sm font-medium text-slate-900">{{ option.primaryName }}</span>
+                @if (option.secondaryName) {
+                  <span class="block truncate text-xs text-slate-500">{{ option.secondaryName }}</span>
+                }
+                @if (option.matchTypeLabels.length) {
+                  <span class="mt-1 flex flex-wrap gap-1" [attr.data-testid]="'org-easycla-group-match-types-' + option.claGroupId">
+                    @for (label of option.matchTypeLabels; track label) {
+                      <span class="rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-600">{{ label }}</span>
+                    }
+                  </span>
+                }
+                <!--
+                  Shown only for a repository match, where the row would otherwise contain nothing the
+                  viewer typed: pasting a repo link resolves to the CLA Group covering it, whose project
+                  and group names need share no text with the address. Without this the row reads as an
+                  unrelated result. It is inside the option, so it is part of the accessible name and is
+                  read when the highlight arrives.
+                -->
+                @if (option.matchedRepositoryName) {
+                  <span
+                    class="mt-1 flex items-center gap-1.5 text-xs text-slate-500"
+                    [attr.data-testid]="'org-easycla-group-matched-repo-' + option.claGroupId">
+                    <i class="fa-light fa-code-branch text-slate-400" aria-hidden="true"></i>
+                    <span class="truncate">{{ option.matchedRepositoryName }}</span>
+                  </span>
+                }
+                @if (option.orgViews.length === 1) {
+                  @let org = option.orgViews[0];
+                  <span class="mt-1 flex items-center gap-1.5 text-xs text-slate-500" [attr.data-testid]="'org-easycla-group-org-' + option.claGroupId">
+                    <i [class]="org.sourceIcon + ' text-slate-400'" aria-hidden="true"></i>
+                    <span class="truncate">{{ org.name }}</span>
+                    <span class="text-slate-400">{{ org.sourceLabel }}</span>
+                  </span>
+                }
+                @if (option.disabledReason) {
+                  <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
+                    {{ option.disabledReason }}
+                  </span>
+                }
+              </div>
               @if (option.orgViews.length > 1) {
                 <button
                   type="button"
-                  class="mt-1 flex w-full cursor-pointer items-center gap-1.5 text-left text-xs text-slate-500 hover:text-slate-700"
+                  class="flex w-full cursor-pointer items-center gap-1.5 px-4 pb-2.5 text-left text-xs text-slate-500 hover:text-slate-700"
                   [attr.aria-expanded]="option.expanded"
                   [attr.data-testid]="'org-easycla-group-orgs-toggle-' + option.claGroupId"
-                  (click)="toggleOrgs($event, option)">
+                  (click)="toggleOrgs($event, option)"
+                  (keydown)="$event.stopPropagation()">
                   <i class="fa-light" [class.fa-chevron-right]="!option.expanded" [class.fa-chevron-down]="option.expanded" aria-hidden="true"></i>
                   {{ option.orgViews.length }} linked orgs
                 </button>
                 @if (option.expanded) {
-                  <ul class="mt-1 pl-5" [attr.data-testid]="'org-easycla-group-orgs-' + option.claGroupId">
+                  <ul class="px-4 pb-2.5 pl-9" [attr.data-testid]="'org-easycla-group-orgs-' + option.claGroupId">
                     @for (org of option.orgViews; track org.source + '/' + org.name) {
                       <li class="flex items-center gap-1.5 py-0.5 text-xs text-slate-500">
                         <i [class]="org.sourceIcon + ' text-slate-400'" aria-hidden="true"></i>
@@ -176,11 +186,6 @@ SPDX-License-Identifier: MIT
                     }
                   </ul>
                 }
-              }
-              @if (option.disabledReason) {
-                <span class="mt-1 block text-xs text-amber-700" [attr.data-testid]="'org-easycla-group-disabled-' + option.claGroupId">
-                  {{ option.disabledReason }}
-                </span>
               }
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -365,6 +365,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
     const toggle = testid(fixture, `org-easycla-group-orgs-toggle-${withOrgs.claGroupId}`);
     expect(toggle?.textContent).toContain('2 linked orgs');
+    expect(toggle?.getAttribute('aria-label')).toBe('Cascade — Cascade CLA, 2 linked orgs');
     expect(row(fixture, withOrgs).contains(toggle)).toBe(false);
     expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)).toBeNull();
     expect(toggle?.getAttribute('aria-controls')).toBeNull();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -367,6 +367,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     expect(toggle?.textContent).toContain('2 linked orgs');
     expect(row(fixture, withOrgs).contains(toggle)).toBe(false);
     expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)).toBeNull();
+    expect(toggle?.getAttribute('aria-controls')).toBeNull();
 
     toggle?.click();
     fixture.detectChanges();
@@ -378,6 +379,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     toggle?.click();
     fixture.detectChanges();
     expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle?.getAttribute('aria-controls')).toBeNull();
     expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)).toBeNull();
 
     toggle?.click();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -387,6 +387,10 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     listbox?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     fixture.detectChanges();
     expect(continueButton(fixture).disabled).toBe(false);
+
+    toggle?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    fixture.detectChanges();
+    expect(close).toHaveBeenCalledWith(null);
   });
 
   it('cannot be continued before a CLA group is chosen', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -365,6 +365,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
     const toggle = testid(fixture, `org-easycla-group-orgs-toggle-${withOrgs.claGroupId}`);
     expect(toggle?.textContent).toContain('2 linked orgs');
+    expect(row(fixture, withOrgs).contains(toggle)).toBe(false);
     expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)).toBeNull();
 
     toggle?.click();
@@ -373,6 +374,19 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)?.textContent).toContain('acme-gitlab');
     expect(continueButton(fixture).disabled).toBe(true);
     expect(close).not.toHaveBeenCalled();
+
+    const listbox = testid(fixture, 'org-easycla-group-select-results');
+    listbox?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    fixture.detectChanges();
+
+    toggle?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+    expect(continueButton(fixture).disabled).toBe(true);
+    expect(close).not.toHaveBeenCalled();
+
+    listbox?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+    expect(continueButton(fixture).disabled).toBe(false);
   });
 
   it('cannot be continued before a CLA group is chosen', async () => {
@@ -620,9 +634,9 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       await search(fixture);
 
       const listbox = results_(fixture);
-      // Every child of the listbox is an option — nothing else.
-      const nonOptionChildren = Array.from(listbox.children).filter((child) => child.getAttribute('role') !== 'option');
-      expect(nonOptionChildren).toEqual([]);
+      for (const child of Array.from(listbox.children)) {
+        expect(child.querySelectorAll('[role="option"]').length).toBe(1);
+      }
 
       // And the "more matched than can be shown" note sits *outside* the listbox, in the panel.
       const truncated = testid(fixture, 'org-easycla-group-select-truncated');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -5,7 +5,7 @@ import '@angular/compiler';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { CCLA_SIGN_COPY, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import { CCLA_SIGN_COPY, CLA_GROUP_MATCH_TYPE_LABELS, CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
 import type { ClaGroupOption, ClaGroupSearchResponse, OrgClaGroup } from '@lfx-one/shared/interfaces';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -323,6 +323,58 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     expect(testid(fixture, `org-easycla-group-matched-repo-${signable.claGroupId}`)).toBeNull();
   });
 
+  it('names why the row matched, the same way My CLA does', async () => {
+    getSignOptions.mockReturnValue(of(results([signable])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    expect(testid(fixture, `org-easycla-group-match-types-${signable.claGroupId}`)?.textContent).toContain(CLA_GROUP_MATCH_TYPE_LABELS.project);
+    expect(row(fixture, signable).textContent).toContain('Cascade');
+    expect(row(fixture, signable).textContent).toContain('Cascade CLA');
+  });
+
+  it('names a single linked organization on the row', async () => {
+    const withOrg: ClaGroupOption = {
+      ...signable,
+      organizations: [{ name: 'acme-org', source: 'github' }],
+    };
+    getSignOptions.mockReturnValue(of(results([withOrg])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    const org = testid(fixture, `org-easycla-group-org-${withOrg.claGroupId}`);
+    expect(org?.textContent).toContain('acme-org');
+    expect(org?.textContent).toContain('GitHub');
+    expect(row(fixture, withOrg).contains(org)).toBe(true);
+  });
+
+  it('expands several linked orgs without choosing the row', async () => {
+    const withOrgs: ClaGroupOption = {
+      ...signable,
+      organizations: [
+        { name: 'acme-org', source: 'github' },
+        { name: 'acme-gitlab', source: 'gitlab' },
+      ],
+    };
+    getSignOptions.mockReturnValue(of(results([withOrgs])));
+
+    const fixture = await render();
+    await search(fixture);
+
+    const toggle = testid(fixture, `org-easycla-group-orgs-toggle-${withOrgs.claGroupId}`);
+    expect(toggle?.textContent).toContain('2 linked orgs');
+    expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)).toBeNull();
+
+    toggle?.click();
+    fixture.detectChanges();
+
+    expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)?.textContent).toContain('acme-gitlab');
+    expect(continueButton(fixture).disabled).toBe(true);
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it('cannot be continued before a CLA group is chosen', async () => {
     getSignOptions.mockReturnValue(of(results([signable])));
 
@@ -415,7 +467,9 @@ describe('OrgEasyclaGroupSelectComponent', () => {
     const fixture = await render();
     await search(fixture);
 
-    expect(testid(fixture, 'org-easycla-group-select-truncated')).not.toBeNull();
+    expect(testid(fixture, 'org-easycla-group-select-truncated')?.textContent?.trim()).toBe(
+      'More projects matched than we can show. Narrow the search to see the rest.'
+    );
   });
 
   it('offers a retry when the search fails rather than reading as no matches', async () => {
@@ -530,7 +584,7 @@ describe('OrgEasyclaGroupSelectComponent', () => {
       const listbox = results_(fixture);
       expect(listbox.id).toBe('org-easycla-group-select-results');
       expect(listbox.getAttribute('role')).toBe('listbox');
-      expect(listbox.getAttribute('aria-label')).toBe('Matching CLA groups');
+      expect(listbox.getAttribute('aria-label')).toBe('Matching projects');
     });
 
     /**

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.spec.ts
@@ -370,8 +370,18 @@ describe('OrgEasyclaGroupSelectComponent', () => {
 
     toggle?.click();
     fixture.detectChanges();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle?.getAttribute('aria-controls')).toBe(`org-easycla-group-orgs-${withOrgs.claGroupId}`);
 
     expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)?.textContent).toContain('acme-gitlab');
+
+    toggle?.click();
+    fixture.detectChanges();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(testid(fixture, `org-easycla-group-orgs-${withOrgs.claGroupId}`)).toBeNull();
+
+    toggle?.click();
+    fixture.detectChanges();
     expect(continueButton(fixture).disabled).toBe(true);
     expect(close).not.toHaveBeenCalled();
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -34,6 +34,10 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
  * the selectability rule would rewrite the component the Me-lens signing flow depends on, inside a
  * slice whose risk is already spent on a write path and legal copy.
  *
+ * The row rendering (match-type chips, matched-repository line, linked-orgs expander) is a
+ * deliberate copy of the Me-lens picker, kept in lockstep by hand — change one, change both.
+ * If the two pickers converge further, that copy is the thing to extract first.
+ *
  * Closes with the chosen group, or `null` if the viewer backs out.
  */
 @Component({

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -34,10 +34,6 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
  * the selectability rule would rewrite the component the Me-lens signing flow depends on, inside a
  * slice whose risk is already spent on a write path and legal copy.
  *
- * What is genuinely shared is shared: the debounce and minimum-term constants, and
- * `toClaGroupOptionView`. If the two pickers later converge, that is the moment for a common
- * base — not now, when they disagree about what a row means.
- *
  * Closes with the chosen group, or `null` if the viewer backs out.
  */
 @Component({
@@ -326,6 +322,11 @@ export class OrgEasyclaGroupSelectComponent {
       orgUid: this.orgUid,
     };
     this.ref.close(result);
+  }
+
+  protected toggleOrgs(event: Event, option: OrgClaGroupOptionView): void {
+    event.stopPropagation();
+    this.options.update((options) => options.map((row) => (row.claGroupId === option.claGroupId ? { ...row, expanded: !row.expanded } : row)));
   }
 
   protected onCancel(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-group-select.component.ts
@@ -333,6 +333,15 @@ export class OrgEasyclaGroupSelectComponent {
     this.options.update((options) => options.map((row) => (row.claGroupId === option.claGroupId ? { ...row, expanded: !row.expanded } : row)));
   }
 
+  /**
+   * The disclosure sits beside the option, so its visible "N linked orgs" text is no longer
+   * inside that option's accessible name. Name the result here so two expanders are distinguishable.
+   */
+  protected orgsToggleLabel(option: OrgClaGroupOptionView): string {
+    const name = option.secondaryName ? `${option.primaryName} — ${option.secondaryName}` : option.primaryName;
+    return `${name}, ${option.orgViews.length} linked orgs`;
+  }
+
   protected onCancel(): void {
     this.ref.close(null);
   }

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -335,7 +335,7 @@ export const CCLA_SIGN_COPY = {
     body: 'Choose the project, CLA group, or repository source (GitHub, GitLab, or Gerrit), for which you want to sign a CLA.',
     placeholder: 'Search projects, CLA groups, repo sources, or paste a repo link',
     empty: 'Search for a project, CLA group, repo source, or paste a repo link.',
-    noMatch: 'No matching projects, CLA groups, or foundations.',
+    noMatch: 'No matching projects, CLA groups, repo sources, or repo links.',
     continueLabel: 'Continue to sign →',
     cancelLabel: 'Cancel',
     /** Why a row cannot be signed. Shown on the row, because the row stays visible. */


### PR DESCRIPTION
The Org Lens Sign CLA picker now renders each search hit the same way My CLA does — project name, CLA group name, match-type chips, repository line, and linked orgs — and uses the same picker copy.

Refs #1983