### PR TITLE
fix(committees): join dialog validation and error toast fixes (GH-2349)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -83,7 +83,7 @@ import {
   tap,
   timer,
 } from 'rxjs';
-import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
+import { committeeJoinErrorMessage, committeeLeaveErrorMessage, getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
 import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invite-organization-dialog/accept-invite-organization-dialog.component';
@@ -605,7 +605,7 @@ export class CommitteeViewComponent {
             this.refreshCommitteeAfterMembershipChange();
           },
           error: (err: HttpErrorResponse) => {
-            const detail = this.getJoinErrorMessage(err, committee.name);
+            const detail = committeeJoinErrorMessage(err, committee.name);
             this.messageService.add({ severity: 'error', summary: 'Unable to Join', detail, life: 6000 });
           },
         });
@@ -648,8 +648,7 @@ export class CommitteeViewComponent {
           this.membersRefresh.update((v) => v + 1);
         },
         error: (err: HttpErrorResponse) => {
-          const detail =
-            err.status === 404 ? 'You are not a member of this group.' : (err.error?.message ?? `Failed to leave "${committee.name}". Please try again.`);
+          const detail = committeeLeaveErrorMessage(err, committee.name);
           this.messageService.add({ severity: 'error', summary: 'Unable to Leave', detail, life: 6000 });
         },
       });
