### PR TITLE
ci(github): sync issue type field from label automatically

### DIFF
--- a/.github/workflows/sync-issue-type.yml
+++ b/.github/workflows/sync-issue-type.yml
@@ -1,0 +1,43 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+name: Sync Issue Type From Label
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  sync-type:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Map label to issue type and update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          # Issue type IDs are org-level (shared across all linuxfoundation repos with
+          # Issue Types enabled), so they're stable to hardcode rather than look up per run.
+          case "$LABEL_NAME" in
+            bug)
+              TYPE_ID="IT_kwDOAA_egs4AAnET" # Bug
+              ;;
+            enhancement)
+              TYPE_ID="IT_kwDOAA_egs4AAnEX" # Feature
+              ;;
+            *)
+              echo "No issue type mapping for label '$LABEL_NAME' — skipping."
+              exit 0
+              ;;
+          esac
+
+          gh api graphql -f query='
+            mutation($issueId: ID!, $typeId: ID!) {
+              updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $typeId }) {
+                issue { id issueType { name } }
+              }
+            }' -f issueId="$ISSUE_NODE_ID" -f typeId="$TYPE_ID"

--- a/.github/workflows/sync-issue-type.yml
+++ b/.github/workflows/sync-issue-type.yml
@@ -23,10 +23,10 @@ jobs:
           # Issue type IDs are org-level (shared across all linuxfoundation repos with
           # Issue Types enabled), so they're stable to hardcode rather than look up per run.
           case "$LABEL_NAME" in
-            bug)
+            bug | type:bug)
               TYPE_ID="IT_kwDOAA_egs4AAnET" # Bug
               ;;
-            enhancement)
+            enhancement | type:enhancement)
               TYPE_ID="IT_kwDOAA_egs4AAnEX" # Feature
               ;;
             *)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-issue-type.yml`, triggered on `issues: labeled`
- Maps `bug` → `Bug` issue type and `enhancement` → `Feature` issue type via the GraphQL `updateIssueIssueType` mutation
- Unmapped labels are a no-op

Companion PR for `linuxfoundation/lfx-self-serve-ops` to follow with the identical workflow.

Closes #2361

## Test plan
- [ ] Merge to main
- [ ] Apply the `bug` label to a test issue and confirm the Type field updates to `Bug`
- [ ] Apply the `enhancement` label to a test issue and confirm the Type field updates to `Feature`
- [ ] Apply an unrelated label and confirm the workflow run succeeds as a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)