### PR TITLE
feat(formation): wire the real activity feed into the item drawer

### DIFF
--- a/apps/lfx-one/e2e/fixtures/mock-data/formation-item.mock.ts
+++ b/apps/lfx-one/e2e/fixtures/mock-data/formation-item.mock.ts
@@ -146,12 +146,13 @@ export const mockFormationActivity: Record<string, FormationActivity[]> = {
   'formation-item:cascade-data-alliance:contribution_agreement_executed': [
     {
       uid: 'formation-activity:1',
-      formation_uid: 'formation:cascade-data-alliance',
       formation_item_uid: 'formation-item:cascade-data-alliance:contribution_agreement_executed',
-      type: 'note_added',
+      action: 'note_changed',
+      action_raw: 'note_changed',
+      set_by: 'user',
       actor: { username: 'sam.chen', name: 'Sam Chen' },
-      message: 'updated notes',
-      metadata: null,
+      before: null,
+      after: null,
       created_at: new Date(0).toISOString(),
     },
   ],

--- a/apps/lfx-one/e2e/formation-checklist.spec.ts
+++ b/apps/lfx-one/e2e/formation-checklist.spec.ts
@@ -65,7 +65,7 @@ test.describe('Formation Checklist section (GH-1958)', () => {
 
     const drawer = page.getByTestId('formation-item-drawer');
     await expect(drawer).toBeVisible();
-    await expect(page.getByTestId('formation-item-drawer-history')).toContainText('updated notes');
+    await expect(page.getByTestId('formation-item-drawer-history')).toContainText('updated the note');
   });
 
   test('the "Choose a template" empty state renders when no template has been chosen', async ({ page }) => {

--- a/apps/lfx-one/e2e/helpers/formation-api-mock.helper.ts
+++ b/apps/lfx-one/e2e/helpers/formation-api-mock.helper.ts
@@ -53,7 +53,7 @@ export class FormationApiMockHelper {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ item, history: mockFormationActivity[item.uid] ?? [] }),
+        body: JSON.stringify({ item, history: mockFormationActivity[item.uid] ?? [], history_state: 'complete' }),
       });
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.html
@@ -168,17 +168,32 @@
 
       <div class="flex flex-col gap-2" data-testid="formation-item-drawer-history">
         <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">History</span>