@@ -1491,22 +1490,5 @@ export class CommitteeViewComponent {
     const username = this.userService.viewerUsername()?.toLowerCase();
     if (!email && !username) return false;
     return auditors?.some((u) => (email && u.email?.toLowerCase() === email) || (username && u.username?.toLowerCase() === username)) ?? false;
-  }
-
-  private getJoinErrorMessage(err: HttpErrorResponse, committeeName: string): string {
-    const upstream = err.error?.message as string | undefined;
-    if (err.status === 409) {
-      return 'You are already a member of this group.';
-    }
-    if (upstream?.includes('organization')) {
-      return 'This group requires a verified organization to join. Please contact an admin for access.';
-    }
-    if (upstream?.includes('business email')) {
-      return 'This group requires a business email address to join. Please contact an admin for access.';
-    }
-    if (err.status === 403) {
-      return 'You do not have permission to join this group.';
-    }
-    return upstream ?? `Failed to join "${committeeName}". Please try again.`;
   }
 }

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.spec.ts
@@ -1,0 +1,106 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ApplicationRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { OrganizationService } from '@services/organization.service';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AcceptInviteOrganizationDialogComponent } from './accept-invite-organization-dialog.component';
+
+// Locks in the finish()-time completeness guard (GH-2349): the join/invite-accept submit path
+// must not close with an organization that lacks a name or a parseable https website, even if
+// the form-validator wiring above it were to regress. OrganizationService is mocked — the CDP
+// resolve is not what these tests pin.
+describe('AcceptInviteOrganizationDialogComponent', () => {
+  let dialogRef: { close: ReturnType<typeof vi.fn> };
+
+  const createComponent = async () => {
+    const fixture = TestBed.createComponent(AcceptInviteOrganizationDialogComponent);
+    await TestBed.inject(ApplicationRef).whenStable();
+    return fixture;
+  };
+
+  beforeEach(() => {
+    dialogRef = { close: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DynamicDialogRef, useValue: dialogRef },
+        { provide: DynamicDialogConfig, useValue: { data: { committeeName: 'TSC', organization: null } } },
+        {
+          provide: OrganizationService,
+          useValue: {
+            searchOrganizations: vi.fn().mockReturnValue(of([])),
+            resolveOrganization: vi.fn().mockReturnValue(of({ id: 'cdp-1', name: 'Acme Motors', logo: null })),
+            registerSessionOrg: vi.fn(),
+          },
+        },
+        provideNoopAnimations(),
+      ],
+    });
+  });
+
+  it('does not close when the website is empty, even with validator wiring bypassed', async () => {
+    const fixture = await createComponent();
+    const component = fixture.componentInstance;
+    component.form.patchValue({ organization: 'Acme Motors', organization_url: '', organization_id: null });
+    // Simulates a validator-wiring regression so the test pins finish()'s own guard rather
+    // than the form.valid early-return — the guard is the belt-and-braces this ticket added.
+    component.form.get('organization_url')!.clearValidators();
+    component.form.get('organization_url')!.updateValueAndValidity();
+
+    component.onConfirm();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(component.submitting()).toBe(false);
+  });
+
+  it('does not close when the website is not a valid https URL', async () => {
+    const fixture = await createComponent();
+    const component = fixture.componentInstance;
+    component.form.patchValue({ organization: 'Acme Motors', organization_url: 'not-a-url', organization_id: null });
+    component.form.get('organization_url')!.clearValidators();
+    component.form.get('organization_url')!.updateValueAndValidity();
+
+    component.onConfirm();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(component.submitting()).toBe(false);
+  });
+
+  it('does not close for a non-https website', async () => {
+    const fixture = await createComponent();
+    const component = fixture.componentInstance;
+    component.form.patchValue({ organization: 'Acme Motors', organization_url: 'http://acme-motors.example', organization_id: null });
+
+    component.onConfirm();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('closes with the built organization payload for a complete name + https website', async () => {
+    const fixture = await createComponent();
+    const component = fixture.componentInstance;
+    component.form.patchValue({ organization: 'Acme Motors', organization_url: 'https://acme-motors.example', organization_id: null });
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    component.onConfirm();
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({ organization: { id: null, name: 'Acme Motors', website: 'https://acme-motors.example' } });
+  });
+
+  it('cancel closes without a value', async () => {
+    const fixture = await createComponent();
+
+    fixture.componentInstance.onCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -7,7 +7,7 @@ import { FormControl, FormControlStatus, FormGroup, ReactiveFormsModule } from '
 import { ButtonComponent } from '@components/button/button.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { AcceptInviteOrganizationDialogData, AcceptInviteOrganizationDialogResult, OrganizationResolveResult } from '@lfx-one/shared/interfaces';
-import { buildCommitteeOrganizationPayload } from '@lfx-one/shared/utils';
+import { buildCommitteeOrganizationPayload, committeeOrganizationFormComplete } from '@lfx-one/shared/utils';
 import { httpsUrlValidator, trimmedRequired } from '@lfx-one/shared/validators';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { startWith, take } from 'rxjs';
@@ -150,7 +150,7 @@ export class AcceptInviteOrganizationDialogComponent {
         organization_url: raw.organization_url ?? '',
         organization_id: raw.organization_id,
       });
-      if (!organization?.name?.trim()) {
+      if (!organization?.name?.trim() || !committeeOrganizationFormComplete(raw)) {
         this.submitting.set(false);
         return;
       }

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,7 +5,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { extractErrorMessage, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
+import { committeeJoinErrorMessage, committeeLeaveErrorMessage, extractErrorMessage, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });
@@ -189,5 +189,77 @@ describe('serverAuthoredMessage', () => {
   it('answers the fallback for anything that is not an HTTP failure', () => {
     expect(serverAuthoredMessage(new Error('boom'), 'fallback')).toBe('fallback');
     expect(serverAuthoredMessage(undefined, 'fallback')).toBe('fallback');
+  });
+});
+
+// GH-2349: the join error handler used to read `err.error?.message` only, which is dead code on
+// the BFF error-class path (that shape carries the text under `error`) — every rejection rendered
+// the generic "Failed to join" toast. These cases pin the branch copy against both shapes.
+describe('committeeJoinErrorMessage', () => {
+  const ORG_REQUIRED = 'organization id or organization name and domain are required';
+
+  it.each([
+    ['error', { error: ORG_REQUIRED }],
+    ['message', { message: ORG_REQUIRED }],
+  ])('reads the organization-requirement text under %s', (_key, body) => {
+    expect(committeeJoinErrorMessage(httpErrorWithBody(400, body), 'TSC')).toBe(
+      'This group requires a verified organization to join. Please contact an admin for access.'
+    );
+  });
+
+  it('maps the business-email requirement to its own copy', () => {
+    const error = httpErrorWithBody(400, { error: 'A business email is required to join this group' });
+
+    expect(committeeJoinErrorMessage(error, 'TSC')).toBe('This group requires a business email address to join. Please contact an admin for access.');
+  });
+
+  it('answers the already-a-member copy on 409', () => {
+    expect(committeeJoinErrorMessage(httpError(409), 'TSC')).toBe('You are already a member of this group.');
+  });
+
+  it('answers the no-permission copy on 403', () => {
+    expect(committeeJoinErrorMessage(httpError(403), 'TSC')).toBe('You do not have permission to join this group.');
+  });
+
+  it('answers the check-your-details fallback on a 400 the server wrote no message for', () => {
+    expect(committeeJoinErrorMessage(httpErrorWithBody(400, {}), 'TSC')).toBe('Unable to join "TSC". Please check your details and try again.');
+  });
+
+  it('shows the server-authored 400 message when it is not a known branch', () => {
+    const error = httpErrorWithBody(400, { error: 'join window is closed' });
+
+    expect(committeeJoinErrorMessage(error, 'TSC')).toBe('join window is closed');
+  });
+
+  it('answers the generic fallback for an unknown status with no server message', () => {
+    expect(committeeJoinErrorMessage(httpErrorWithBody(500, {}), 'TSC')).toBe('Failed to join "TSC". Please try again.');
+  });
+
+  it('never surfaces Angular’s synthesized Http failure response string', () => {
+    const shown = committeeJoinErrorMessage(httpErrorWithBody(400, null), 'TSC');
+
+    expect(shown).toBe('Unable to join "TSC". Please check your details and try again.');
+    expect(shown).not.toContain('Http failure response');
+  });
+});
+
+describe('committeeLeaveErrorMessage', () => {
+  it('answers the not-a-member copy on 404', () => {
+    expect(committeeLeaveErrorMessage(httpError(404), 'TSC')).toBe('You are not a member of this group.');
+  });
+
+  // Same two BFF shapes as join: the error-class proxy emits under `error`, a direct controller reply under `message`.
+  it.each([
+    ['error', { error: 'membership is frozen' }],
+    ['message', { message: 'membership is frozen' }],
+  ])('shows the server-authored message under %s', (_key, body) => {
+    expect(committeeLeaveErrorMessage(httpErrorWithBody(400, body), 'TSC')).toBe('membership is frozen');
+  });
+
+  it('answers the generic fallback when the server wrote nothing', () => {
+    const shown = committeeLeaveErrorMessage(httpErrorWithBody(500, {}), 'TSC');
+
+    expect(shown).toBe('Failed to leave "TSC". Please try again.');
+    expect(shown).not.toContain('Http failure response');
   });
 });

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,7 +5,14 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { committeeJoinErrorMessage, committeeLeaveErrorMessage, extractErrorMessage, isTransientHttpError, retryTransientHttpError, serverAuthoredMessage } from './http-error.utils';
+import {
+  committeeJoinErrorMessage,
+  committeeLeaveErrorMessage,
+  extractErrorMessage,
+  isTransientHttpError,
+  retryTransientHttpError,
+  serverAuthoredMessage,
+} from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -60,6 +60,44 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
 }
 
 /**
+ * Maps a join-committee failure to actionable toast copy. Reads the upstream text through
+ * `serverAuthoredMessage` (both BFF error shapes) — never `err.error?.message` alone, which is
+ * dead code on the error-class proxy path that emits under `error` (GH-2349).
+ */
+export function committeeJoinErrorMessage(err: HttpErrorResponse, committeeName: string): string {
+  if (err.status === 409) {
+    return 'You are already a member of this group.';
+  }
+  if (err.status === 403) {
+    return 'You do not have permission to join this group.';
+  }
+  const upstream = serverAuthoredMessage(err, '');
+  if (upstream.includes('organization')) {
+    return 'This group requires a verified organization to join. Please contact an admin for access.';
+  }
+  if (upstream.includes('business email')) {
+    return 'This group requires a business email address to join. Please contact an admin for access.';
+  }
+  const fallback =
+    err.status === 400
+      ? `Unable to join "${committeeName}". Please check your details and try again.`
+      : `Failed to join "${committeeName}". Please try again.`;
+  return upstream || fallback;
+}
+
+/**
+ * Maps a leave-committee failure to toast copy. Same BFF-shape rationale as
+ * {@link committeeJoinErrorMessage} — reads through `serverAuthoredMessage` because the
+ * error-class proxy path carries the text under `error`, where `err.error?.message` reads nothing.
+ */
+export function committeeLeaveErrorMessage(err: HttpErrorResponse, committeeName: string): string {
+  if (err.status === 404) {
+    return 'You are not a member of this group.';
+  }
+  return serverAuthoredMessage(err, `Failed to leave "${committeeName}". Please try again.`);
+}
+
+/**
  * The message the server wrote, or `fallback` when it wrote none.
  *
  * `extractErrorMessage` ends with `error.message || fallback`, and Angular always synthesizes a

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -79,9 +79,7 @@ export function committeeJoinErrorMessage(err: HttpErrorResponse, committeeName:
     return 'This group requires a business email address to join. Please contact an admin for access.';
   }
   const fallback =
-    err.status === 400
-      ? `Unable to join "${committeeName}". Please check your details and try again.`
-      : `Failed to join "${committeeName}". Please try again.`;
+    err.status === 400 ? `Unable to join "${committeeName}". Please check your details and try again.` : `Failed to join "${committeeName}". Please try again.`;
   return upstream || fallback;
 }
 


### PR DESCRIPTION
## Summary

Two related fixes to the committee join flow. First, rejected joins (and leaves) now show actionable toast copy: the error mapper read `err.error?.message`, but the BFF error-class path carries the response text under the `error` key, so the "organization required" and "business email required" branches were unreachable and every rejection fell through to the generic "Failed to join" toast. Second, the organization step's submit path now verifies at `finish()` time that the organization is complete (name + valid https website) instead of checking the name only, so the dialog cannot close with an incomplete organization even if the form-validator wiring above it regresses. This is the frontend companion to #2348 (backend: `join-committee` drops the organization body, fixed in lfx-v2-committee-service).

Resolves #2349

## Behavior changes

### Join/leave error toasts

| Before | After |
|---|---|
| A rejected join almost always showed a generic "Failed to join" toast with no explanation — even when the server had sent a specific reason (e.g. a verified organization or business email is required) — because the app looked for that reason in the wrong field of the error response. | Rejections show a specific, readable reason: already a member, no permission, organization required, business email required, or the server's own message when it provided one. A bad-request rejection with no server message says "Unable to join … Please check your details and try again." The same fix applies when leaving a group. |

### Organization step submit guard

| Before | After |
|---|---|
| The organization step of the join / invite-accept dialog only re-checked that an organization name was present at the moment of submit; the website requirement rested on form validation alone, with nothing verifying it when the dialog actually closes. | The dialog double-checks at submit time that both an organization name and a valid https website are present before closing — an incomplete organization can't be submitted even if the form's validation wiring breaks. |

## Technical changes

`apps/lfx-one/src/app/shared/utils/http-error.utils.ts` — Shared error-message helpers

- Adds `committeeJoinErrorMessage(err, committeeName)`: 409 → "already a member", 403 → "no permission", upstream text containing `organization` / `business email` → the corresponding requirement copy, otherwise the server-authored message or a fallback (400 gets a new "Unable to join … check your details" variant; other statuses keep the generic "Failed to join" copy)
- Adds `committeeLeaveErrorMessage(err, committeeName)`: 404 → "not a member", otherwise the server-authored message or the generic leave fallback
- Both read the upstream text through `serverAuthoredMessage`, which covers both BFF error-body shapes (`error` key from the error-class proxy path, `message` key from direct controller replies) — the old `err.error?.message` read was dead code on the proxy path

`apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts` — Committee view

- Join and leave error handlers delegate to the new shared helpers
- Removes the private `getJoinErrorMessage` method (its logic moved into the tested shared helper)

`apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts` — Join / invite-accept organization dialog

- The `finish()` guard now also requires `committeeOrganizationFormComplete(raw)` — name plus parseable https website, the same check the add-member dialog uses — instead of checking the organization name only
- Applies equally to the invite-accept flow, which shares this dialog and carries the same backend organization requirement

`apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.spec.ts` — Tests (new file)

- Pins the `finish()` guard: does not close on an empty website, a non-URL website, or an http-only website — including with the form validators deliberately cleared, so the test pins the guard itself rather than the validator wiring
- Covers the happy path closing with the built organization payload and cancel closing with `null`

`apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts` — Tests

- Pins every join/leave copy branch against both BFF body shapes (`error` and `message` keys), including the new 400 fallback and a guard that Angular's synthesized "Http failure response" string never reaches the toast
