### PR TITLE
fix(org-lens): strip merge-only emails from the people roster payload

### DIFF
--- a/apps/lfx-one/src/server/services/org-lens-people.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-people.service.spec.ts
@@ -438,7 +438,7 @@ describe('OrgLensPeopleService person-key company emails', () => {
   });
 });
 
-describe('OrgLensPeopleService roster wire shape (issue #2179)', () => {
+describe('OrgLensPeopleService roster wire shape (#2179)', () => {
   it('strips merge-only fields from the wire roster while the internal roster retains them', async () => {
     execute
       .mockResolvedValueOnce({

--- a/apps/lfx-one/src/server/services/org-lens-people.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-people.service.spec.ts
@@ -437,3 +437,45 @@ describe('OrgLensPeopleService person-key company emails', () => {
     expect(await service.getEmployeeDetail({} as never, ACCOUNT, personKey)).toMatchObject(UNAVAILABLE);
   });
 });
+
+describe('OrgLensPeopleService roster wire shape (issue #2179)', () => {
+  it('strips merge-only fields from the wire roster while the internal roster retains them', async () => {
+    execute
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            PERSON_KEY: 'person-wire-user',
+            LFID: null,
+            LF_USERNAME: 'WireUser',
+            CDP_MEMBER_ID: null,
+            NAME: 'Wire User',
+            TITLE: null,
+            EMAIL: 'WireUser@Example.COM',
+            PHOTO: null,
+            SEATS_COUNT: 0,
+            BOARD_SEATS_COUNT: 0,
+            COMMITTEE_SEATS_COUNT: 0,
+            COMMITS_COUNT: 0,
+            EVENTS_COUNT: 0,
+            COURSES_COUNT: 0,
+            ENGAGED_FOUNDATION_IDS: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ ACTIVE_IN_OSS: 1, IN_GOVERNANCE: 0, CODE_CONTRIBUTORS: 0, EVENT_ATTENDEES: 0, TRAINEES: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const wire = await service.getAllEmployees(ACCOUNT);
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(wire.rows).toHaveLength(1);
+    expect(wire.rows[0]).not.toHaveProperty('emails');
+    expect(wire.rows[0]).not.toHaveProperty('mergedFrom');
+    expect(wire.rows[0].email).toBe('WireUser@Example.COM');
+
+    // The internal accessor serves the same cached raw rows; merge-only fields survive for the live merge.
+    const internal = await service.getAllEmployeesInternal(ACCOUNT);
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(internal.rows[0].emails).toEqual(['wireuser@example.com']);
+  });
+});

--- a/apps/lfx-one/src/server/services/org-lens-people.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-people.service.ts
@@ -358,7 +358,6 @@ export class OrgLensPeopleService {
       title: row.TITLE,
       email: row.EMAIL,
       emails: row.EMAIL ? [row.EMAIL.trim().toLowerCase()] : [],
-      mergedFrom: [],
       avatarUrl: row.PHOTO ?? null,
       sources: ['snowflake'] as OrgPersonSource[],
       seatsCount: row.SEATS_COUNT ?? 0,

--- a/apps/lfx-one/src/server/services/org-lens-people.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-people.service.ts
@@ -7,11 +7,12 @@ import type {
   OrgAllEmployeeCommitteeMembership,
   OrgAllEmployeeDetail,
   OrgAllEmployeeEvent,
-  OrgAllEmployeeRow,
+  OrgAllEmployeeRowInternal,
   OrgAllEmployeeStats,
   OrgAllEmployeeTraining,
   OrgAllEmployeeTrainingStatus,
   OrgAllEmployeeVotingStatus,
+  OrgAllEmployeesInternalResponse,
   OrgAllEmployeesResponse,
   OrgCompanyEmailsStatus,
   OrgPersonCompanyEmailsResponse,
@@ -25,6 +26,7 @@ import { Request } from 'express';
 import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { logger } from './logger.service';
 import { OrgPeopleDirectoryService } from './org-people-directory.service';
+import { toWireResponse } from './org-people-wire.mapper';
 import { SnowflakeService } from './snowflake.service';
 import { withOrgCache } from './valkey.service';
 
@@ -135,8 +137,17 @@ export class OrgLensPeopleService {
     this.snowflakeService = SnowflakeService.getInstance();
   }
 
-  /** Bundled rows + stats + foundations payload; three Snowflake queries in parallel, served through the shared per-org cache. */
+  /** Bundled rows + stats + foundations payload; the wire projection of the internal roster. */
   public async getAllEmployees(accountId: string): Promise<OrgAllEmployeesResponse> {
+    return toWireResponse(await this.getAllEmployeesInternal(accountId));
+  }
+
+  /**
+   * Internal roster with merge-only fields retained — the live directory's stored seed. The cache
+   * holds raw warehouse rows and both accessors map after every read, so this split changes no
+   * cached shape.
+   */
+  public async getAllEmployeesInternal(accountId: string): Promise<OrgAllEmployeesInternalResponse> {
     const raw = await withOrgCache(
       accountId,
       'people-all',
@@ -333,7 +344,7 @@ export class OrgLensPeopleService {
     return { rowsRaw: rowsResult.rows, statsRaw: statsResult.rows, foundationRaw: foundationResult.rows };
   }
 
-  private mapEmployeeRow(row: OrgPeopleAllRowRaw): OrgAllEmployeeRow {
+  private mapEmployeeRow(row: OrgPeopleAllRowRaw): OrgAllEmployeeRowInternal {
     const name = cleanDisplayName(row.NAME, row.EMAIL);
     const [firstName, lastName] = splitDisplayName(name);
     return {
@@ -347,6 +358,7 @@ export class OrgLensPeopleService {
       title: row.TITLE,
       email: row.EMAIL,
       emails: row.EMAIL ? [row.EMAIL.trim().toLowerCase()] : [],
+      mergedFrom: [],
       avatarUrl: row.PHOTO ?? null,
       sources: ['snowflake'] as OrgPersonSource[],
       seatsCount: row.SEATS_COUNT ?? 0,

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -15,12 +15,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Mirrors access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
 // vitest config, so runtime collaborators are mocked. The four source services are constructed in
 // OrgPeopleDirectoryService's constructor, so they must be mocked at module level. `withPerUserCache`
-// is stubbed to a pass-through so tests exercise the merge rather than the cache.
-const { getAllEmployeesInternal, fetchAllOrgSeats, getKeyContactEmployees, getAccessPrincipals } = vi.hoisted(() => ({
+// is stubbed to a pass-through so tests exercise the merge rather than the cache, capturing the
+// `accept` guard so the fail-closed validator stays covered.
+const { getAllEmployeesInternal, fetchAllOrgSeats, getKeyContactEmployees, getAccessPrincipals, capturedCacheGuard } = vi.hoisted(() => ({
   getAllEmployeesInternal: vi.fn(),
   fetchAllOrgSeats: vi.fn(),
   getKeyContactEmployees: vi.fn(),
   getAccessPrincipals: vi.fn(),
+  capturedCacheGuard: { accept: null as ((value: unknown) => boolean) | null },
 }));
 
 vi.mock('./org-lens-people.service', () => ({
@@ -44,7 +46,10 @@ vi.mock('./org-lens-access.service', () => ({
   },
 }));
 vi.mock('./valkey.service', () => ({
-  withPerUserCache: (_ns: string, _user: string, _org: string, _ttl: number, fetcher: () => Promise<unknown>) => fetcher(),
+  withPerUserCache: (_ns: string, _user: string, _org: string, _ttl: number, fetcher: () => Promise<unknown>, accept?: (value: unknown) => boolean) => {
+    capturedCacheGuard.accept = accept ?? null;
+    return fetcher();
+  },
 }));
 vi.mock('./logger.service', () => ({
   logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -150,6 +155,7 @@ async function run(): Promise<OrgAllEmployeesResponse> {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  capturedCacheGuard.accept = null;
   getAllEmployeesInternal.mockResolvedValue(baseResponse([]));
   fetchAllOrgSeats.mockResolvedValue([]);
   getKeyContactEmployees.mockResolvedValue([] as KeyContactEmployee[]);
@@ -709,5 +715,32 @@ describe('OrgPeopleDirectoryService.getLive — merge-only fields never reach th
       expect(row).not.toHaveProperty('emails');
       expect(row).not.toHaveProperty('mergedFrom');
     }
+  });
+});
+
+describe('OrgPeopleDirectoryService.getLive — cache guard stays fail-closed (issue #2179)', () => {
+  it('accepts a stripped roster after a Valkey JSON round-trip', async () => {
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockResolvedValue([seat()]);
+
+    const response = await run();
+    const accept = capturedCacheGuard.accept;
+
+    expect(accept).toBeTypeOf('function');
+    // Valkey stores JSON: undefined fields (e.g. an unset accessBadge) are dropped on the round-trip.
+    expect(accept!(JSON.parse(JSON.stringify(response)))).toBe(true);
+  });
+
+  it('rejects a roster still carrying merge-only fields', async () => {
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
+
+    const response = await run();
+    const accept = capturedCacheGuard.accept;
+    const roundTripped = JSON.parse(JSON.stringify(response)) as OrgAllEmployeesResponse;
+
+    expect(accept).toBeTypeOf('function');
+    expect(roundTripped.rows.length).toBeGreaterThan(0);
+    expect(accept!({ ...roundTripped, rows: [{ ...roundTripped.rows[0], emails: ['x@y.example'] }] })).toBe(false);
+    expect(accept!({ ...roundTripped, rows: [{ ...roundTripped.rows[0], mergedFrom: ['email:x@y.example'] }] })).toBe(false);
   });
 });

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -97,7 +97,6 @@ function storedRow(over: Partial<OrgAllEmployeeRowInternal> = {}): OrgAllEmploye
     title: 'VP Product',
     email: 'dclarke@lfx-partner.example',
     emails: ['dclarke@lfx-partner.example'],
-    mergedFrom: [],
     avatarUrl: null,
     sources: ['snowflake'],
     seatsCount: 22,
@@ -702,7 +701,7 @@ describe('OrgPeopleDirectoryService.merge — stats count people, not rows (US2)
   });
 });
 
-describe('OrgPeopleDirectoryService.getLive — merge-only fields never reach the wire (issue #2179)', () => {
+describe('OrgPeopleDirectoryService.getLive — merge-only fields never reach the wire (#2179)', () => {
   it('strips emails and mergedFrom from every row', async () => {
     getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat()]);
@@ -718,7 +717,7 @@ describe('OrgPeopleDirectoryService.getLive — merge-only fields never reach th
   });
 });
 
-describe('OrgPeopleDirectoryService.getLive — cache guard stays fail-closed (issue #2179)', () => {
+describe('OrgPeopleDirectoryService.getLive — cache guard stays fail-closed (#2179)', () => {
   it('accepts a stripped roster after a Valkey JSON round-trip', async () => {
     getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat()]);

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -3,15 +3,21 @@
 
 import { createHmac } from 'crypto';
 
-import type { OrgAccessUser, OrgAllEmployeeRow, OrgAllEmployeesResponse, KeyContactEmployee } from '@lfx-one/shared/interfaces';
+import type {
+  OrgAccessUser,
+  OrgAllEmployeeRowInternal,
+  OrgAllEmployeesInternalResponse,
+  OrgAllEmployeesResponse,
+  KeyContactEmployee,
+} from '@lfx-one/shared/interfaces';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
 // vitest config, so runtime collaborators are mocked. The four source services are constructed in
 // OrgPeopleDirectoryService's constructor, so they must be mocked at module level. `withPerUserCache`
 // is stubbed to a pass-through so tests exercise the merge rather than the cache.
-const { getAllEmployees, fetchAllOrgSeats, getKeyContactEmployees, getAccessPrincipals } = vi.hoisted(() => ({
-  getAllEmployees: vi.fn(),
+const { getAllEmployeesInternal, fetchAllOrgSeats, getKeyContactEmployees, getAccessPrincipals } = vi.hoisted(() => ({
+  getAllEmployeesInternal: vi.fn(),
   fetchAllOrgSeats: vi.fn(),
   getKeyContactEmployees: vi.fn(),
   getAccessPrincipals: vi.fn(),
@@ -19,7 +25,7 @@ const { getAllEmployees, fetchAllOrgSeats, getKeyContactEmployees, getAccessPrin
 
 vi.mock('./org-lens-people.service', () => ({
   OrgLensPeopleService: class {
-    public getAllEmployees = getAllEmployees;
+    public getAllEmployeesInternal = getAllEmployeesInternal;
   },
 }));
 vi.mock('./org-lens-board-committee.service', () => ({
@@ -74,7 +80,7 @@ import { OrgPeopleDirectoryService, resolveMergeKey } from './org-people-directo
 const ACCOUNT = '0014100000Te2ovAAB';
 const req = {} as never;
 
-function storedRow(over: Partial<OrgAllEmployeeRow> = {}): OrgAllEmployeeRow {
+function storedRow(over: Partial<OrgAllEmployeeRowInternal> = {}): OrgAllEmployeeRowInternal {
   return {
     personKey: 'lfnEMOUiFenugGty80',
     lfid: 'lfnEMOUiFenugGty80',
@@ -86,6 +92,7 @@ function storedRow(over: Partial<OrgAllEmployeeRow> = {}): OrgAllEmployeeRow {
     title: 'VP Product',
     email: 'dclarke@lfx-partner.example',
     emails: ['dclarke@lfx-partner.example'],
+    mergedFrom: [],
     avatarUrl: null,
     sources: ['snowflake'],
     seatsCount: 22,
@@ -99,7 +106,7 @@ function storedRow(over: Partial<OrgAllEmployeeRow> = {}): OrgAllEmployeeRow {
   };
 }
 
-function baseResponse(rows: OrgAllEmployeeRow[]): OrgAllEmployeesResponse {
+function baseResponse(rows: OrgAllEmployeeRowInternal[]): OrgAllEmployeesInternalResponse {
   return { accountId: ACCOUNT, rows, stats: { activeInOss: 0, inGovernance: 0, codeContributors: 0, eventAttendees: 0, trainees: 0 }, foundations: [] };
 }
 
@@ -143,7 +150,7 @@ async function run(): Promise<OrgAllEmployeesResponse> {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getAllEmployees.mockResolvedValue(baseResponse([]));
+  getAllEmployeesInternal.mockResolvedValue(baseResponse([]));
   fetchAllOrgSeats.mockResolvedValue([]);
   getKeyContactEmployees.mockResolvedValue([] as KeyContactEmployee[]);
   getAccessPrincipals.mockResolvedValue([]);
@@ -177,7 +184,7 @@ describe('resolveMergeKey', () => {
 
 describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
   it('merges an access principal into the stored row on username, not address (the Dano case)', async () => {
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           personKey: '0032M00003ZzRIsQAN',
@@ -199,21 +206,19 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0].sources).toEqual(expect.arrayContaining(['snowflake', 'access']));
-    expect(rows[0].emails).toEqual(expect.arrayContaining(['dqualls@contractor.lfx-partner.example', 'dqualls@lfx-partner.example']));
   });
 
   it('merges a committee seat into the stored row on username (the Devon case)', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat()]);
 
     const { rows } = await run();
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].emails).toEqual(expect.arrayContaining(['dclarke@lfx-partner.example', 'dclarke@contractor.lfx-partner.example']));
   });
 
   it('collapses a person arriving from three sources into one row (the Jamie Ortiz case)', async () => {
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([storedRow({ lfUsername: 'jortiz', name: 'Jamie Ortiz', email: 'jortiz@vendor-corp.example', emails: ['jortiz@vendor-corp.example'] })])
     );
     fetchAllOrgSeats.mockResolvedValue([
@@ -224,11 +229,11 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
     const { rows } = await run();
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].emails).toHaveLength(3);
+    expect(rows[0].sources).toEqual(expect.arrayContaining(['snowflake', 'committee', 'board']));
   });
 
   it('keeps the stored personKey so a merged row stays expandable', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat()]);
 
     const { rows } = await run();
@@ -240,7 +245,7 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
 
 describe('OrgPeopleDirectoryService.merge — access badge is server-attributed', () => {
   it('stamps the merged principal\u2019s badge on the row', async () => {
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           lfUsername: 'dqualls',
@@ -266,7 +271,7 @@ describe('OrgPeopleDirectoryService.merge — access badge is server-attributed'
   });
 
   it('leaves the badge unset on a person the merge attributed no access to', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
 
     const { rows } = await run();
 
@@ -276,7 +281,7 @@ describe('OrgPeopleDirectoryService.merge — access badge is server-attributed'
   it('does not stamp one person\u2019s badge onto another who shares an address', async () => {
     // Two distinct identities, one shared address. Only the person the access principal actually
     // resolves to may carry the badge — an address-based join could not tell them apart.
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           personKey: 'p-dano',
@@ -309,7 +314,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
   it('absorbs a live seat that reports no username, at an address the person already owns', async () => {
     // The regression this covers: sources disagree on whether they report an identity, so the same
     // person at the same address landed on two rows -- one keyed on identity, one on the address.
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           lfUsername: 'dqualls',
@@ -331,7 +336,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
   });
 
   it('keeps the stored counters authoritative when absorbing', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'dclarke@lfx-partner.example' })]);
 
     const { rows } = await run();
@@ -353,7 +358,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
   });
 
   it('does not absorb an address the identity row does not own', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'someone.else@example.com' })]);
 
     const { rows } = await run();
@@ -363,7 +368,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
 
   it('never absorbs a row that carries its own identity', async () => {
     // Two verified identities at one address stay apart: only identity-less rows are candidates.
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           personKey: 'p-a',
@@ -395,12 +400,12 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
       storedRow({ personKey: 'p-b', lfUsername: 'beta', name: 'Beta Two', email: 'other@example.com', emails: ['other@example.com', 'shared@example.com'] }),
     ];
 
-    getAllEmployees.mockResolvedValue(baseResponse(both));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse(both));
     fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'shared@example.com' })]);
     const forward = await run();
 
     vi.clearAllMocks();
-    getAllEmployees.mockResolvedValue(baseResponse([both[1], both[0]]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([both[1], both[0]]));
     fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'shared@example.com' })]);
     getKeyContactEmployees.mockResolvedValue([]);
     getAccessPrincipals.mockResolvedValue([]);
@@ -415,7 +420,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
   });
 
   it('never absorbs a stored orphan, which owns activity this fold does not carry', async () => {
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           personKey: 'p-live-target',
@@ -458,7 +463,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
     // The one shape that reaches the badge transfer: accepted, so `isPending` is false and the badge is
     // a real role, but with no username, so it keys on the address and arrives as an orphan. Rare enough
     // that it looks like dead code, and representable enough to keep.
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([storedRow({ lfUsername: 'nobadge', name: 'No Badge', email: 'nobadge@example.com', emails: ['nobadge@example.com'] })])
     );
     getAccessPrincipals.mockResolvedValue([
@@ -489,7 +494,7 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
   it('does not merge two different people who share an address', async () => {
     // The Snowflake address→member index links dqualls@lfx-partner.example to Riley Foster's member
     // record. Two distinct usernames must never collapse, whatever their addresses say.
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([
         storedRow({
           personKey: 'p-dano',
@@ -515,7 +520,7 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
   });
 
   it('does not merge an access principal into a person with a different username', async () => {
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([storedRow({ lfUsername: 'spateloai', name: 'Sam Patel', email: 'spatel@partner-corp.example', emails: ['spatel@partner-corp.example'] })])
     );
     getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@lfx-partner.example', username: 'dclarke', name: 'Devon Clarke' })]);
@@ -528,7 +533,7 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
 
 describe('OrgPeopleDirectoryService.merge — invariants', () => {
   it('a live seat does not increment a stored row\u2019s seat counters', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat(), seat({ uid: 'seat-2', committee_name: 'P&E&IT&Mktg_Ops' })]);
 
     const { rows } = await run();
@@ -551,19 +556,26 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
     expect(rows[0].seatsCount).toBe(2);
   });
 
-  it('sources are de-duplicated and emails are lowercased and unique', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+  it('sources are de-duplicated', async () => {
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat({ email: 'DClarke@Lfx-Partner.Example' }), seat({ uid: 'seat-2', email: 'dclarke@lfx-partner.example' })]);
 
     const { rows } = await run();
 
     expect(new Set(rows[0].sources).size).toBe(rows[0].sources.length);
-    expect(new Set(rows[0].emails).size).toBe(rows[0].emails.length);
-    expect(rows[0].emails.every((e) => e === e.toLowerCase())).toBe(true);
+  });
+
+  it('lowercases the wire email of a live-only row', async () => {
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'MixedCase@Example.COM' })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBe('mixedcase@example.com');
   });
 
   it('a pending invite is not merged into a person, even when the address matches', async () => {
-    getAllEmployees.mockResolvedValue(
+    getAllEmployeesInternal.mockResolvedValue(
       baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@lfx-partner.example', emails: ['dqualls@lfx-partner.example'] })])
     );
     getAccessPrincipals.mockResolvedValue([accessUser({ username: null, inviteStatus: 'pending', isPending: true })]);
@@ -576,7 +588,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
 
 describe('OrgPeopleDirectoryService.merge — no regression for single-source people', () => {
   it('leaves a stored-only person untouched', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
 
     const { rows } = await run();
 
@@ -614,7 +626,7 @@ describe('OrgPeopleDirectoryService.merge — no regression for single-source pe
   });
 
   it('passes through a stored row that has neither identity nor address', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: null, email: null, emails: [] })]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow({ lfUsername: null, email: null, emails: [] })]));
 
     const { rows } = await run();
 
@@ -663,7 +675,7 @@ describe('OrgPeopleDirectoryService.merge — live-only personKey is a keyed HMA
 
 describe('OrgPeopleDirectoryService.merge — stats count people, not rows (US2)', () => {
   it('counts a person who arrived from two sources exactly once', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@contractor.lfx-partner.example', username: 'dclarke', name: 'Devon Clarke' })]);
 
     const { rows, stats } = await run();
@@ -674,12 +686,28 @@ describe('OrgPeopleDirectoryService.merge — stats count people, not rows (US2)
   });
 
   it('degrades gracefully when a live source fails, keeping the stored roster', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockRejectedValue(new Error('committee-service down'));
 
     const { rows } = await run();
 
     expect(rows).toHaveLength(1);
     expect(rows[0].sources).toEqual(['snowflake']);
+  });
+});
+
+describe('OrgPeopleDirectoryService.getLive — merge-only fields never reach the wire (issue #2179)', () => {
+  it('strips emails and mergedFrom from every row', async () => {
+    getAllEmployeesInternal.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockResolvedValue([seat()]);
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@contractor.lfx-partner.example', username: 'dclarke', name: 'Devon Clarke' })]);
+
+    const { rows } = await run();
+
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row).not.toHaveProperty('emails');
+      expect(row).not.toHaveProperty('mergedFrom');
+    }
   });
 });

--- a/apps/lfx-one/src/server/services/org-people-directory.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.ts
@@ -10,7 +10,9 @@ import type {
   OrgAccessUser,
   OrgAllEmployeeFoundationOption,
   OrgAllEmployeeRow,
+  OrgAllEmployeeRowInternal,
   OrgAllEmployeeStats,
+  OrgAllEmployeesInternalResponse,
   OrgAllEmployeesResponse,
   OrgPersonSource,
 } from '@lfx-one/shared/interfaces';
@@ -24,6 +26,7 @@ import { OrgLensAccessService } from './org-lens-access.service';
 import { OrgLensBoardCommitteeService } from './org-lens-board-committee.service';
 import { OrgLensKeyContactsService } from './org-lens-key-contacts.service';
 import { OrgLensPeopleService } from './org-lens-people.service';
+import { toWireRow } from './org-people-wire.mapper';
 import { withPerUserCache } from './valkey.service';
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -38,18 +41,19 @@ function isStringArray(value: unknown): boolean {
  * Every row must match the wire shape: the cached value is replayed straight to the client, so a
  * corrupt element would otherwise crash on `sources` spreading or `name.localeCompare`.
  *
- * `lfUsername` and `emails` are required so an entry written by a pre-merge-key deployment is
- * rejected as a miss and recomputed, rather than replayed into a renderer that expects them.
+ * The merge-only fields are asserted absent: an entry carrying `emails` or `mergedFrom` — written
+ * before the strip or by a regressed writer — degrades to a miss and is recomputed, never replayed.
  */
 function isAllEmployeeRow(value: unknown): boolean {
-  const r = value as Partial<OrgAllEmployeeRow>;
+  const r = value as Partial<OrgAllEmployeeRow> & { emails?: unknown; mergedFrom?: unknown };
   return (
     isObject(value) &&
     typeof r.personKey === 'string' &&
     typeof r.name === 'string' &&
     (r.email === null || typeof r.email === 'string') &&
     (r.lfUsername === null || typeof r.lfUsername === 'string') &&
-    isStringArray(r.emails) &&
+    r.emails === undefined &&
+    r.mergedFrom === undefined &&
     isStringArray(r.sources) &&
     isStringArray(r.engagedFoundationIds) &&
     typeof r.seatsCount === 'number' &&
@@ -178,13 +182,14 @@ export class OrgPeopleDirectoryService {
     // because this roster also backs the All Employees tab, which needs the complete set. Each source is
     // fetched with `Promise.allSettled` so a single upstream outage degrades the roster gracefully.
     const [snowflake, seats, keyContacts, access] = await Promise.allSettled([
-      this.peopleService.getAllEmployees(accountId),
+      this.peopleService.getAllEmployeesInternal(accountId),
       this.boardCommitteeService.fetchAllOrgSeats(req, accountId),
       this.keyContactsService.getEmployees(req, accountId),
       this.accessService.getAccessPrincipals(req, accountId),
     ]);
 
-    const base = snowflake.status === 'fulfilled' ? snowflake.value : { ...EMPTY_ORG_ALL_EMPLOYEES_RESPONSE, accountId };
+    const base: OrgAllEmployeesInternalResponse =
+      snowflake.status === 'fulfilled' ? snowflake.value : { ...EMPTY_ORG_ALL_EMPLOYEES_RESPONSE, accountId, rows: [] };
     if (snowflake.status === 'rejected') {
       logger.warning(req, 'get_org_people_directory', 'Snowflake roster failed; serving live sources only', {
         org_uid: accountId,
@@ -199,13 +204,13 @@ export class OrgPeopleDirectoryService {
   private merge(
     req: Request,
     accountId: string,
-    base: OrgAllEmployeesResponse,
+    base: OrgAllEmployeesInternalResponse,
     seats: PromiseSettledResult<CommitteeServiceOrgSeat[]>,
     keyContacts: PromiseSettledResult<KeyContactEmployee[]>,
     access: PromiseSettledResult<OrgAccessUser[]>
   ): OrgAllEmployeesResponse {
-    const byKey = new Map<string, OrgAllEmployeeRow>();
-    const unkeyedRows: OrgAllEmployeeRow[] = [];
+    const byKey = new Map<string, OrgAllEmployeeRowInternal>();
+    const unkeyedRows: OrgAllEmployeeRowInternal[] = [];
 
     for (const row of base.rows) {
       const key = resolveMergeKey(row);
@@ -290,11 +295,11 @@ export class OrgPeopleDirectoryService {
 
     this.absorbIdentitylessRows(byKey);
 
-    const rows = [...byKey.values(), ...unkeyedRows].sort((a, b) => a.name.localeCompare(b.name));
+    const merged = [...byKey.values(), ...unkeyedRows].sort((a, b) => a.name.localeCompare(b.name));
     return {
       accountId,
-      rows,
-      stats: computeStats(rows),
+      rows: merged.map(toWireRow),
+      stats: computeStats(merged),
       // Foundation options stay sourced from Snowflake (authoritative id↔name pairs). Live-only people
       // carry no engagedFoundationIds, so they are not foundation-filterable until the next dbt build.
       foundations: base.foundations,
@@ -319,17 +324,17 @@ export class OrgPeopleDirectoryService {
    * Three kinds of orphan are deliberately left standing: a pending invitation (unverified), a stored
    * row (it owns data this fold does not carry), and any row whose address two identities both claim.
    */
-  private absorbIdentitylessRows(byKey: Map<string, OrgAllEmployeeRow>): void {
+  private absorbIdentitylessRows(byKey: Map<string, OrgAllEmployeeRowInternal>): void {
     // An address claimed by more than one identity has no correct owner, so it gets none: picking the
     // first would attribute the orphan by upstream ordering, which is not a property worth depending on.
-    const claims = new Map<string, OrgAllEmployeeRow[]>();
+    const claims = new Map<string, OrgAllEmployeeRowInternal[]>();
     for (const [key, row] of byKey) {
       if (!key.startsWith('identity:')) continue;
       for (const email of row.emails) {
         claims.set(email, [...(claims.get(email) ?? []), row]);
       }
     }
-    const ownerByEmail = new Map<string, OrgAllEmployeeRow>();
+    const ownerByEmail = new Map<string, OrgAllEmployeeRowInternal>();
     for (const [email, owners] of claims) {
       if (owners.length === 1) ownerByEmail.set(email, owners[0]);
     }
@@ -368,14 +373,14 @@ export class OrgPeopleDirectoryService {
     }
   }
 
-  private addSource(row: OrgAllEmployeeRow, source: OrgPersonSource): void {
+  private addSource(row: OrgAllEmployeeRowInternal, source: OrgPersonSource): void {
     if (!row.sources.includes(source)) {
       row.sources.push(source);
     }
   }
 
   /** Record a contributing address. A merged person legitimately holds several; `email` stays the preferred display one. */
-  private addEmail(row: OrgAllEmployeeRow, email: string): void {
+  private addEmail(row: OrgAllEmployeeRowInternal, email: string): void {
     if (email && !row.emails.includes(email)) {
       row.emails.push(email);
     }
@@ -385,7 +390,7 @@ export class OrgPeopleDirectoryService {
   }
 
   /** Increment seat counters for a live board/committee seat so the Seats column and governance filter stay consistent with the stat cards. */
-  private addSeat(row: OrgAllEmployeeRow, source: OrgPersonSource): void {
+  private addSeat(row: OrgAllEmployeeRowInternal, source: OrgPersonSource): void {
     row.seatsCount += 1;
     if (source === 'board') {
       row.boardSeatsCount += 1;
@@ -395,14 +400,17 @@ export class OrgPeopleDirectoryService {
   }
 
   /** Fill only the fields a stored row is missing — never overwrite richer Snowflake data with a live blank. */
-  private fill(row: OrgAllEmployeeRow, patch: { firstName?: string | null; lastName?: string | null; title?: string | null; avatarUrl?: string | null }): void {
+  private fill(
+    row: OrgAllEmployeeRowInternal,
+    patch: { firstName?: string | null; lastName?: string | null; title?: string | null; avatarUrl?: string | null }
+  ): void {
     if (!row.firstName && patch.firstName) row.firstName = patch.firstName;
     if (!row.lastName && patch.lastName) row.lastName = patch.lastName;
     if (!row.title && patch.title) row.title = patch.title;
     if (!row.avatarUrl && patch.avatarUrl) row.avatarUrl = patch.avatarUrl;
   }
 
-  private rowFromSeat(seat: CommitteeServiceOrgSeat, email: string, source: OrgPersonSource, key: string): OrgAllEmployeeRow {
+  private rowFromSeat(seat: CommitteeServiceOrgSeat, email: string, source: OrgPersonSource, key: string): OrgAllEmployeeRowInternal {
     const firstName = (seat.first_name ?? '').trim() || null;
     const lastName = (seat.last_name ?? '').trim() || null;
     const row = this.liveRow(email, firstName, lastName, seat.job_title?.trim() || null, null, source, key, seat.username ?? null);
@@ -411,11 +419,11 @@ export class OrgPeopleDirectoryService {
     return row;
   }
 
-  private rowFromKeyContact(emp: KeyContactEmployee, email: string, key: string): OrgAllEmployeeRow {
+  private rowFromKeyContact(emp: KeyContactEmployee, email: string, key: string): OrgAllEmployeeRowInternal {
     return this.liveRow(email, emp.firstName || null, emp.lastName || null, emp.jobTitle, emp.avatarUrl ?? null, 'keyContact', key, emp.lfUsername ?? null);
   }
 
-  private rowFromAccess(user: OrgAccessUser, email: string, key: string): OrgAllEmployeeRow {
+  private rowFromAccess(user: OrgAccessUser, email: string, key: string): OrgAllEmployeeRowInternal {
     const [firstName, lastName] = splitDisplayName(user.name);
     const row = this.liveRow(email, firstName, lastName, user.jobTitle, user.avatarUrl, 'access', key, user.username);
     row.accessBadge = badgeOf(user);
@@ -441,7 +449,7 @@ export class OrgPeopleDirectoryService {
     source: OrgPersonSource,
     key: string,
     lfUsername: string | null
-  ): OrgAllEmployeeRow {
+  ): OrgAllEmployeeRowInternal {
     const username = (lfUsername ?? '').trim().toLowerCase() || null;
     const name = [firstName, lastName].filter(Boolean).join(' ').trim() || email || username || '';
     return {

--- a/apps/lfx-one/src/server/services/org-people-directory.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.ts
@@ -216,7 +216,7 @@ export class OrgPeopleDirectoryService {
       const key = resolveMergeKey(row);
       if (key) {
         // Clone so we can mutate sources/enrichment without aliasing the snowflake service's array.
-        byKey.set(key, { ...row, sources: [...row.sources], emails: [...row.emails], mergedFrom: [key] });
+        byKey.set(key, { ...row, sources: [...row.sources], emails: [...row.emails] });
       } else {
         unkeyedRows.push(row);
       }
@@ -362,7 +362,6 @@ export class OrgPeopleDirectoryService {
       }
       for (const source of orphan.sources) this.addSource(owner, source);
       for (const email of orphan.emails) this.addEmail(owner, email);
-      owner.mergedFrom = [...(owner.mergedFrom ?? []), key];
       this.fill(owner, { firstName: orphan.firstName, lastName: orphan.lastName, title: orphan.title, avatarUrl: orphan.avatarUrl });
       // Reachable only for an accepted principal whose settings record carries no username: it keys on
       // the address like any orphan, but `isPending` is false so its badge is a real role rather than
@@ -463,7 +462,6 @@ export class OrgPeopleDirectoryService {
       title,
       email,
       emails: email ? [email] : [],
-      mergedFrom: [key],
       avatarUrl,
       sources: [source],
       seatsCount: 0,

--- a/apps/lfx-one/src/server/services/org-people-wire.mapper.ts
+++ b/apps/lfx-one/src/server/services/org-people-wire.mapper.ts
@@ -4,14 +4,14 @@
 import type { OrgAllEmployeeRow, OrgAllEmployeeRowInternal, OrgAllEmployeesInternalResponse, OrgAllEmployeesResponse } from '@lfx-one/shared/interfaces';
 
 /**
- * Project an in-memory merge row onto the wire shape. The merge-only fields (`emails`,
- * `mergedFrom`) carry every address that contributed to the row — personal, other-employer,
- * and unrelated-foundation addresses included — and the UI reads none of them, so they stay
+ * Project an in-memory merge row onto the wire shape. The merge-only field (`emails`)
+ * carries every address that contributed to the row — personal, other-employer, and
+ * unrelated-foundation addresses included — and the UI reads none of it, so it stays
  * server-side.
  *
  * Explicit allowlist, not a rest-spread denylist: a field added to the internal row later is
- * dropped by default instead of leaking, and a field added to the wire row fails to compile
- * until it is listed here.
+ * dropped by default instead of leaking, and a required field added to the wire row fails to
+ * compile until it is listed here (optional additions must be listed by hand).
  */
 export function toWireRow(row: OrgAllEmployeeRowInternal): OrgAllEmployeeRow {
   return {

--- a/apps/lfx-one/src/server/services/org-people-wire.mapper.ts
+++ b/apps/lfx-one/src/server/services/org-people-wire.mapper.ts
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { OrgAllEmployeeRow, OrgAllEmployeeRowInternal, OrgAllEmployeesInternalResponse, OrgAllEmployeesResponse } from '@lfx-one/shared/interfaces';
+
+/**
+ * Project an in-memory merge row onto the wire shape. The merge-only fields (`emails`,
+ * `mergedFrom`) carry every address that contributed to the row — personal, other-employer,
+ * and unrelated-foundation addresses included — and the UI reads none of them, so they stay
+ * server-side.
+ *
+ * Explicit allowlist, not a rest-spread denylist: a field added to the internal row later is
+ * dropped by default instead of leaking, and a field added to the wire row fails to compile
+ * until it is listed here.
+ */
+export function toWireRow(row: OrgAllEmployeeRowInternal): OrgAllEmployeeRow {
+  return {
+    personKey: row.personKey,
+    lfid: row.lfid,
+    lfUsername: row.lfUsername,
+    cdpMemberId: row.cdpMemberId,
+    name: row.name,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    title: row.title,
+    email: row.email,
+    accessBadge: row.accessBadge,
+    avatarUrl: row.avatarUrl,
+    sources: row.sources,
+    seatsCount: row.seatsCount,
+    boardSeatsCount: row.boardSeatsCount,
+    committeeSeatsCount: row.committeeSeatsCount,
+    commitsCount: row.commitsCount,
+    eventsCount: row.eventsCount,
+    coursesCount: row.coursesCount,
+    engagedFoundationIds: row.engagedFoundationIds,
+  };
+}
+
+/** Project a pre-strip merge payload onto the wire envelope. Stats and foundations carry no merge-only fields. */
+export function toWireResponse(response: OrgAllEmployeesInternalResponse): OrgAllEmployeesResponse {
+  return {
+    accountId: response.accountId,
+    rows: response.rows.map(toWireRow),
+    stats: response.stats,
+    foundations: response.foundations,
+  };
+}

--- a/packages/shared/src/constants/valkey-cache.constants.ts
+++ b/packages/shared/src/constants/valkey-cache.constants.ts
@@ -38,8 +38,12 @@ export const VALKEY_CACHE = {
   /** Domain + schema-version segment for the per-user org access-list cache. */
   ORG_ACCESS_LIST_NAMESPACE: 'org-access-list:v1',
 
-  /** Domain + schema-version segment for the per-user org People directory cache. */
-  ORG_PEOPLE_DIRECTORY_NAMESPACE: 'org-people-dir:v1',
+  /**
+   * Domain + schema-version segment for the per-user org People directory cache. `v2`: merge-only
+   * fields are stripped before the write and the validator asserts their absence — stale `v1`
+   * entries must never be served as the new shape.
+   */
+  ORG_PEOPLE_DIRECTORY_NAMESPACE: 'org-people-dir:v2',
 
   /** Domain + schema-version segment for the express-openid-connect session store (server-side session data keyed by opaque session id). */
   SESSION_NAMESPACE: 'session:v1',

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -231,6 +231,7 @@ export * from './org-key-contacts.internal.interface';
 
 // Org People interfaces
 export * from './org-people.interface';
+export * from './org-people.internal.interface';
 
 // Org Lens Access tab (spec 025)
 export * from './org-lens-access.interface';

--- a/packages/shared/src/interfaces/org-people.interface.ts
+++ b/packages/shared/src/interfaces/org-people.interface.ts
@@ -66,10 +66,6 @@ export interface OrgAllEmployeeRow {
   title: string | null;
   /** Preferred display address: the stored roster's when the row has one, else the first live address contributing. */
   email: string | null;
-  /** Every lowercased address that contributed to this row. Length > 1 is the normal result of a merge. */
-  emails: string[];
-  /** Diagnostic: the merge keys that collapsed into this row (e.g. `identity:mcderk`). Lets a reviewer explain a merge without re-deriving it. */
-  mergedFrom?: string[];
   /**
    * Org Lens access badge for the principal the merge actually attributed to this person, or `null`
    * when none was. Authoritative: the client's own address-based join cannot tell two people who

--- a/packages/shared/src/interfaces/org-people.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people.internal.interface.ts
@@ -1,0 +1,30 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Internal All Employees roster shapes for the Org Lens People backend services.
+// They live in the shared package because CLAUDE.md prohibits module-level interfaces
+// inside apps/lfx-one/; they are NOT part of the wire contract consumed by the frontend.
+// The merge-only fields below never leave the server: `toWireRow` strips them before the
+// response is cached or sent, and the cache validator rejects any entry carrying them.
+
+import type {
+  OrgAllEmployeeFoundationOption,
+  OrgAllEmployeeRow,
+  OrgAllEmployeeStats,
+} from './org-people.interface';
+
+/** In-memory merge row — the wire shape plus the fields the identity merge accumulates. Never cached, never sent. */
+export interface OrgAllEmployeeRowInternal extends OrgAllEmployeeRow {
+  /** Every lowercased address that contributed to this row. Length > 1 is the normal result of a merge. */
+  emails: string[];
+  /** Diagnostic: the merge keys that collapsed into this row (e.g. `identity:mcderk`). Lets a reviewer explain a merge without re-deriving it. */
+  mergedFrom?: string[];
+}
+
+/** In-memory merge payload — the stored seed and the pre-strip merge result. Never cached, never sent. */
+export interface OrgAllEmployeesInternalResponse {
+  accountId: string;
+  rows: OrgAllEmployeeRowInternal[];
+  stats: OrgAllEmployeeStats;
+  foundations: OrgAllEmployeeFoundationOption[];
+}

--- a/packages/shared/src/interfaces/org-people.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people.internal.interface.ts
@@ -7,11 +7,7 @@
 // The merge-only fields below never leave the server: `toWireRow` strips them before the
 // response is cached or sent, and the cache validator rejects any entry carrying them.
 
-import type {
-  OrgAllEmployeeFoundationOption,
-  OrgAllEmployeeRow,
-  OrgAllEmployeeStats,
-} from './org-people.interface';
+import type { OrgAllEmployeeFoundationOption, OrgAllEmployeeRow, OrgAllEmployeeStats } from './org-people.interface';
 
 /** In-memory merge row — the wire shape plus the fields the identity merge accumulates. Never cached, never sent. */
 export interface OrgAllEmployeeRowInternal extends OrgAllEmployeeRow {

--- a/packages/shared/src/interfaces/org-people.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people.internal.interface.ts
@@ -4,17 +4,15 @@
 // Internal All Employees roster shapes for the Org Lens People backend services.
 // They live in the shared package because CLAUDE.md prohibits module-level interfaces
 // inside apps/lfx-one/; they are NOT part of the wire contract consumed by the frontend.
-// The merge-only fields below never leave the server: `toWireRow` strips them before the
-// response is cached or sent, and the cache validator rejects any entry carrying them.
+// Merge-only data never leaves the server: `toWireRow` strips it before the
+// response is cached or sent, and the cache validator rejects any entry carrying it.
 
 import type { OrgAllEmployeeFoundationOption, OrgAllEmployeeRow, OrgAllEmployeeStats } from './org-people.interface';
 
-/** In-memory merge row — the wire shape plus the fields the identity merge accumulates. Never cached, never sent. */
+/** In-memory merge row — the wire shape plus the field the identity merge accumulates. Never cached, never sent. */
 export interface OrgAllEmployeeRowInternal extends OrgAllEmployeeRow {
   /** Every lowercased address that contributed to this row. Length > 1 is the normal result of a merge. */
   emails: string[];
-  /** Diagnostic: the merge keys that collapsed into this row (e.g. `identity:mcderk`). Lets a reviewer explain a merge without re-deriving it. */
-  mergedFrom?: string[];
 }
 
 /** In-memory merge payload — the stored seed and the pre-strip merge result. Never cached, never sent. */


### PR DESCRIPTION
Fixes #2179.

## Problem
`GET /api/orgs/:orgUid/lens/people/all[?live]` shipped `emails[]` (every contributing address per row: personal, other-employer, unrelated-foundation) plus `mergedFrom[]` merge diagnostics to the browser, though nothing in the UI reads either field.

## Fix (list-only, wire shape)
- **Wire/internal type split**: `OrgAllEmployeeRow` loses `emails`/`mergedFrom`; the merge keeps working on `OrgAllEmployeeRowInternal` in memory only, so identity matching (incl. the orphan-absorb dedupe) is unchanged.
- **Explicit allowlist boundary**: new `org-people-wire.mapper.ts` (`toWireRow`/`toWireResponse`) projects rows onto the wire shape on both paths — before the per-user cache persist on the live path, after the org-cache read on the stored path (the org cache holds raw warehouse rows). A field added to the internal row later is dropped by default; a required field added to the wire row fails to compile until listed (optional additions must be listed by hand).
- **Cache namespace bump** `org-people-dir:v1` → `v2` so rolling deploys never serve stale entries as the new shape.
- **Fail-closed validator**: the directory cache validator now asserts both fields are *absent* — a regressed writer degrades to a miss and recomputes, never replays.
- **Dead `mergedFrom` removed** (review follow-up): after the strip the merge-key diagnostic was written but never read, so the internal field and its writes are gone; the validator still rejects any cached entry carrying it.

The single display `email` is untouched (no UI change, same audience/gating).

## Verification
- New absence assertions on both public methods (`not.toHaveProperty('emails'/'mergedFrom')`); internal accessor proven to retain `emails` for the merge.
- Validator round-trip test: stripped roster accepted after Valkey JSON round-trip; `emails`/`mergedFrom` each rejected independently.
- Full server suite: 117 files / 3320 tests pass; `ng build`, eslint, prettier, fixture/company-email guards all green.