-        @if (history().length === 0) {
+        @if (historyState() === 'unavailable') {
+          <span class="text-sm text-red-600" data-testid="formation-item-drawer-history-unavailable">Couldn't load activity for this item.</span>
+        } @else if (historyEntries().length === 0) {
           <span class="text-sm text-gray-500">No activity yet.</span>
         } @else {
           <div class="flex flex-col gap-2">
-            @for (entry of history(); track entry.uid) {
+            @for (row of historyEntries(); track row.entry.uid) {
               <div class="flex flex-col text-sm border-b border-gray-100 pb-2 last:border-b-0">
-                <span class="text-gray-700">{{ entry.actor.name }} {{ entry.message }}</span>
-                <span class="text-xs text-gray-400">{{ entry.created_at | date: 'medium' }}</span>
+                @if (row.entry.action) {
+                  <span class="text-gray-700">{{ row.entry.actor.name }} {{ row.summary }}</span>
+                } @else {
+                  <span class="text-gray-700 flex items-center gap-1.5">
+                    {{ row.entry.actor.name }}
+                    <span class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 text-xs">{{ row.summary }}</span>
+                  </span>
+                }
+                @if (row.detail) {
+                  <span class="text-xs text-gray-500">{{ row.detail }}</span>
+                }
+                <span class="text-xs text-gray-400">{{ row.entry.created_at | date: 'medium' }}</span>
               </div>
             }
           </div>
+          @if (historyState() === 'truncated') {
+            <span class="text-xs text-gray-400 italic" data-testid="formation-item-drawer-history-truncated">Older activity not shown.</span>
+          }
         }
       </div>
     } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/formation-item-drawer.component.ts
@@ -13,7 +13,7 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { FormationService } from '@services/formation.service';
 import type { FormationDrawerData, FormationItem, FormationItemLink } from '@lfx-one/shared/interfaces';
 import { createEmptyFormationDrawerData, FORMATION_ITEM_STATUS_LABELS, FORMATION_ITEM_STATUS_SEVERITY } from '@lfx-one/shared/constants';
-import { isValidUrl, toLocalDateOnlyString, tryParseLocalDateString } from '@lfx-one/shared/utils';
+import { getFormationActivityDisplay, isValidUrl, toLocalDateOnlyString, tryParseLocalDateString } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { catchError, finalize, map, merge, of, skip, Subject, switchMap, take, tap } from 'rxjs';
@@ -127,6 +127,14 @@ export class FormationItemDrawerComponent {
   protected readonly drawerData: Signal<FormationDrawerData> = this.initDrawerData();
   protected readonly item = computed(() => this.drawerData().item);
   protected readonly history = computed(() => this.drawerData().history);
+  /** Distinguishes the History panel's honest empty/partial/failed states (GH-2372) — see `FormationActivityHistoryState`'s doc comment. */
+  protected readonly historyState = computed(() => this.drawerData().history_state);
+  /**
+   * Precomputed per-entry summary/detail so the template never calls a function per
+   * change-detection cycle — same reason `committee-overview.component.ts` precomputes
+   * `formatRelativeTime` instead of calling it from the template.
+   */
+  protected readonly historyEntries = computed(() => this.history().map((entry) => ({ entry, ...getFormationActivityDisplay(entry) })));
   /** `link.href` is API-sourced — never trust it into `[href]` unvalidated; drop anything that isn't http(s). */
   protected readonly safeLinks: Signal<FormationItemLink[]> = computed(() => (this.item()?.links ?? []).filter((link) => isValidUrl(link.href)));
   /** "Mark complete" relabels to "Accept" once the item is sitting with the formation team and this caller can close it out — mirrors `FormationChecklistRowComponent`'s `completeLabel`. */

--- a/apps/lfx-one/src/app/shared/services/formation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/formation.service.ts
@@ -4,9 +4,9 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import type {
-  FormationActivity,
   FormationChecklistResponse,
   FormationItem,
+  FormationItemDetail,
   FormationItemStatus,
   FormationSubStage,
   FormationsQueueResponse,
@@ -49,8 +49,8 @@ export class FormationService {
     return this.http.get<FormationChecklistResponse>(`/api/projects/${encodeURIComponent(projectSlug)}/formation`);
   }
 
-  public getFormationItem(projectUid: string, itemKey: string): Observable<{ item: FormationItem; history: FormationActivity[] }> {
-    return this.http.get<{ item: FormationItem; history: FormationActivity[] }>(itemPath(projectUid, itemKey));
+  public getFormationItem(projectUid: string, itemKey: string): Observable<FormationItemDetail> {
+    return this.http.get<FormationItemDetail>(itemPath(projectUid, itemKey));
   }
 
   public completeFormationItem(projectUid: string, itemKey: string, notes?: string): Observable<FormationItem> {

--- a/apps/lfx-one/src/server/helpers/formation-activity.helper.ts
+++ b/apps/lfx-one/src/server/helpers/formation-activity.helper.ts
@@ -1,0 +1,156 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { FormationActivity, FormationUser, UpstreamFormationActivityEntry, UpstreamFormationActivityPage } from '@lfx-one/shared/interfaces';
+import { normalizeFormationActivityAction } from '@lfx-one/shared/utils';
+import { Request } from 'express';
+
+import { logger } from '../services/logger.service';
+
+/**
+ * A new sibling to `formation-mapper.helper.ts` rather than an addition to it (GH-2372) — that
+ * file's `deriveFormationSubStage` is owned by a parallel worktree (GH-2328); keeping activity
+ * mapping here means neither branch touches the other's file.
+ */
+
+/** Upstream's own cap (`cmd/formation-api/design/design.go`'s `dsl.Maximum(100)`). */
+export const FORMATION_ACTIVITY_PAGE_LIMIT = 100;
+
+/**
+ * `GET /formations/{project_uid}/activity` is formation-scoped with no item filter — the
+ * repository query filters on `formation_uid` alone (verified against
+ * `linuxfoundation/lfx-v2-formation-service` @ `beaa6371ff94a1ae01f3e624922897cb34ee199b`). Finding
+ * one item's entries means scanning the formation's whole feed newest-first until either the item
+ * has enough history or the feed ends. Fetching a single page and filtering it is wrong — an
+ * item's entries can start on any page — and unbounded paging is unacceptable for an interactive
+ * drawer open, so this caps the scan at 5 pages of 100 (500 entries): each item mutation writes
+ * exactly one entry and a template runs on the order of dozens of items, so 500 exceeds a whole
+ * formation's realistic history — the bound exists to cap the pathological case at 5 sequential
+ * upstream calls, not because 500 is expected to be hit. Confirm against observed prod volume and
+ * report it (GH-2372's "report, do not fix" item) — the real fix is an upstream `item_uid` query
+ * param, which would collapse this to one call.
+ */
+export const FORMATION_ACTIVITY_MAX_PAGES = 5;
+
+export interface FormationActivityFetchResult {
+  entries: FormationActivity[];
+  /** True when the page bound was hit with more pages outstanding, or a later page failed to load. */
+  truncated: boolean;
+}
+
+/**
+ * Maps upstream's bare-username actor onto {@link FormationUser}, same precedent as
+ * `formation-mapper.helper.ts`'s item-owner mapping (`raw.assignee ? { username, name } : null`) —
+ * except every entry needs an actor, so the system-authored case (`set_by === 'system'`, or the
+ * literal username `"system"`) maps to a `FormationUser` naming itself rather than `null`, keeping
+ * the field non-optional for template simplicity.
+ */
+function mapActor(raw: UpstreamFormationActivityEntry): FormationUser {
+  if (raw.set_by === 'system' || raw.actor === 'system') {
+    return { username: 'system', name: 'System' };
+  }
+  return { username: raw.actor, name: raw.actor };
+}
+
+/**
+ * Upstream's redacted before/after summary carries only `status`/`assignee` for item entries and a
+ * richer, differently-shaped object for the two formation-level actions (`template_expanded`/
+ * `template_upgraded`) — neither of those reach this mapper (filtered out before mapping, since
+ * they carry no `item_uid`), so this only ever needs to read the two-key item shape. Reads
+ * defensively regardless, since the field is `unknown` on the wire.
+ */
+function toSnapshot(value: Record<string, unknown> | null | undefined): { status: string | null; assignee: string | null } | null {
+  if (!value || typeof value !== 'object') return null;
+  const status = typeof value['status'] === 'string' ? (value['status'] as string) : null;
+  const assignee = typeof value['assignee'] === 'string' ? (value['assignee'] as string) : null;
+  return { status, assignee };
+}
+
+/** Maps one upstream activity entry onto the canonical shape. Exported for the helper's own spec. */
+export function mapUpstreamFormationActivity(raw: UpstreamFormationActivityEntry): FormationActivity {
+  return {
+    uid: raw.ulid,
+    formation_item_uid: raw.item_uid ?? null,
+    action: normalizeFormationActivityAction(raw.action),
+    action_raw: raw.action ?? '',
+    set_by: raw.set_by,
+    actor: mapActor(raw),
+    before: toSnapshot(raw.before),
+    after: toSnapshot(raw.after),
+    created_at: raw.at,
+  };
+}
+
+/**
+ * Scans a formation's activity feed, newest-first, for one item's entries — bounded at
+ * {@link FORMATION_ACTIVITY_MAX_PAGES} pages of {@link FORMATION_ACTIVITY_PAGE_LIMIT}. Order is
+ * preserved exactly as upstream serves it (`ORDER BY ulid DESC`); nothing here re-sorts.
+ *
+ * A page-1 failure propagates — the caller decides whether that means "the whole drawer fetch
+ * fails" or "history degrades to unavailable" (GH-2372: the latter, since the item read has
+ * already succeeded by the time this runs). A later-page failure does not: this is a deliberate
+ * departure from `fetchAllQueryResources`'s `failOnPartial` default — silently presenting a
+ * partial feed as an item's complete history is exactly the dishonesty this ticket forbids, so a
+ * later-page failure returns what was gathered so far with `truncated: true` rather than throwing.
+ */
+export async function fetchItemFormationActivity(
+  req: Request,
+  fetchPage: (cursor: string | undefined) => Promise<UpstreamFormationActivityPage>,
+  itemUid: string
+): Promise<FormationActivityFetchResult> {
+  const entries: FormationActivity[] = [];
+  let cursor: string | undefined;
+  let truncated = false;
+
+  for (let page = 1; page <= FORMATION_ACTIVITY_MAX_PAGES; page++) {
+    let result: UpstreamFormationActivityPage;
+    try {
+      result = await fetchPage(cursor);
+    } catch (error) {
+      if (page === 1) throw error;
+      logger.warning(req, 'fetch_item_formation_activity', 'Activity page failed after the first — returning partial history', {
+        item_uid: itemUid,
+        page,
+        err: error,
+      });
+      truncated = true;
+      break;
+    }
+
+    logger.debug(req, 'fetch_item_formation_activity', 'Fetched activity page', { item_uid: itemUid, page, entries: result.entries.length });
+
+    const unmappedActions = new Set<string>();
+    for (const raw of result.entries) {
+      if (raw.item_uid !== itemUid) continue;
+      const mapped = mapUpstreamFormationActivity(raw);
+      if (mapped.action === null) unmappedActions.add(mapped.action_raw);
+      entries.push(mapped);
+    }
+    if (unmappedActions.size > 0) {
+      logger.debug(req, 'fetch_item_formation_activity', 'Upstream activity action has no canonical equivalent', {
+        item_uid: itemUid,
+        unmapped_actions: [...unmappedActions],
+      });
+    }
+
+    // Repeated cursor would loop forever — an upstream regression, not a bound we should silently
+    // absorb by exhausting every page.
+    if (result.next_cursor && result.next_cursor === cursor) {
+      logger.warning(req, 'fetch_item_formation_activity', 'Upstream returned a repeated cursor — stopping early', { item_uid: itemUid, page });
+      truncated = true;
+      break;
+    }
+
+    if (!result.next_cursor) {
+      // Last page — the full feed was scanned.
+      return { entries, truncated };
+    }
+    cursor = result.next_cursor;
+
+    if (page === FORMATION_ACTIVITY_MAX_PAGES) {
+      truncated = true;
+    }
+  }
+
+  return { entries, truncated };
+}

--- a/apps/lfx-one/src/server/services/formation.service.spec.ts
+++ b/apps/lfx-one/src/server/services/formation.service.spec.ts
@@ -3,7 +3,14 @@
 
 import '@angular/compiler';
 
-import type { QueryServiceResponse, UpstreamFormationChecklist, UpstreamFormationItem, UpstreamFormationQueueRow } from '@lfx-one/shared/interfaces';
+import type {
+  QueryServiceResponse,
+  UpstreamFormationActivityEntry,
+  UpstreamFormationActivityPage,
+  UpstreamFormationChecklist,
+  UpstreamFormationItem,
+  UpstreamFormationQueueRow,
+} from '@lfx-one/shared/interfaces';
 import { deriveFormationEntityType } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -90,6 +97,25 @@ function checklist(items: UpstreamFormationItem[], overrides: Partial<UpstreamFo
     is_activating: false,
     ...overrides,
   };
+}
+
+/** One `GET /formations/{project_uid}/activity` entry, straight off the upstream wire (no canonicalization). */
+function activityEntry(overrides: Partial<UpstreamFormationActivityEntry> = {}): UpstreamFormationActivityEntry {
+  return {
+    ulid: 'activity-ulid-1',
+    item_uid: 'formation-item:live-project-1:item-key-1',
+    actor: 'sam.chen',
+    set_by: 'user',
+    action: 'status_changed',
+    before: { status: 'not_started', assignee: null },
+    after: { status: 'in_progress', assignee: null },
+    at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function activityPage(entries: UpstreamFormationActivityEntry[], nextCursor = ''): UpstreamFormationActivityPage {
+  return { entries, next_cursor: nextCursor };
 }
 
 describe('FormationService', () => {
@@ -269,14 +295,127 @@ describe('FormationService', () => {
   });
 
   describe('getFormationItemDetail', () => {
-    it('returns the enriched item with an empty history — the real activity feed is Phase 5', async () => {
-      proxyRequest.mockResolvedValue(checklist([rawItem()]));
+    const itemUid = 'formation-item:live-project-1:item-key-1';
+
+    /** Path-aware mock: checklist for `/formations/:uid`, an activity page for `/formations/:uid/activity`. */
+    function mockRoutes(activityByPage: UpstreamFormationActivityPage[]): void {
+      let call = 0;
+      proxyRequest.mockImplementation((_req: Request, _service: string, path: string) => {
+        if (path === '/formations/live-project-1') {
+          return Promise.resolve(checklist([rawItem()]));
+        }
+        if (path === '/formations/live-project-1/activity') {
+          const page = activityByPage[Math.min(call, activityByPage.length - 1)];
+          call += 1;
+          return Promise.resolve(page);
+        }
+        throw new Error(`unexpected path: ${path}`);
+      });
+    }
+
+    it('maps a real status_changed entry for the item, preserving newest-first order', async () => {
+      const newer = activityEntry({ ulid: 'activity-ulid-2', at: '2026-01-02T00:00:00.000Z' });
+      const older = activityEntry({ ulid: 'activity-ulid-1', at: '2026-01-01T00:00:00.000Z' });
+      mockRoutes([activityPage([newer, older])]);
 
       const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
 
       expect(result.item.template_item_key).toBe('item-key-1');
       expect(result.item.can_complete).toBe(true);
+      expect(result.history_state).toBe('complete');
+      expect(result.history.map((entry) => entry.uid)).toEqual(['activity-ulid-2', 'activity-ulid-1']);
+      expect(result.history[0]).toMatchObject({
+        formation_item_uid: itemUid,
+        action: 'status_changed',
+        action_raw: 'status_changed',
+        actor: { username: 'sam.chen', name: 'sam.chen' },
+      });
+    });
+
+    it('renders an unrecognized action as unmapped — action: null, action_raw verbatim', async () => {
+      mockRoutes([activityPage([activityEntry({ action: 'item_teleported' })])]);
+
+      const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.history[0].action).toBeNull();
+      expect(result.history[0].action_raw).toBe('item_teleported');
+    });
+
+    it('returns an empty, complete history when the feed has entries but none for this item', async () => {
+      mockRoutes([activityPage([activityEntry({ item_uid: 'formation-item:live-project-1:other-item' })])]);
+
+      const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
+
       expect(result.history).toEqual([]);
+      expect(result.history_state).toBe('complete');
+    });
+
+    it('pages through a bounded pager to find this item’s entries on a later page, threading the cursor', async () => {
+      mockRoutes([
+        activityPage([activityEntry({ ulid: 'p1', item_uid: 'formation-item:live-project-1:other-item' })], 'cursor-1'),
+        activityPage([activityEntry({ ulid: 'p2', item_uid: 'formation-item:live-project-1:other-item' })], 'cursor-2'),
+        activityPage([activityEntry({ ulid: 'p3' })], ''),
+      ]);
+
+      const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.history.map((entry) => entry.uid)).toEqual(['p3']);
+      expect(result.history_state).toBe('complete');
+      const activityCalls = proxyRequest.mock.calls.filter((c) => c[2] === '/formations/live-project-1/activity');
+      expect(activityCalls).toHaveLength(3);
+      expect(activityCalls[0][4]).toEqual({ limit: 100 });
+      expect(activityCalls[1][4]).toEqual({ limit: 100, cursor: 'cursor-1' });
+      expect(activityCalls[2][4]).toEqual({ limit: 100, cursor: 'cursor-2' });
+    });
+
+    it('flags history_state truncated when a next_cursor remains after the bounded page cap', async () => {
+      // FORMATION_ACTIVITY_MAX_PAGES = 5 — every page carries a distinct next_cursor (a repeated
+      // cursor would instead trip the pager's own infinite-loop guard), so the pager stops at the
+      // cap rather than looping forever.
+      mockRoutes([
+        activityPage([activityEntry({ ulid: 'p1' })], 'cursor-1'),
+        activityPage([activityEntry({ ulid: 'p2' })], 'cursor-2'),
+        activityPage([activityEntry({ ulid: 'p3' })], 'cursor-3'),
+        activityPage([activityEntry({ ulid: 'p4' })], 'cursor-4'),
+        activityPage([activityEntry({ ulid: 'p5' })], 'cursor-5'),
+      ]);
+
+      const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.history_state).toBe('truncated');
+      const activityCalls = proxyRequest.mock.calls.filter((c) => c[2] === '/formations/live-project-1/activity');
+      expect(activityCalls).toHaveLength(5);
+    });
+
+    it('degrades to history_state unavailable, item still returned, when the activity fetch rejects (500)', async () => {
+      proxyRequest.mockImplementation((_req: Request, _service: string, path: string) => {
+        if (path === '/formations/live-project-1') return Promise.resolve(checklist([rawItem()]));
+        if (path === '/formations/live-project-1/activity') return Promise.reject(new Error('upstream unavailable'));
+        throw new Error(`unexpected path: ${path}`);
+      });
+
+      const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.item.template_item_key).toBe('item-key-1');
+      expect(result.history).toEqual([]);
+      expect(result.history_state).toBe('unavailable');
+      expect(vi.mocked(logger.warning)).toHaveBeenCalled();
+    });
+
+    it('degrades to history_state unavailable on a 403 from the activity route, without masking the item as not-found', async () => {
+      // The checklist pre-read (getFormationItemOrThrow) already proved project#auditor access on the
+      // identical relation — a 403 here cannot mean "no access" that read didn't already catch, so the
+      // item itself still renders; only history degrades.
+      proxyRequest.mockImplementation((_req: Request, _service: string, path: string) => {
+        if (path === '/formations/live-project-1') return Promise.resolve(checklist([rawItem()]));
+        if (path === '/formations/live-project-1/activity') return Promise.reject(new MicroserviceError('forbidden', 403, 'FORBIDDEN'));
+        throw new Error(`unexpected path: ${path}`);
+      });
+
+      const result = await service.getFormationItemDetail(buildReq(), 'live-project-1', 'item-key-1');
+
+      expect(result.item.template_item_key).toBe('item-key-1');
+      expect(result.history_state).toBe('unavailable');
     });
   });
 

--- a/apps/lfx-one/src/server/services/formation.service.ts
+++ b/apps/lfx-one/src/server/services/formation.service.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import type {
-  FormationActivity,
   FormationChecklistResponse,
   FormationItem,
+  FormationItemDetail,
   FormationItemMapContext,
   FormationItemStatus,
   FormationQueueRow,
@@ -12,6 +12,7 @@ import type {
   FormationSubStage,
   MyFormationWorkResponse,
   Project,
+  UpstreamFormationActivityPage,
   UpstreamFormationChecklist,
   UpstreamFormationItem,
   UpstreamFormationQueueRow,
@@ -22,6 +23,7 @@ import { deriveFormationEntityType, normalizeFormationSubStage } from '@lfx-one/
 import { Request } from 'express';
 
 import { isMicroserviceError, PreconditionFailedError, ResourceNotFoundError, AuthorizationError, ServiceValidationError, ConflictError } from '../errors';
+import { fetchItemFormationActivity, FORMATION_ACTIVITY_PAGE_LIMIT } from '../helpers/formation-activity.helper';
 import { mapUpstreamFormationChecklist, mapUpstreamFormationItem, sectionTitlesFromChecklist } from '../helpers/formation-mapper.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { collapseRootParentUid, resolveRootProjectUid } from '../helpers/root-project.helper';
@@ -36,8 +38,8 @@ import { ProjectService } from './project.service';
  * item mutations (complete/skip/request/status/update/accept/reject/reopen), the queue read
  * {@link getFormationsQueue}, and {@link getProjectFormation}'s checklist read all call the real
  * `lfx-v2-formation-service` unconditionally (GH-2267 Phase 7 deleted the fixture/live switch and
- * the fixture layer it gated). History (`getFormationItemDetail`) still returns an empty array —
- * wiring the real activity feed is Phase 5.
+ * the fixture layer it gated). {@link getFormationItemDetail} wires the real activity feed
+ * (`GET /formations/{project_uid}/activity`, GH-2372) — see {@link fetchItemActivityOrDegrade}.
  */
 export class FormationService {
   private readonly projectService = new ProjectService();
@@ -162,11 +164,11 @@ export class FormationService {
     return this.mapLiveItem(req, projectUid, raw);
   }
 
-  public async getFormationItemDetail(req: Request, projectUid: string, itemKey: string): Promise<{ item: FormationItem; history: FormationActivity[] }> {
+  public async getFormationItemDetail(req: Request, projectUid: string, itemKey: string): Promise<FormationItemDetail> {
     const item = await this.getFormationItemOrThrow(req, projectUid, itemKey);
     const enriched = await this.enrichSingle(req, item);
-    // No history yet — the real activity feed (`GET /formations/{project_uid}/activity`) is Phase 5.
-    return { item: enriched, history: [] };
+    const { history, history_state } = await this.fetchItemActivityOrDegrade(req, projectUid, enriched.uid);
+    return { item: enriched, history, history_state };
   }
 
   /**
@@ -929,6 +931,45 @@ export class FormationService {
   private async enrichSingle(req: Request, item: FormationItem): Promise<FormationItem> {
     const canComplete = await formationItemAccessService.canComplete(req, item);
     return { ...item, can_complete: canComplete };
+  }
+
+  /**
+   * `getFormationItemDetail`'s activity fetch (GH-2372). `getFormationItemOrThrow` has already run
+   * the item's pre-read through `fetchLiveChecklistOrDenyNotFound`, proving `project:<projectUid>#auditor`
+   * access on the identical Heimdall relation this route is gated on — so an error here cannot mean
+   * "no access" that the checklist read didn't already catch. That's why this degrades to
+   * `history_state: 'unavailable'` on any failure instead of reusing the checklist's
+   * throw-and-mask pattern: the item itself is valid and should still render, just without history.
+   * 403/404 log at `DEBUG` (matching `fetchLiveChecklistOrDenyNotFound`'s own level for the
+   * equivalent case); anything else logs at `WARN` per the graceful-degradation convention.
+   */
+  private async fetchItemActivityOrDegrade(
+    req: Request,
+    projectUid: string,
+    itemUid: string
+  ): Promise<Pick<FormationItemDetail, 'history' | 'history_state'>> {
+    try {
+      const { entries, truncated } = await fetchItemFormationActivity(
+        req,
+        (cursor) =>
+          this.microserviceProxy.proxyRequest<UpstreamFormationActivityPage>(
+            req,
+            'LFX_V2_FORMATION_SERVICE',
+            `/formations/${encodeURIComponent(projectUid)}/activity`,
+            'GET',
+            { limit: FORMATION_ACTIVITY_PAGE_LIMIT, ...(cursor ? { cursor } : {}) }
+          ),
+        itemUid
+      );
+      return { history: entries, history_state: truncated ? 'truncated' : 'complete' };
+    } catch (error) {
+      if (isMicroserviceError(error) && (error.statusCode === 403 || error.statusCode === 404)) {
+        logger.debug(req, 'get_formation_item_detail', 'Activity fetch denied; degrading history to unavailable', { projectUid, itemUid, err: error });
+      } else {
+        logger.warning(req, 'get_formation_item_detail', 'Activity fetch failed; degrading history to unavailable', { projectUid, itemUid, err: error });
+      }
+      return { history: [], history_state: 'unavailable' };
+    }
   }
 }
 

--- a/packages/shared/src/constants/formation.constants.ts
+++ b/packages/shared/src/constants/formation.constants.ts
@@ -5,6 +5,7 @@ import { ProjectStage } from '../enums/project-stage.enum';
 import type { TagSeverity } from '../interfaces/components.interface';
 import type { FormationDrawerData, FormationLinkRowActionConfig, FormationRowActionConfig } from '../interfaces/formation-checklist.interface';
 import type {
+  FormationActivityAction,
   FormationEntityType,
   FormationItemStatus,
   FormationQueueTiles,
@@ -83,8 +84,32 @@ export const FORMATION_ORPHAN_SECTION = { key: '__orphan__', title: 'Other' } as
  * array across every call site.
  */
 export function createEmptyFormationDrawerData(): FormationDrawerData {
-  return { item: null, history: [] };
+  return { item: null, history: [], history_state: 'complete' };
 }
+
+/**
+ * Display verb phrases for {@link FormationActivityAction}, read after the actor's name (GH-2372) —
+ * e.g. "Jane changed the status". Total (unlike `UPSTREAM_SUB_STAGE_TO_FORMATION_SUB_STAGE`'s
+ * deliberate `Partial`): the action union is closed here, matching `FORMATION_ITEM_STATUS_LABELS`'s
+ * pattern. An off-taxonomy `action` never reaches this map — `getFormationActivityDisplay` falls
+ * back to `action_raw` verbatim instead of a lookup miss.
+ */
+export const FORMATION_ACTIVITY_ACTION_LABELS = {
+  status_changed: 'changed the status',
+  assignee_changed: 'changed the assignee',
+  evidence_link_changed: 'updated the evidence link',
+  due_date_changed: 'changed the due date',
+  note_changed: 'updated the note',
+  sub_items_changed: 'updated the sub-items',
+  skip_reason_changed: 'updated the skip reason',
+  item_updated: 'updated this item',
+  item_accepted: 'accepted this item',
+  item_rejected: 'rejected this item',
+  item_reopened: 'reopened this item',
+  platform_check_resolved: 'resolved this item automatically',
+  template_expanded: 'created the checklist from a template',
+  template_upgraded: 'upgraded the checklist template',
+} as const satisfies Record<FormationActivityAction, string>;
 
 /**
  * `FormationChecklistRowComponent`'s `provisionable`/`request` action-button config, keyed by

--- a/packages/shared/src/interfaces/formation-checklist.interface.ts
+++ b/packages/shared/src/interfaces/formation-checklist.interface.ts
@@ -32,10 +32,31 @@ export interface FormationEntryCardSummary {
   totalGatingItems: number;
 }
 
+/**
+ * Distinguishes why the History panel looks the way it does (GH-2372) — a genuinely-empty feed,
+ * `complete`, must never look like `truncated` (the per-item scan hit its page bound, or a later
+ * page failed — older entries may exist unseen) or `unavailable` (the activity fetch itself
+ * failed; the item above is still valid).
+ */
+export type FormationActivityHistoryState = 'complete' | 'truncated' | 'unavailable';
+
 /** `FormationItemDrawerComponent`'s lazy-loaded data shape — the empty-sentinel object doubles as both "not yet loaded" and "closed"; loading/error are tracked separately by the component. */
 export interface FormationDrawerData {
   item: FormationItem | null;
   history: FormationActivity[];
+  history_state: FormationActivityHistoryState;
+}
+
+/**
+ * `FormationService.getFormationItemDetail`'s (BFF) response shape (GH-2372) — same fields as
+ * {@link FormationDrawerData} but `item` is never `null`: the drawer's own empty-sentinel state has
+ * no server-side equivalent, since `getFormationItemDetail` either returns a real item or throws
+ * (mirroring {@link FormationDrawerData}'s comment, not duplicating its history-state doc).
+ */
+export interface FormationItemDetail {
+  item: FormationItem;
+  history: FormationActivity[];
+  history_state: FormationActivityHistoryState;
 }
 
 /** `FormationsTableComponent`'s emitted filter state — also the shape `FormationService.getFormationsQueue` accepts. */

--- a/packages/shared/src/interfaces/formation.interface.ts
+++ b/packages/shared/src/interfaces/formation.interface.ts
@@ -207,25 +207,86 @@ export interface FormationItemLink {
   href: string;
 }
 
-export type FormationActivityType =
-  | 'item_completed'
-  | 'item_skipped'
-  | 'item_reopened'
-  | 'item_requested'
-  | 'note_added'
+/**
+ * The real set upstream emits (GH-2372; read from `linuxfoundation/lfx-v2-formation-service`'s Go
+ * source at `beaa6371ff94a1ae01f3e624922897cb34ee199b`, not inferred from this repo's prior type,
+ * which modeled only 3 of these 14 and 4 members that don't exist — see the GH-2372 PR for the
+ * full comparison table). `action` is an unconstrained `dsl.String` on the wire with no enum, so
+ * an unrecognized value is always possible — see {@link FormationActivity.action_raw}.
+ *
+ * Notable gaps versus what the previous type implied: there is no `item_completed` or
+ * `item_skipped` — both arrive as `status_changed` with `after.status` telling you which; no
+ * `note_added` (it's `note_changed`); no `item_requested` (never emitted).
+ */
+export type FormationActivityAction =
+  | 'status_changed'
   | 'assignee_changed'
-  | 'due_date_changed';
+  | 'evidence_link_changed'
+  | 'due_date_changed'
+  | 'note_changed'
+  | 'sub_items_changed'
+  | 'skip_reason_changed'
+  | 'item_updated'
+  | 'item_accepted'
+  | 'item_rejected'
+  | 'item_reopened'
+  | 'platform_check_resolved'
+  | 'template_expanded'
+  | 'template_upgraded';
 
+/**
+ * One entry from `GET /formations/{project_uid}/activity`, mapped onto the wire (GH-2372). Field
+ * names follow the upstream wire (`ulid`→`uid`, `item_uid`→`formation_item_uid`, `at`→`created_at`)
+ * rather than the previous type's invented ones (`type`, `message`, `metadata`) — there is no
+ * `message` on the wire; the display string is built at render time by
+ * {@link FormationActivityAction} + {@link before}/{@link after} (see `getFormationActivityDisplay`,
+ * `formation.utils.ts`).
+ */
 export interface FormationActivity {
+  /** Upstream `ulid` — time-ordered primary key and the feed's own paging cursor. */
   uid: string;
-  formation_uid: string;
-  /** Always item-scoped today — every {@link FormationActivityType} is an item-level action. */
+  /** Upstream `item_uid`. `null` for a formation-level entry (`template_expanded`/`template_upgraded`). */
   formation_item_uid: string | null;
-  type: FormationActivityType;
+  /**
+   * `null` when upstream's `action` isn't one of the 14 modeled values — never coerced into a
+   * plausible neighbour (the GH-2366/GH-2328 defect class). Always read alongside {@link action_raw}.
+   */
+  action: FormationActivityAction | null;
+  /** Upstream `action`, verbatim — rendered as-is when {@link action} is `null`. */
+  action_raw: string;
+  set_by: 'user' | 'system';
+  /** Upstream sends a bare username (or the literal `"system"`); `name` mirrors it, same precedent as `mapLiveItem`'s `owner`. */
   actor: FormationUser;
-  message: string;
-  metadata: Record<string, unknown> | null;
+  /**
+   * Upstream's redacted `{status, assignee}` summary — the only structured payload the feed
+   * carries. For `due_date_changed`/`note_changed`/`evidence_link_changed`/`sub_items_changed`/
+   * `skip_reason_changed` the actual old/new value is NOT in the feed at all: `before` and `after`
+   * are identical for those actions.
+   */
+  before: { status: string | null; assignee: string | null } | null;
+  after: { status: string | null; assignee: string | null } | null;
+  /** Upstream `at`, RFC3339. */
   created_at: string;
+}
+
+/** Wire shape of one `GET /formations/{project_uid}/activity` entry, pre-mapping (GH-2372). */
+export interface UpstreamFormationActivityEntry {
+  ulid: string;
+  item_uid?: string | null;
+  actor: string;
+  set_by: 'user' | 'system';
+  /** Unconstrained upstream — deliberately `string`, never the canonical union. */
+  action: string;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  at: string;
+}
+
+/** Response body for `GET /formations/{project_uid}/activity`. */
+export interface UpstreamFormationActivityPage {
+  entries: UpstreamFormationActivityEntry[];
+  /** Always present; `''` means last page — a consumer must not test only for `undefined`. */
+  next_cursor: string;
 }
 
 /**

--- a/packages/shared/src/utils/formation.utils.spec.ts
+++ b/packages/shared/src/utils/formation.utils.spec.ts
@@ -4,7 +4,14 @@
 import { describe, expect, it } from 'vitest';
 
 import { ProjectStage } from '../enums/project-stage.enum';
-import { deriveFormationEntityType, getFormationQueueStageDisplay, normalizeFormationSubStage } from './formation.utils';
+import type { FormationActivity } from '../interfaces/formation.interface';
+import {
+  deriveFormationEntityType,
+  getFormationActivityDisplay,
+  getFormationQueueStageDisplay,
+  normalizeFormationActivityAction,
+  normalizeFormationSubStage,
+} from './formation.utils';
 
 describe('deriveFormationEntityType', () => {
   it('derives foundation when is_foundation is true, regardless of parent_uid', () => {
@@ -73,5 +80,103 @@ describe('getFormationQueueStageDisplay (GH-2366)', () => {
 
   it('falls back to an em dash when the raw value itself is empty', () => {
     expect(getFormationQueueStageDisplay(null, '')).toEqual({ label: '—', severity: 'secondary' });
+  });
+});
+
+describe('normalizeFormationActivityAction (GH-2372)', () => {
+  it('recognizes every one of the 14 real upstream actions', () => {
+    const actions = [
+      'status_changed',
+      'assignee_changed',
+      'evidence_link_changed',
+      'due_date_changed',
+      'note_changed',
+      'sub_items_changed',
+      'skip_reason_changed',
+      'item_updated',
+      'item_accepted',
+      'item_rejected',
+      'item_reopened',
+      'platform_check_resolved',
+      'template_expanded',
+      'template_upgraded',
+    ] as const;
+
+    for (const action of actions) {
+      expect(normalizeFormationActivityAction(action)).toBe(action);
+    }
+  });
+
+  it('never coerces an unrecognized action into a plausible neighbour', () => {
+    expect(normalizeFormationActivityAction('item_teleported')).toBeNull();
+  });
+
+  it('guards Object.prototype key collisions via Object.hasOwn, not `in`', () => {
+    expect(normalizeFormationActivityAction('__proto__')).toBeNull();
+    expect(normalizeFormationActivityAction('toString')).toBeNull();
+    expect(normalizeFormationActivityAction('constructor')).toBeNull();
+  });
+
+  it('returns null for null/undefined/empty', () => {
+    expect(normalizeFormationActivityAction(null)).toBeNull();
+    expect(normalizeFormationActivityAction(undefined)).toBeNull();
+    expect(normalizeFormationActivityAction('')).toBeNull();
+  });
+});
+
+describe('getFormationActivityDisplay (GH-2372)', () => {
+  function entry(overrides: Partial<FormationActivity> = {}): FormationActivity {
+    return {
+      uid: 'activity-1',
+      formation_item_uid: 'item-1',
+      action: 'status_changed',
+      action_raw: 'status_changed',
+      set_by: 'user',
+      actor: { username: 'sam.chen', name: 'sam.chen' },
+      before: { status: 'not_started', assignee: null },
+      after: { status: 'in_progress', assignee: null },
+      created_at: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('renders the mapped label as the summary for a recognized action', () => {
+    expect(getFormationActivityDisplay(entry()).summary).toBe('changed the status');
+  });
+
+  it('renders action_raw verbatim as the summary for an unmapped action', () => {
+    const result = getFormationActivityDisplay(entry({ action: null, action_raw: 'item_teleported' }));
+    expect(result.summary).toBe('item_teleported');
+    expect(result.detail).toBeNull();
+  });
+
+  it('builds a status detail line through FORMATION_ITEM_STATUS_LABELS for status-bearing actions', () => {
+    expect(getFormationActivityDisplay(entry()).detail).toBe('Not started → In progress');
+  });
+
+  it('builds an assignee detail line, falling back to "Unassigned" for a null assignee', () => {
+    const result = getFormationActivityDisplay(
+      entry({ action: 'assignee_changed', action_raw: 'assignee_changed', before: { status: null, assignee: null }, after: { status: null, assignee: 'sam.chen' } })
+    );
+    expect(result.detail).toBe('Unassigned → sam.chen');
+  });
+
+  it('returns a null detail for actions whose changed value is not carried in the feed', () => {
+    // due_date_changed / note_changed / evidence_link_changed / sub_items_changed / skip_reason_changed:
+    // upstream's redacted before/after summary only carries {status, assignee}, so the actual new
+    // value is genuinely unavailable — never fabricated.
+    for (const action of ['due_date_changed', 'note_changed', 'evidence_link_changed', 'sub_items_changed', 'skip_reason_changed'] as const) {
+      const result = getFormationActivityDisplay(entry({ action, action_raw: action, before: { status: 'in_progress', assignee: null }, after: { status: 'in_progress', assignee: null } }));
+      expect(result.detail).toBeNull();
+    }
+  });
+
+  it('returns a null detail for template-level actions', () => {
+    expect(getFormationActivityDisplay(entry({ action: 'template_expanded', action_raw: 'template_expanded' })).detail).toBeNull();
+    expect(getFormationActivityDisplay(entry({ action: 'template_upgraded', action_raw: 'template_upgraded' })).detail).toBeNull();
+  });
+
+  it('returns a null detail when before/after are absent', () => {
+    expect(getFormationActivityDisplay(entry({ before: null, after: null })).detail).toBeNull();
   });
 });

--- a/packages/shared/src/utils/formation.utils.ts
+++ b/packages/shared/src/utils/formation.utils.ts
@@ -1,9 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { FORMATION_SUB_STAGE_LABELS, FORMATION_SUB_STAGE_SEVERITY, UPSTREAM_SUB_STAGE_TO_FORMATION_SUB_STAGE } from '../constants/formation.constants';
+import {
+  FORMATION_ACTIVITY_ACTION_LABELS,
+  FORMATION_ITEM_STATUS_LABELS,
+  FORMATION_SUB_STAGE_LABELS,
+  FORMATION_SUB_STAGE_SEVERITY,
+  UPSTREAM_SUB_STAGE_TO_FORMATION_SUB_STAGE,
+} from '../constants/formation.constants';
 import type { TagSeverity } from '../interfaces/components.interface';
-import type { Formation, FormationEntityType, FormationSubStage } from '../interfaces/formation.interface';
+import type { Formation, FormationActivity, FormationActivityAction, FormationEntityType, FormationItemStatus, FormationSubStage } from '../interfaces/formation.interface';
 
 /**
  * Derives the Formations queue's Type-column taxonomy from the two inputs the formation service
@@ -76,4 +82,69 @@ export function getFormationQueueStageDisplay(subStage: FormationSubStage | null
     return { label: FORMATION_SUB_STAGE_LABELS[subStage], severity: FORMATION_SUB_STAGE_SEVERITY[subStage] };
   }
   return { label: rawSubStage || '—', severity: 'secondary' };
+}
+
+/**
+ * Upstream's `action` is an unconstrained `dsl.String` with no enum on the wire (GH-2372) — an
+ * unrecognized value is always possible, and must resolve to `null` here rather than the nearest
+ * plausible member (the GH-2366/GH-2328 defect class this repo has hit twice already). Same
+ * `Object.hasOwn` guard as {@link normalizeFormationSubStage}, for the same prototype-collision
+ * reason.
+ */
+export function normalizeFormationActivityAction(rawAction: string | null | undefined): FormationActivityAction | null {
+  if (!rawAction) {
+    return null;
+  }
+  return Object.hasOwn(FORMATION_ACTIVITY_ACTION_LABELS, rawAction) ? (rawAction as FormationActivityAction) : null;
+}
+
+function statusDetailValue(status: string | null): string {
+  if (!status) {
+    return 'Unassigned';
+  }
+  return Object.hasOwn(FORMATION_ITEM_STATUS_LABELS, status) ? FORMATION_ITEM_STATUS_LABELS[status as FormationItemStatus] : status;
+}
+
+/**
+ * `FormationItemDrawerComponent`'s History-panel row resolver (GH-2372). `summary` reads after the
+ * actor's name (`"{{ actor.name }} {{ summary }}"`); `detail` is a second, optional line.
+ *
+ * Upstream's `before`/`after` carry only a redacted `{status, assignee}` snapshot — for every
+ * action other than the ones listed below, the actual old/new value (a due date, a note's text, a
+ * link, a sub-item list, a skip reason) **is not in the feed at all**, so `detail` is `null` there
+ * rather than a fabricated guess.
+ */
+export function getFormationActivityDisplay(entry: FormationActivity): { summary: string; detail: string | null } {
+  // Off-taxonomy action: the raw wire value, verbatim — never coerced into a mapped label (same
+  // rule as getFormationQueueStageDisplay's unmapped-substage branch).
+  if (!entry.action) {
+    return { summary: entry.action_raw || '—', detail: null };
+  }
+
+  const summary = FORMATION_ACTIVITY_ACTION_LABELS[entry.action];
+
+  switch (entry.action) {
+    case 'status_changed':
+    case 'item_accepted':
+    case 'item_rejected':
+    case 'item_reopened':
+    case 'platform_check_resolved': {
+      if (!entry.before || !entry.after) return { summary, detail: null };
+      return { summary, detail: `${statusDetailValue(entry.before.status)} → ${statusDetailValue(entry.after.status)}` };
+    }
+    case 'assignee_changed': {
+      if (!entry.before || !entry.after) return { summary, detail: null };
+      return { summary, detail: `${entry.before.assignee || 'Unassigned'} → ${entry.after.assignee || 'Unassigned'}` };
+    }
+    // Formation-level entries: upstream's `after` carries item counts, not a status/assignee pair
+    // — surfacing that shape reliably needs its own upstream contract read, which this ticket is
+    // explicitly scoped away from (item-drawer History only). No detail line for now.
+    case 'template_expanded':
+    case 'template_upgraded':
+      return { summary, detail: null };
+    default:
+      // evidence_link_changed, due_date_changed, note_changed, sub_items_changed,
+      // skip_reason_changed, item_updated — the changed value isn't in the feed at all.
+      return { summary, detail: null };
+  }
 }


### PR DESCRIPTION
## Summary

`FormationService.getFormationItemDetail` returned a hardcoded `history: []` — every item drawer showed "No activity yet." regardless of real activity. This wires `GET /formations/{project_uid}/activity` through, closing out the last stub from GH-2267.

## Contract reshape (full, not additive)

The upstream wire contract (`linuxfoundation/lfx-v2-formation-service` @ `beaa6371`) does not match the placeholder `FormationActivityType`/`FormationActivity` types at all — every field name differs (`ulid`/`item_uid`/`actor` (bare string)/`set_by`/`action`/`before`/`after`/`at` vs. `uid`/`formation_uid`/`formation_item_uid`/`type`/`actor: FormationUser`/`message`/`metadata`/`created_at`), and there is no `message` field upstream at all — the old drawer template's `{{ entry.message }}` could never have rendered real data. This landed as a full reshape in this PR rather than a quiet addition because no real payload could render through the old shape.

**Report, do not fix (a) — real action set vs. the old `FormationActivityType`'s 7:**

| Old `FormationActivityType` (7) | Real upstream `action` (14) | Notes |
| --- | --- | --- |
| `item_completed` | — | arrives as `status_changed` with `after.status = "completed"` |
| `item_skipped` | — | arrives as `status_changed` with `after.status = "skipped"` |
| `item_requested` | — | never emitted upstream |
| `note_added` | `note_changed` | renamed |
| `assignee_changed` | `assignee_changed` | kept |
| `due_date_changed` | `due_date_changed` | kept |
| `item_reopened` | `item_reopened` | kept |
| — | `status_changed` | covers complete/skip/block/start transitions |
| — | `evidence_link_changed` | new |
| — | `sub_items_changed` | new |
| — | `skip_reason_changed` | new |
| — | `item_updated` | new |
| — | `item_accepted` | new |
| — | `item_rejected` | new |
| — | `platform_check_resolved` | new |
| — | `template_expanded` | template-level, new |
| — | `template_upgraded` | template-level, new |

`action` is an unconstrained `dsl.String` upstream (no wire enum), so an unrecognized value is always possible going forward — `normalizeFormationActivityAction` returns `null` for anything off this list (`Object.hasOwn` guard, never a nearest-match coercion), and the drawer renders `action_raw` verbatim in that case instead of masking it as a known type.

## Design decisions

**Item-scoping (bounded 5×100 BFF pager).** `GET /formations/{project_uid}/activity` is formation-scoped with no item filter — the repository query filters on `formation_uid` alone. Fetching one page and filtering client-side would silently under-report an item's real history on any formation with enough unrelated activity, so the BFF pages up to `FORMATION_ACTIVITY_MAX_PAGES = 5` pages of `FORMATION_ACTIVITY_PAGE_LIMIT = 100` (upstream's max), filtering each page to the target `item_uid` and accumulating. 5×100 = 500 entries scanned per drawer open is the bound for the pathological case; ordinary usage (one entry per mutation, ~20-40 items per template) should stay far under it. **Follow-up filed against the upstream service to add an `item_uid` query filter** so this pager becomes unnecessary — will file as a separate issue against `lfx-v2-formation-service`.

**Ordering.** Upstream returns newest-first (`ORDER BY ulid DESC`) and the BFF does not reorder — `fetchItemFormationActivity` preserves upstream order verbatim across pages.

**Fail-whole-call vs. partial-and-flagged.** A single page error propagates as a whole-call failure (not `failOnPartial: false` the way `fetchAllQueryResources` handles it) — silently presenting a partial feed as an item's complete history would be exactly the kind of quiet data-loss this ticket exists to prevent. The caller (`fetchItemActivityOrDegrade`) converts any throw into `history_state: 'unavailable'`, which the drawer renders as an honest "couldn't load activity" state, distinct from "no activity" and from "truncated by the page bound."

**Access gating — no second rule invented.** `getFormationItemOrThrow` already proves `project:<project_uid>#auditor` via the existing `fetchLiveChecklistOrDenyNotFound` masking helper before the activity fetch ever runs, on the identical Heimdall relation the activity route is gated on. So an activity-fetch failure cannot mean "no access" that the checklist read didn't already catch — it degrades to `unavailable` (403/404 logged at `DEBUG` matching the masking helper's own level; anything else at `WARN` per the graceful-degradation convention) rather than being run through a second throw-and-mask gate.

**`formation-mapper.helper.ts` deliberately untouched.** The new mapper/pager lives in a new sibling file, `formation-activity.helper.ts`, specifically so the parallel `~/lfx/ss-2328` worktree's `deriveFormationSubStage` fix rebases cleanly against this branch.

## What changed

- `packages/shared/src/interfaces/formation.interface.ts` — `UpstreamFormationActivityEntry`/`UpstreamFormationActivityPage` (wire shapes), `FormationActivityAction` (14-value union replacing the old 7-value `FormationActivityType`), reshaped `FormationActivity`, `FormationActivityHistoryState` (`'complete' | 'truncated' | 'unavailable'`), `FormationItemDetail.history_state`.
- `packages/shared/src/constants/formation.constants.ts` — `FORMATION_ACTIVITY_ACTION_LABELS` (total map over the 14 actions), `createEmptyFormationDrawerData()` gains `history_state: 'complete'`.
- `packages/shared/src/utils/formation.utils.ts` — `normalizeFormationActivityAction` (mirrors `normalizeFormationSubStage`'s `Object.hasOwn` pattern), `getFormationActivityDisplay` (summary + optional detail line; `null` detail wherever upstream's redacted `{status, assignee}` summary doesn't actually carry the changed value — never fabricated).
- `apps/lfx-one/src/server/helpers/formation-activity.helper.ts` (new) — `mapUpstreamFormationActivity`, `fetchItemFormationActivity` (the bounded pager).
- `apps/lfx-one/src/server/services/formation.service.ts` — `getFormationItemDetail` now fetches real history via `fetchItemActivityOrDegrade`; class doc updated.
- `apps/lfx-one/src/app/modules/dashboards/components/formation-item-drawer/` — History panel renders `unavailable` / empty+`complete` / entries / `truncated` as four distinct states with distinct `data-testid`s; unmapped actions render `action_raw` verbatim.
- e2e fixtures/helpers (`formation-item.mock.ts`, `formation-api-mock.helper.ts`) reshaped to the new wire-aligned `FormationActivity`; assertions in `formation-checklist.spec.ts` / `formation-checklist-robust.spec.ts` updated to match.
- Specs: `formation.service.spec.ts` (7 new cases covering mapping, unrecognized action, no-match, pagination cursor threading, page-cap truncation, 500 degrade, 403 degrade) and `formation.utils.spec.ts` (`normalizeFormationActivityAction`, `getFormationActivityDisplay`) — 73 + 23 tests, all passing.

## Verification

- ✅ `yarn lint` — clean (0 errors; 2 pre-existing unrelated warnings untouched by this PR)
- ✅ `yarn test` (root, via turbo) — all passing, including the new/updated specs above
- ✅ `apps/lfx-one` direct `tsc --noEmit -p tsconfig.json` — clean (root `yarn check-types` only covers `@lfx-one/shared`, a pre-existing pipeline gap unrelated to this PR)
- ✅ `./check-headers.sh` — clean
- ⚠️ **`yarn e2e` blocked — pre-existing repo issue, confirmed unrelated to this PR.** `formation-checklist.spec.ts` / `formation-checklist-robust.spec.ts` fail to even collect: their helper (`e2e/helpers/formation-api-mock.helper.ts`) imports `deriveFormationEntityType` from the `@lfx-one/shared/utils` barrel, which re-exports `form.utils.ts`, which statically imports `@angular/forms` → `@angular/common`'s `PlatformLocation` hits a JIT-compile path that fails outside an Angular bootstrap context (`@angular/compiler` isn't loaded in Playwright's plain Node/tsx runtime). Verified this barrel import already exists at the merge-base commit (`d36971ea4`, before any GH-2372 change) — reproducible on `main` today, nothing introduced here. Other e2e specs that import a shared-utils submodule path directly (not the barrel, e.g. `@lfx-one/shared/utils/number.utils`) collect fine. Will file as a separate tracked issue; out of scope to fix in this PR.
- ⚠️ **Prod read-only validation via Claude in Chrome not performed** — this sandboxed worktree lacks the OIDC/Auth0 environment wiring needed to boot the app against prod. As a result, **report, do not fix (b)** — whether a formation-level activity view is worth building — **cannot be honestly answered yet**: it depends on real entries-per-formation volume that needs to be observed against prod, which this session could not do. Deferring that assessment to whoever runs prod validation before merge.

## Out of scope (confirmed unchanged)

`getFormationsQueueLive`, queue types, `FormationItemStatus`, `FormationSubStage`, and `deriveFormationSubStage`/`formation-mapper.helper.ts` (owned by the parallel GH-2328 fix) are all untouched.

Refs linuxfoundation/lfx-self-serve#2372

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXjtvSD8WytCgjoEVmVY7c
