### PR TITLE
fix(easycla): own ccla hand-off heading in the child

### DIFF
--- a/apps/lfx-one/e2e/org-easycla-sign.spec.ts
+++ b/apps/lfx-one/e2e/org-easycla-sign.spec.ts
@@ -111,6 +111,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
     await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
 
     await expect(page.getByTestId('org-easycla-sign-ready')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-sign-handoff-heading')).toHaveText('Review CCLA');
     await page.getByTestId('org-easycla-sign-review').locator('button').click();
 
     // The whole point of the hand-off: the address is the server's, byte for byte, and the
@@ -283,6 +284,7 @@ test.describe('Org Lens EasyCLA corporate self-sign — content', () => {
     await page.getByTestId('org-easycla-attestation-continue').locator('button').click();
 
     await expect(page.getByTestId('org-easycla-sign-failed')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    await expect(page.getByTestId('org-easycla-sign-handoff-close')).toBeVisible();
     await expect(page.getByTestId('org-easycla-sign-failure-message')).toHaveText(refusal);
     await expect(page.getByTestId('org-easycla-sign-failure-message')).not.toContainText('We could not prepare this CLA');
   });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.spec.ts
@@ -373,12 +373,14 @@ describe('OrgEasyclaDetailComponent', () => {
 
     it('hands the confirmations to the signing step for this agreement', async () => {
       const attestations = { authorityAcked: true, embargoAcked: true };
-      const opened: { component: unknown; config: { data?: unknown; closable?: boolean } }[] = [];
-      openDialog.mockImplementation((component: unknown, config: { data?: unknown; closable?: boolean } = {}) => {
-        opened.push({ component, config });
-        const result = opened.length === 1 ? attestations : null;
-        return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
-      });
+      const opened: { component: unknown; config: { data?: unknown; closable?: boolean; showHeader?: boolean; ariaLabelledBy?: string } }[] = [];
+      openDialog.mockImplementation(
+        (component: unknown, config: { data?: unknown; closable?: boolean; showHeader?: boolean; ariaLabelledBy?: string } = {}) => {
+          opened.push({ component, config });
+          const result = opened.length === 1 ? attestations : null;
+          return { onClose: of(result), onDestroy: of(undefined), close: vi.fn() };
+        }
+      );
 
       const signable = {
         ...notStarted,
@@ -392,6 +394,8 @@ describe('OrgEasyclaDetailComponent', () => {
 
       expect(opened).toHaveLength(2);
       expect(opened[1].component).toBe(OrgEasyclaSignHandoffComponent);
+      expect(opened[1].config.showHeader).toBe(false);
+      expect(opened[1].config.ariaLabelledBy).toBe(OrgEasyclaSignHandoffComponent.headingId);
       expect(opened[1].config.data).toEqual({
         orgUid: SELECTED_ACCOUNT.uid,
         projectSfid: 'a09410000182dD2AAI',

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-detail/org-easycla-detail.component.ts
@@ -398,9 +398,11 @@ export class OrgEasyclaDetailComponent {
 
   private openHandOff(orgUid: string, chosen: OrgClaGroupPickerResult, attestations: OrgClaSignAttestations): void {
     const handoffRef = this.dialogService.open(OrgEasyclaSignHandoffComponent, {
-      header: CCLA_SIGN_COPY.preparing.header,
+      showHeader: false,
+      ariaLabelledBy: OrgEasyclaSignHandoffComponent.headingId,
       width: '40rem',
       style: { maxWidth: '90vw' },
+      contentStyle: { padding: '1.5rem' },
       modal: true,
       closable: false,
       closeOnEscape: false,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.html
@@ -19,7 +19,15 @@ SPDX-License-Identifier: MIT
   The failure branch below keeps its own role="alert" and so stays assertive: it interrupts, which
   a refusal should, and a nested live region overrides this one for its own subtree.
 -->
-<div class="flex flex-col" role="status" aria-live="polite" data-testid="org-easycla-sign-handoff-dialog">
+<div class="flex flex-col gap-4" role="status" aria-live="polite" data-testid="org-easycla-sign-handoff-dialog">
+  <div class="flex items-start justify-between gap-4">
+    <h2 [id]="headingId" class="text-lg font-semibold text-gray-900" data-testid="org-easycla-sign-handoff-heading">{{ heading() }}</h2>
+    @if (state() === 'failed') {
+      <button type="button" class="text-gray-400 hover:text-gray-600" data-testid="org-easycla-sign-handoff-close" aria-label="Close" (click)="onCancel()">
+        <i class="fa-light fa-xmark text-lg" aria-hidden="true"></i>
+      </button>
+    }
+  </div>
   @switch (state()) {
     @case ('preparing') {
       <div class="flex flex-col items-center gap-3 py-6 text-center" data-testid="org-easycla-sign-preparing">
@@ -32,8 +40,6 @@ SPDX-License-Identifier: MIT
     }
 
     @case ('ready') {
-      <!-- The state's name is the dialog's title, set from the component, and is deliberately not
-           repeated here: it used to be, which put "Review CCLA" on screen twice. -->
       <div class="flex flex-col gap-4" data-testid="org-easycla-sign-ready">
         <div class="flex items-start gap-2">
           <i class="fa-light fa-circle-check mt-0.5 text-xl text-emerald-700" aria-hidden="true"></i>
@@ -49,8 +55,7 @@ SPDX-License-Identifier: MIT
       <div class="flex flex-col gap-4" role="alert" data-testid="org-easycla-sign-failed">
         <!-- The CLA service's own sentence when it refused in words; the generic copy otherwise.
              A trade-compliance refusal names the reason and how to challenge it, which nothing
-             written here could reproduce and keep current. The state's name is the dialog's
-             title, set from the component, so it is not repeated alongside the message. -->
+             written here could reproduce and keep current. -->
         <div class="flex items-start gap-2">
           <i class="fa-light fa-triangle-exclamation mt-0.5 text-xl text-red-700" aria-hidden="true"></i>
           <p class="text-sm text-slate-600" data-testid="org-easycla-sign-failure-message">{{ failureMessage() }}</p>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.spec.ts
@@ -46,10 +46,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
   // Explicit rather than defaulted: a defaulted parameter would substitute the real selection for
   // the `undefined` the missing-data test means to pass, and that test would silently assert
   // nothing.
-  async function renderWith(
-    dialogData: OrgClaSignHandoffDialogData | undefined,
-    options: { render: boolean } = { render: true }
-  ): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
+  async function renderWith(dialogData: OrgClaSignHandoffDialogData | undefined): Promise<ComponentFixture<OrgEasyclaSignHandoffComponent>> {
     let href = 'https://example.test/org/easycla';
     location = {
       get href() {
@@ -60,9 +57,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
         href = value;
       },
     };
-    // The real shape and the real initial values from the call site, because the component drives
-    // three of these and a bare `{ data }` stub would let a wrong initial value pass unnoticed.
-    config = { data: dialogData, header: CCLA_SIGN_COPY.preparing.header, closable: false, closeOnEscape: false };
+    config = { data: dialogData };
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [OrgEasyclaSignHandoffComponent],
@@ -88,7 +83,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     }).compileComponents();
 
     const fixture = TestBed.createComponent(OrgEasyclaSignHandoffComponent);
-    if (options.render) fixture.detectChanges();
+    fixture.detectChanges();
     return fixture;
   }
 
@@ -285,6 +280,7 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     const fixture = await render();
 
     expect(testid(fixture, 'org-easycla-sign-cancel')).toBeNull();
+    expect(testid(fixture, 'org-easycla-sign-handoff-close')).toBeNull();
     expect(testid(fixture, 'org-easycla-sign-review')).not.toBeNull();
     expect(close).not.toHaveBeenCalled();
   });
@@ -303,13 +299,12 @@ describe('OrgEasyclaSignHandoffComponent', () => {
    * with nobody holding it. Neither exit is available until there is something to lose.
    */
   describe('while the signing request is in flight', () => {
-    it('cannot be dismissed by the header control or by Escape', async () => {
+    it('cannot be dismissed by the header control', async () => {
       requestCorporateSignature.mockReturnValue(new Observable<OrgClaSignResponse>(() => undefined));
 
-      await render();
+      const fixture = await render();
 
-      expect(config.closable).toBe(false);
-      expect(config.closeOnEscape).toBe(false);
+      expect(testid(fixture, 'org-easycla-sign-handoff-close')).toBeNull();
     });
 
     // Still sealed on success, not just in flight. The envelope exists by then and the address on
@@ -319,10 +314,9 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     it('still cannot be dismissed once the session is open', async () => {
       requestCorporateSignature.mockReturnValue(of(response));
 
-      await render();
+      const fixture = await render();
 
-      expect(config.closable).toBe(false);
-      expect(config.closeOnEscape).toBe(false);
+      expect(testid(fixture, 'org-easycla-sign-handoff-close')).toBeNull();
     });
 
     // The one dismissible state: no envelope to strand, and trapping someone in a dialog that
@@ -330,19 +324,13 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     it('can be dismissed once it reaches failed', async () => {
       requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
 
-      await render();
+      const fixture = await render();
 
-      expect(config.closable).toBe(true);
-      expect(config.closeOnEscape).toBe(true);
+      expect(testid(fixture, 'org-easycla-sign-handoff-close')).not.toBeNull();
+      (testid(fixture, 'org-easycla-sign-handoff-close') as HTMLButtonElement).click();
+      expect(close).toHaveBeenCalledWith(null);
     });
 
-    /**
-     * The key itself, not the flag that is supposed to enable it.
-     *
-     * The shell decides its Escape handling once, as it becomes visible, from the values it holds
-     * then — and this dialog opens sealed. Asserting only the flag would report a dismissible
-     * failure state that a keyboard user cannot actually leave.
-     */
     describe('pressing Escape', () => {
       function pressEscape(): void {
         globalThis.document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
@@ -415,11 +403,6 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     });
   });
 
-  /**
-   * The shell dialog's title is PrimeNG's, and it is a static string at the call site. Left alone
-   * it keeps saying "Configuring CLA Manager Settings…" above a panel that says the session is
-   * ready, or that it failed.
-   */
   describe('the dialog title', () => {
     it.each([
       ['preparing', () => new Observable<OrgClaSignResponse>(() => undefined), CCLA_SIGN_COPY.preparing.header],
@@ -428,47 +411,19 @@ describe('OrgEasyclaSignHandoffComponent', () => {
     ])('names the %s state', async (_state, source, expected) => {
       requestCorporateSignature.mockReturnValue(source());
 
-      await render();
+      const fixture = await render();
 
-      expect(config.header).toBe(expected);
+      expect(testid(fixture, 'org-easycla-sign-handoff-heading')?.textContent).toBe(expected);
     });
 
-    // Would have been the whole bug: the title is set once at the call site and the panel moves on
-    // without it.
     it('does not leave the preparing title above a ready panel', async () => {
       requestCorporateSignature.mockReturnValue(of(response));
 
       const fixture = await render();
 
       expect(testid(fixture, 'org-easycla-sign-ready')).not.toBeNull();
-      expect(config.header).not.toBe(CCLA_SIGN_COPY.preparing.header);
-    });
-
-    /**
-     * The shell reads these as it renders, and nothing re-renders it when they change on their own.
-     * Deferring the write to a render pass therefore dresses the frame for the state before this
-     * one — so the assertions below are deliberately made with no pass having run at all. Rendering
-     * first would hide exactly the ordering they exist to hold.
-     */
-    describe('without waiting for a render pass', () => {
-      it('names the state the panel is already in', async () => {
-        requestCorporateSignature.mockReturnValue(of(response));
-
-        await renderWith(data, { render: false });
-
-        expect(config.header).toBe(CCLA_SIGN_COPY.ready.header);
-      });
-
-      // The sealed-on-failure case: a frame still refusing Escape over a panel reporting a failure
-      // traps the signatory in it, and there is no envelope here to justify holding them.
-      it('unseals a failure', async () => {
-        requestCorporateSignature.mockReturnValue(throwError(() => bffError(500, { error: 'nope' })));
-
-        await renderWith(data, { render: false });
-
-        expect(config.closable).toBe(true);
-        expect(config.closeOnEscape).toBe(true);
-      });
+      expect(testid(fixture, 'org-easycla-sign-handoff-heading')?.textContent).toBe(CCLA_SIGN_COPY.ready.header);
+      expect(testid(fixture, 'org-easycla-sign-handoff-heading')?.textContent).not.toBe(CCLA_SIGN_COPY.preparing.header);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla-sign/org-easycla-sign-handoff.component.ts
@@ -3,7 +3,7 @@
 
 import { DOCUMENT } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, DestroyRef, HostListener, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, HostListener, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CCLA_SIGN_COPY } from '@lfx-one/shared/constants';
 import type { OrgClaSignHandoffDialogData, OrgClaSignResponse } from '@lfx-one/shared/interfaces';
@@ -35,6 +35,8 @@ import { ButtonComponent } from '@components/button/button.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OrgEasyclaSignHandoffComponent {
+  static readonly headingId = 'org-easycla-sign-handoff-heading';
+
   private readonly ref = inject(DynamicDialogRef);
   private readonly destroyRef = inject(DestroyRef);
   private readonly claService = inject(OrgLensClaService);
@@ -42,6 +44,7 @@ export class OrgEasyclaSignHandoffComponent {
   private readonly config = inject<DynamicDialogConfig<OrgClaSignHandoffDialogData>>(DynamicDialogConfig);
 
   protected readonly copy = CCLA_SIGN_COPY;
+  protected readonly headingId = OrgEasyclaSignHandoffComponent.headingId;
 
   protected readonly state = signal<'preparing' | 'ready' | 'failed'>('preparing');
   /** The CLA service's own words for a refusal it explained; the generic copy otherwise. */
@@ -49,12 +52,13 @@ export class OrgEasyclaSignHandoffComponent {
 
   private readonly prepared = signal<OrgClaSignResponse | null>(null);
 
-  /** Shell-dialog title per state, so the frame never contradicts the panel inside it. */
   private readonly headerFor: Record<'preparing' | 'ready' | 'failed', string> = {
     preparing: CCLA_SIGN_COPY.preparing.header,
     ready: CCLA_SIGN_COPY.ready.header,
     failed: CCLA_SIGN_COPY.failure.header,
   };
+
+  protected readonly heading = computed(() => this.headerFor[this.state()]);
 
   public constructor() {
     this.enter('preparing');
@@ -125,14 +129,6 @@ export class OrgEasyclaSignHandoffComponent {
 
   /**
    * Escape, in the one state that permits leaving.
-   *
-   * Handled here because the shell's own Escape handling is decided once, when it becomes visible,
-   * from the values it holds at that moment — and this dialog opens sealed. Turning the flag on
-   * afterwards puts the close control on the frame but installs no key listener, so the state that
-   * is meant to be dismissible would be dismissible only by pointer.
-   *
-   * Guarded on the state rather than on the flag it sets, so a frame that is somehow drawn ahead
-   * of the panel cannot become an exit from a session that is open.
    */
   @HostListener('document:keydown.escape')
   protected onEscape(): void {
@@ -141,15 +137,6 @@ export class OrgEasyclaSignHandoffComponent {
   }
 
   /**
-   * Moves to a state and dresses the shell dialog to match, in one step.
-   *
-   * The shell is PrimeNG's and reads `header`, `closable` and `closeOnEscape` off this config
-   * object as it renders. They are plain properties rather than signals, so nothing re-renders the
-   * shell when they change: written from an effect — which runs *after* the pass that has already
-   * drawn the frame — the title and the dismiss controls would describe the state before this one,
-   * and stay that way until some unrelated event happened to schedule another pass. Writing them
-   * with the state is what keeps the frame from contradicting the panel inside it.
-   *
    * The dialog cannot be dismissed while the request is in flight, and still cannot once it
    * succeeds. The signature record and the DocuSign envelope are created by that one call, and
    * the address it returns is the only copy — so every exit before the signatory follows it
@@ -161,12 +148,7 @@ export class OrgEasyclaSignHandoffComponent {
    * in a dialog that reports a failure would leave them no way out at all.
    */
   private enter(state: 'preparing' | 'ready' | 'failed'): void {
-    const dismissible = state === 'failed';
-
     this.state.set(state);
-    this.config.header = this.headerFor[state];
-    this.config.closable = dismissible;
-    this.config.closeOnEscape = dismissible;
   }
 
   /**


### PR DESCRIPTION
The CCLA sign hand-off now owns its heading and failed-only close control in the child, and never mutates DynamicDialog config after open. That keeps the chrome in sync in the zoneless app after the corporate-CLA flow landed.

Closes [#2319](https://github.com/linuxfoundation/lfx-self-serve/issues/2319)