### PR TITLE
feat(formation): scope formations queue to selected foundation

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -333,15 +333,18 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/documents/documents.routes').then((m) => m.DOCUMENT_ROUTES),
       },
       // Formations queue (GH-1958) — dark-launched behind `formation-enabled` (CanMatch), auditor-only
-      // (CanActivate). Deliberately no projectQueryParamGuard and no `:id`/`:slug` child — the queue is
-      // locked to the LF root, not scoped by `?project=`, and has no nested per-formation drill-down.
+      // (CanActivate). As of GH-2367, the queue scopes to the selected foundation's direct-child
+      // formations via ProjectContextService.selectedFoundation; with no foundation selected (LF root)
+      // it shows every formation, matching the original behavior. projectQueryParamGuard seeds that
+      // selection from a `?project=<slug>` deep link, same as every other `foundation/*` route. Still
+      // no `:id`/`:slug` child — no nested per-formation drill-down.
       // Linked from the dashboard's FormationEntryCardComponent (GH-1955), not from any nav item.
       {
         path: 'foundation/formations',
         title: 'Formations',
         data: { lens: 'foundation' },
         canMatch: [formationEnabledGuard],
-        canActivate: [formationsQueueAuditorGuard],
+        canActivate: [projectQueryParamGuard, formationsQueueAuditorGuard],
         loadComponent: () => import('./modules/formations/formations-queue/formations-queue.component').then((m) => m.FormationsQueueComponent),
       },
       // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -344,7 +344,7 @@ export const routes: Routes = [
         title: 'Formations',
         data: { lens: 'foundation' },
         canMatch: [formationEnabledGuard],
-        canActivate: [projectQueryParamGuard, formationsQueueAuditorGuard],
+        canActivate: [formationsQueueAuditorGuard, projectQueryParamGuard],
         loadComponent: () => import('./modules/formations/formations-queue/formations-queue.component').then((m) => m.FormationsQueueComponent),
       },
       // Marketing OS agents — dark-launched behind `mktg-os-agents-enabled` (CanMatch); invisible when the flag is off.

--- a/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.html
+++ b/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.html
@@ -5,7 +5,7 @@
   <div class="flex items-center gap-3">
     <h1 class="font-display font-light text-2xl m-0">Formations</h1>
   </div>
-  <p class="text-sm text-gray-500 -mt-4">Every foundation, project, and child project between Prospect and Active.</p>
+  <p class="text-sm text-gray-500 -mt-4">{{ subtitle() }}</p>
 
   @if (loadFailed()) {
     <div class="flex flex-col items-center gap-3 py-8 border border-red-200 bg-red-50 rounded-xl" data-testid="formations-queue-inline-error">

--- a/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.spec.ts
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { FormationService } from '@services/formation.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { createEmptyFormationsQueueResponse } from '@lfx-one/shared/constants';
+import type { ProjectContext } from '@lfx-one/shared/interfaces';
+import { of } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FormationsQueueComponent } from './formations-queue.component';
+
+describe('FormationsQueueComponent — foundation scoping (GH-2367)', () => {
+  let fixture: ComponentFixture<FormationsQueueComponent>;
+  let getFormationsQueue: ReturnType<typeof vi.fn>;
+  let selectedFoundation: ReturnType<typeof signal<ProjectContext | null>>;
+
+  const render = async (): Promise<void> => {
+    TestBed.resetTestingModule();
+    getFormationsQueue = vi.fn(() => of(createEmptyFormationsQueueResponse()));
+    selectedFoundation = signal<ProjectContext | null>(null);
+
+    await TestBed.configureTestingModule({
+      imports: [FormationsQueueComponent],
+      providers: [
+        provideRouter([]),
+        { provide: FormationService, useValue: { getFormationsQueue } },
+        { provide: ProjectContextService, useValue: { selectedFoundation } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormationsQueueComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  };
+
+  it('fetches root-scoped (no foundation_uid) when no foundation is selected', async () => {
+    await render();
+
+    expect(getFormationsQueue).toHaveBeenCalledWith(undefined, '', undefined);
+  });
+
+  it('forwards the selected foundation uid once a foundation is chosen', async () => {
+    await render();
+
+    selectedFoundation.set({ uid: 'aaif-uid-1', name: 'AAIF', slug: 'aaif' } as ProjectContext);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getFormationsQueue).toHaveBeenLastCalledWith(undefined, '', 'aaif-uid-1');
+  });
+
+  it('drops the foundation_uid param again once the selection is cleared', async () => {
+    await render();
+
+    selectedFoundation.set({ uid: 'aaif-uid-1', name: 'AAIF', slug: 'aaif' } as ProjectContext);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    selectedFoundation.set(null);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getFormationsQueue).toHaveBeenLastCalledWith(undefined, '', undefined);
+  });
+});

--- a/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, inject, Signal, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { FormationService } from '@services/formation.service';
+import { ProjectContextService } from '@services/project-context.service';
 import type { FormationsQueueFilterState, FormationsQueueResponse, StatCardItem } from '@lfx-one/shared/interfaces';
 import { createEmptyFormationsQueueResponse } from '@lfx-one/shared/constants';
 import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
@@ -19,6 +20,7 @@ import { FormationsTableComponent } from '../components/formations-table/formati
 })
 export class FormationsQueueComponent {
   private readonly formationService = inject(FormationService);
+  private readonly projectContextService = inject(ProjectContextService);
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined);
   private readonly filters = signal<FormationsQueueFilterState>({ subStage: undefined, search: '' });
