### PR TITLE
feat(org-lens): resolve CCLA return org through the access-aware catalogue

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -8,7 +8,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { ORG_CLA_SIGNED_SIGNATURE_KEY } from '@lfx-one/shared/constants';
-import type { Account, OrgClaGroup } from '@lfx-one/shared/interfaces';
+import type { Account, OrgClaGroup, OrgItem } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensClaService } from '@services/org-lens-cla.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
@@ -1013,11 +1013,20 @@ describe('OrgEasyclaComponent', () => {
     const MICROSOFT = { uid: '0014100000Te0OKAAZ', accountName: 'Microsoft Corporation', accountId: 'acct-microsoft' };
     const CONTAINERSHIP = { uid: '0014100000Te2QjAAJ', accountName: 'ContainerShip, Inc.', accountId: 'acct-containership' };
 
-    async function renderReturnedFrom(namedOrg: string | null, authorized: Partial<Account>[] = [CONTAINERSHIP, MICROSOFT]) {
+    function toCatalogueItem(account: Partial<Account>): OrgItem {
+      return {
+        uid: account.uid ?? account.accountId ?? '',
+        accountId: account.accountId ?? account.uid ?? null,
+        name: account.accountName ?? '',
+        logoUrl: null,
+      };
+    }
+
+    async function renderReturnedFrom(namedOrg: string | null, catalogue: Partial<Account>[] = [CONTAINERSHIP, MICROSOFT], opts: { holdPin?: boolean } = {}) {
       const setAccount = vi.fn();
+      const items = signal(catalogue.map(toCatalogueItem));
       const resetAndReload = vi.fn();
       const navigate = vi.fn();
-      const availableAccounts = signal(authorized);
 
       selectedAccount.set(CONTAINERSHIP);
       getClaGroups.mockReturnValue(of({ orgUid: CONTAINERSHIP.uid, claGroups: [] }));
@@ -1028,10 +1037,13 @@ describe('OrgEasyclaComponent', () => {
         providers: [
           provideRouter([]),
           provideNoopAnimations(),
-          { provide: AccountContextService, useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts, setAccount } },
+          {
+            provide: AccountContextService,
+            useValue: { selectedAccount, hasOrgSelectorAccess, availableAccounts: signal([]), setAccount },
+          },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
-          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload } },
+          { provide: OrgNavigationService, useValue: { items, loaded: navLoaded, resetAndReload } },
           { provide: OrgLensClaService, useValue: { getClaGroups } },
           { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(namedOrg ? { org: namedOrg } : {}) } } },
           MessageService,
@@ -1048,14 +1060,26 @@ describe('OrgEasyclaComponent', () => {
       fixture.detectChanges();
       await fixture.whenStable();
 
-      return { fixture, setAccount, resetAndReload, navigate, availableAccounts };
+      if (resetAndReload.mock.calls.length > 0 && !opts.holdPin) {
+        items.update((current) => [...current]);
+        await fixture.whenStable();
+      }
+
+      return { fixture, setAccount, resetAndReload, navigate, items };
     }
 
     it('selects the organization the signature was made for, not the first in the list', async () => {
       const { setAccount } = await renderReturnedFrom(MICROSOFT.uid);
 
       // `setAccount` also rewrites the cookie, so the selection that went missing is repaired.
-      expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+      expect(setAccount).toHaveBeenCalledWith(expect.objectContaining({ uid: MICROSOFT.uid, accountName: MICROSOFT.accountName }));
+    });
+
+    it('selects from the catalogue when the persona-seeded account list is empty', async () => {
+      const { setAccount, resetAndReload } = await renderReturnedFrom(MICROSOFT.uid, [MICROSOFT]);
+
+      expect(setAccount).toHaveBeenCalledWith(expect.objectContaining({ uid: MICROSOFT.uid, accountName: MICROSOFT.accountName }));
+      expect(resetAndReload).not.toHaveBeenCalled();
     });
 
     /**
@@ -1075,30 +1099,26 @@ describe('OrgEasyclaComponent', () => {
       const { setAccount, resetAndReload } = await renderReturnedFrom(MICROSOFT.uid, [CONTAINERSHIP, enriched]);
 
       expect(setAccount).toHaveBeenCalledWith(expect.objectContaining({ accountName: MICROSOFT.accountName, uid: MICROSOFT.uid }));
-      expect(resetAndReload).toHaveBeenCalledWith(MICROSOFT.uid);
-    });
-
-    /**
-     * Selecting it is not enough to keep it.
-     *
-     * The org selector requests its first page for whichever organization was current at bootstrap,
-     * which on a cold return is still the stale cookie. When that page lands, the pending default
-     * selection reassigns to its first row unless the current selection is on it — so adopting
-     * without re-pinning is overwritten a beat later by a page requested before the adoption
-     * happened, and the signatory lands back on the organization they did not sign for.
-     */
-    it('re-pins the catalogue on the adopted organization, so the pending default selection cannot reassign it', async () => {
-      const { resetAndReload } = await renderReturnedFrom(MICROSOFT.uid);
-
-      expect(resetAndReload).toHaveBeenCalledWith(MICROSOFT.uid);
-    });
-
-    // The mirror of ignoring it above: an organization that was not adopted must not be pinned
-    // either, or a crafted link would reorder the viewer's catalogue around a company it named.
-    it('does not re-pin an organization the viewer does not hold', async () => {
-      const { resetAndReload } = await renderReturnedFrom('0014100000TeZZZAAA');
-
       expect(resetAndReload).not.toHaveBeenCalled();
+    });
+
+    it('reloads the catalogue pinned to the named organization before selecting it', async () => {
+      const { setAccount, resetAndReload, items } = await renderReturnedFrom(MICROSOFT.uid, [CONTAINERSHIP], { holdPin: true });
+
+      expect(resetAndReload).toHaveBeenCalledWith(MICROSOFT.uid);
+      expect(setAccount).not.toHaveBeenCalled();
+
+      items.set([toCatalogueItem(CONTAINERSHIP), toCatalogueItem(MICROSOFT)]);
+      await TestBed.inject(ApplicationRef).whenStable();
+
+      expect(setAccount).toHaveBeenCalledWith(expect.objectContaining({ uid: MICROSOFT.uid, accountName: MICROSOFT.accountName }));
+    });
+
+    it('asks the catalogue for an organization it does not yet list, but does not select it when the page comes back without it', async () => {
+      const { setAccount, resetAndReload } = await renderReturnedFrom('0014100000TeZZZAAA');
+
+      expect(resetAndReload).toHaveBeenCalledWith('0014100000TeZZZAAA');
+      expect(setAccount).not.toHaveBeenCalled();
     });
 
     /**
@@ -1142,15 +1162,15 @@ describe('OrgEasyclaComponent', () => {
     // with would throw away a legitimate hand-off.
     it('waits for the authorized list rather than discarding the hand-off against an empty one', async () => {
       navLoaded.set(false);
-      const { setAccount, availableAccounts } = await renderReturnedFrom(MICROSOFT.uid, []);
+      const { setAccount, items } = await renderReturnedFrom(MICROSOFT.uid, []);
 
       expect(setAccount).not.toHaveBeenCalled();
 
-      availableAccounts.set([CONTAINERSHIP, MICROSOFT]);
+      items.set([toCatalogueItem(CONTAINERSHIP), toCatalogueItem(MICROSOFT)]);
       navLoaded.set(true);
       await TestBed.inject(ApplicationRef).whenStable();
 
-      expect(setAccount).toHaveBeenCalledWith(MICROSOFT);
+      expect(setAccount).toHaveBeenCalledWith(expect.objectContaining({ uid: MICROSOFT.uid, accountName: MICROSOFT.accountName }));
     });
 
     // The mirror of the wait above: once the organization list has genuinely settled without it,
@@ -1180,6 +1200,15 @@ describe('OrgEasyclaComponent', () => {
   describe('when EasyCLA returns the signatory after a signing ceremony', () => {
     const SIGNED = ['/org/easycla', 'signature-uuid-1'];
 
+    function toCatalogueItem(account: Partial<Account>): OrgItem {
+      return {
+        uid: account.uid ?? account.accountId ?? '',
+        accountId: account.accountId ?? account.uid ?? null,
+        name: account.accountName ?? '',
+        logoUrl: null,
+      };
+    }
+
     async function renderAfterSigning(
       options: { stash?: string; org?: string | null; listOrgUid?: string; claGroups?: OrgClaGroup[]; authorized?: Partial<Account>[] } = {}
     ) {
@@ -1195,6 +1224,9 @@ describe('OrgEasyclaComponent', () => {
       selectedAccount.set(SELECTED_ACCOUNT);
       getClaGroups.mockReturnValue(of({ orgUid: listOrgUid, claGroups }));
 
+      const items = signal(authorized.map(toCatalogueItem));
+      const resetAndReload = vi.fn(() => items.update((current) => [...current]));
+
       TestBed.resetTestingModule();
       await TestBed.configureTestingModule({
         imports: [OrgEasyclaComponent],
@@ -1209,13 +1241,13 @@ describe('OrgEasyclaComponent', () => {
             useValue: {
               selectedAccount,
               hasOrgSelectorAccess,
-              availableAccounts: signal(authorized),
+              availableAccounts: signal([]),
               setAccount: (account: Account) => selectedAccount.set(account),
             },
           },
           { provide: OrgRoleGrantsService, useValue: { loaded: grantsLoaded } },
           { provide: PersonaService, useValue: { personaLoaded } },
-          { provide: OrgNavigationService, useValue: { loaded: navLoaded, resetAndReload: vi.fn() } },
+          { provide: OrgNavigationService, useValue: { items, loaded: navLoaded, resetAndReload } },
           { provide: OrgLensClaService, useValue: { getClaGroups } },
           { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(org ? { org } : {}) } } },
           MessageService,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.spec.ts
@@ -1182,6 +1182,16 @@ describe('OrgEasyclaComponent', () => {
       expect(navigate).toHaveBeenCalled();
     });
 
+    it('strips the parameter when the viewer has no Org Lens access, without waiting for a catalogue that never loads', async () => {
+      hasOrgSelectorAccess.set(false);
+      navLoaded.set(false);
+      const { setAccount, resetAndReload, navigate } = await renderReturnedFrom(MICROSOFT.uid, []);
+
+      expect(setAccount).not.toHaveBeenCalled();
+      expect(resetAndReload).not.toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { org: null }, replaceUrl: true }));
+    });
+
     it('touches nothing on an ordinary visit that carries no organization', async () => {
       const { setAccount, navigate } = await renderReturnedFrom(null);
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -13,7 +13,7 @@ import {
   ORG_EASYCLA_PATH,
   ORG_EASYCLA_RETURN_ORG_PARAM,
 } from '@lfx-one/shared/constants';
-import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaSignSelection } from '@lfx-one/shared/interfaces';
+import type { Account, OrgClaGroup, OrgClaGroupList, OrgClaSignSelection, OrgItem } from '@lfx-one/shared/interfaces';
 import { orgClaOpenLabel } from '@lfx-one/shared/utils';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -28,6 +28,7 @@ import {
   merge,
   Observable,
   of,
+  shareReplay,
   skip,
   skipWhile,
   switchMap,
@@ -121,6 +122,8 @@ export class OrgEasyclaComponent {
    * awaited, so it reads true no matter which of them resolves first.
    */
   private returnLandingPending = false;
+
+  private namedOrganizationResolved$: Observable<Account | null> | null = null;
 
   // ── Search (client-side; the upstream list takes no search parameter) ──────
   protected readonly orgClaOpenLabel = orgClaOpenLabel;
@@ -477,12 +480,6 @@ export class OrgEasyclaComponent {
    * the first organization in the viewer's list — so signing for one company returns them looking
    * at another, with their new agreement nowhere in sight. The return address names the
    * organization the session was opened for so this page does not have to guess.
-   *
-   * **The parameter names an organization; it does not grant one.** It is resolved against the
-   * viewer's own authorized accounts and anything absent from that list is ignored, so a crafted
-   * link cannot select a company they do not hold. Deliberately no stub is built from the value —
-   * that is how the cookie path hydrates an id it trusts, and doing it here would render an
-   * arbitrary organization's name from the URL.
    */
   private adoptOrganizationFromReturnAddress(): void {
     // The address is only followed in a browser, and the strip below is a browser navigation.
@@ -491,70 +488,59 @@ export class OrgEasyclaComponent {
     const named = this.route.snapshot.queryParamMap.get(ORG_EASYCLA_RETURN_ORG_PARAM);
     if (!named) return;
 
-    // The authorized list arrives after this component is constructed, so resolving immediately
-    // would discard a legitimate hand-off against an empty list. Waits for whichever comes first:
-    // the organization appearing, or the org context settling without it.
-    combineLatest([toObservable(this.accountContext.availableAccounts), toObservable(this.orgContextLoaded)])
-      .pipe(
-        map(([accounts, loaded]) => ({ match: this.authorizedAccountNamed(accounts, named), loaded })),
-        filter(({ match, loaded }) => !!match || loaded),
-        take(1),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe(({ match }) => {
+    this.organizationNamedOnReturn(named)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((match) => {
         // `setAccount` also rewrites the cookie, so the round trip repairs the selection that went
         // missing rather than leaving the next reload to fall back all over again.
-        //
-        // Selecting it is not enough to keep it. The org selector bootstraps its catalogue with
-        // whichever organization was current at the time, which on a cold return is still the stale
-        // cookie — so the first page comes back pinned to that one. When it lands, the pending
-        // default selection asks whether the *current* selection is on the page it received, and
-        // reassigns to the first row when it is not. Adopting early therefore gets overwritten a
-        // beat later by a page that was requested before the adoption happened.
-        //
-        // Re-pinning refetches that page for the organization actually selected, which both
-        // supersedes the in-flight one and satisfies the check when the replacement arrives.
-        if (match) {
-          this.accountContext.setAccount(match);
-          this.orgNavigation.resetAndReload(match.uid);
-        }
+        if (match) this.accountContext.setAccount(match);
 
         // Not when a landing is intended. `landOnSignedAgreement` navigates off this route, and the
         // navigation below is relative to it, so both in flight means Angular cancels whichever
         // started first — leaving the signatory on the list either way.
-        //
-        // A flag rather than a look at `this.router.url`, which is the *committed* address: both
-        // flows start from this constructor and `navigate` resolves later, so at this point the
-        // committed address is still the return address whichever one goes on to win. The flag is
-        // set synchronously, before anything is awaited, so it is already true here. Removing the
-        // parameter then belongs to the landing, which does it if it declines to navigate.
         if (this.returnLandingPending) return;
 
         this.stripReturnOrganizationFromAddress();
       });
   }
 
-  /**
-   * The viewer's own account for the organization named on the return address, or null.
-   *
-   * Resolved on either identifier the record may carry. The authorized list starts as persona
-   * seeds, which hold `uid`, and is then replaced row by row with the Snowflake-enriched record
-   * for the same company — which carries `accountId` and no `uid` at all. Matching on `uid` alone
-   * therefore stops matching the moment enrichment lands, and the company the signatory has just
-   * signed for reads as one they do not hold. For an organization account the two are the same
-   * Salesforce id (spec 002: the b2b_org uid *is* the 18-char SFID), which is what makes either
-   * one an honest answer to the same question.
-   *
-   * `uid` is pinned onto the result because the enriched record has none and everything
-   * downstream is keyed on it — `setAccount` persists the selection by `uid`, and clears the
-   * cookie outright when it is absent.
-   *
-   * Still only a resolution, never a grant: an organization that is not in this list is not
-   * matched, so a crafted address selects nothing.
-   */
-  private authorizedAccountNamed(accounts: Account[], named: string): Account | null {
-    const match = accounts.find((account: Account) => account.uid === named || account.accountId === named);
-    return match ? { ...match, uid: named } : null;
+  private organizationNamedOnReturn(named: string): Observable<Account | null> {
+    this.namedOrganizationResolved$ ??= this.resolveNamedOrganization(named).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    return this.namedOrganizationResolved$;
+  }
+
+  private resolveNamedOrganization(named: string): Observable<Account | null> {
+    const items$ = toObservable(this.orgNavigation.items);
+    const loaded$ = toObservable(this.orgNavigation.loaded);
+
+    return combineLatest([items$, loaded$]).pipe(
+      filter(([, loaded]) => loaded),
+      map(([items]) => this.catalogueAccountNamed(items, named)),
+      take(1),
+      switchMap((immediate) => {
+        if (immediate) return of(immediate);
+        this.orgNavigation.resetAndReload(named);
+        return combineLatest([items$, loaded$]).pipe(
+          skip(1),
+          filter(([, loaded]) => loaded),
+          map(([items]) => this.catalogueAccountNamed(items, named)),
+          take(1)
+        );
+      })
+    );
+  }
+
+  private catalogueAccountNamed(items: OrgItem[], named: string): Account | null {
+    const match = items.find((item: OrgItem) => item.uid === named || item.accountId === named);
+    if (!match) return null;
+    return {
+      accountId: match.accountId ?? named,
+      accountName: match.name,
+      accountSlug: '',
+      membershipTier: '',
+      logoUrl: match.logoUrl ?? null,
+      uid: named,
+    };
   }
 
   /**
@@ -622,13 +608,8 @@ export class OrgEasyclaComponent {
 
     type Outcome = { kind: 'list'; list: OrgClaGroupList | null } | { kind: 'failed' } | { kind: 'unreachable' } | { kind: 'cancelled' };
 
-    const outcome$ = combineLatest([
-      toObservable(this.claData),
-      toObservable(this.accountContext.availableAccounts),
-      toObservable(this.orgContextLoaded),
-      toObservable(this.failedOrgUid),
-    ]).pipe(
-      map(([data, accounts, loaded, failedFor]): Outcome | null => {
+    const outcome$ = combineLatest([toObservable(this.claData), this.organizationNamedOnReturn(named), toObservable(this.failedOrgUid)]).pipe(
+      map(([data, account, failedFor]): Outcome | null => {
         // A failed request answers nothing about the row, but it does answer the question of
         // whether to keep waiting. The page fetches once per organization, so nothing is coming
         // to replace the failure, and a wait for the list it did not return never ends — leaving
@@ -645,7 +626,7 @@ export class OrgEasyclaComponent {
         // Nothing will ever fetch a list for an organization the viewer does not hold, so once the
         // context has settled without it there is no list coming and waiting on one would leave
         // the parameter on the address for good.
-        if (loaded && !this.authorizedAccountNamed(accounts, named)) return { kind: 'unreachable' };
+        if (!account) return { kind: 'unreachable' };
         if (data?.orgUid === named) return { kind: 'list', list: data };
         return null;
       }),

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-easycla/org-easycla.component.ts
@@ -512,18 +512,20 @@ export class OrgEasyclaComponent {
   private resolveNamedOrganization(named: string): Observable<Account | null> {
     const items$ = toObservable(this.orgNavigation.items);
     const loaded$ = toObservable(this.orgNavigation.loaded);
+    const noAccess$ = toObservable(this.hasNoOrgAccess);
 
-    return combineLatest([items$, loaded$]).pipe(
-      filter(([, loaded]) => loaded),
-      map(([items]) => this.catalogueAccountNamed(items, named)),
+    return combineLatest([items$, loaded$, noAccess$]).pipe(
+      filter(([, loaded, noAccess]) => noAccess || loaded),
       take(1),
-      switchMap((immediate) => {
+      switchMap(([items, , noAccess]) => {
+        if (noAccess) return of(null);
+        const immediate = this.catalogueAccountNamed(items, named);
         if (immediate) return of(immediate);
         this.orgNavigation.resetAndReload(named);
         return combineLatest([items$, loaded$]).pipe(
           skip(1),
           filter(([, loaded]) => loaded),
-          map(([items]) => this.catalogueAccountNamed(items, named)),
+          map(([current]) => this.catalogueAccountNamed(current, named)),
           take(1)
         );
       })


### PR DESCRIPTION
Resolve the organization EasyCLA names on the `/org/easycla` return address against the access-aware catalogue, not persona-seeded accounts. Reload and pin first, then select; a name that is not in the catalogue still selects nothing.

Closes #2308