@@ -45,12 +47,16 @@ export class FormationsQueueComponent {
   }
 
   private initResponse(): Signal<FormationsQueueResponse> {
+    // Unlike foundation-health.component.ts's selectedFoundationSlug$, this deliberately does NOT
+    // filter(slug => !!slug): a null/no-foundation selection is a legitimate, must-still-fetch state
+    // here (root scope = every formation, today's behavior), not an incomplete-context state to wait
+    // out.
     return toSignal(
-      combineLatest([this.refresh$, toObservable(this.filters)]).pipe(
-        switchMap(([, filters]) => {
+      combineLatest([this.refresh$, toObservable(this.filters), toObservable(this.projectContextService.selectedFoundation)]).pipe(
+        switchMap(([, filters, foundation]) => {
           this.loadFailed.set(false);
           this.loading.set(true);
-          return this.formationService.getFormationsQueue(filters.subStage, filters.search).pipe(
+          return this.formationService.getFormationsQueue(filters.subStage, filters.search, foundation?.uid).pipe(
             catchError((error: unknown) => {
               console.error('[FormationsQueue] Failed to load Formations queue', error);
               this.loadFailed.set(true);

--- a/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
@@ -36,7 +36,9 @@ export class FormationsQueueComponent {
   // "every foundation" once a `parent` filter has narrowed the rows to one.
   protected readonly subtitle = computed(() => {
     const foundation = this.projectContextService.selectedFoundation();
-    return foundation ? `${foundation.name}'s formations between Prospect and Active.` : 'Every foundation, project, and child project between Prospect and Active.';
+    return foundation
+      ? `${foundation.name}'s formations between Prospect and Active.`
+      : 'Every foundation, project, and child project between Prospect and Active.';
   });
 
   protected onFiltersChange(filters: FormationsQueueFilterState): void {

--- a/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
+++ b/apps/lfx-one/src/app/modules/formations/formations-queue/formations-queue.component.ts
@@ -8,7 +8,7 @@ import { FormationService } from '@services/formation.service';
 import { ProjectContextService } from '@services/project-context.service';
 import type { FormationsQueueFilterState, FormationsQueueResponse, StatCardItem } from '@lfx-one/shared/interfaces';
 import { createEmptyFormationsQueueResponse } from '@lfx-one/shared/constants';
-import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, finalize, map, of, switchMap } from 'rxjs';
 
 import { FormationsTableComponent } from '../components/formations-table/formations-table.component';
 
@@ -32,6 +32,12 @@ export class FormationsQueueComponent {
   private readonly response: Signal<FormationsQueueResponse> = this.initResponse();
   protected readonly rows = computed(() => this.response().rows);
   protected readonly tiles: Signal<StatCardItem[]> = this.initTiles();
+  // GH-2367: reflects the foundation the queue is actually scoped to, so the copy doesn't claim
+  // "every foundation" once a `parent` filter has narrowed the rows to one.
+  protected readonly subtitle = computed(() => {
+    const foundation = this.projectContextService.selectedFoundation();
+    return foundation ? `${foundation.name}'s formations between Prospect and Active.` : 'Every foundation, project, and child project between Prospect and Active.';
+  });
 
   protected onFiltersChange(filters: FormationsQueueFilterState): void {
     this.filters.set(filters);
@@ -50,13 +56,23 @@ export class FormationsQueueComponent {
     // Unlike foundation-health.component.ts's selectedFoundationSlug$, this deliberately does NOT
     // filter(slug => !!slug): a null/no-foundation selection is a legitimate, must-still-fetch state
     // here (root scope = every formation, today's behavior), not an incomplete-context state to wait
-    // out.
+    // out. That does mean a cold load fires one root-scoped fetch before
+    // NavigationService.applyDefaultSelection seeds the default foundation, which switchMap then
+    // discards — accepted, not fixed here, since skipping it would mean filtering out the same null
+    // state this comment just said must still fetch. distinctUntilChanged only dedupes repeated
+    // emissions of the *same* foundation (setFoundation's isSameProjectContext gate can still let a
+    // re-enriched same-foundation object through) so an unrelated filters() change doesn't also
+    // retrigger it as if the foundation had changed.
+    const foundationUid$ = toObservable(this.projectContextService.selectedFoundation).pipe(
+      map((foundation) => foundation?.uid),
+      distinctUntilChanged()
+    );
     return toSignal(
-      combineLatest([this.refresh$, toObservable(this.filters), toObservable(this.projectContextService.selectedFoundation)]).pipe(
-        switchMap(([, filters, foundation]) => {
+      combineLatest([this.refresh$, toObservable(this.filters), foundationUid$]).pipe(
+        switchMap(([, filters, foundationUid]) => {
           this.loadFailed.set(false);
           this.loading.set(true);
-          return this.formationService.getFormationsQueue(filters.subStage, filters.search, foundation?.uid).pipe(
+          return this.formationService.getFormationsQueue(filters.subStage, filters.search, foundationUid).pipe(
             catchError((error: unknown) => {
               console.error('[FormationsQueue] Failed to load Formations queue', error);
               this.loadFailed.set(true);

--- a/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.spec.ts
@@ -123,6 +123,19 @@ describe('FormationService', () => {
     filtered.flush({});
   });
 
+  // GH-2367: scope the queue to the selected foundation.
+  it('getFormationsQueue sets foundation_uid only when a foundation uid is passed', () => {
+    service.getFormationsQueue().subscribe();
+    const bare = http.expectOne((r) => r.url === '/api/formations');
+    expect(bare.request.params.has('foundation_uid')).toBe(false);
+    bare.flush({});
+
+    service.getFormationsQueue(undefined, undefined, 'aaif-uid-1').subscribe();
+    const scoped = http.expectOne((r) => r.url === '/api/formations');
+    expect(scoped.request.params.get('foundation_uid')).toBe('aaif-uid-1');
+    scoped.flush({});
+  });
+
   it('getMyFormationWork shares one GET across concurrent subscribers', () => {
     service.getMyFormationWork().subscribe();
     service.getMyFormationWork().subscribe();

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -117,10 +117,11 @@ export class FormationService {
     );
   }
 
-  public getFormationsQueue(subStage?: FormationSubStage, search?: string): Observable<FormationsQueueResponse> {
+  public getFormationsQueue(subStage?: FormationSubStage, search?: string, foundationUid?: string): Observable<FormationsQueueResponse> {
     let params = new HttpParams();
     if (subStage) params = params.set('sub_stage', subStage);
     if (search) params = params.set('search', search);
+    if (foundationUid) params = params.set('foundation_uid', foundationUid);
     return this.http.get<FormationsQueueResponse>('/api/formations', { params });
   }
 

--- a/apps/lfx-one/src/server/controllers/formation.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/formation.controller.spec.ts
@@ -1,0 +1,102 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { getFormationsQueue } = vi.hoisted(() => ({
+  getFormationsQueue: vi.fn(),
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
+vi.mock('@lfx-one/shared/constants', () => ({ FORMATION_QUEUE_SUB_STAGES: ['exploratory', 'engaged', 'on_hold'] }));
+vi.mock('@lfx-one/shared/interfaces', () => ({}));
+
+// validation.helper.ts pulls in @lfx-one/shared/utils, which transitively drags in @angular/common
+// (JIT-compilation failure under vitest's node environment) — mock it wholesale, same as
+// committee.controller.spec.ts, reimplementing only the `foundation_uid` behavior under test.
+vi.mock('../helpers/validation.helper', async () => {
+  const { ServiceValidationError } = await import('../errors');
+  return {
+    validateUidParameter: vi.fn(() => true),
+    validateItemKeyParameter: vi.fn(() => true),
+    validateFoundationUidParameter: vi.fn((value: unknown, req: any, next: any, options: any) => {
+      if (value === undefined) {
+        return true;
+      }
+      if (typeof value !== 'string' || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+        next(
+          new ServiceValidationError(
+            [{ field: 'foundation_uid', message: 'foundation_uid must be a valid project uid', code: 'VALIDATION_ERROR' }],
+            'Validation failed',
+            { operation: options.operation, path: req.path }
+          )
+        );
+        return false;
+      }
+      return true;
+    }),
+  };
+});
+
+vi.mock('../services/formation.service', () => ({
+  formationService: { getFormationsQueue },
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+vi.mock('../utils/auth-helper', () => ({ getUsernameFromAuth: vi.fn() }));
+
+import { getFormationsQueue as getFormationsQueueController } from './formation.controller';
+
+function buildReq(query: Record<string, unknown> = {}): any {
+  return { query, path: '/api/formations', log: {} };
+}
+
+function buildRes(): any {
+  return { json: vi.fn() };
+}
+
+describe('formation.controller — getFormationsQueue foundation_uid handling (GH-2367)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFormationsQueue.mockResolvedValue({ rows: [], tiles: {} });
+  });
+
+  it('passes undefined when foundation_uid is absent', async () => {
+    await getFormationsQueueController(buildReq(), buildRes(), vi.fn());
+
+    expect(getFormationsQueue).toHaveBeenCalledWith(expect.anything(), undefined, undefined, undefined);
+  });
+
+  it('forwards a valid foundation_uid to the service', async () => {
+    await getFormationsQueueController(buildReq({ foundation_uid: 'aaif-uid-1' }), buildRes(), vi.fn());
+
+    expect(getFormationsQueue).toHaveBeenCalledWith(expect.anything(), undefined, undefined, 'aaif-uid-1');
+  });
+
+  it('rejects a malformed foundation_uid via next() instead of silently widening to root scope', async () => {
+    const next = vi.fn();
+
+    await getFormationsQueueController(buildReq({ foundation_uid: 'has a space' }), buildRes(), next);
+
+    expect(getFormationsQueue).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ServiceValidationError' }));
+  });
+
+  it('rejects a non-string foundation_uid (e.g. a repeated query param) via next()', async () => {
+    const next = vi.fn();
+
+    await getFormationsQueueController(buildReq({ foundation_uid: ['a', 'b'] }), buildRes(), next);
+
+    expect(getFormationsQueue).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ServiceValidationError' }));
+  });
+});

--- a/apps/lfx-one/src/server/controllers/formation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/formation.controller.ts
@@ -5,7 +5,7 @@ import { FORMATION_QUEUE_SUB_STAGES } from '@lfx-one/shared/constants';
 import type { FormationSubStage } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
-import { validateItemKeyParameter, validateUidParameter } from '../helpers/validation.helper';
+import { validateFoundationUidParameter, validateItemKeyParameter, validateUidParameter } from '../helpers/validation.helper';
 import { formationService } from '../services/formation.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
@@ -223,26 +223,14 @@ function parseSubStage(value: unknown): FormationSubStage | undefined {
   return typeof value === 'string' && (FORMATION_QUEUE_SUB_STAGES as string[]).includes(value) ? (value as FormationSubStage) : undefined;
 }
 
-// This value is forwarded verbatim into the upstream `parent: project:<uid>` query-service param
-// (see formation.service.ts), so unlike sub_stage/search it's guarded against whitespace/oversized
-// junk reaching that call rather than just left as a lenient string passthrough.
-const MAX_FOUNDATION_UID_LENGTH = 128;
-
-function parseFoundationUid(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.length > MAX_FOUNDATION_UID_LENGTH || /\s/.test(trimmed)) {
-    return undefined;
-  }
-  return trimmed;
-}
-
 export const getFormationsQueue = async (req: Request, res: Response, next: NextFunction) => {
   const subStage = parseSubStage(req.query['sub_stage']);
   const search = typeof req.query['search'] === 'string' ? req.query['search'] : undefined;
-  const foundationUid = parseFoundationUid(req.query['foundation_uid']);
+  const foundationUidParam = req.query['foundation_uid'];
+  if (!validateFoundationUidParameter(foundationUidParam, req, next, { operation: 'get_formations_queue' })) {
+    return;
+  }
+  const foundationUid = foundationUidParam;
   const startTime = logger.startOperation(req, 'get_formations_queue', { subStage, search, foundation_uid: foundationUid });
 
   try {

--- a/apps/lfx-one/src/server/controllers/formation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/formation.controller.ts
@@ -223,13 +223,30 @@ function parseSubStage(value: unknown): FormationSubStage | undefined {
   return typeof value === 'string' && (FORMATION_QUEUE_SUB_STAGES as string[]).includes(value) ? (value as FormationSubStage) : undefined;
 }
 
+// This value is forwarded verbatim into the upstream `parent: project:<uid>` query-service param
+// (see formation.service.ts), so unlike sub_stage/search it's guarded against whitespace/oversized
+// junk reaching that call rather than just left as a lenient string passthrough.
+const MAX_FOUNDATION_UID_LENGTH = 128;
+
+function parseFoundationUid(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_FOUNDATION_UID_LENGTH || /\s/.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export const getFormationsQueue = async (req: Request, res: Response, next: NextFunction) => {
   const subStage = parseSubStage(req.query['sub_stage']);
   const search = typeof req.query['search'] === 'string' ? req.query['search'] : undefined;
-  const startTime = logger.startOperation(req, 'get_formations_queue', { subStage, search });
+  const foundationUid = parseFoundationUid(req.query['foundation_uid']);
+  const startTime = logger.startOperation(req, 'get_formations_queue', { subStage, search, foundation_uid: foundationUid });
 
   try {
-    const result = await formationService.getFormationsQueue(req, subStage, search);
+    const result = await formationService.getFormationsQueue(req, subStage, search, foundationUid);
     logger.success(req, 'get_formations_queue', startTime, { row_count: result.rows.length });
     return res.json(result);
   } catch (error) {

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -20,7 +20,7 @@ import { describe, expect, it, vi } from 'vitest';
 // undefined -> string | undefined) is directly, exhaustively pinned by name.
 vi.mock('@lfx-one/shared/utils', () => ({}));
 
-import { getStringQueryParam, validateItemKeyParameter } from './validation.helper';
+import { getStringQueryParam, validateFoundationUidParameter, validateItemKeyParameter } from './validation.helper';
 
 describe('validateItemKeyParameter', () => {
   const req = {} as any;
@@ -43,6 +43,43 @@ describe('validateItemKeyParameter', () => {
   it('rejects a non-string value', () => {
     const next = vi.fn();
     expect(validateItemKeyParameter(undefined, req, next, options)).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('validateFoundationUidParameter', () => {
+  const req = {} as any;
+  const options = { operation: 'test_operation' };
+
+  it('accepts an absent value — unscoped root is valid', () => {
+    const next = vi.fn();
+    expect(validateFoundationUidParameter(undefined, req, next, options)).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid project uid', () => {
+    const next = vi.fn();
+    expect(validateFoundationUidParameter('aaif-uid-1', req, next, options)).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a value with invalid characters (e.g. a space) with a 400 validation error', () => {
+    const next = vi.fn();
+    expect(validateFoundationUidParameter('has a space', req, next, options)).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+    const error = next.mock.calls[0][0];
+    expect(error.statusCode).toBe(400);
+  });
+
+  it('rejects a non-string value (e.g. a repeated query param parsed as an array)', () => {
+    const next = vi.fn();
+    expect(validateFoundationUidParameter(['a', 'b'], req, next, options)).toBe(false);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a value over the 128-character length cap', () => {
+    const next = vi.fn();
+    expect(validateFoundationUidParameter('a'.repeat(129), req, next, options)).toBe(false);
     expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -88,6 +88,34 @@ export function validateItemKeyParameter(itemKey: unknown, req: Request, next: N
   return true;
 }
 
+/** query-service `parent`'s uid segment, per its OpenAPI schema (`^[a-zA-Z][a-zA-Z0-9_]*:[a-zA-Z0-9_-]+$` after the `project:` prefix). */
+const FOUNDATION_UID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+/**
+ * Validates the optional `?foundation_uid=` query param (GH-2367), forwarded verbatim into the
+ * upstream `parent: project:<uid>` query-service filter. Absent is valid — it means unscoped
+ * (root) — but a present, malformed value is rejected with a 400 rather than silently falling back
+ * to unscoped: that fallback would widen the result set the caller asked to narrow, the opposite of
+ * a safe failure direction for a filter param.
+ */
+export function validateFoundationUidParameter(value: unknown, req: Request, next: NextFunction, options: ValidationOptions): value is string | undefined {
+  if (value === undefined) {
+    return true;
+  }
+  if (typeof value !== 'string' || !FOUNDATION_UID_PATTERN.test(value)) {
+    const validationError = ServiceValidationError.forField('foundation_uid', 'foundation_uid must be a valid project uid', {
+      operation: options.operation,
+      service: options.service || 'controller',
+      path: req.path,
+    });
+
+    next(validationError);
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Validates that an array parameter exists and is not empty
  * @param array The array to validate

--- a/apps/lfx-one/src/server/middleware/require-auditor.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/require-auditor.middleware.ts
@@ -10,9 +10,11 @@ import { personaDetectionService } from '../utils/persona-helper';
 /**
  * Guards the Formations queue endpoints (`foundation/formations`, GH-1958) — root-scoped `auditor`
  * FGA grant, with a root-writer bypass matching every sibling ED/marketing-access middleware's
- * convention. Deliberately simpler than `require-marketing-access.middleware.ts`: the queue has no
- * `?project=`/`?foundationSlug=` scoping to fall back to (it is locked to the LF root, no nested
- * views), so there is no per-project relation check below the root one.
+ * convention. Deliberately simpler than `require-marketing-access.middleware.ts`: as of GH-2367 the
+ * queue does take an optional `?foundation_uid=` scope, but that's a query-level `parent` narrowing
+ * of an already-permitted row set (`/query/resources` still enforces per-row `auditor` upstream), so
+ * it can only shrink what a root auditor sees — never grant access to a row they couldn't already
+ * read. There is intentionally no per-project relation check here below the root one.
  */
 export async function requireAuditor(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {

--- a/apps/lfx-one/src/server/routes/formations.route.ts
+++ b/apps/lfx-one/src/server/routes/formations.route.ts
@@ -38,7 +38,8 @@ router.post('/formations/:projectUid/items/:itemKey/reject', rejectFormationItem
 router.post('/formations/:projectUid/items/:itemKey/reopen', reopenFormationItem);
 router.patch('/formations/:projectUid/items/:itemKey', updateFormationItem);
 
-// Formations queue (GH-1958) — LF-root-scoped, auditor-only.
+// Formations queue (GH-1958), auditor-only. Root-scoped by default (every formation); an optional
+// `?foundation_uid=` narrows to that foundation's direct-child formations (GH-2367).
 router.get('/formations', requireAuditor, getFormationsQueue);
 
 export default router;

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -864,6 +864,88 @@ describe('FormationService', () => {
       expect(bySearch.rows).toHaveLength(1);
       expect(bySearch.rows[0].project_uid).toBe('live-project-2');
     });
+
+    // GH-2367: scope the queue to the selected foundation via query-service's `parent` param.
+    describe('foundation scoping (GH-2367)', () => {
+      const rowA: FormationQueueRow = {
+        formation_uid: 'formation:live-project-1',
+        project_uid: 'live-project-1',
+        project_name: 'Live Project',
+        project_slug: 'live-project',
+        is_foundation: false,
+        parent_uid: null,
+        sub_stage: 'engaged',
+        lifecycle: 'live',
+        gates_cleared: false,
+        is_activating: false,
+        announcement_date: null,
+        progress: {},
+        blocked_item_titles: [],
+        assignees: [],
+      };
+      const rowB: FormationQueueRow = {
+        ...rowA,
+        formation_uid: 'formation:live-project-2',
+        project_uid: 'live-project-2',
+        project_name: 'Cascade Systems',
+        sub_stage: 'on_hold',
+      };
+
+      beforeEach(() => {
+        proxyRequest.mockResolvedValue({
+          resources: [
+            { type: 'formation', id: rowA.formation_uid, data: rowA },
+            { type: 'formation', id: rowB.formation_uid, data: rowB },
+          ],
+        } satisfies QueryServiceResponse<FormationQueueRow>);
+      });
+
+      it('sends no `parent` param when no foundation is selected', async () => {
+        await service.getFormationsQueue(buildReq());
+
+        const call = proxyRequest.mock.calls.find((c) => c[2] === '/query/resources');
+        expect(call).toBeDefined();
+        const params = call?.[4] as Record<string, unknown>;
+        expect(params).not.toHaveProperty('parent');
+        expect(params).toMatchObject({ type: 'formation' });
+      });
+
+      it('sends `parent: project:<uid>` exactly when a foundation is selected', async () => {
+        await service.getFormationsQueue(buildReq(), undefined, undefined, 'aaif-uid-1');
+
+        const call = proxyRequest.mock.calls.find((c) => c[2] === '/query/resources');
+        const params = call?.[4] as Record<string, unknown>;
+        expect(params).toMatchObject({ type: 'formation', parent: 'project:aaif-uid-1' });
+      });
+
+      it('counts tiles over the foundation-scoped rows, not a global set', async () => {
+        proxyRequest.mockResolvedValue({
+          resources: [{ type: 'formation', id: rowA.formation_uid, data: rowA }],
+        } satisfies QueryServiceResponse<FormationQueueRow>);
+
+        const result = await service.getFormationsQueue(buildReq(), undefined, undefined, 'aaif-uid-1');
+        expect(result.tiles.total).toBe(1);
+      });
+
+      it('still applies subStage/search to rows without affecting tiles, with a foundation selected', async () => {
+        const result = await service.getFormationsQueue(buildReq(), 'engaged', undefined, 'aaif-uid-1');
+
+        expect(result.tiles.total).toBe(2);
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0].project_uid).toBe('live-project-1');
+      });
+
+      it('still propagates failOnPartial with a foundation selected', async () => {
+        proxyRequest
+          .mockResolvedValueOnce({
+            resources: [{ type: 'formation', id: rowA.formation_uid, data: rowA }],
+            page_token: 'next-page',
+          } satisfies QueryServiceResponse<FormationQueueRow>)
+          .mockRejectedValueOnce(new Error('query service unavailable'));
+
+        await expect(service.getFormationsQueue(buildReq(), undefined, undefined, 'aaif-uid-1')).rejects.toThrow(/query service unavailable/);
+      });
+    });
   });
 
   describe('getMyFormationWork (GH-1956)', () => {

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -562,9 +562,11 @@ export class FormationService {
    * selected sends no `parent` key at all, returning every formation, same as before this change.
    * Never resolve the LF root uid and pass it here: root scope means "every formation", not
    * "formations whose immediate parent is the root" — those are different sets. `subStage`/`search`
-   * stay client-side below, not as query-service params — the contract (GH-2267 plan §7's
-   * `getFormationsQueue` row) only documents `type`/`parent` and an `assignee:<username>` tag for
-   * "Mine"; there's no confirmed server-side sub_stage/name filter.
+   * stay client-side below even though a server-side `sub_stage:` tag does exist upstream
+   * (indexer_publisher.go's `projectionTags()`): `buildQueueTilesFromRows` needs every sub_stage
+   * present in `normalizedRows` to count them, so pushing the filter into the query would break the
+   * tiles it's computed from. `search`'s `project_name` substring match has no upstream equivalent
+   * (only a `name` typeahead param) and stays client-side for the same pre-tile reason.
    * failOnPartial: true — buildQueueTilesFromRows below is pure counting over rawRows, and a
    * silently-partial page set would render wrong tile totals with no indication anything failed.
    */

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -570,12 +570,7 @@ export class FormationService {
    * failOnPartial: true — buildQueueTilesFromRows below is pure counting over rawRows, and a
    * silently-partial page set would render wrong tile totals with no indication anything failed.
    */
-  private async getFormationsQueueLive(
-    req: Request,
-    subStage?: FormationSubStage,
-    search?: string,
-    foundationUid?: string
-  ): Promise<FormationsQueueResponse> {
+  private async getFormationsQueueLive(req: Request, subStage?: FormationSubStage, search?: string, foundationUid?: string): Promise<FormationsQueueResponse> {
     const rawRows = await fetchAllQueryResources<FormationQueueRow>(
       req,
       (pageToken) =>

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -522,10 +522,10 @@ export class FormationService {
     return this.enrichSingle(req, updated);
   }
 
-  public async getFormationsQueue(req: Request, subStage?: FormationSubStage, search?: string): Promise<FormationsQueueResponse> {
-    logger.debug(req, 'get_formations_queue', 'Fetching Formations queue', { subStage, search });
+  public async getFormationsQueue(req: Request, subStage?: FormationSubStage, search?: string, foundationUid?: string): Promise<FormationsQueueResponse> {
+    logger.debug(req, 'get_formations_queue', 'Fetching Formations queue', { subStage, search, foundationUid });
 
-    return this.getFormationsQueueLive(req, subStage, search);
+    return this.getFormationsQueueLive(req, subStage, search, foundationUid);
   }
 
   /**
@@ -556,18 +556,30 @@ export class FormationService {
    * only ROOT collapse and the subStage/search filters below. `search` matches on `project_name`.
    * Rows the caller can't read are simply absent from `/query/resources` (per-row `auditor`
    * enforcement upstream), so no additional access filtering is needed here.
+   *
+   * `foundationUid`, when present, is sent as `parent: project:<uid>` — the documented query-service
+   * navigation filter that matches a formation's *immediate* `parent_refs` (GH-2367). No foundation
+   * selected sends no `parent` key at all, returning every formation, same as before this change.
+   * Never resolve the LF root uid and pass it here: root scope means "every formation", not
+   * "formations whose immediate parent is the root" — those are different sets. `subStage`/`search`
+   * stay client-side below, not as query-service params — the contract (GH-2267 plan §7's
+   * `getFormationsQueue` row) only documents `type`/`parent` and an `assignee:<username>` tag for
+   * "Mine"; there's no confirmed server-side sub_stage/name filter.
+   * failOnPartial: true — buildQueueTilesFromRows below is pure counting over rawRows, and a
+   * silently-partial page set would render wrong tile totals with no indication anything failed.
    */
-  private async getFormationsQueueLive(req: Request, subStage?: FormationSubStage, search?: string): Promise<FormationsQueueResponse> {
-    // subStage/search are applied client-side below, not as query-service params — the contract
-    // (GH-2267 plan §7's `getFormationsQueue` row) only documents `type=formation` and an
-    // `assignee:<username>` tag for "Mine"; there's no confirmed server-side sub_stage/name filter.
-    // failOnPartial: true — buildQueueTilesFromRows below is pure counting over rawRows, and a
-    // silently-partial page set would render wrong tile totals with no indication anything failed.
+  private async getFormationsQueueLive(
+    req: Request,
+    subStage?: FormationSubStage,
+    search?: string,
+    foundationUid?: string
+  ): Promise<FormationsQueueResponse> {
     const rawRows = await fetchAllQueryResources<FormationQueueRow>(
       req,
       (pageToken) =>
         this.microserviceProxy.proxyRequest<QueryServiceResponse<FormationQueueRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'formation',
+          ...(foundationUid && { parent: `project:${foundationUid}` }),
           ...(pageToken && { page_token: pageToken }),
         }),
       { failOnPartial: true }
@@ -596,6 +608,11 @@ export class FormationService {
       rows = rows.filter((row) => row.project_name.toLowerCase().includes(term));
     }
 
+    // Tiles are counted over normalizedRows (pre subStage/search), not the filtered `rows` below,
+    // so they describe the whole queue rather than the filtered view. With a foundation selected,
+    // normalizedRows is already narrowed to that foundation's rows by the `parent` query param
+    // above, so "the whole queue" here correctly means "the whole queue within that foundation" —
+    // no separate foundation-aware tile computation is needed.
     const tiles = this.buildQueueTilesFromRows(normalizedRows);
 
     return { tiles, rows };


### PR DESCRIPTION
## Summary

- The Formations queue at `/foundation/formations` ignored the foundation picker and always returned all 126 production formations server-side, regardless of the selected foundation — selecting AAIF surfaced CNCF's rows.
- Scope the query-service read by the selected foundation's uid via the documented `parent: project:<uid>` filter. No foundation selected (root / The Linux Foundation) keeps returning every formation, matching current behavior.
- Tiles are computed over the already foundation-scoped rows, so tile totals change with the foundation as intended.
- Post-full-branch-review fixes (three-reviewer batch): `foundation_uid` now fails closed on a malformed value via `validateFoundationUidParameter` (400, following the repo's `validateUidParameter`/`validateItemKeyParameter` convention) instead of silently widening to root scope; fixed the formations queue route guard order to match the repo's `[accessGuard, projectQueryParamGuard]` convention (`formationsQueueAuditorGuard` before `projectQueryParamGuard`) — order has no functional effect here since the auditor guard depends only on persona/FGA state, not project context, but this keeps the route consistent with every other combined-guard route; corrected a stale doc comment about server-side `sub_stage` filtering; added a dynamic subtitle reflecting the selected foundation; added `distinctUntilChanged` to dedupe redundant re-fetches from re-enriched same-foundation emissions; added `formation.controller.spec.ts` for the new validation path.

## Open questions / known gaps — reporting, not fixing here

- **Ancestry/coverage gap:** `parent` matches the **immediate** parent only. Production has 126 formations across 33 distinct `parent_uid` values, so a formation nested under an intermediate project (not directly under its foundation) won't appear in that foundation's queue. Tracked on #2368. Not a reason to hold this PR — today the page is wrong for every foundation; after this it's right for direct children and incomplete for nested ones. When an ancestry key lands on the projection, it's a one-line swap from `parent` to that key.
- **Wire-format choice:** `?foundation_uid=<uid>` was chosen to match the existing uid-flavored scope param on `/api/committees/my-committees`, since the client already holds the uid (`ProjectContextService.selectedFoundation()`) and query-service's `parent` filter wants a uid — a slug-based convention would need an extra NATS resolve per queue load for no gain.
- **Sizing number from prod:** not yet captured — the manual production verification pass (sign in as root auditor, compare AAIF vs. CNCF vs. no-foundation row/tile counts) has not been performed in this session. Should be done before merge.
- **Empty-state copy:** raising, not inventing — should the empty state say something distinct when a foundation has zero *direct-child* formations but may have nested ones currently hidden by the ancestry gap above?
- **Other fetch-everything-then-narrow callers:** this function's own `search` filter was the only remaining in-process narrowing pattern found; two near-misses worth a follow-up tracking issue: `weekly-brief.service.ts:418-425` (filters a server-paginated page by date in process) and `committee.service.ts:187-219` (fetches the unscoped listing then narrows by access).

## Protected files touched

- `apps/lfx-one/src/server/middleware/require-auditor.middleware.ts` — doc-comment-only change (corrects a claim about the queue having no scope param), no behavior change. Flagging per repo policy for code-owner review.

## Test plan

- [x] `yarn check-types`, `yarn lint`, `yarn build`, `./check-headers.sh` all clean
- [x] `yarn test` — 155 test files / 2750 tests passing, including new `formation.controller.spec.ts` and `formation.service.spec.ts` coverage for foundation-scoping
- [ ] Manual prod verification (root auditor, AAIF vs. CNCF vs. no-foundation row/tile counts) — outstanding, should happen before merge

Refs #2367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EkG4FRbMFRDtE8up7CvbH
